### PR TITLE
frontend/guide: allow skipping screen key

### DIFF
--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -57,7 +57,7 @@ export function hide() {
 }
 
 interface ProvidedProps {
-    screen: string;
+    screen?: string;
 }
 
 type Props = ProvidedProps & SharedProps & TranslateProp;

--- a/frontends/web/src/routes/account/account.jsx
+++ b/frontends/web/src/routes/account/account.jsx
@@ -233,7 +233,7 @@ export default class Account extends Component {
                         </Status>
                     </div>
                 </div>
-                <Guide screen="account">
+                <Guide>
                     <Entry key="accountDescription" title={t('guide.accountDescription.title')}>
                         <p>{t('guide.accountDescription.text')}</p>
                     </Entry>


### PR DESCRIPTION
Account guide has no entries in "guide.account", only manual entries.