### PR TITLE
backend/keystore: SupportsAccount()

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -247,11 +247,26 @@ func (backend *Backend) createAndAddAccount(
 	keypath string,
 	scriptType signing.ScriptType,
 ) {
+	log := backend.log.WithField("code", code).WithField("name", name)
 	if !backend.arguments.Multisig() && !backend.config.AppConfig().Backend.AccountActive(code) {
-		backend.log.WithField("code", code).WithField("name", name).Info("skipping inactive account")
+		log.WithField("name", name).Info("skipping inactive account")
 		return
 	}
-	backend.log.WithField("code", code).WithField("name", name).Info("init account")
+
+	var meta interface{}
+	switch coin.(type) {
+	case *btc.Coin:
+		meta = scriptType
+	default:
+	}
+	for _, keystore := range backend.keystores.Keystores() {
+		if !keystore.SupportsAccount(coin, backend.arguments.Multisig(), meta) {
+			log.Info("skipping unsupported account")
+			return
+		}
+	}
+
+	log.Info("init account")
 	absoluteKeypath, err := signing.NewAbsoluteKeypath(keypath)
 	if err != nil {
 		panic(err)

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -682,7 +682,7 @@ func (account *Account) CanVerifyExtendedPublicKey() []int {
 // VerifyExtendedPublicKey verifies an account's public key. Returns false, nil if no secure output exists.
 // index is the position of an xpub in the []*hdkeychain which corresponds to the particular keystore in []Keystore
 func (account *Account) VerifyExtendedPublicKey(index int) (bool, error) {
-	keystore := account.Keystores().AccessKeystoreByIndex(index)
+	keystore := account.Keystores().Keystores()[index]
 	if keystore.CanVerifyExtendedPublicKey() {
 		return true, keystore.VerifyExtendedPublicKey(account.Coin(), account.signingConfiguration.AbsoluteKeypath(), account.signingConfiguration)
 	}

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -46,6 +46,17 @@ func (keystore *keystore) CosignerIndex() int {
 	return keystore.cosignerIndex
 }
 
+// SupportsAccount implements keystore.Keystore.
+func (keystore *keystore) SupportsAccount(
+	coin coin.Coin, multisig bool, meta interface{}) bool {
+	switch coin.(type) {
+	case *btc.Coin:
+		return true
+	default:
+		return !multisig
+	}
+}
+
 // CanVerifyAddress implements keystore.Keystore.
 func (keystore *keystore) CanVerifyAddress(
 	configuration *signing.Configuration, coin coin.Coin) (bool, bool, error) {

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -18,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/ltc"
@@ -38,6 +39,18 @@ type keystore struct {
 // CosignerIndex implements keystore.Keystore.
 func (keystore *keystore) CosignerIndex() int {
 	return keystore.cosignerIndex
+}
+
+// SupportsAccount implements keystore.Keystore.
+func (keystore *keystore) SupportsAccount(
+	coin coin.Coin, multisig bool, meta interface{}) bool {
+	switch coin.(type) {
+	case *btc.Coin:
+		scriptType := meta.(signing.ScriptType)
+		return !multisig && scriptType != signing.ScriptTypeP2PKH
+	default:
+		return false
+	}
 }
 
 // CanVerifyAddress implements keystore.Keystore.

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -35,6 +35,10 @@ type Keystore interface {
 	// The returned value is always zero for a singlesig configuration.
 	CosignerIndex() int
 
+	// SupportsAccount returns true if they keystore supports the given coin/account.
+	// meta is a coin-specific metadata related to the account type.
+	SupportsAccount(coin coin.Coin, multisig bool, meta interface{}) bool
+
 	// CanVerifyAddress returns whether the keystore supports to output an address securely.
 	// This is typically done through a screen on the device or through a paired mobile phone.
 	// optional is true if the user can skip verification, and false if they should be incentivized

--- a/backend/keystore/keystores.go
+++ b/backend/keystore/keystores.go
@@ -149,7 +149,7 @@ func (keystores *Keystores) Configuration(
 		scriptType, absoluteKeypath, extendedPublicKeys, "", signingThreshold), nil
 }
 
-// AccessKeystoreByIndex returns a specific keystore from the slice of keystores
-func (keystores *Keystores) AccessKeystoreByIndex(index int) Keystore {
-	return keystores.keystores[index]
+// Keystores returns all keystores.
+func (keystores *Keystores) Keystores() []Keystore {
+	return keystores.keystores
 }

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -75,6 +75,17 @@ func (keystore *Keystore) CosignerIndex() int {
 	return keystore.cosignerIndex
 }
 
+// SupportsAccount implements keystore.Keystore.
+func (keystore *Keystore) SupportsAccount(
+	coin coin.Coin, multisig bool, meta interface{}) bool {
+	switch coin.(type) {
+	case *btc.Coin:
+		return !multisig
+	default:
+		return false
+	}
+}
+
 // Identifier implements keystore.Keystore.
 func (keystore *Keystore) Identifier() (string, error) {
 	return keystore.identifier, nil


### PR DESCRIPTION
A keystore can indicate if it supports a specific coin/account.