### PR TITLE
Makefile: use MAKE variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ osx-init:
 	export CPPFLAGS="-I/usr/local/opt/qt/include"
 	export GOPATH=~/go/
 	export PATH=$PATH:~/go/bin
-	make envinit
+	$(MAKE) envinit
 servewallet:
 	go install ./cmd/servewallet/... && servewallet
 servewallet-mainnet:
@@ -49,33 +49,33 @@ buildweb:
 	yarn --cwd=${WEBROOT} install
 	yarn --cwd=${WEBROOT} run build
 webdev:
-	make -C frontends/web dev
+	cd frontends/web && $(MAKE) dev
 webdev-i18n:
-	PREACT_APP_I18NEDITOR=1 make webdev
+	PREACT_APP_I18NEDITOR=1 $(MAKE) webdev
 weblint:
-	make -C frontends/web lint
+	cd frontends/web && $(MAKE) lint
 webtest:
-	make -C frontends/web jstest
+	cd frontends/web && $(MAKE) jstest
 qt:
-	make buildweb
-	make -C frontends/qt
+	$(MAKE) buildweb
+	cd frontends/qt && $(MAKE)
 qt-linux: # run inside dockerdev
-	make buildweb
-	make -C frontends/qt linux
+	$(MAKE) buildweb
+	cd frontends/qt && $(MAKE) linux
 qt-osx: # run on OSX.
-	make buildweb
-	make -C frontends/qt osx
-	make osx-sec-check
+	$(MAKE) buildweb
+	cd frontends/qt && $(MAKE) osx
+	$(MAKE) osx-sec-check
 qt-windows:
-	make buildweb
-	make -C frontends/qt windows
+	$(MAKE) buildweb
+	cd frontends/qt && $(MAKE) windows
 osx-sec-check:
 	@echo "Checking build output"
 	./scripts/osx-build-check.sh
 ci:
 	./scripts/ci.sh
 clean:
-	make -C frontends/qt clean
+	cd frontends/qt && $(MAKE) clean
 dockerinit:
 	docker build --pull --force-rm -t bitbox-wallet .
 dockerdev:

--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -16,14 +16,14 @@ base:
 	mkdir build
 	./genassets.sh
 	qmake -o build/Makefile
-	make -C build
+	cd build && $(MAKE)
 clean:
 	-rm -rf build
-	make -C server clean
+	cd server && $(MAKE) clean
 linux:
-	make clean
-	make -C server/ linux
-	make base
+	$(MAKE) clean
+	cd server && $(MAKE) linux
+	$(MAKE) base
 	mkdir build/linux-tmp build/linux
 	mv build/BitBox build/linux-tmp
 	cp build/assets.rcc build/linux-tmp/
@@ -41,9 +41,9 @@ linux:
 	mv build/linux-tmp/BitBox-x86_64.AppImage build/linux/
 	rm build/linux-tmp/libserver.so
 osx:
-	make clean
-	make -C server/ macosx
-	make base
+	$(MAKE) clean
+	cd server && $(MAKE) macosx
+	$(MAKE) base
 	mkdir build/osx
 	mv build/BitBox.app build/osx/
 	cp resources/MacOS/Info.plist build/osx/BitBox.app/Contents/

--- a/frontends/qt/server/Makefile
+++ b/frontends/qt/server/Makefile
@@ -1,23 +1,23 @@
 include ../../../env.mk.inc
 
 linux:
-	make -f Makefile.linux linux
+	$(MAKE) -f Makefile.linux linux
 linux-clean:
-	-make -f Makefile.linux clean
+	-$(MAKE) -f Makefile.linux clean
 
 macosx:
-	make -f Makefile.macosx darwin
+	$(MAKE) -f Makefile.macosx darwin
 macosx-clean:
-	-make -f Makefile.macosx clean
+	-$(MAKE) -f Makefile.macosx clean
 
 windows:
-	make -f Makefile.windows windows
+	$(MAKE) -f Makefile.windows windows
 windows-cross:
-	make -f Makefile.windows windows-cross
+	$(MAKE) -f Makefile.windows windows-cross
 windows-legacy:
-	make -f Makefile.windows windows-legacy
+	$(MAKE) -f Makefile.windows windows-legacy
 windows-clean:
-	-make -f Makefile.windows clean
+	-$(MAKE) -f Makefile.windows clean
 
 install:
 	install ${LIBNAME}.so ${DESTDIR}/usr/lib/${LIBNAME}.so


### PR DESCRIPTION
Otherwise, flags such as `-j` are not propagated which would benefit the compilation of the Qt part.

See:
https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html