### PR TITLE
fixes to the windows build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,32 +13,24 @@ matrix:
 
 before_build:
   - set PATH=%QT5%\bin;C:\Qt\Tools\QtCreator\bin\;%GO%\bin;C:\gopath\bin\;C:\Qt\5.11.1\msvc2017_64\bin\;C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin;C:\MinGW\bin;%PATH%
+  - set MINGW_BIN=/c/mingw-w64/x86_64-7.3.0-posix-seh-rt_v5-rev0/mingw64/bin
 
 build_script:
   - echo on
   - choco install make
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - go get -u gopkg.in/alecthomas/gometalinter.v1
-  - gometalinter.v1 --install
-  - go get -u github.com/golang/dep/cmd/dep
-  - go get -u github.com/stretchr/testify # needed for mockery
-  - go get -u github.com/vektra/mockery/cmd/mockery
-  - go get golang.org/x/tools/cmd/goimports
-  - go get -u github.com/jteeuwen/go-bindata/...
-  - cd ../
-  - mkdir C:\gopath\src\github.com\digitalbitbox
-  - mv bitbox-wallet-app C:\gopath\src\github.com\digitalbitbox\
-  - cd C:\gopath\src\github.com\digitalbitbox\bitbox-wallet-app\
-  - dep ensure
+  - mkdir %GOPATH%\src\github.com\digitalbitbox
+  - cd ..
+  - mv bitbox-wallet-app %GOPATH%\src\github.com\digitalbitbox\
+  - cd %GOPATH%\src\github.com\digitalbitbox\bitbox-wallet-app\
   - yarn --cwd=frontends/web install
   - yarn --cwd=frontends/web run build
-  - go generate ./...
   - cd frontends/qt/server/
-  - make -f Makefile.windows windows-appveyor
-  - ls -al
+  - make -f Makefile.windows windows-legacy
   - cd ..
   - mkdir build
-  - qmake BitBox.pro
-  - qmake
+  - cd build
+  - qmake ..\BitBox.pro
   - nmake
-  - bash -c "make -f Makefile windows_post"
+  - cd ..
+  - bash windows_post.sh

--- a/frontends/qt/server/Makefile.windows
+++ b/frontends/qt/server/Makefile.windows
@@ -11,11 +11,6 @@ windows:
 	GOARCH=${GOARCH} CGO_ENABLED=${CGO} GOOS=${GOOS} \
        	go build -x \
         -buildmode="${BUILDMODE}" -o ${LIBNAME}.dll
-windows-appveyor:
-	CGO_ENABLED=${CGO} go build -ldflags="-s -w" -buildmode=c-archive \
-		-o libserver.a
-	gcc server.def libserver.a -shared -lwinmm -lhid -lsetupapi -lWs2_32 \
-		-o libserver.dll -Wl,--out-implib,libserver.lib
 
 windows-cross:
 	CC=/usr/bin/x86_64-w64-mingw32-gcc \

--- a/frontends/qt/windows_post.sh
+++ b/frontends/qt/windows_post.sh
@@ -19,4 +19,4 @@ windeployqt build/windows/BitBox.exe
 cp /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/Community/VC/Redist/MSVC/14.14.26405/x64/Microsoft.VC141.CRT/msvcp140.dll build/windows/
 cp "/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Redist/MSVC/14.14.26405/x64/Microsoft.VC141.CRT/vccorlib140.dll" build/windows/
 cp "/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Redist/MSVC/14.14.26405/x64/Microsoft.VC141.CRT/vcruntime140.dll" build/windows/
-cp "/c/mingw/bin/libssp-0.dll" build/windows/
+cp $MINGW_BIN/libssp-0.dll build/windows/


### PR DESCRIPTION
qmake needs to be called in a different dir, it overwrites the
Makefile.

The `go get` packages are not needed to build the app.