### PR TITLE
Windows CI with Appveyor [wip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ bridge, and one to invoke calls in the backend.
 Similarly to the Desktop variant, the Go library can be statically compiled and added to an Android
 Studio / XCode project. This is not part of this repo yet.
 
+## Build status
+
+[![Build Status](https://travis-ci.org/digitalbitbox/bitbox-wallet-app.svg?branch=master)](https://travis-ci.org/digitalbitbox/bitbox-wallet-app)
+[![Build Status](https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva?retina=true)](https://ci.appveyor.com/project/digitalbitbox/bitbox-wallet-app)
+
 ## Directories (subject to change)
 
 - `cmd/`: Go projects which generate binaries are here.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+image: Visual Studio 2017
+
+environment:
+  matrix:
+    - QT: C:\Qt\5.11.1\msvc2017_64
+      GO: C:\go
+      GOPATH: C:\gopath\
+      PLATFORM: amd64
+      COMPILER: msvc
+
+matrix:
+  fast_finish: true
+
+before_build:
+  - set PATH=%QT5%\bin;C:\Qt\Tools\QtCreator\bin\;%GO%\bin;C:\gopath\bin\;C:\Qt\5.11.1\msvc2017_64\bin\;C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin;C:\MinGW\bin;%PATH%
+
+build_script:
+  - echo on
+  - choco install make
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - go get -u gopkg.in/alecthomas/gometalinter.v1
+  - gometalinter.v1 --install
+  - go get -u github.com/golang/dep/cmd/dep
+  - go get -u github.com/stretchr/testify # needed for mockery
+  - go get -u github.com/vektra/mockery/cmd/mockery
+  - go get golang.org/x/tools/cmd/goimports
+  - go get -u github.com/jteeuwen/go-bindata/...
+  - cd ../
+  - mkdir C:\gopath\src\github.com\digitalbitbox
+  - mv bitbox-wallet-app C:\gopath\src\github.com\digitalbitbox\
+  - cd C:\gopath\src\github.com\digitalbitbox\bitbox-wallet-app\
+  - dep ensure
+  - yarn --cwd=frontends/web install
+  - yarn --cwd=frontends/web run build
+  - go generate ./...
+  - cd frontends/qt/server/
+  - make -f Makefile.windows windows-appveyor
+  - ls -al
+  - cd ..
+  - mkdir build
+  - qmake BitBox.pro
+  - qmake
+  - nmake
+  - bash -c "make -f Makefile windows_post"

--- a/frontends/qt/server/Makefile.windows
+++ b/frontends/qt/server/Makefile.windows
@@ -11,6 +11,11 @@ windows:
 	GOARCH=${GOARCH} CGO_ENABLED=${CGO} GOOS=${GOOS} \
        	go build -x \
         -buildmode="${BUILDMODE}" -o ${LIBNAME}.dll
+windows-appveyor:
+	CGO_ENABLED=${CGO} go build -ldflags="-s -w" -buildmode=c-archive \
+		-o libserver.a
+	gcc server.def libserver.a -shared -lwinmm -lhid -lsetupapi -lWs2_32 \
+		-o libserver.dll -Wl,--out-implib,libserver.lib
 
 windows-cross:
 	CC=/usr/bin/x86_64-w64-mingw32-gcc \


### PR DESCRIPTION
Currently this branch is building with Appveyor for CI on Windows. To make this work, @benma or @douglasbakkum will need to enable Appveyor for at least the bitbox-wallet-app repository.

This could be improved by removing the call to choco and using make from the system. It could also be improved by folding much of it back into Makefile targets. I think it is essentially functional at the moment. It currently uses the legacy cgo windows DLL build process, so it does not currently enable hardening as on other platforms.

Feedback welcome.