### PR TITLE
.dockerignore: Initial commit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/frontends/qt/build


### PR DESCRIPTION
This reduces the context that needs to be copied with `make dockerinit`
from ~1.21GB to ~0.35GB on my machine, which improves performance
when building Docker images.