### PR TITLE
qt: software rendering bug in 5.9

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
     qputenv("QV4_FORCE_INTERPRETER", "1");
     qputenv("DRAW_USE_LLVM", "0");
 #endif
-#if QT_VERSION >= QT_VERSION_CHECK(5,9,0)
+#if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
     qputenv("QMLSCENE_DEVICE", "softwarecontext");
     qputenv("QT_QUICK_BACKEND", "software");
 #endif


### PR DESCRIPTION
Weird grid was drawn on macOS when either of the two flags was
enabled.

Looks like https://bugreports.qt.io/browse/QTBUG-60393, but also
present in 5.9.4.

Problem does not appear in 5.11.