### PR TITLE
frontend/account: error with locked device

### DIFF
--- a/backend/devices/bitbox/device.go
+++ b/backend/devices/bitbox/device.go
@@ -57,6 +57,10 @@ var (
 
 var errNoBootloader = errors.New("invalid command in bootloader")
 
+// ErrMustBeLoggedIn is returned by API calls when a login is required, but the device has not beed
+// unlocked.
+var ErrMustBeLoggedIn = errors.New("must be logged in")
+
 const (
 	// EventStatusChanged is fired when the status changes. Check the status using Status().
 	EventStatusChanged device.Event = "statusChanged"
@@ -377,6 +381,9 @@ func (dbb *Device) deviceInfo(pin string) (*DeviceInfo, error) {
 
 // DeviceInfo gets device information.
 func (dbb *Device) DeviceInfo() (*DeviceInfo, error) {
+	if dbb.pin == "" {
+		return nil, errp.WithStack(ErrMustBeLoggedIn)
+	}
 	return dbb.deviceInfo(dbb.pin)
 }
 

--- a/backend/devices/bitbox/handlers/handlers.go
+++ b/backend/devices/bitbox/handlers/handlers.go
@@ -171,7 +171,11 @@ func (handlers *Handlers) getBootloaderStatusHandler(_ *http.Request) (interface
 }
 
 func (handlers *Handlers) getDeviceInfoHandler(_ *http.Request) (interface{}, error) {
-	return handlers.bitbox.DeviceInfo()
+	info, err := handlers.bitbox.DeviceInfo()
+	if errp.Cause(err) == bitbox.ErrMustBeLoggedIn {
+		return nil, nil
+	}
+	return info, err
 }
 
 func (handlers *Handlers) getPairedHandler(_ *http.Request) (interface{}, error) {

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -127,7 +127,12 @@ class Account extends Component<Props, State> {
     private checkSDCards() {
         Promise.all(this.props.deviceIDs.map(deviceID => {
             return apiGet(`devices/${deviceID}/info`)
-                .then(({ sdcard }) => sdcard);
+                .then(info => {
+                    if (!info) {
+                        return false;
+                    }
+                    return info.sdcard;
+                });
         }))
             .then(sdcards => sdcards.some(sdcard => sdcard))
             .then(hasCard => this.setState({ hasCard }));


### PR DESCRIPTION
The sd card check assumes the device is unlocked, but that is not the
case with for example watch only accounts.