### PR TITLE
ci: reduce memory consumption of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,21 +33,14 @@ linters-settings:
     enabled-checks:
       - assignOp
       - builtinShadow
-      - busySelect
       - caseOrder
       - captLocal
-      - deadCodeAfterLogFatal
-      - deferInLoop
       - dupArg
       - dupBranchBody
       - dupCase
       - elseif
-      - evalOrder
       - flagDeref
-      - floatCompare
       - ifElseChain
-      - indexOnlyLoop
-      - namedConst
       - nilValReturn
       - rangeExprCopy
       - rangeValCopy
@@ -59,7 +52,6 @@ linters-settings:
       - underef
       - unlambda
       - unslice
-      - rangeValCopy
       - defaultCaseOrder
   gocyclo:
     min-complexity: 25

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WEBROOT:=`pwd`/frontends/web
 catch:
 	@echo "Choose a make target."
 envinit:
-	./scripts/go-get.sh v1.12 github.com/golangci/golangci-lint/cmd/golangci-lint
+	./scripts/go-get.sh v1.16.0 github.com/golangci/golangci-lint/cmd/golangci-lint
 	go get -u github.com/golang/dep/cmd/dep
 	go get -u github.com/stretchr/testify # needed for mockery
 	go get -u github.com/vektra/mockery/cmd/mockery

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -379,13 +379,12 @@ func (account *Account) updateFeeTargets() {
 	defer account.RLock()()
 	for _, feeTarget := range account.feeTargets {
 		func(feeTarget *FeeTarget) {
-			setFee := func(feeRatePerKb btcutil.Amount) error {
+			setFee := func(feeRatePerKb btcutil.Amount) {
 				defer account.Lock()()
 				feeTarget.feeRatePerKb = &feeRatePerKb
 				account.log.WithFields(logrus.Fields{"blocks": feeTarget.blocks,
 					"fee-rate-per-kb": feeRatePerKb}).Debug("Fee estimate per kb")
 				account.onEvent(accounts.EventFeeTargetsChanged)
-				return nil
 			}
 
 			account.blockchain.EstimateFee(
@@ -399,7 +398,8 @@ func (account *Account) updateFeeTargets() {
 						account.blockchain.RelayFee(setFee, func(error) {})
 						return nil
 					}
-					return setFee(*feeRatePerKb)
+					setFee(*feeRatePerKb)
+					return nil
 				},
 				func(error) {},
 			)

--- a/backend/coins/btc/blockchain/blockchain.go
+++ b/backend/coins/btc/blockchain/blockchain.go
@@ -104,7 +104,7 @@ type Interface interface {
 	ScriptHashSubscribe(func() func(error), ScriptHashHex, func(string) error)
 	HeadersSubscribe(func() func(error), func(*Header) error)
 	TransactionBroadcast(*wire.MsgTx) error
-	RelayFee(func(btcutil.Amount) error, func(error))
+	RelayFee(func(btcutil.Amount), func(error))
 	EstimateFee(int, func(*btcutil.Amount) error, func(error))
 	Headers(int, int, func([]*wire.BlockHeader, int) error, func(error))
 	GetMerkle(chainhash.Hash, int, func(merkle []TXHash, pos int) error, func(error))

--- a/backend/coins/btc/blockchain/mocks/Interface.go
+++ b/backend/coins/btc/blockchain/mocks/Interface.go
@@ -58,7 +58,7 @@ func (_m *Interface) RegisterOnConnectionStatusChangedEvent(_a0 func(blockchain.
 }
 
 // RelayFee provides a mock function with given fields: _a0, _a1
-func (_m *Interface) RelayFee(_a0 func(btcutil.Amount) error, _a1 func(error)) {
+func (_m *Interface) RelayFee(_a0 func(btcutil.Amount), _a1 func(error)) {
 	_m.Called(_a0, _a1)
 }
 

--- a/backend/coins/btc/electrum/client/client.go
+++ b/backend/coins/btc/electrum/client/client.go
@@ -393,7 +393,7 @@ func (client *ElectrumClient) TransactionBroadcast(transaction *wire.MsgTx) erro
 // RelayFee does the blockchain.relayfee() RPC call.
 // https://github.com/kyuupichan/electrumx/blob/159db3f8e70b2b2cbb8e8cd01d1e9df3fe83828f/docs/PROTOCOL.rst#blockchainrelayfee
 func (client *ElectrumClient) RelayFee(
-	success func(btcutil.Amount) error,
+	success func(btcutil.Amount),
 	cleanup func(error),
 ) {
 	client.rpc.Method(func(responseBytes []byte) error {
@@ -405,7 +405,8 @@ func (client *ElectrumClient) RelayFee(
 		if err != nil {
 			return errp.Wrap(err, "Failed to construct BTC amount")
 		}
-		return success(amount)
+		success(amount)
+		return nil
 	}, func() func(error) { return cleanup }, "blockchain.relayfee")
 }
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -16,7 +16,9 @@
 # This script has to be called from the project root directory.
 go build ./...
 go test ./...
+
 golangci-lint run
+
 yarn --cwd=frontends/web install # needed to install the eslint dev dep.
 make weblint
 yarn --cwd=frontends/web test --ci --no-color --coverage


### PR DESCRIPTION
Running out of memory since upgrading to v1.12