### PR TITLE
frontend: handle preact input change to update state correctly

### DIFF
--- a/frontends/web/src/routes/device/settings/components/changepin.jsx
+++ b/frontends/web/src/routes/device/settings/components/changepin.jsx
@@ -115,7 +115,7 @@ export default class ChangePIN extends Component {
                                     idPrefix="oldPIN"
                                     label={t('changePin.oldLabel')}
                                     value={oldPIN}
-                                    onChange={this.setValidOldPIN} />
+                                    onInput={this.setValidOldPIN} />
                                 {t('changePin.newTitle') && <h4>{t('changePin.newTitle')}</h4>}
                                 <PasswordRepeatInput
                                     idPrefix="newPIN"


### PR DESCRIPTION
Preact uses different event handlers than React. The state of the input field was not updating using `onChange`. Use `onInput` instead.