### PR TITLE
frontend: add translation key to language switcher button

### DIFF
--- a/frontends/web/src/components/language/language.jsx
+++ b/frontends/web/src/components/language/language.jsx
@@ -112,7 +112,7 @@ export default class LanguageSwitcher extends Component {
                     className={[style.button, 'flex flex-row flex-items-center'].join(' ')}
                     onClick={() => this.setState({ activeDialog: true })}>
                     <img src={globe} />
-                    {languages[selectedIndex].display}
+                    {languages[selectedIndex].code === 'en' ? 'Other languages' : 'English'}
                 </Button>
                 {
                     activeDialog && (


### PR DESCRIPTION
I added a new translation key to the language button. As mentioned in the issue, this button will be 'Other languages' in English, and 'English' for other languages.