### PR TITLE
frontend/account: show info link only for btc based accounts

### DIFF
--- a/frontends/web/src/routes/account/account.jsx
+++ b/frontends/web/src/routes/account/account.jsx
@@ -177,7 +177,7 @@ export default class Account extends Component {
                         title={
                             <h2 className={componentStyle.title}>
                                 {account.name}
-                                <a href={`/account/${code}/info`}><img src={InfoIcon} /></a>
+                                { isBitcoinBased(account.coinCode) ? <a href={`/account/${code}/info`}><img src={InfoIcon} /></a> : '' }
                             </h2>
                         }
                         {...this.props}>


### PR DESCRIPTION
it shows xpubs at the moment. Re-add when we have more generic account info.