### PR TITLE
backend/coin: init only when account active and opened

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -289,7 +289,6 @@ func (backend *Backend) Coin(code string) coin.Coin {
 	default:
 		panic(errp.Newf("unknown coin code %s", code))
 	}
-	coin.Init()
 	backend.coins[code] = coin
 	return coin
 }

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -239,6 +239,7 @@ func (account *Account) Init() error {
 			account.log.Panicf("Status %d is unknown.", status)
 		}
 	}
+	account.coin.Init()
 	account.blockchain = account.coin.Blockchain()
 	account.offline = account.blockchain.ConnectionStatus() == blockchain.DISCONNECTED
 	account.onEvent(EventStatusChanged)

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -127,6 +127,7 @@ func (account *Account) Init() error {
 	account.address = Address{
 		Address: crypto.PubkeyToAddress(*account.signingConfiguration.PublicKeys()[0].ToECDSA()),
 	}
+	account.coin.Init()
 	defer account.synchronizer.IncRequestsCounter()()
 	balance, err := account.coin.client.BalanceAt(context.TODO(), account.address.Address, nil)
 	if err != nil {


### PR DESCRIPTION
All existing coins were initialized, regardless of whether activated
in the settings, or whether the account using it was
initialized. Initialized coins start syncing headers and creating
unused connections, which caused a noticable pause between unlocking
the device and the accounts showing up.

This fixes this regression.