### PR TITLE
Makefile: locize push should also add/remove keys in every language

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,6 @@ dockerinit:
 dockerdev:
 	./scripts/dockerdev.sh
 locize-push:
-	cd frontends/web/src/locales && locize sync
+	cd frontends/web/src/locales && locize sync --reference-language-only=false
 locize-pull:
 	cd frontends/web/src/locales && locize download


### PR DESCRIPTION
Say someone adds a key to English, and in the same go adds it to some
other languages they know. Locize push would lose the changes to other
languages (something that should be avoided, but if it happens, we
don't want the work to be lost). This flag fixes that.