### PR TITLE
deps: add tool to fix version of dev tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV GOROOT /opt/go_dist/go
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 
 ADD Makefile /tmp/
+ADD scripts/go-get.sh /tmp/scripts/
 RUN make -C /tmp/ envinit
 
 # Needed for qt5. fuse is needed to run the linuxdeployqt appimage.

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WEBROOT:=`pwd`/frontends/web
 catch:
 	@echo "Choose a make target."
 envinit:
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	./scripts/go-get.sh v1.11 github.com/golangci/golangci-lint/cmd/golangci-lint
 	go get -u github.com/golang/dep/cmd/dep
 	go get -u github.com/stretchr/testify # needed for mockery
 	go get -u github.com/vektra/mockery/cmd/mockery

--- a/scripts/go-get.sh
+++ b/scripts/go-get.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+# This is like `go get`, but while that always gets `master`, you can provide an additional
+# revision/tag/branch.
+# The first parameter must be the revision.
+# The second parameter must be the package name.
+# Example ./go-get v1.12 github.com/golangci/golangci-lint/cmd/golangci-lint
+
+
+REVISION=$1
+shift
+go get -u $@
+cd "$GOPATH/src/$1"
+git checkout "$REVISION"
+go install ./...


### PR DESCRIPTION
`go get ...` always gets master, which is not reliable/robust.

Start by fixing the linter version, so the CI does not break when that
updates in a backwards incompatible manner.