### PR TITLE
Allow connection to bitbox-base electrs

### DIFF
--- a/backend/bitboxbase/handlers/handlers.go
+++ b/backend/bitboxbase/handlers/handlers.go
@@ -24,6 +24,7 @@ import (
 //Base models the api of the base middleware
 type Base interface {
 	BlockInfo() string
+	ConnectElectrum() error
 }
 
 // Handlers provides a web API to the Bitbox.
@@ -40,6 +41,7 @@ func NewHandlers(
 	handlers := &Handlers{log: log.WithField("bitboxbase", "base")}
 
 	handleFunc("/blockinfo", handlers.getBlockInfoHandler).Methods("GET")
+	handleFunc("/connect-electrum", handlers.postConnectElectrumHandler).Methods("POST")
 
 	return handlers
 }
@@ -60,4 +62,12 @@ func (handlers *Handlers) Uninit() {
 func (handlers *Handlers) getBlockInfoHandler(_ *http.Request) (interface{}, error) {
 	handlers.log.Debug("Block Info")
 	return handlers.base.BlockInfo(), nil
+}
+
+func (handlers *Handlers) postConnectElectrumHandler(r *http.Request) (interface{}, error) {
+	err := handlers.base.ConnectElectrum()
+	if err != nil {
+		return map[string]interface{}{"success": false}, nil
+	}
+	return map[string]interface{}{"success": true}, nil
 }

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -228,6 +228,39 @@ func NewConfig(appConfigFilename string, accountsConfigFilename string) (*Config
 	return config, nil
 }
 
+// SetBtcOnly sets non-bitcoin accounts in the config to false
+func (config *Config) SetBtcOnly() {
+	config.appConfig.Backend.LitecoinP2WPKHP2SHActive = false
+	config.appConfig.Backend.LitecoinP2WPKHActive = false
+	config.appConfig.Backend.EthereumActive = false
+}
+
+// SetBTCElectrumServers sets the BTC configuration to the provided electrumIP and electrumCert
+func (config *Config) SetBTCElectrumServers(electrumAddress, electrumCert string) {
+	config.appConfig.Backend.BTC = btcCoinConfig{
+		ElectrumServers: []*rpc.ServerInfo{
+			{
+				Server:  electrumAddress,
+				TLS:     true,
+				PEMCert: electrumCert,
+			},
+		},
+	}
+}
+
+// SetTBTCElectrumServers sets the TBTC configuration to the provided electrumIP and electrumCert
+func (config *Config) SetTBTCElectrumServers(electrumAddress, electrumCert string) {
+	config.appConfig.Backend.TBTC = btcCoinConfig{
+		ElectrumServers: []*rpc.ServerInfo{
+			{
+				Server:  electrumAddress,
+				TLS:     true,
+				PEMCert: electrumCert,
+			},
+		},
+	}
+}
+
 func (config *Config) load() {
 	jsonBytes, err := ioutil.ReadFile(config.appConfigFilename)
 	if err != nil {

--- a/frontends/web/src/components/bitboxbase/connectbase.tsx
+++ b/frontends/web/src/components/bitboxbase/connectbase.tsx
@@ -51,17 +51,25 @@ export class ConnectedBase extends Component<Props, State> {
         }
     }
 
-    private removeBitBoxBase = (event: Event) => {
-        event.preventDefault();
+    private removeBitBoxBase = () => {
         apiPost('bitboxbases/disconnectbase', {
             bitboxBaseID : this.props.bitboxBaseID,
-        }).then(data => {
-            const { success } = data;
+        }).then(({ success }) => {
             if (!success) {
                 alertUser('Did not work');
             }
         });
 
+    }
+
+    private connectElectrum = () => {
+        apiPost('bitboxbases/' + this.props.bitboxBaseID + '/connect-electrum', {
+            bitboxBaseID : this.props.bitboxBaseID,
+        }).then(({success}) => {
+            if (!success) {
+                alertUser(success.errorMessage);
+            }
+        });
     }
 
     public render(
@@ -95,6 +103,11 @@ export class ConnectedBase extends Component<Props, State> {
                         <p>Lightning Alias: {alias}</p>
                         <div class="buttons flex flex-row flex-end">
                             <Button onClick={this.removeBitBoxBase} danger>Delete</Button>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="buttons flex flex-row flex-end">
+                            <Button onClick={this.connectElectrum}>Connect Electrum</Button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This commit adds support to connect with electrs running testnet or mainnet on the BitBox Base. A new postConnectElectrumHandler was created for this purpose. It takes a bitboxBaseID, from that gets
the connected BitBox Bases'IP and initiates a connection with the base.

The electrs port and network type (mainnet/testnet) are fetched with the GetEnv get request.

Once connected, other active backends will be unset, such that only bitcoin accounts will be available.