### PR TITLE
frontend/send: fix race condition in error msgs

### DIFF
--- a/frontends/web/src/routes/account/send/send.jsx
+++ b/frontends/web/src/routes/account/send/send.jsx
@@ -165,6 +165,8 @@ export default class Send extends Component {
             this.setState({ valid: result.success });
             if (result.success) {
                 this.setState({
+                    addressError: null,
+                    amountError: null,
                     proposedFee: result.fee,
                     proposedAmount: result.amount,
                     proposedTotal: result.total,


### PR DESCRIPTION
Error message not cleared at the right time. Shows if you input an
amount fast and the callback is slow.