### PR TITLE
Rates

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -116,7 +116,7 @@ func NewBackend(arguments *arguments.Arguments) *Backend {
 		coins:     map[string]coin.Coin{},
 		log:       log,
 	}
-	ratesUpdater := btc.NewRatesUpdater()
+	ratesUpdater := NewRatesUpdater()
 	ratesUpdater.Observe(func(event observable.Event) { backend.events <- event })
 	backend.ratesUpdater = ratesUpdater
 	return backend

--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -43,7 +43,6 @@ type Coin struct {
 	servers               []*rpc.ServerInfo
 	blockExplorerTxPrefix string
 
-	ratesUpdater coinpkg.RatesUpdater
 	observable.Implementation
 
 	blockchain blockchain.Interface
@@ -60,7 +59,6 @@ func NewCoin(
 	dbFolder string,
 	servers []*rpc.ServerInfo,
 	blockExplorerTxPrefix string,
-	ratesUpdater coinpkg.RatesUpdater,
 ) *Coin {
 	coin := &Coin{
 		code:                  code,
@@ -69,7 +67,6 @@ func NewCoin(
 		dbFolder:              dbFolder,
 		servers:               servers,
 		blockExplorerTxPrefix: blockExplorerTxPrefix,
-		ratesUpdater:          ratesUpdater,
 
 		log: logging.Get().WithGroup("coin").WithField("code", code),
 	}
@@ -106,10 +103,6 @@ func (coin *Coin) Init() {
 			})
 		}
 	})
-
-	if coin.ratesUpdater != nil {
-		coin.ratesUpdater.Observe(coin.Notify)
-	}
 }
 
 // Code implements coin.Coin.
@@ -133,11 +126,6 @@ func (coin *Coin) FormatAmount(amount coinpkg.Amount) string {
 		new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(unitSatoshi)).FloatString(8),
 		"0.",
 	)
-}
-
-// RatesUpdater returns current exchange rates.
-func (coin *Coin) RatesUpdater() coinpkg.RatesUpdater {
-	return coin.ratesUpdater
 }
 
 // Blockchain connects to a blockchain backend.

--- a/backend/coins/btc/maketx/maketx_test.go
+++ b/backend/coins/btc/maketx/maketx_test.go
@@ -37,7 +37,7 @@ import (
 
 var noDust = btcutil.Amount(0)
 
-var tbtc = btc.NewCoin("tbtc", "TBTC", &chaincfg.TestNet3Params, ".", []*rpc.ServerInfo{}, "https://testnet.blockchain.info/tx/", nil)
+var tbtc = btc.NewCoin("tbtc", "TBTC", &chaincfg.TestNet3Params, ".", []*rpc.ServerInfo{}, "https://testnet.blockchain.info/tx/")
 
 // For reference, tx vsizes assuming two outputs (normal + change), for N inputs:
 // 1 inputs: 226

--- a/backend/coins/btc/rates.go
+++ b/backend/coins/btc/rates.go
@@ -85,7 +85,7 @@ func (updater *RatesUpdater) update() {
 	updater.last = rates
 	updater.log.WithField("data", spew.Sprintf("%v", rates)).Debug("Exchange rates changed.")
 	updater.Notify(observable.Event{
-		Subject: "coins/rates",
+		Subject: "rates",
 		Action:  action.Replace,
 		Object:  rates,
 	})

--- a/backend/rates.go
+++ b/backend/rates.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package btc
+package backend
 
 import (
 	"encoding/json"

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -129,11 +129,14 @@ function Conversion({
     } else {
         mainnetCoin = coin as MainnetCoin;
     }
-    const value = rates[mainnetCoin][active] * Number(amount.amount);
+    let formattedValue = '';
+    if (rates[mainnetCoin]) {
+        formattedValue = formatAsCurrency(rates[mainnetCoin][active] * Number(amount.amount));
+    }
     if (tableRow) {
         return (
             <tr className={unstyled ? '' : style.fiatRow}>
-                <td className={unstyled ? '' : style.availableFiatAmount}>{formatAsCurrency(value)}</td>
+                <td className={unstyled ? '' : style.availableFiatAmount}>{formattedValue}</td>
                 <td className={unstyled ? '' : style.availableFiatUnit} onClick={rotateFiat}>{active}</td>
             </tr>
         );
@@ -141,7 +144,7 @@ function Conversion({
     return (
         <span className={style.rates}>
             {children}
-            {formatAsCurrency(value)}
+            {formattedValue}
             {' '}
             <span className={style.unit} onClick={rotateFiat}>{active}</span>
         </span>


### PR DESCRIPTION
Rates were observed when coins were initialized, which is after
unlock. The first rates notification happens immediately when the
backend is initalized, so the frontend misses the first notification,
and waits a full minute for the first one arrives.

Also, for each coin, one notification was made, but there is a single
global observer/rates variable for all coins in the frontend, so it
does redundant work.

Now, the rates are removed from coins and are part of the backend, to
match how they are used in the frontend. Can move it back if we ever
do per-coin fetches, but that seems unlikely.