### PR TITLE
Move devmode electrum config from backend to config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ servewallet-regtest:
 	go install ./cmd/servewallet/... && servewallet -regtest
 servewallet-multisig:
 	go install ./cmd/servewallet/... && servewallet -multisig
+servewallet-prodservers:
+	go install ./cmd/servewallet/... && servewallet -devservers=false
 buildweb:
 	node --version
 	rm -rf ${WEBROOT}/build

--- a/backend/arguments/arguments.go
+++ b/backend/arguments/arguments.go
@@ -47,8 +47,11 @@ type Arguments struct {
 	// Multisig stores whether the application is in multisig mode.
 	multisig bool
 
-	// devmode stores whether the application is in dev mode and, therefore, connects to the dev environment
+	// devmode stores whether the application is in dev mode
 	devmode bool
+
+	//devservers stores wether the app should connect to the dev servers. The devservers configuration is not persisted when switching back to production.
+	devservers bool
 
 	// log is the logger for this context
 	log *logrus.Entry
@@ -61,6 +64,7 @@ func NewArguments(
 	regtest bool,
 	multisig bool,
 	devmode bool,
+	devservers bool,
 ) *Arguments {
 	if !testing && regtest {
 		panic("Cannot use -regtest with -mainnet.")
@@ -87,6 +91,7 @@ func NewArguments(
 		regtest:                regtest,
 		multisig:               multisig,
 		devmode:                devmode,
+		devservers:             devservers,
 		log:                    log,
 	}
 
@@ -130,6 +135,11 @@ func (arguments *Arguments) Testing() bool {
 // DevMode returns whether the backend is in developer mode.
 func (arguments *Arguments) DevMode() bool {
 	return arguments.devmode
+}
+
+// DevServers returns whether the backend should use the development servers.
+func (arguments *Arguments) DevServers() bool {
+	return arguments.devservers
 }
 
 // Regtest returns whether the backend is for regtest only.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -379,7 +379,7 @@ O3nOxjgSfRAfKWQ2Ny1APKcn6I83P5PFLhtO5I12
 }
 
 func (backend *Backend) defaultElectrumXServers(code string) []*rpc.ServerInfo {
-	if backend.arguments.DevMode() {
+	if backend.arguments.DevServers() {
 		return defaultDevServers(code)
 	}
 

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -34,7 +34,7 @@ func TestListRoutes(t *testing.T) {
 	}
 	connectionData := handlers.NewConnectionData(8082, "")
 	backend, err := backend.NewBackend(arguments.NewArguments(
-		test.TstTempDir("bitbox-wallet-listroutes-"), false, false, false, false),
+		test.TstTempDir("bitbox-wallet-listroutes-"), false, false, false, false, false),
 		nil,
 	)
 	if err != nil {

--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -72,6 +72,7 @@ func main() {
 	regtest := flag.Bool("regtest", false, "use regtest instead of testnet coins")
 	multisig := flag.Bool("multisig", false, "use the app in multisig mode")
 	devmode := flag.Bool("devmode", true, "switch to dev mode")
+	devservers := flag.Bool("devservers", true, "switch to dev servers")
 	flag.Parse()
 
 	logging.Set(&logging.Configuration{Output: "STDERR", Level: logrus.DebugLevel})
@@ -88,7 +89,7 @@ func main() {
 	// since we are in dev-mode, we can drop the authorization token
 	connectionData := backendHandlers.NewConnectionData(-1, "")
 	backend, err := backend.NewBackend(
-		arguments.NewArguments(config.AppDir(), !*mainnet, *regtest, *multisig, *devmode),
+		arguments.NewArguments(config.AppDir(), !*mainnet, *regtest, *multisig, *devmode, *devservers),
 		webdevEnvironment{})
 	if err != nil {
 		log.Fatal(err)

--- a/frontends/android/android.go
+++ b/frontends/android/android.go
@@ -48,7 +48,7 @@ func Serve() {
 	}
 	connectionData := backendHandlers.NewConnectionData(8082, token)
 	backend, err := backend.NewBackend(
-		arguments.NewArguments(".", false, false, false, false),
+		arguments.NewArguments(".", false, false, false, false, false),
 		androidEnvironment{},
 	)
 	if err != nil {

--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -146,7 +146,7 @@ func serve(
 		log.WithError(err).Fatal("Failed to generate random string")
 	}
 	theBackend, err := backend.NewBackend(arguments.NewArguments(
-		config.AppDir(), *testnet, false, false, false),
+		config.AppDir(), *testnet, false, false, false, false),
 		&qtEnvironment{
 			notifyUser: func(text string) {
 				C.notifyUser(notifyUserCallback, C.CString(text))


### PR DESCRIPTION
This pull request moves the devmode certificates from the backend to the config. They are reachable by passing the DevMode argument when creating a new Config.