### PR TITLE
tools: pass all args to go test -coverprofile

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -14,9 +14,15 @@
 # limitations under the License.
 
 
-# Call this script in the directory of a package. A html page will be
-# opened, showing the coverage of that package.
+# Call this script in the directory of a package or provide package paths
+# as positional arguments. For instance, to check coverage on all backend
+# packages, use the following:
+#
+#     scripts/coverage.sh ./backend/...
+#
+# An html page will be opened, showing the coverage of the indicated
+# packages.
 
-go test -coverprofile=coverage.cov .
+go test -coverprofile=coverage.cov "$@"
 go tool cover -html=coverage.cov
 rm coverage.cov


### PR DESCRIPTION
So that it's possible to run coverage for multiple packages.
For instance:

    scripts/coverage.sh ./backend/...

This does not change the existing behaviour.
If no arguments are provided to the coverage.sh script,
the "go test" uses a package under the current directory.

R: @benma 