### PR TITLE
backend: guard Device's internals against concurrent access

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -37,6 +37,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/usb"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
+	utilconf "github.com/digitalbitbox/bitbox-wallet-app/util/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/jsonrpc"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
@@ -471,7 +472,8 @@ func (backend *Backend) Deregister(deviceID string) {
 }
 
 func (backend *Backend) listenHID() {
-	usb.NewManager(backend.Register, backend.Deregister).ListenHID()
+	// TODO: Merge utilconf with backend/config and/or arguments.ConfigFilename.
+	usb.NewManager(utilconf.DirectoryPath(), backend.Register, backend.Deregister).ListenHID()
 }
 
 // Rates return the latest rates.

--- a/backend/devices/bitbox/device_test.go
+++ b/backend/devices/bitbox/device_test.go
@@ -76,6 +76,7 @@ func (s *dbbTestSuite) SetupTest() {
 	s.mockCommunication.On("Close").Run(func(mock.Arguments) {
 		s.mockCommClosed = true
 	})
+	s.mockCommClosed = false
 	dbb, err := NewDevice(deviceID, false /* bootloader */, firmVer400, s.configDir, s.mockCommunication)
 	dbb.Init(true)
 	require.NoError(s.T(), err)
@@ -361,6 +362,7 @@ func (s *dbbTestSuite) TestSignSixteen() {
 
 func (s *dbbTestSuite) TestDeviceClose() {
 	require.False(s.T(), s.dbb.closed, "s.dbb.closed")
+	require.False(s.T(), s.mockCommClosed, "s.mockCommClosed")
 	s.dbb.Close()
 	require.True(s.T(), s.dbb.closed, "s.dbb.closed")
 	require.True(s.T(), s.mockCommClosed, "s.mockCommClosed")

--- a/backend/devices/bitbox/device_test.go
+++ b/backend/devices/bitbox/device_test.go
@@ -17,7 +17,6 @@ package bitbox
 import (
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -30,6 +29,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/util/jsonp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/semver"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/test"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -47,15 +47,6 @@ const (
 	stretchedKey     = "e3306aa321df2b4ae9ee131b385c19d73d41b92678c554ba9ec1737e6d141381465b881e3fec3d4edda3d93609ca5ec4e625a5a56107ab6e0f5019b199aa0fdb"
 )
 
-// mustTempDir creates a new temp directory with the given prefix and returns its path.
-func mustTempDir(prefix string) string {
-	dir, err := ioutil.TempDir("", prefix)
-	if err != nil {
-		panic(err.Error()) // should never happen
-	}
-	return dir
-}
-
 type dbbTestSuite struct {
 	suite.Suite
 	mockCommunication *mocks.CommunicationInterface
@@ -67,7 +58,7 @@ type dbbTestSuite struct {
 }
 
 func (s *dbbTestSuite) SetupTest() {
-	s.configDir = mustTempDir("dbb_device_test")
+	s.configDir = test.TstTempDir("dbb_device_test")
 	s.log = logging.Get().WithGroup("bitbox_test")
 	s.mockCommunication = new(mocks.CommunicationInterface)
 	s.mockCommunication.On("SendPlain", jsonArgumentMatcher(map[string]interface{}{"ping": ""})).
@@ -383,7 +374,7 @@ func (s *dbbTestSuite) TestDeviceStatusEvent() {
 }
 
 func TestNewDeviceReadsChannel(t *testing.T) {
-	configDir := mustTempDir("dbb_device_test")
+	configDir := test.TstTempDir("dbb_device_test")
 	defer os.RemoveAll(configDir)
 	mobchan := relay.NewChannelWithRandomKey()
 	if err := mobchan.StoreToConfigFile(configDir); err != nil {

--- a/backend/devices/bitbox/relay/channel.go
+++ b/backend/devices/bitbox/relay/channel.go
@@ -76,8 +76,8 @@ func NewChannelWithRandomKey() *Channel {
 
 // NewChannelFromConfigFile returns a new channel with the channel identifier and encryption key
 // from the config file or nil if the config file does not exist.
-func NewChannelFromConfigFile() *Channel {
-	configFile := config.NewFile(configFileName)
+func NewChannelFromConfigFile(configDir string) *Channel {
+	configFile := config.NewFile(configDir, configFileName)
 	if configFile.Exists() {
 		var configuration configuration
 		if err := configFile.ReadJSON(&configuration); err != nil {
@@ -88,16 +88,18 @@ func NewChannelFromConfigFile() *Channel {
 	return nil
 }
 
-// StoreToConfigFile stores the channel to the config file.
-func (channel *Channel) StoreToConfigFile() error {
+// StoreToConfigFile stores the channel to the config file located in the provided configDir.
+// Callers can use config.DirectoryPath to obtain standard user location config dir.
+func (channel *Channel) StoreToConfigFile(configDir string) error {
 	configuration := newConfiguration(channel)
-	configFile := config.NewFile(configFileName)
+	configFile := config.NewFile(configDir, configFileName)
 	return configFile.WriteJSON(configuration)
 }
 
 // RemoveConfigFile removes the config file.
-func (channel *Channel) RemoveConfigFile() error {
-	return config.NewFile(configFileName).Remove()
+// Callers can use config.DirectoryPath to obtain standard user location config dir.
+func (channel *Channel) RemoveConfigFile(configDir string) error {
+	return config.NewFile(configDir, configFileName).Remove()
 }
 
 // relayServer returns the configured relay server.

--- a/util/config/file.go
+++ b/util/config/file.go
@@ -22,9 +22,10 @@ import (
 	"runtime"
 )
 
-// DirectoryPath returns the absolute path to the application's directory.
+// DirectoryPath returns the absolute path to the application's directory
+// in the user standard config location.
 func DirectoryPath() string {
-	switch goos := runtime.GOOS; goos {
+	switch runtime.GOOS {
 	case "darwin":
 		return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "bitbox")
 	case "windows":
@@ -36,17 +37,19 @@ func DirectoryPath() string {
 
 // File models a config file in the application's directory.
 type File struct {
+	dir  string
 	name string
 }
 
-// NewFile creates a new config file with the given name in the application's directory.
-func NewFile(name string) *File {
-	return &File{name}
+// NewFile creates a new config file with the given name in the application's directory dir.
+// Callers can use DirectoryPath function to use a standard user config dir.
+func NewFile(dir, name string) *File {
+	return &File{dir: dir, name: name}
 }
 
 // Path returns the absolute path to the config file.
 func (file *File) Path() string {
-	return filepath.Join(DirectoryPath(), file.name)
+	return filepath.Join(file.dir, file.name)
 }
 
 // Exists checks whether the file exists with suitable permissions as a file and not as a directory.
@@ -76,7 +79,7 @@ func (file *File) ReadJSON(object interface{}) error {
 
 // write writes the given data to the config file (and creates parent directories if necessary).
 func (file *File) write(data []byte) error {
-	if err := os.MkdirAll(DirectoryPath(), os.ModePerm); err != nil {
+	if err := os.MkdirAll(file.dir, 0700); err != nil {
 		return err
 	}
 	return ioutil.WriteFile(file.Path(), data, 0600)

--- a/util/logging/instance.go
+++ b/util/logging/instance.go
@@ -37,7 +37,7 @@ var once sync.Once
 func Get() *Logger {
 	once.Do(func() {
 		var configuration Configuration
-		configFile := config.NewFile(configFileName)
+		configFile := config.NewFile(config.DirectoryPath(), configFileName)
 		if configFile.Exists() {
 			if err := configFile.ReadJSON(&configuration); err != nil {
 				panic(errp.WithStack(err))


### PR DESCRIPTION
`devices/bitbox.Device`'s channel, onEvent and closed fields are accessed concurrently and need to be guarded with a mutex.

I consider this an intermediate solution, built on top of existing code structure. I believe a more elegant solution exists but would require substantial refactoring.

`bitbox.Device` now has a new unexported field which holds the channel config dir to aid automated testing. A couple nice side effects of this:

- your real channel.json config in the HOME dir is not touched during
  tests, if present;
- tests shouldn't hammer prod relay endpoint anymore because
  the channel config dir is a newly created temp dir for each run,
  missing the channel.json file so dbb.listenForMobile isn't run.

Verified locally with `go test` and manually resetting a real bitbox device and going through the pairing flow.

R: @stephaniestroka @benma 