### PR TITLE
backend/keystore: improve HasSecureOutput/OutputAddress

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -570,7 +570,7 @@ func (account *Account) VerifyAddress(addressID string) (bool, error) {
 	if address == nil {
 		return false, errp.New("unknown address not found")
 	}
-	if account.Keystores().HaveSecureOutput() {
+	if account.Keystores().HaveSecureOutput(address.Configuration, account.Coin()) {
 		return true, account.Keystores().OutputAddress(address.Configuration, account.Coin())
 	}
 	return false, nil

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -47,17 +47,19 @@ func (keystore *keystore) CosignerIndex() int {
 }
 
 // HasSecureOutput implements keystore.Keystore.
-func (keystore *keystore) HasSecureOutput() bool {
-	return keystore.dbb.channel != nil
+func (keystore *keystore) HasSecureOutput(
+	configuration *signing.Configuration, coin coin.Coin) bool {
+	return keystore.dbb.channel != nil && configuration.Singlesig()
 }
 
 // OutputAddress implements keystore.Keystore.
 func (keystore *keystore) OutputAddress(
-	keyPath signing.AbsoluteKeypath, scriptType signing.ScriptType, coin coin.Coin) error {
-	if !keystore.HasSecureOutput() {
+	configuration *signing.Configuration, coin coin.Coin) error {
+	if !keystore.HasSecureOutput(configuration, coin) {
 		panic("HasSecureOutput must be true")
 	}
-	return keystore.dbb.displayAddress(keyPath.Encode(), fmt.Sprintf("%s-%s", coin.Code(), string(scriptType)))
+	return keystore.dbb.displayAddress(
+		configuration.AbsoluteKeypath().Encode(), fmt.Sprintf("%s-%s", coin.Code(), string(configuration.ScriptType())))
 }
 
 // ExtendedPublicKey implements keystore.Keystore.

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -38,11 +38,11 @@ type Keystore interface {
 
 	// HasSecureOutput returns whether the keystore supports to output an address securely.
 	// This is typically done through a screen on the device or through a paired mobile phone.
-	HasSecureOutput() bool
+	HasSecureOutput(*signing.Configuration, coin.Coin) bool
 
-	// OutputAddress outputs the public key at the given absolute keypath for the given coin.
+	// OutputAddress outputs the public key at the given configuration for the given coin.
 	// Please note that this is only supported if the keystore has a secure output channel.
-	OutputAddress(signing.AbsoluteKeypath, signing.ScriptType, coin.Coin) error
+	OutputAddress(*signing.Configuration, coin.Coin) error
 
 	// ExtendedPublicKey returns the extended public key at the given absolute keypath.
 	ExtendedPublicKey(signing.AbsoluteKeypath) (*hdkeychain.ExtendedKey, error)

--- a/backend/keystore/keystores.go
+++ b/backend/keystore/keystores.go
@@ -33,7 +33,7 @@ type Keystores interface {
 	Remove(Keystore) error
 
 	// HaveSecureOutput returns whether any of the keystores has a secure output.
-	HaveSecureOutput() bool
+	HaveSecureOutput(*signing.Configuration, coin.Coin) bool
 
 	// OutputAddress outputs the address for the given coin with the given configuration on all
 	// keystores that have a secure output.
@@ -89,9 +89,10 @@ func (keystores *implementation) Remove(keystore Keystore) error {
 }
 
 // HaveSecureOutput implements the above interface.
-func (keystores *implementation) HaveSecureOutput() bool {
+func (keystores *implementation) HaveSecureOutput(
+	configuration *signing.Configuration, coin coin.Coin) bool {
 	for _, keystore := range keystores.keystores {
-		if keystore.HasSecureOutput() {
+		if keystore.HasSecureOutput(configuration, coin) {
 			return true
 		}
 	}
@@ -103,11 +104,10 @@ func (keystores *implementation) OutputAddress(
 	configuration *signing.Configuration,
 	coin coin.Coin,
 ) error {
-	keypath := configuration.AbsoluteKeypath()
 	found := false
 	for _, keystore := range keystores.keystores {
-		if keystore.HasSecureOutput() && configuration.Singlesig() {
-			if err := keystore.OutputAddress(keypath, configuration.ScriptType(), coin); err != nil {
+		if keystore.HasSecureOutput(configuration, coin) {
+			if err := keystore.OutputAddress(configuration, coin); err != nil {
 				return err
 			}
 			found = true

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -81,12 +81,12 @@ func (keystore *Keystore) Identifier() (string, error) {
 }
 
 // HasSecureOutput implements keystore.Keystore.
-func (keystore *Keystore) HasSecureOutput() bool {
+func (keystore *Keystore) HasSecureOutput(*signing.Configuration, coin.Coin) bool {
 	return false
 }
 
 // OutputAddress implements keystore.Keystore.
-func (keystore *Keystore) OutputAddress(signing.AbsoluteKeypath, signing.ScriptType, coin.Coin) error {
+func (keystore *Keystore) OutputAddress(*signing.Configuration, coin.Coin) error {
 	return errp.New("The software-based keystore has no secure output to display the address.")
 }
 


### PR DESCRIPTION
- keypath and scripttype is both in Configuration
- relevant whether we are in singlesig or multisig, which is also in
  the Configuration
- HasSecureOutput needs to have the same signature to be able to check
  properly.