### PR TITLE
build: don't call go generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,23 +44,22 @@ servewallet-regtest:
 	go install ./cmd/servewallet/... && servewallet -regtest
 servewallet-multisig:
 	go install ./cmd/servewallet/... && servewallet -multisig
-generate:
+buildweb:
 	rm -rf ${WEBROOT}/build
 	yarn --cwd=${WEBROOT} install
 	yarn --cwd=${WEBROOT} run build
-	go generate ./...
 webdev:
 	make -C frontends/web dev
 weblint:
 	make -C frontends/web lint
 qt:
-	make generate
+	make buildweb
 	make -C frontends/qt
 qt-linux: # run inside dockerdev
-	make generate
+	make buildweb
 	make -C frontends/qt linux
 qt-osx: # run on OSX.
-	make generate
+	make buildweb
 	make -C frontends/qt osx
 	make osx-sec-check
 osx-sec-check:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Run `make ci` to run all static analysis tools and tests.
 
 ### Build the UI
 
-To statically compile the UI, run `make generate` again, which compiles the web ui into a compact
+To statically compile the UI, run `make buildweb` again, which compiles the web ui into a compact
 bundle.
 
 ## Develop using Docker


### PR DESCRIPTION
It recreates the mockery mock files and the firmware asset file
everytime. Those are committed and don't need to be recreated when
building. One can call go generate manually when working on mocks or
changing the firmware asset.