### PR TITLE
frontend/send: hide fee targets if there are none

### DIFF
--- a/backend/coins/btc/feetarget.go
+++ b/backend/coins/btc/feetarget.go
@@ -25,6 +25,8 @@ type FeeTargetCode string
 // NewFeeTargetCode checks if the code is valid and returns a FeeTargetCode in that case.
 func NewFeeTargetCode(code string) (FeeTargetCode, error) {
 	switch code {
+	case "":
+		return defaultFeeTarget, nil
 	case string(FeeTargetCodeLow):
 	case string(FeeTargetCodeEconomy):
 	case string(FeeTargetCodeNormal):

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -271,7 +271,7 @@ func (account *Account) SendTx(
 
 // FeeTargets implements btc.Interface.
 func (account *Account) FeeTargets() ([]*btc.FeeTarget, btc.FeeTargetCode) {
-	return []*btc.FeeTarget{{Blocks: 2, Code: "low"}}, "low"
+	return nil, ""
 }
 
 // TxProposal implements btc.Interface.

--- a/frontends/web/src/routes/account/send/feetargets.jsx
+++ b/frontends/web/src/routes/account/send/feetargets.jsx
@@ -65,7 +65,7 @@ export default class FeeTargets extends Component {
         feeTargets,
         feeTarget,
     }) {
-        if (!feeTargets) {
+        if (feeTargets === null) {
             return (
                 <Input
                     label={label}
@@ -73,6 +73,9 @@ export default class FeeTargets extends Component {
                     disabled
                     transparent />
             );
+        }
+        if (feeTargets.length === 0) {
+            return null;
         }
 
         return (

--- a/frontends/web/src/routes/account/send/send.jsx
+++ b/frontends/web/src/routes/account/send/send.jsx
@@ -151,14 +151,14 @@ export default class Send extends Component {
     txInput = () => ({
         address: this.state.recipientAddress,
         amount: this.state.amount,
-        feeTarget: this.state.feeTarget,
+        feeTarget: this.state.feeTarget || '',
         sendAll: this.state.sendAll ? 'yes' : 'no',
         selectedUTXOs: Object.keys(this.selectedUTXOs),
     })
 
     sendDisabled = () => {
         const txInput = this.txInput();
-        return !txInput.address || !txInput.feeTarget || (txInput.sendAll === 'no' && !txInput.amount);
+        return !txInput.address || this.state.feeTarget === null || (txInput.sendAll === 'no' && !txInput.amount);
     }
 
     validateAndDisplayFee = updateFiat => {


### PR DESCRIPTION
Stop-gap solution to hide it in ETH. The proper step would be to move
FeeTargets and make it more generic.