### PR TITLE
btc: hold onto account config and rel. keypath of an address

### DIFF
--- a/backend/coins/btc/addresses/test/test.go
+++ b/backend/coins/btc/addresses/test/test.go
@@ -59,6 +59,7 @@ func GetAddress(scriptType signing.ScriptType) *addresses.AccountAddress {
 	configuration := signing.NewSinglesigConfiguration(scriptType, absoluteKeypath, extendedPublicKey)
 	return addresses.NewAccountAddress(
 		configuration,
+		signing.NewEmptyRelativeKeypath(),
 		net,
 		logging.Get().WithGroup("addresses_test"),
 	)
@@ -85,6 +86,7 @@ func GetMultisigAddress(signingThreshold, numberOfSigners int) *addresses.Accoun
 	configuration := signing.NewConfiguration(signing.ScriptTypeP2PKH, absoluteKeypath, xpubs, "", signingThreshold)
 	return addresses.NewAccountAddress(
 		configuration,
+		signing.NewEmptyRelativeKeypath(),
 		net,
 		logging.Get().WithGroup("addresses_test"),
 	)


### PR DESCRIPTION
Useful information for keystores to know the relative keypath of the
address to the account.