### PR TITLE
Makefile: locize-push should only touch the reference language

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ dockerinit:
 dockerdev:
 	./scripts/dockerdev.sh
 locize-push:
-	cd frontends/web/src/locales && locize sync --reference-language-only=false
+	cd frontends/web/src/locales && locize sync
 locize-pull:
 	cd frontends/web/src/locales && locize download
 locize-fix:

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -9,6 +9,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
 fi
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    export HOMEBREW_NO_AUTO_UPDATE=1
     brew outdated go || brew upgrade go
     brew install yarn
     brew install qt


### PR DESCRIPTION
Easy to shoot oneself in the foot by force writing the other
files (e.g. accidentally pushing stale/uncommitted language files).