### PR TITLE
Add MacOS to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,14 @@ sudo: true
 services:
   - docker
 
+os:
+  - linux
+  - osx
+
 addons:
   apt:
     packages:
       - make
 
 script:
-- set -e
-- docker build --tag bitbox-wallet-dev -f Dockerfile .
-- docker build --tag bitbox-wallet-ci -f Dockerfile.travis .
-- docker run -i bitbox-wallet-ci bash -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app ci" &
-- while [ -e /proc/$! ]; do echo -n "."  && sleep 60; done
-- docker run --privileged -i bitbox-wallet-ci bash -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app qt-linux"
-- set +e
+- ./scripts/travis-ci.sh

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ osx-init:
 	export GOPATH=~/go/
 	export PATH=$PATH:~/go/bin
 	make init
-
 servewallet:
 	go install ./cmd/servewallet/... && servewallet
 servewallet-mainnet:

--- a/scripts/osx-build-check.sh
+++ b/scripts/osx-build-check.sh
@@ -56,4 +56,4 @@ inspect $BITBOX
 inspect $QTWEBENGINE
 inspect $LIBSERVER
 
-exit $EXIT 
+exit $EXIT

--- a/scripts/osx-build-check.sh
+++ b/scripts/osx-build-check.sh
@@ -55,5 +55,3 @@ function inspect {
 inspect $BITBOX
 inspect $QTWEBENGINE
 inspect $LIBSERVER
-
-exit $EXIT

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    set -e
+    docker build --tag bitbox-wallet-dev -f Dockerfile .
+    docker build --tag bitbox-wallet-ci -f Dockerfile.travis .
+    docker run -i bitbox-wallet-ci bash \
+        -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app ci" &
+    while [ -e /proc/$! ]; do echo -n "."  && sleep 60; done
+    docker run --privileged -i bitbox-wallet-ci bash \
+        -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app qt-linux"
+    set +e
+fi
+
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    brew install go
+    brew install yarn
+    brew install qt
+    export PATH="/usr/local/opt/qt/bin:$PATH"
+    export LDFLAGS="-L/usr/local/opt/qt/lib"
+    export CPPFLAGS="-I/usr/local/opt/qt/include"
+    export GOPATH=~/go/
+    export PATH=$PATH:~/go/bin
+    mkdir -p $GOPATH/src/github.com/digitalbitbox/
+    cd ../ && mv bitbox-wallet-app $GOPATH/src/github.com/digitalbitbox/
+    cd $GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app/
+    make init
+    make qt-osx
+fi


### PR DESCRIPTION
This adds MacOS to the Travis CI build process. It preps the Travis machine with a Makefile target and then builds the QT target for Mac OS.