### PR TITLE
qt: remove unused tcp listener, auth headers

### DIFF
--- a/frontends/qt/libserver.h
+++ b/frontends/qt/libserver.h
@@ -12,10 +12,6 @@ typedef void (*responseCallback) (int, const char*);
 static void respond(responseCallback f, int queryID, const char* msg) {
     f(queryID, msg);
 }
-
-typedef struct ConnectionData {
-    char* token;
-} ConnectionData;
 #endif
 
 #ifdef __cplusplus
@@ -25,7 +21,7 @@ extern "C" {
 
 extern void backendCall(int p0, char* p1);
 
-extern struct ConnectionData serve(pushNotificationsCallback p0, responseCallback p1);
+extern void serve(pushNotificationsCallback p0, responseCallback p1);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Before release, we used a live webserver in the qt app, and added the
auth headers on every request. We switched to a direct bridge instead,
leaving this code unused.