### PR TITLE
backend: fix multisig accounts

### DIFF
--- a/frontends/web/src/components/icon/logo.tsx
+++ b/frontends/web/src/components/icon/logo.tsx
@@ -42,12 +42,16 @@ export const Shift = (props: GenericProps) => <img {...props} draggable={false} 
 
 const logoMap = {
     'tbtc': [BTC, BTC_GREY], // eslint-disable-line quote-props
+    'btc-multisig': [BTC, BTC_GREY],
+    'tbtc-multisig': [BTC, BTC_GREY],
     'btc-p2pkh': [BTC, BTC_GREY],
     'tbtc-p2pkh': [BTC, BTC_GREY],
     'btc-p2wpkh-p2sh': [BTC, BTC_GREY],
     'btc-p2wpkh': [BTC, BTC_GREY],
     'tbtc-p2wpkh-p2sh': [BTC, BTC_GREY],
     'tbtc-p2wpkh': [BTC, BTC_GREY],
+    'ltc-multisig': [LTC, LTC_GREY],
+    'tltc-multisig': [LTC, LTC_GREY],
     'ltc-p2wpkh-p2sh': [LTC, LTC_GREY],
     'ltc-p2wpkh': [LTC, LTC_GREY],
     'tltc-p2wpkh-p2sh': [LTC, LTC_GREY],

--- a/frontends/web/src/components/sidebar/sidebar.jsx
+++ b/frontends/web/src/components/sidebar/sidebar.jsx
@@ -29,12 +29,14 @@ import { share } from '../../decorators/share';
 import { store } from '../../components/guide/guide';
 
 const labelMap = {
+    'tbtc-multisig': 'BTC',
     'btc-p2pkh': 'BTC',
     'tbtc-p2pkh': 'TBTC',
     'btc-p2wpkh-p2sh': 'BTC',
     'btc-p2wpkh': 'BTC',
     'tbtc-p2wpkh-p2sh': 'TBTC SW',
     'tbtc-p2wpkh': 'TBTC NSW',
+    'ltc-multisig': 'LTC',
     'ltc-p2wpkh-p2sh': 'LTC',
     'ltc-p2wpkh': 'LTC',
     'tltc-p2wpkh-p2sh': 'TLTC',


### PR DESCRIPTION
Before, each account was converted into a multisig one, with the
signle-sig keypath. All used the same multisig type too, disregard the
account type.