### PR TITLE
backend,frontends/qt: unify app config dir

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -37,7 +37,6 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/usb"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
-	utilconf "github.com/digitalbitbox/bitbox-wallet-app/util/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/jsonrpc"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
@@ -472,8 +471,7 @@ func (backend *Backend) Deregister(deviceID string) {
 }
 
 func (backend *Backend) listenHID() {
-	// TODO: Merge utilconf with backend/config and/or arguments.ConfigFilename.
-	usb.NewManager(utilconf.DirectoryPath(), backend.Register, backend.Deregister).ListenHID()
+	usb.NewManager(backend.arguments.MainDirectoryPath(), backend.Register, backend.Deregister).ListenHID()
 }
 
 // Rates return the latest rates.

--- a/backend/devices/bitbox/device.go
+++ b/backend/devices/bitbox/device.go
@@ -130,7 +130,6 @@ type Device struct {
 
 	// BitBox desktop app config directory.
 	// Used to read/store channel settings.
-	// TODO: merge this with backend/config.
 	channelConfigDir string
 
 	mu sync.RWMutex
@@ -150,7 +149,7 @@ type Device struct {
 // communication is used for transporting messages to/from the device.
 //
 // The channelConfigDir is the location of the channel settings file.
-// Callers can use util/config.DirectoryPath to obtain user standard config dir.
+// Callers can use util/config.AppDir to obtain user standard config dir.
 func NewDevice(
 	deviceID string,
 	bootloader bool,

--- a/backend/devices/bitbox/relay/channel.go
+++ b/backend/devices/bitbox/relay/channel.go
@@ -89,7 +89,7 @@ func NewChannelFromConfigFile(configDir string) *Channel {
 }
 
 // StoreToConfigFile stores the channel to the config file located in the provided configDir.
-// Callers can use config.DirectoryPath to obtain standard user location config dir.
+// Callers can use config.AppDir to obtain standard user location config dir.
 func (channel *Channel) StoreToConfigFile(configDir string) error {
 	configuration := newConfiguration(channel)
 	configFile := config.NewFile(configDir, configFileName)
@@ -97,7 +97,7 @@ func (channel *Channel) StoreToConfigFile(configDir string) error {
 }
 
 // RemoveConfigFile removes the config file.
-// Callers can use config.DirectoryPath to obtain standard user location config dir.
+// Callers can use config.AppDir to obtain standard user location config dir.
 func (channel *Channel) RemoveConfigFile(configDir string) error {
 	return config.NewFile(configDir, configFileName).Remove()
 }

--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -42,14 +42,12 @@ import (
 	"flag"
 	"net"
 	"net/http"
-	"os"
-	"path"
-	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"strings"
 	"time"
 
+	"github.com/digitalbitbox/bitbox-wallet-app/util/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/jsonp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/random"
@@ -134,26 +132,6 @@ func backendCall(queryID C.int, s *C.char) {
 	}()
 }
 
-// getAppFolder returns the production application folder.
-func getAppFolder() string {
-	var appFolder string
-	switch runtime.GOOS {
-	case "windows":
-		appFolder = os.Getenv("APPDATA")
-	case "darwin":
-		// Usually /Users/<User>/Library/Application Support
-		appFolder = os.Getenv("HOME") + "/Library/Application Support"
-	case "linux":
-		if os.Getenv("XDG_CONFIG_HOME") != "" {
-			// Usually /home/<User>/.config/
-			appFolder = os.Getenv("XDG_CONFIG_HOME")
-		} else {
-			appFolder = filepath.Join(os.Getenv("HOME"), ".config")
-		}
-	}
-	return path.Join(appFolder, "bitbox")
-}
-
 //export serve
 func serve(pushNotificationsCallback C.pushNotificationsCallback, theResponseCallback C.responseCallback) C.struct_ConnectionData {
 	responseCallback = theResponseCallback
@@ -178,7 +156,7 @@ func serve(pushNotificationsCallback C.pushNotificationsCallback, theResponseCal
 	const port = -1
 	connectionData := backendHandlers.NewConnectionData(port, token)
 	theBackend := backend.NewBackend(arguments.NewArguments(
-		getAppFolder(), *testnet, false, false, false))
+		config.AppDir(), *testnet, false, false, false))
 	events := theBackend.Events()
 	go func() {
 		for {

--- a/util/config/appdir.go
+++ b/util/config/appdir.go
@@ -1,0 +1,52 @@
+// Copyright 2018 Shift Devices AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// AppDir returns the absolute path to the default BitBox desktop app directory
+// in the user standard config location.
+func AppDir() string {
+	var appFolder string
+	switch runtime.GOOS {
+	case "darwin":
+		// Usually /Users/$USER/Library/Application Support.
+		appFolder = os.Getenv("HOME") + "/Library/Application Support"
+	case "windows":
+		appFolder = os.Getenv("APPDATA")
+	case "linux":
+		// Previously, we always used $HOME/.config/bitbox to store paired channel data.
+		// Because XDG_CONFIG_HOME is preferred over HOME env var in default setup,
+		// existing users may suffer if they loose existing pairing channel info,
+		// especially when 2FA is enabled, requiring full device reset.
+		// So, check for the existing dir first. If that fails, use the regular approach.
+		// For most users, it is a noop.
+		// See https://github.com/digitalbitbox/bitbox-wallet-app/pull/16 for more details.
+		appFolder = filepath.Join(os.Getenv("HOME"), ".config")
+		if fi, err := os.Stat(appFolder + "/bitbox"); err == nil && fi.IsDir() {
+			break
+		}
+		// Usually /home/$USER/.config.
+		appFolder = os.Getenv("XDG_CONFIG_HOME")
+		if appFolder == "" {
+			appFolder = filepath.Join(os.Getenv("HOME"), ".config")
+		}
+	}
+	return filepath.Join(appFolder, "bitbox")
+}

--- a/util/config/file.go
+++ b/util/config/file.go
@@ -19,30 +19,16 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
-// DirectoryPath returns the absolute path to the application's directory
-// in the user standard config location.
-func DirectoryPath() string {
-	switch runtime.GOOS {
-	case "darwin":
-		return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "bitbox")
-	case "windows":
-		return filepath.Join(os.Getenv("APPDATA"), "bitbox")
-	default:
-		return filepath.Join(os.Getenv("HOME"), ".config", "bitbox")
-	}
-}
-
 // File models a config file in the application's directory.
+// Callers can use AppDir function to obtain the default app config dir.
 type File struct {
 	dir  string
 	name string
 }
 
-// NewFile creates a new config file with the given name in the application's directory dir.
-// Callers can use DirectoryPath function to use a standard user config dir.
+// NewFile creates a new config file with the given name in a directory dir.
 func NewFile(dir, name string) *File {
 	return &File{dir: dir, name: name}
 }

--- a/util/logging/instance.go
+++ b/util/logging/instance.go
@@ -37,7 +37,7 @@ var once sync.Once
 func Get() *Logger {
 	once.Do(func() {
 		var configuration Configuration
-		configFile := config.NewFile(config.DirectoryPath(), configFileName)
+		configFile := config.NewFile(config.AppDir(), configFileName)
 		if configFile.Exists() {
 			if err := configFile.ReadJSON(&configuration); err != nil {
 				panic(errp.WithStack(err))
@@ -45,7 +45,7 @@ func Get() *Logger {
 			fmt.Printf("Logging configuration taken from '%s'.\n", configFile.Path())
 		} else {
 			configuration = Configuration{
-				Output: filepath.Join(config.DirectoryPath(), "log.txt"),
+				Output: filepath.Join(config.AppDir(), "log.txt"),
 				Level:  logrus.DebugLevel, // Change to InfoLevel before a release.
 			}
 			if err := configFile.WriteJSON(configuration); err != nil {


### PR DESCRIPTION
Previously, there were two code paths which obtained the app's main config dir. They did it in roughly the same way but not identical on linux distributions.

This change attempts at unifying the two, sticking to the existing app dir, if present.

Unfortunately, github cannot recognize all commits are already in #16 except for the last one with the actual change.