### PR TITLE
reduce attack surface in QT desktop application

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -54,6 +54,15 @@ int main(int argc, char *argv[])
 //     qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", QByteArray("1"));
 // #endif // QT_VERSION
 
+// QT configuration parameters which change the attack surface for memory
+// corruption vulnerabilities
+#if QT_VERSION >= QT_VERSION_CHECK(5,8,0)
+    qputenv("QMLSCENE_DEVICE", "softwarecontext");
+    qputenv("QT_QUICK_BACKEND", "software");
+    qputenv("QT_ENABLE_REGEXP_JIT", "0");
+    qputenv("QV4_FORCE_INTERPRETER", "1");
+#endif
+
     QApplication a(argc, argv);
     a.setApplicationName(QString("BitBox Wallet"));
     a.setOrganizationDomain("shiftcrypto.ch");

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -57,11 +57,15 @@ int main(int argc, char *argv[])
 // QT configuration parameters which change the attack surface for memory
 // corruption vulnerabilities
 #if QT_VERSION >= QT_VERSION_CHECK(5,8,0)
-    qputenv("QMLSCENE_DEVICE", "softwarecontext");
-    qputenv("QT_QUICK_BACKEND", "software");
     qputenv("QT_ENABLE_REGEXP_JIT", "0");
     qputenv("QV4_FORCE_INTERPRETER", "1");
+    qputenv("DRAW_USE_LLVM", "0");
 #endif
+#if QT_VERSION >= QT_VERSION_CHECK(5,9,0)
+    qputenv("QMLSCENE_DEVICE", "softwarecontext");
+    qputenv("QT_QUICK_BACKEND", "software");
+#endif
+
 
     QApplication a(argc, argv);
     a.setApplicationName(QString("BitBox Wallet"));


### PR DESCRIPTION
The first two changes force the use of the 2d software rendering engine:

	qputenv("QMLSCENE_DEVICE", "softwarecontext");
	qputenv("QT_QUICK_BACKEND", "software");

Disable just-in-time regex engine:

	qputenv("QT_ENABLE_REGEXP_JIT", "0");

Disable just-in-time javascript engine:

	qputenv("QV4_FORCE_INTERPRETER", "1");