### PR TITLE
frontend: caps lock detection without event.getModifierState('CapsLock')

### DIFF
--- a/frontends/web/src/components/password.css
+++ b/frontends/web/src/components/password.css
@@ -1,5 +1,6 @@
 .capsWarning {
     color: var(--color-warn);
+    font-weight: bold;
     line-height: 42px;
     position: absolute;
     right: 0;

--- a/frontends/web/src/components/password.jsx
+++ b/frontends/web/src/components/password.jsx
@@ -41,8 +41,7 @@ export class PasswordSingleInput extends Component {
     }
 
     componentWillMount() {
-        document.addEventListener('keydown', this.handleCheckCaps);
-        document.addEventListener('keyup', this.handleCheckCaps);
+        window.addEventListener('keydown', this.handleCheckCaps);
     }
 
     componentDidMount() {
@@ -52,8 +51,7 @@ export class PasswordSingleInput extends Component {
     }
 
     componentWillUnmount() {
-        document.removeEventListener('keydown', this.handleCheckCaps);
-        document.removeEventListener('keyup', this.handleCheckCaps);
+        window.removeEventListener('keydown', this.handleCheckCaps);
     }
 
     tryPaste = event => {
@@ -95,8 +93,10 @@ export class PasswordSingleInput extends Component {
     }
 
     handleCheckCaps = event => {
-        const capsLock = event.getModifierState && event.getModifierState('CapsLock');
-        this.setState({ capsLock });
+        const capsLock = hasCaps(event);
+        if (capsLock !== null) {
+            this.setState({ capsLock });
+        }
     }
 
     render({
@@ -129,8 +129,6 @@ export class PasswordSingleInput extends Component {
                     placeholder={placeholder}
                     onInput={this.handleFormChange}
                     onPaste={this.tryPaste}
-                    onKeyUp={this.handleCheckCaps}
-                    onKeyDown={this.handleCheckCaps}
                     getRef={ref => this.password = ref}
                     value={password}>
                     {warning}
@@ -164,8 +162,7 @@ export class PasswordRepeatInput extends Component {
     }
 
     componentWillMount() {
-        document.addEventListener('keydown', this.handleCheckCaps);
-        document.addEventListener('keyup', this.handleCheckCaps);
+        window.addEventListener('keydown', this.handleCheckCaps);
     }
 
     componentDidMount() {
@@ -175,8 +172,7 @@ export class PasswordRepeatInput extends Component {
     }
 
     componentWillUnmount() {
-        document.removeEventListener('keydown', this.handleCheckCaps);
-        document.removeEventListener('keyup', this.handleCheckCaps);
+        window.removeEventListener('keydown', this.handleCheckCaps);
     }
 
     tryPaste = event => {
@@ -219,8 +215,10 @@ export class PasswordRepeatInput extends Component {
     }
 
     handleCheckCaps = event => {
-        const capsLock = event.getModifierState && event.getModifierState('CapsLock');
-        this.setState({ capsLock });
+        const capsLock = hasCaps(event);
+        if (capsLock != null) { // eslint-disable-line
+            this.setState({ capsLock });
+        }
     }
 
     render({
@@ -256,8 +254,6 @@ export class PasswordRepeatInput extends Component {
                     placeholder={placeholder}
                     onInput={this.handleFormChange}
                     onPaste={this.tryPaste}
-                    onKeyUp={this.handleCheckCaps}
-                    onKeyDown={this.handleCheckCaps}
                     getRef={ref => this.password = ref}
                     value={password}>
                     {warning}
@@ -276,8 +272,6 @@ export class PasswordRepeatInput extends Component {
                     placeholder={repeatPlaceholder}
                     onInput={this.handleFormChange}
                     onPaste={this.tryPaste}
-                    onKeyUp={this.handleCheckCaps}
-                    onKeyDown={this.handleCheckCaps}
                     getRef={ref => this.passwordRepeat = ref}
                     value={passwordRepeat}>
                     {warning}
@@ -308,4 +302,15 @@ function MatchesPattern({ regex, value = '', text }) {
     return (
         <p style="color: var(--color-error);">{text}</p>
     );
+}
+
+const excludeKeys = /^(Shift|Alt|Backspace|CapsLock|Tab)$/i;
+
+function hasCaps({ key }) {
+    // will return null, when we cannot clearly detect if capsLock is active or not
+    if (key.length > 1 || key.toUpperCase() === key.toLowerCase() || excludeKeys.test(key)) {
+        return null;
+    }
+    // ideally we return event.getModifierState('CapsLock')) but this currently does always return false in Qt
+    return key.toUpperCase() === key && key.toLowerCase() !== key && !event.shiftKey;
 }

--- a/frontends/web/src/routes/device/waiting.jsx
+++ b/frontends/web/src/routes/device/waiting.jsx
@@ -17,7 +17,8 @@
 import { Component, h } from 'preact';
 import i18n from '../../i18n/i18n';
 import { apiPost } from '../../utils/request';
-import { Button, Input } from '../../components/forms';
+import { Button } from '../../components/forms';
+import { PasswordSingleInput } from '../../components/password';
 import { Shift, Alert } from '../../components/icon';
 import { Guide } from '../../components/guide/guide';
 import { Entry } from '../../components/guide/entry';
@@ -69,8 +70,8 @@ class SkipForTestingButton extends Component {
         e.preventDefault();
     }
 
-    handleFormChange = event => {
-        this.setState({ [event.target.id]: event.target.value });
+    handleFormChange = value => {
+        this.setState({ testPIN: value });
     };
 
     render({ show }, { testPIN }) {
@@ -79,12 +80,11 @@ class SkipForTestingButton extends Component {
         }
         return (
             <form onSubmit={this.registerTestingDevice} style="flex-grow: 0; max-width: 400px; width: 100%; align-self: center;">
-                <Input
+                <PasswordSingleInput
                     type="password"
                     autoFocus
-                    id="testPIN"
                     label="Test Password"
-                    onInput={this.handleFormChange}
+                    onValidPassword={this.handleFormChange}
                     value={testPIN} />
                 <Button type="submit" secondary>
                     Skip for Testing


### PR DESCRIPTION
for some reason event.getModifierState('CapsLock') does not work in Qt

I do not prefer this change if possible as the caps indication will be delayed to the next event instead of appearing immediately  