### PR TITLE
eth: synchronization improvement

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -319,6 +319,7 @@ func (account *Account) Notifier() accounts.Notifier {
 
 // Transactions implements accounts.Interface.
 func (account *Account) Transactions() []accounts.Transaction {
+	account.synchronizer.WaitSynchronized()
 	return account.transactions
 }
 


### PR DESCRIPTION
Increase etherscan rate limit (was 5req/s, not 1req/5s).

Transactions() should also wait until synced.