### PR TITLE
frontend/i18n: remove unused/empty keys

### DIFF
--- a/frontends/web/src/i18n/en.json
+++ b/frontends/web/src/i18n/en.json
@@ -31,25 +31,23 @@
     },
     "welcome": {
         "title": "Welcome",
-        "paragraph": "",
         "insertDevice": "Please connect your device to get started"
     },
     "deviceTampered": "Has your BitBox been supplied with a recovery password? If so, stop the setup process and contact support immediately. Shift will never give you a ready made wallet or make password recommendations.",
     "setup": "Setup device",
     "goal": {
-        "title": "",
         "paragraph": "Please select one of the following options:",
         "buttons": {
             "create": "Create a new wallet",
             "restore": "Restore a wallet from a backup"
         },
         "step": {
-            "1": { "title": "Security Information", "description": "" },
+            "1": { "title": "Security Information" },
             "2": { "title": "Device", "description": "Set a device password" },
             "3_create": { "title": "Wallet", "description": "Create a new wallet" },
             "3_restore": { "title": "Restore", "description": "from a backup" },
-            "4_create": { "title": "Summary", "description": "" },
-            "4_restore": { "title": "Summary", "description": "" }
+            "4_create": { "title": "Summary" },
+            "4_restore": { "title": "Summary" }
         }
     },
     "device": {
@@ -234,13 +232,9 @@
             "btc-p2pkh": "This is a legacy Bitcoin account. It is recommended that you use the Segwit Bitcoin account instead, as it incurs lower network fees.",
             "btc-p2wpkh-p2sh": "This is a Segwit Bitcoin account, and is recommended for lower network fees. If you have just upgraded from the previous app, you can find your funds in the Bitcoin Legacy account, which you can enable in the settings. If you want to try cutting edge technology and save even more network fees, go to Settings and enable a Native Segwit Bitcoin account, which uses Bech32-style addresses.",
             "btc-p2wpkh": "This is a Native Segwit Bitcoin account, which incurs even lower network fees. It uses Bech32-style addresses, which are not yet widely supported. Use this only if you want to try bleeding edge technology.",
-            "ltc-p2wpkh": "",
-            "ltc-p2wpkh-p2sh": "",
             "tbtc-p2pkh": "$t(account.info.btc-p2pkh)",
             "tbtc-p2wpkh-p2sh": "$t(account.info.btc-p2wpkh-p2sh)",
-            "tbtc-p2wpkh": "$t(account.info.btc-p2wpkh)",
-            "tltc-p2wpkh": "",
-            "tltc-p2wpkh-p2sh": ""
+            "tbtc-p2wpkh": "$t(account.info.btc-p2wpkh)"
         }
     },
     "headerssync": {
@@ -304,8 +298,7 @@
                 "economy": "24 blocks (around 4 hours for Bitcoin, 1 hour for Litecoin)",
                 "low": "12 blocks (around 2 hours for Bitcoin, 30 minutes for Litecoin)",
                 "normal": "6 blocks (around 1 hour for Bitcoin, 15 minutes for Litecoin)",
-                "high": "2 blocks (around 20 minutes for Bitcoin, 5 minutes for Litecoin)",
-                "loading": ""
+                "high": "2 blocks (around 20 minutes for Bitcoin, 5 minutes for Litecoin)"
             }
         },
         "customFee": {
@@ -336,8 +329,7 @@
         },
         "createDescription": "Initialize the wallet and automatically create a backup on the micro SD card.",
         "walletName": {
-            "label": "Wallet Name",
-            "placeholder": ""
+            "label": "Wallet Name"
         },
         "password": {
             "label": "Recovery password",
@@ -397,8 +389,7 @@
         "input": {
             "label": "Device password",
             "labelRepeat": "Repeat device password",
-            "placeholderRepeat": "Please confirm device password",
-            "invalid": ""
+            "placeholderRepeat": "Please confirm device password"
         },
         "create": "Set device password",
         "creating": "Setting device password…",
@@ -407,9 +398,7 @@
         }
     },
     "changePin": {
-        "oldTitle": "",
         "oldLabel": "Current device password",
-        "oldPlaceholder": "",
         "newTitle": "New device password"
     },
     "backup": {

--- a/frontends/web/src/routes/account/account.jsx
+++ b/frontends/web/src/routes/account/account.jsx
@@ -157,7 +157,7 @@ export default class Account extends Component {
         hasCard,
     }) {
         if (!accounts) return null;
-        const account = accounts.find(({ code }) => code === this.props.code);
+        const account = accounts.find(account => account.code === code);
         if (!account) return null;
         const noTransactions = (initialized && transactions.length <= 0);
         return (
@@ -217,8 +217,8 @@ export default class Account extends Component {
                                 />
                             )
                         }
-                        <Status dismissable keyName={`info-${this.props.code}`} type="info">
-                            {t(`account.info.${this.props.code}`)}
+                        <Status dismissable keyName={`info-${code}`} type="info">
+                            {t(`account.info.${code}`, { defaultValue: '' })}
                         </Status>
                     </div>
                 </div>

--- a/frontends/web/src/routes/account/send/send.jsx
+++ b/frontends/web/src/routes/account/send/send.jsx
@@ -417,7 +417,7 @@ export default class Send extends Component {
                                     />
                                     */}
                                 </div>
-                                <p class={style.feeDescription}>{t('send.feeTarget.description.' + (feeTarget || 'loading'))}</p>
+                                <p class={style.feeDescription}>{feeTarget && t('send.feeTarget.description.' + feeTarget) || ''}</p>
                             </div>
                             <div class="row buttons flex flex-row flex-between flex-start">
                                 <ButtonLink

--- a/frontends/web/src/routes/device/settings/components/changepin.jsx
+++ b/frontends/web/src/routes/device/settings/components/changepin.jsx
@@ -107,12 +107,10 @@ export default class ChangePIN extends Component {
                     activeDialog && (
                         <Dialog title={t('button.changepin')}>
                             <form onSubmit={this.changePin}>
-                                {t('changePin.oldTitle') && <h4>{t('changePin.oldTitle')}</h4>}
                                 <PasswordInput
                                     idPrefix="oldPIN"
                                     label={t('changePin.oldLabel')}
                                     title={t('initialize.input.invalid')}
-                                    placeholder={t('changePin.oldPlaceholder')}
                                     value={oldPIN}
                                     onChange={this.setValidOldPIN} />
                                 {t('changePin.newTitle') && <h4>{t('changePin.newTitle')}</h4>}

--- a/frontends/web/src/routes/device/setup/goal.jsx
+++ b/frontends/web/src/routes/device/setup/goal.jsx
@@ -12,18 +12,12 @@ export default class Goal extends Component {
         onCreate,
         onRestore,
     }) {
-        const title = t('goal.title');
         return (
             <div class="contentWithGuide">
                 <div className={[style.container].join(' ')}>
                     <div className={style.content} style="text-align: center;">
                         <div className="flex-1 flex flex-column flex-center">
                             <h1 className={style.title}>{t('setup')}</h1>
-                            {
-                                title && (
-                                    <h2>{title}</h2>
-                                )
-                            }
                             <p class="first">{t('goal.paragraph')}</p>
                             <div class={style.verticalButtons}>
                                 <Button primary onClick={onCreate}>

--- a/frontends/web/src/routes/device/setup/initialize.jsx
+++ b/frontends/web/src/routes/device/setup/initialize.jsx
@@ -136,7 +136,6 @@ export default class Initialize extends Component {
             <form onSubmit={this.handleSubmit} class="flex-1">
                 <PasswordRepeatInput
                     pattern="^.{4,}$"
-                    title={t('initialize.input.invalid')}
                     label={t('initialize.input.label')}
                     repeatLabel={t('initialize.input.labelRepeat')}
                     repeatPlaceholder={t('initialize.input.placeholderRepeat')}

--- a/frontends/web/src/routes/device/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/setup/seed-create-new.jsx
@@ -178,7 +178,6 @@ export default class SeedCreateNew extends Component {
                         autoFocus
                         id="walletName"
                         label={t('seed.walletName.label')}
-                        placeholder={t('seed.walletName.placeholder')}
                         disabled={status === STATUS.CREATING}
                         onInput={this.handleFormChange}
                         getRef={ref => this.walletNameInput = ref}
@@ -239,7 +238,7 @@ export default class SeedCreateNew extends Component {
                             <Step divider />
                             <Step title={t(`goal.step.3_create.title`)} description={t(`goal.step.3_create.description`)} />
                             <Step divider />
-                            <Step title={t(`goal.step.4_create.title`)} description={t(`goal.step.4_create.description`)} />
+                            <Step title={t(`goal.step.4_create.title`)} />
                         </Steps>
                         <hr />
                         {

--- a/frontends/web/src/routes/device/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/setup/seed-restore.jsx
@@ -84,13 +84,13 @@ export default class SeedRestore extends Component {
                 <div className={[style.container, style.scrollable].join(' ')}>
                     <div className={style.content}>
                         <Steps current={2}>
-                            <Step title={t('goal.step.1.title')} description={t('goal.step.1.description')} />
+                            <Step title={t('goal.step.1.title')} />
                             <Step divider />
                             <Step title={t('goal.step.2.title')} description={t('goal.step.2.description')} />
                             <Step divider />
                             <Step title={t(`goal.step.3_restore.title`)} description={t(`goal.step.3_restore.description`)} />
                             <Step divider />
-                            <Step title={t(`goal.step.4_restore.title`)} description={t(`goal.step.4_restore.description`)} />
+                            <Step title={t(`goal.step.4_restore.title`)} />
                         </Steps>
                         <hr />
                         {

--- a/frontends/web/src/routes/device/waiting.jsx
+++ b/frontends/web/src/routes/device/waiting.jsx
@@ -41,7 +41,6 @@ export default class Waiting extends Component {
                     <div className={style.content}>
                         <div className="flex-1 flex flex-column flex-center">
                             <h3 style="text-align: center;">{t('welcome.insertDevice')}</h3>
-                            {t('welcome.paragraph')}
                             <Message type="warning" style="max-width: 400px; align-self: center;">
                                 <Alert />
                                 <p class="first">{t('deviceTampered')}</p>


### PR DESCRIPTION
When processing the i18n json files, the empty translation keys can be
dropped completely, resulting in the key being showed in the frontend.

Also, they are simply not needed.