### PR TITLE
android: use subfolder in internal storage

### DIFF
--- a/frontends/android/BitBox/app/src/main/java/com/shiftcryptosecurity/bitbox/GoViewModel.java
+++ b/frontends/android/BitBox/app/src/main/java/com/shiftcryptosecurity/bitbox/GoViewModel.java
@@ -158,7 +158,7 @@ public class GoViewModel extends AndroidViewModel {
         this.goEnvironment = new GoEnvironment();
         this.goAPI = new GoAPI();
 
-        Goserver.serve(app.getApplicationInfo(). dataDir, this.goEnvironment, this.goAPI);
+        Goserver.serve(app.getApplicationContext().getFilesDir().getAbsolutePath(), this.goEnvironment, this.goAPI);
     }
 
     @Override

--- a/frontends/android/BitBox/app/src/main/java/com/shiftcryptosecurity/bitbox/MainActivity.java
+++ b/frontends/android/BitBox/app/src/main/java/com/shiftcryptosecurity/bitbox/MainActivity.java
@@ -110,8 +110,6 @@ public class MainActivity extends AppCompatActivity {
         vw.clearCache(true);
         vw.clearHistory();
         vw.getSettings().setJavaScriptEnabled(true);
-        vw.getSettings().setDomStorageEnabled(true);
-        // For the frontend to be able to access the Go api on localhost:8082
         vw.getSettings().setAllowUniversalAccessFromFileURLs(true);
 
         vw.setWebViewClient(new WebViewClient() {


### PR DESCRIPTION
According to
https://developer.android.com/training/data-storage/files.html#WriteInternalStorage

Also remove unused setDomStorageEnabled().