### PR TITLE
account: move json business to handlers

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -15,7 +15,6 @@
 package btc
 
 import (
-	"encoding/json"
 	"fmt"
 	"path"
 	"sort"
@@ -52,6 +51,8 @@ type Interface interface {
 	Info() *Info
 	Code() string
 	Coin() coin.Coin
+	// Name returns a human readable long name.
+	Name() string
 	Init() error
 	InitialSyncDone() bool
 	Offline() bool
@@ -98,21 +99,6 @@ type Account struct {
 	offline         bool
 	onEvent         func(Event)
 	log             *logrus.Entry
-}
-
-// MarshalJSON implements json.Marshaler.
-func (account *Account) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		CoinCode              string `json:"coinCode"`
-		Code                  string `json:"code"`
-		Name                  string `json:"name"`
-		BlockExplorerTxPrefix string `json:"blockExplorerTxPrefix"`
-	}{
-		CoinCode:              account.coin.Name(),
-		Code:                  account.code,
-		Name:                  account.name,
-		BlockExplorerTxPrefix: account.coin.blockExplorerTxPrefix,
-	})
 }
 
 // Status indicates the connection and initialization status.
@@ -191,6 +177,11 @@ func (account *Account) String() string {
 // Code returns the code of the account.
 func (account *Account) Code() string {
 	return account.code
+}
+
+// Name returns the name of the account.
+func (account *Account) Name() string {
+	return account.name
 }
 
 // Coin returns the coin of the account.

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -171,7 +171,7 @@ func NewAccount(
 
 // String returns a representation of the account for logging.
 func (account *Account) String() string {
-	return fmt.Sprintf("%s-%s", account.Coin().Name(), account.code)
+	return fmt.Sprintf("%s-%s", account.Coin().Code(), account.code)
 }
 
 // Code returns the code of the account.

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -49,6 +49,7 @@ const (
 // Interface is the API of a Account.
 type Interface interface {
 	Info() *Info
+	// Code is a identifier for the account (to identify the account in databases, apis, etc.).
 	Code() string
 	Coin() coin.Coin
 	// Name returns a human readable long name.

--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -186,3 +186,8 @@ func (coin *Coin) Headers() *headers.Headers {
 func (coin *Coin) String() string {
 	return coin.name
 }
+
+// BlockExplorerTransactionURLPrefix implements coin.Coin.
+func (coin *Coin) BlockExplorerTransactionURLPrefix() string {
+	return coin.blockExplorerTxPrefix
+}

--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -37,7 +37,7 @@ import (
 
 // Coin models a Bitcoin-related coin.
 type Coin struct {
-	name                  string
+	code                  string
 	unit                  string
 	net                   *chaincfg.Params
 	dbFolder              string
@@ -55,7 +55,7 @@ type Coin struct {
 
 // NewCoin creates a new coin with the given parameters.
 func NewCoin(
-	name string,
+	code string,
 	unit string,
 	net *chaincfg.Params,
 	dbFolder string,
@@ -64,7 +64,7 @@ func NewCoin(
 	ratesUpdater coinpkg.RatesUpdater,
 ) *Coin {
 	coin := &Coin{
-		name:                  name,
+		code:                  code,
 		unit:                  unit,
 		net:                   net,
 		dbFolder:              dbFolder,
@@ -72,7 +72,7 @@ func NewCoin(
 		blockExplorerTxPrefix: blockExplorerTxPrefix,
 		ratesUpdater:          ratesUpdater,
 
-		log: logging.Get().WithGroup("coin").WithField("name", name),
+		log: logging.Get().WithGroup("coin").WithField("code", code),
 	}
 	return coin
 }
@@ -84,7 +84,7 @@ func (coin *Coin) Init() {
 
 	// Init Headers
 	db, err := headersdb.NewDB(
-		path.Join(coin.dbFolder, fmt.Sprintf("headers-%s.db", coin.name)))
+		path.Join(coin.dbFolder, fmt.Sprintf("headers-%s.db", coin.code)))
 	if err != nil {
 		coin.log.WithError(err).Panic("Could not open headers DB")
 	}
@@ -101,7 +101,7 @@ func (coin *Coin) Init() {
 				coin.log.Error("Could not get headers status")
 			}
 			coin.Notify(observable.Event{
-				Subject: fmt.Sprintf("coins/%s/headers/status", coin.name),
+				Subject: fmt.Sprintf("coins/%s/headers/status", coin.code),
 				Action:  action.Replace,
 				Object:  status,
 			})
@@ -113,9 +113,9 @@ func (coin *Coin) Init() {
 	}
 }
 
-// Name returns the coin's name.
-func (coin *Coin) Name() string {
-	return coin.name
+// Code implements coin.Coin.
+func (coin *Coin) Code() string {
+	return coin.code
 }
 
 // Net returns the coin's network params.
@@ -184,7 +184,7 @@ func (coin *Coin) Headers() *headers.Headers {
 }
 
 func (coin *Coin) String() string {
-	return coin.name
+	return coin.code
 }
 
 // BlockExplorerTransactionURLPrefix implements coin.Coin.

--- a/backend/coins/coin/coin.go
+++ b/backend/coins/coin/coin.go
@@ -57,6 +57,6 @@ type Coin interface {
 	// // Account-based transactions can have only one output and need no change address.
 	// AccountBased() bool
 
-	// // BlockExplorerTransactionURLPrefix returns the URL prefix of the block explorer.
-	// BlockExplorerTransactionURLPrefix() string
+	// BlockExplorerTransactionURLPrefix returns the URL prefix of the block explorer.
+	BlockExplorerTransactionURLPrefix() string
 }

--- a/backend/coins/coin/coin.go
+++ b/backend/coins/coin/coin.go
@@ -26,14 +26,13 @@ type FormattedAmount struct {
 // Coin models the currency of a blockchain.
 type Coin interface {
 	observable.Interface
-	// Code returns the acronym of the currency in lowercase.
-	// Code() string
+
+	// Code returns the code used to identify the coin (should be the acronym of the coin in
+	// lowercase).
+	Code() string
 
 	// Init initializes the coin (blockchain connection, header feed, etc.).
 	Init()
-
-	// Name returns the written-out name of the coin.
-	Name() string
 
 	// // Type returns the coin type according to BIP44:
 	// // https://github.com/satoshilabs/slips/blob/master/slip-0044.md

--- a/backend/devices/bitbox/device.go
+++ b/backend/devices/bitbox/device.go
@@ -1030,7 +1030,7 @@ func (dbb *Device) signBatch(
 			return nil, errp.WithMessage(err, "The signing echo from the BitBox was not a string.")
 		}
 		typ := string(txProposal.AccountConfiguration.ScriptType())
-		if err := mobchan.SendSigningEcho(signingEcho, txProposal.Coin.Name(), typ, transaction); err != nil {
+		if err := mobchan.SendSigningEcho(signingEcho, txProposal.Coin.Code(), typ, transaction); err != nil {
 			return nil, errp.WithMessage(err, "Could not send the signing echo to the mobile.")
 		}
 	}

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -63,7 +63,7 @@ func (keystore *keystore) OutputAddress(
 	if !keystore.HasSecureOutput() {
 		panic("HasSecureOutput must be true")
 	}
-	return keystore.dbb.DisplayAddress(keyPath.Encode(), fmt.Sprintf("%s-%s", coin.Name(), string(scriptType)))
+	return keystore.dbb.DisplayAddress(keyPath.Encode(), fmt.Sprintf("%s-%s", coin.Code(), string(scriptType)))
 }
 
 // ExtendedPublicKey implements keystore.Keystore.

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -261,7 +261,22 @@ func (handlers *Handlers) getTestingHandler(_ *http.Request) (interface{}, error
 }
 
 func (handlers *Handlers) getAccountsHandler(_ *http.Request) (interface{}, error) {
-	return handlers.backend.Accounts(), nil
+	type accountJSON struct {
+		CoinCode              string `json:"coinCode"`
+		Code                  string `json:"code"`
+		Name                  string `json:"name"`
+		BlockExplorerTxPrefix string `json:"blockExplorerTxPrefix"`
+	}
+	accounts := []*accountJSON{}
+	for _, account := range handlers.backend.Accounts() {
+		accounts = append(accounts, &accountJSON{
+			CoinCode:              account.Coin().Name(),
+			Code:                  account.Code(),
+			Name:                  account.Name(),
+			BlockExplorerTxPrefix: account.Coin().BlockExplorerTransactionURLPrefix(),
+		})
+	}
+	return accounts, nil
 }
 
 func (handlers *Handlers) getAccountsStatusHandler(_ *http.Request) (interface{}, error) {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -270,7 +270,7 @@ func (handlers *Handlers) getAccountsHandler(_ *http.Request) (interface{}, erro
 	accounts := []*accountJSON{}
 	for _, account := range handlers.backend.Accounts() {
 		accounts = append(accounts, &accountJSON{
-			CoinCode:              account.Coin().Name(),
+			CoinCode:              account.Coin().Code(),
 			Code:                  account.Code(),
 			Name:                  account.Name(),
 			BlockExplorerTxPrefix: account.Coin().BlockExplorerTransactionURLPrefix(),


### PR DESCRIPTION
- It is used in the http layer and defines the http API, so the
  definition should be local
- Other coins shouldn't reimplement the same function - reuse for
  other coins using the account interface.