### PR TITLE
backend: change infura endpoint to use new API keys

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -183,13 +183,13 @@ func NewDefaultAppConfig() AppConfig {
 				},
 			},
 			ETH: ethCoinConfig{
-				NodeURL: "https://mainnet.infura.io",
+				NodeURL: "https://mainnet.infura.io/v3/2ce516f67c0b48e8af5387b714ab8a61",
 			},
 			TETH: ethCoinConfig{
-				NodeURL: "https://ropsten.infura.io",
+				NodeURL: "https://ropsten.infura.io/v3/2ce516f67c0b48e8af5387b714ab8a61",
 			},
 			RETH: ethCoinConfig{
-				NodeURL: "https://rinkeby.infura.io",
+				NodeURL: "https://rinkeby.infura.io/v3/2ce516f67c0b48e8af5387b714ab8a61",
 			},
 		},
 	}


### PR DESCRIPTION
I have also prepared the functionality to whitelist the User
Agent for the http requests so we can restrict the API key usage if we
decide to implement this in the future.