### PR TITLE
backend: support only one device at a time

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -571,11 +571,13 @@ func (backend *Backend) OnDeviceUninit(f func(string)) {
 // Start starts the background services. It returns a channel of events to handle by the library
 // client.
 func (backend *Backend) Start() <-chan interface{} {
+	// We support only one device at a time at the moment.
+	onlyOne := !backend.arguments.Multisig()
 	usb.NewManager(
 		backend.arguments.MainDirectoryPath(),
 		backend.arguments.BitBox02DirectoryPath(),
 		backend.Register,
-		backend.Deregister).Start()
+		backend.Deregister, onlyOne).Start()
 	backend.initPersistedAccounts()
 	return backend.events
 }

--- a/backend/devices/usb/manager.go
+++ b/backend/devices/usb/manager.go
@@ -79,6 +79,8 @@ type Manager struct {
 	onRegister   func(device.Interface) error
 	onUnregister func(string)
 
+	onlyOne bool
+
 	log *logrus.Entry
 }
 
@@ -92,6 +94,7 @@ func NewManager(
 	bitbox02ConfigDir string,
 	onRegister func(device.Interface) error,
 	onUnregister func(string),
+	onlyOne bool,
 ) *Manager {
 	return &Manager{
 		devices:           map[string]device.Interface{},
@@ -99,6 +102,7 @@ func NewManager(
 		bitbox02ConfigDir: bitbox02ConfigDir,
 		onRegister:        onRegister,
 		onUnregister:      onUnregister,
+		onlyOne:           onlyOne,
 
 		log: logging.Get().WithGroup("manager"),
 	}
@@ -270,6 +274,10 @@ func (manager *Manager) listen() {
 			deviceID := deviceIdentifier(deviceInfo)
 			// Skip if already registered.
 			if _, ok := manager.devices[deviceID]; ok {
+				continue
+			}
+			// Skip if we already have another device registered and we only support one device.
+			if manager.onlyOne && len(manager.devices) != 0 {
 				continue
 			}
 			var device device.Interface


### PR DESCRIPTION
The UX is still too confusing when multiple devices are plugged in, as
only one keystore is actually loaded.