### PR TITLE
ci: fix --fast flag

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -14,13 +14,6 @@
 # limitations under the License.
 
 
-# use `ci.sh --fast` to only run fast checkers.
-if [ "$1" == "--fast" ]; then
-    fast="--fast"
-else
-    fast=""
-fi
-
 go build ./...
 go test ./...
 golangci-lint run


### PR DESCRIPTION
When migrating to the `golangci-lint` tool the fast linting
was removed from the Makefile. However, in `ci.sh` there's
still some dead code dealing with the `--fast` flag.

Since `golangci-lint` does support a `--fast` flag I've
opted to resurrect the flag in your build scripts.

Also, the unnecessary `else` case has been removed.