### PR TITLE
backend: fix pairing finish error test case

### DIFF
--- a/backend/devices/bitbox/pairing_test.go
+++ b/backend/devices/bitbox/pairing_test.go
@@ -79,7 +79,7 @@ func TestFinishPairing(t *testing.T) {
 		wantPaired bool
 	}{
 		{okTempDir, EventPairingSuccess, true},
-		// {"/", EventPairingError, false}, // assumes never writable; reconsider if flaky
+		{"\x00", EventPairingError, false}, // assumes never writable; reconsider if flaky
 	}
 	for i, test := range tt {
 		t.Run(fmt.Sprintf("%d: %s", i, test.wantEvent), func(t *testing.T) {


### PR DESCRIPTION
The assumption that the '/' directory is non-writable turned out
to be incorrect under Docker environment.

This change uses a character in the dummy config dir name
which should fail dicrectory creation under all supported
environments.

R: @benma 