### PR TITLE
docker: Give hint in dockerdev.sh if godbb image is missing

### DIFF
--- a/scripts/dockerdev.sh
+++ b/scripts/dockerdev.sh
@@ -17,6 +17,11 @@
 dockerdev () {
     local container_name=godbb-dev
 
+    if ! docker images | grep -q godbb; then
+        echo "No godbb docker image found! Maybe you need to run 'make dockerinit'?" >&2
+        exit 1
+    fi
+
     # If already running, enter the container.
     if docker ps | grep -q $container_name; then
         docker exec -it $container_name /opt/go/src/github.com/digitalbitbox/bitbox-wallet-app/scripts/docker_init.sh


### PR DESCRIPTION
Without this change, `./scripts/dockerdev.sh` (and `make dockerdev`) fails
with `Unable to find image 'godbb:latest' locally` on clean checkout (tested at 5d8f347).

After this change, we check for the `godbb` image, and if it does not exist, we build the `Dockerfile`
in the root of the repo and tag it with this name.