### PR TITLE
coin: formatting of 0

### DIFF
--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -126,10 +126,9 @@ func (coin *Coin) Unit() string {
 
 // FormatAmount implements coin.Coin.
 func (coin *Coin) FormatAmount(amount coinpkg.Amount) string {
-	return strings.TrimRight(
+	return strings.TrimRight(strings.TrimRight(
 		new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(unitSatoshi)).FloatString(8),
-		"0.",
-	)
+		"0"), ".")
 }
 
 // Blockchain connects to a blockchain backend.

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -66,10 +66,9 @@ func (coin *Coin) Unit() string {
 // FormatAmount implements coin.Coin.
 func (coin *Coin) FormatAmount(amount coinpkg.Amount) string {
 	ether := big.NewInt(1e18)
-	return strings.TrimRight(
+	return strings.TrimRight(strings.TrimRight(
 		new(big.Rat).SetFrac(amount.BigInt(), ether).FloatString(18),
-		"0.",
-	)
+		"0"), ".")
 }
 
 // BlockExplorerTransactionURLPrefix implements coin.Coin.


### PR DESCRIPTION
The trimming formatted 0 as "" instead of as "0".