### PR TITLE
Create two new OSX Makefile targets and osx-build-check.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,19 @@ init:
 	make envinit
 	dep ensure
 	make generate
+# This must be run in $GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app
+osx-init:
+	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	brew install yarn
+	brew install go
+	brew install qt
+	export PATH="/usr/local/opt/qt/bin:$PATH"
+	export LDFLAGS="-L/usr/local/opt/qt/lib"
+	export CPPFLAGS="-I/usr/local/opt/qt/include"
+	export GOPATH=~/go/
+	export PATH=$PATH:~/go/bin
+	make init
+
 servewallet:
 	go install ./cmd/servewallet/... && servewallet
 servewallet-mainnet:
@@ -55,6 +68,10 @@ qt-linux: # run inside dockerdev
 qt-osx: # run on OSX.
 	make generate
 	make -C frontends/qt osx
+	make osx-sec-check
+osx-sec-check:
+	@echo "Checking build output"
+	./scripts/osx-build-check.sh
 ci:
 	./scripts/ci.sh
 ci-fast:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ Clone/move this repo to `$GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app`
 
 Only the first time, set up the project with `make init`.
 
+## Mac OS X
+
+Install build dependencies for OS X:
+
+`make osx-init`
+
+Build BitBox.app on OS X:
+
+`make qt-osx`
+
+After the build, `BitBox.app` is located in `frontends/qt/build/osx/BitBox.app`
+and the disk image is in `frontends/qt/build/osx/BitBox.dmg`.
+
 ## ElectrumX Backend
 
 The servers used are configurable in the app settings. Currently, when running the app in devmode

--- a/scripts/osx-build-check.sh
+++ b/scripts/osx-build-check.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+EXIT=0
+
+OUTDIR=frontends/qt/build/osx/BitBox.app
+QTWEBENGINE=$OUTDIR/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
+BITBOX=$OUTDIR/Contents/MacOS/BitBox
+LIBSERVER=$OUTDIR/Contents/Frameworks/libserver.so
+
+function inspect {
+        echo "Checking: $1"
+        otool -hv $1 |grep " PIE" 2>&1 > /dev/null
+        PIE=$?
+
+        if [ "$PIE" -eq 0 ];
+        then
+            echo "PIE found";
+        else
+            echo "PIE not found";
+            EXIT=1;
+        fi
+
+        otool -hv $1 |grep " X86_64" 2>&1 > /dev/null
+        BARCH=$?
+        if [ "$BARCH" -eq 0 ];
+        then
+            echo "Build arch is 64bit";
+        else
+            echo "Build arch is not 64bit";
+            EXIT=1
+        fi
+
+        otool -hv $1 |grep " MH_ALLOW_STACK_EXECUTION" 2>&1 > /dev/null
+        NX=$?
+        if [ "$NX" -eq 1 ];
+        then
+            echo "NX appears to be set";
+        else
+            echo "MH_ALLOW_STACK_EXECUTION found, NX not set";
+            EXIT=1
+        fi
+
+        otool -Iv $1 |grep '___stack_chk_guard' 2>&1 > /dev/null
+        SSP=$?
+        if [ "$SSP" -eq 0 ];
+        then
+            echo "SSP found";
+        else
+            echo "SSP not found";
+            EXIT=1
+        fi
+}
+
+
+inspect $BITBOX
+inspect $QTWEBENGINE
+inspect $LIBSERVER
+
+exit $EXIT 


### PR DESCRIPTION
- Update README for MacOSX builder
- Create Makefile target `osx-init` to prep a mostly fresh MacOS system for
  building the qt-osx target
- Create Makefile target `osx-sec-check` to check built files for expected
  symbols and headers. The current git tip build on MacOS will not currently
  return the desired results.
- A bash script `scripts/osx-build-check.sh` for inspecting build artifacts