### PR TITLE
frontend: disable 2FA button unless paired

### DIFF
--- a/frontends/web/src/routes/device/settings/settings.jsx
+++ b/frontends/web/src/routes/device/settings/settings.jsx
@@ -156,7 +156,7 @@ export default class Settings extends Component {
                                     <DeviceLock
                                         deviceID={deviceID}
                                         onLock={() => this.setState({ lock: true })}
-                                        disabled={lock} />
+                                        disabled={lock || !paired} />
                                 </div>
 
                                 <hr />


### PR DESCRIPTION
This change simply prevents enabling 2FA from the web UI
if no phone is paired with the device, as reported by the backend.

It remains to be seen and verified whether the 2FA can be enabled
directy by sending "lock" command to the device
or backend which propagates the command to device.

R: @thisconnect @benma 