### PR TITLE
ci: update golangci to v1.12

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,38 @@ output:
 
 # all available settings of specific linters
 linters-settings:
+  gocritic:
+    enabled-checks:
+      - assignOp
+      - builtinShadow
+      - busySelect
+      - caseOrder
+      - captLocal
+      - deadCodeAfterLogFatal
+      - deferInLoop
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - elseif
+      - evalOrder
+      - flagDeref
+      - floatCompare
+      - ifElseChain
+      - indexOnlyLoop
+      - namedConst
+      - nilValReturn
+      - rangeExprCopy
+      - rangeValCopy
+      - regexpMust
+      - sloppyLen
+      - switchTrue
+      - typeSwitchVar
+      - typeUnparen
+      - underef
+      - unlambda
+      - unslice
+      - rangeValCopy
+      - defaultCaseOrder
   gocyclo:
     min-complexity: 25
   maligned:
@@ -63,6 +95,8 @@ linters:
     - maligned
     - prealloc
     - lll
+    - gochecknoinits
+    - gochecknoglobals
   disable-all: false
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WEBROOT:=`pwd`/frontends/web
 catch:
 	@echo "Choose a make target."
 envinit:
-	./scripts/go-get.sh v1.11 github.com/golangci/golangci-lint/cmd/golangci-lint
+	./scripts/go-get.sh v1.12 github.com/golangci/golangci-lint/cmd/golangci-lint
 	go get -u github.com/golang/dep/cmd/dep
 	go get -u github.com/stretchr/testify # needed for mockery
 	go get -u github.com/vektra/mockery/cmd/mockery

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -176,7 +176,7 @@ func (backend *Backend) createAndAddAccount(
 		return backend.keystores.Configuration(scriptType, absoluteKeypath, backend.keystores.Count())
 	}
 	if backend.arguments.Multisig() {
-		name = name + " Multisig"
+		name += " Multisig"
 	}
 	backend.CreateAndAddAccount(coin, code, name, scriptType, getSigningConfiguration)
 }
@@ -318,20 +318,21 @@ func (backend *Backend) initAccounts() {
 	backend.uninitAccounts()
 
 	if backend.arguments.Testing() {
-		if backend.arguments.Multisig() {
+		switch {
+		case backend.arguments.Multisig():
 			TBTC, _ := backend.Coin(coinTBTC)
 			backend.createAndAddAccount(TBTC, "tbtc-multisig", "Bitcoin Testnet", "m/48'/1'/0'",
 				signing.ScriptTypeP2PKH)
 			TLTC, _ := backend.Coin(coinTLTC)
 			backend.createAndAddAccount(TLTC, "tltc-multisig", "Litecoin Testnet", "m/48'/1'/0'",
 				signing.ScriptTypeP2PKH)
-		} else if backend.arguments.Regtest() {
+		case backend.arguments.Regtest():
 			RBTC, _ := backend.Coin("rbtc")
 			backend.createAndAddAccount(RBTC, "rbtc-p2pkh", "Bitcoin Regtest Legacy", "m/44'/1'/0'",
 				signing.ScriptTypeP2PKH)
 			backend.createAndAddAccount(RBTC, "rbtc-p2wpkh-p2sh", "Bitcoin Regtest Segwit", "m/49'/1'/0'",
 				signing.ScriptTypeP2WPKHP2SH)
-		} else {
+		default:
 			TBTC, _ := backend.Coin(coinTBTC)
 			backend.createAndAddAccount(TBTC, "tbtc-p2wpkh-p2sh", "Bitcoin Testnet", "m/49'/1'/0'",
 				signing.ScriptTypeP2WPKHP2SH)

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -221,18 +221,19 @@ func (account *Account) Initialize() error {
 	account.log.Debugf("Opened the database '%s' to persist the transactions.", dbName)
 
 	onConnectionStatusChanged := func(status blockchain.Status) {
-		if status == blockchain.DISCONNECTED {
+		switch status {
+		case blockchain.DISCONNECTED:
 			account.log.Warn("Connection to blockchain backend lost")
 			account.offline = true
 			account.onEvent(EventStatusChanged)
-		} else if status == blockchain.CONNECTED {
+		case blockchain.CONNECTED:
 			// when we have previously been offline, the initial sync status is set back
 			// as we need to synchronize with the new backend.
 			account.initialized = false
 			account.offline = false
 			account.onEvent(EventStatusChanged)
 			account.log.Debug("Connection to blockchain backend established")
-		} else {
+		default:
 			account.log.Panicf("Status %d is unknown.", status)
 		}
 	}

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -90,7 +90,7 @@ func formatAsCurrency(amount float64) string {
 	position := strings.Index(formatted, ".") - 3
 	for position > 0 {
 		formatted = formatted[:position] + "'" + formatted[position:]
-		position = position - 3
+		position -= 3
 	}
 	return formatted
 }

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
+	ethereum "github.com/ethereum/go-ethereum"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -177,11 +177,9 @@ func (account *Account) poll() {
 				account.offline = true
 				account.onEvent(Event(btc.EventStatusChanged))
 			}
-		} else {
-			if account.offline {
-				account.offline = false
-				account.onEvent(Event(btc.EventStatusChanged))
-			}
+		} else if account.offline {
+			account.offline = false
+			account.onEvent(Event(btc.EventStatusChanged))
 		}
 		timer = time.After(pollInterval)
 	}

--- a/backend/coins/eth/etherscan/etherscan.go
+++ b/backend/coins/eth/etherscan/etherscan.go
@@ -175,14 +175,14 @@ func prepareTransactions(
 		if ours != from && ours != to {
 			return nil, errp.New("transaction does not belong to our account")
 		}
-		if ours == from && ours == to {
+		switch {
+		case ours == from && ours == to:
 			transaction.txType = coin.TxTypeSendSelf
-		} else if ours == from {
+		case ours == from:
 			transaction.txType = coin.TxTypeSend
-		} else {
+		default:
 			transaction.txType = coin.TxTypeReceive
 		}
-
 		castTransactions = append(castTransactions, transaction)
 	}
 	return castTransactions, nil

--- a/backend/devices/bitbox/device.go
+++ b/backend/devices/bitbox/device.go
@@ -1126,7 +1126,7 @@ func (dbb *Device) Sign(
 	if len(signatureHashes)%signatureBatchSize != 0 {
 		steps++
 	}
-	for i := 0; i < len(signatureHashes); i = i + signatureBatchSize {
+	for i := 0; i < len(signatureHashes); i += signatureBatchSize {
 		upper := i + signatureBatchSize
 		if upper > len(signatureHashes) {
 			upper = len(signatureHashes)

--- a/backend/devices/bitbox/error.go
+++ b/backend/devices/bitbox/error.go
@@ -55,6 +55,6 @@ func NewError(message string, code float64) *Error {
 }
 
 // Error implements the error interface.
-func (error *Error) Error() string {
-	return error.message
+func (err *Error) Error() string {
+	return err.message
 }

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -58,7 +58,7 @@ func NewKeystore(
 // NewKeystoreFromPIN creates a new unique keystore derived from the PIN.
 func NewKeystoreFromPIN(cosignerIndex int, pin string) *Keystore {
 	seed := pbkdf2.Key([]byte(pin), []byte("BitBox"), 64, hdkeychain.RecommendedSeedLen, sha256.New)
-	master, err := hdkeychain.NewMaster(seed[:], &chaincfg.TestNet3Params)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.TestNet3Params)
 	if err != nil {
 		panic(errp.WithStack(err))
 	}
@@ -108,10 +108,9 @@ func (keystore *Keystore) sign(
 	if len(signatureHashes) != len(keyPaths) {
 		return nil, errp.New("The number of hashes to sign has to be equal to the number of paths.")
 	}
-	len := len(keyPaths)
-	signatures := make([]btcec.Signature, len)
-	for i := 0; i < len; i++ {
-		xprv, err := keyPaths[i].Derive(keystore.master)
+	signatures := make([]btcec.Signature, len(keyPaths))
+	for i, keyPath := range keyPaths {
+		xprv, err := keyPath.Derive(keystore.master)
 		if err != nil {
 			return nil, err
 		}

--- a/util/logging/logger.go
+++ b/util/logging/logger.go
@@ -36,11 +36,12 @@ func NewLogger(configuration *Configuration) *Logger {
 	logger.AddHook(stackHook{
 		stackLevels: []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel},
 	})
-	if configuration.Output == "STDOUT" {
+	switch configuration.Output {
+	case "STDOUT":
 		logger.Out = os.Stdout
-	} else if configuration.Output == "STDERR" {
+	case "STDERR":
 		logger.Out = os.Stderr
-	} else {
+	default:
 		if err := os.MkdirAll(filepath.Dir(configuration.Output), os.ModeDir|os.ModePerm); err != nil {
 			panic(errp.WithStack(err))
 		}


### PR DESCRIPTION
It enables by default gocritic, gochecknoinits, gochecknoglobals. We
select a few from gocritic (revisit if too invasive) and disable the
other two for now.