### PR TITLE
backend/coin: add isFee to unit, formatting amount

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -414,22 +414,22 @@ func (backend *Backend) Coin(code string) (coin.Coin, error) {
 		coin = btc.NewCoin(coinLTC, "LTC", &ltc.MainNetParams, dbFolder, servers,
 			"https://insight.litecore.io/tx/")
 	case coinETH:
-		coin = eth.NewCoin(code, params.MainnetChainConfig,
+		coin = eth.NewCoin(code, "ETH", "ETH", params.MainnetChainConfig,
 			"https://etherscan.io/tx/",
 			"https://api.etherscan.io/api",
 			backend.config.AppConfig().Backend.ETH.NodeURL, nil)
 	case coinRETH:
-		coin = eth.NewCoin(code, params.RinkebyChainConfig,
+		coin = eth.NewCoin(code, "RETH", "RETH", params.RinkebyChainConfig,
 			"https://rinkeby.etherscan.io/tx/",
 			"https://api-rinkeby.etherscan.io/api",
 			backend.config.AppConfig().Backend.RETH.NodeURL, nil)
 	case coinTETH:
-		coin = eth.NewCoin(code, params.TestnetChainConfig,
+		coin = eth.NewCoin(code, "TETH", "TETH", params.TestnetChainConfig,
 			"https://ropsten.etherscan.io/tx/",
 			"https://api-ropsten.etherscan.io/api",
 			backend.config.AppConfig().Backend.TETH.NodeURL, nil)
 	case coinERC20TEST:
-		coin = eth.NewCoin(code, params.TestnetChainConfig,
+		coin = eth.NewCoin(code, "TEST", "TETH", params.TestnetChainConfig,
 			"https://ropsten.etherscan.io/tx/",
 			"https://api-ropsten.etherscan.io/api",
 			backend.config.AppConfig().Backend.TETH.NodeURL,

--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -122,19 +122,19 @@ func (coin *Coin) Net() *chaincfg.Params {
 }
 
 // Unit implements coin.Coin.
-func (coin *Coin) Unit() string {
+func (coin *Coin) Unit(bool) string {
 	return coin.unit
 }
 
 // FormatAmount implements coin.Coin.
-func (coin *Coin) FormatAmount(amount coin.Amount) string {
+func (coin *Coin) FormatAmount(amount coin.Amount, isFee bool) string {
 	return strings.TrimRight(strings.TrimRight(
 		new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(unitSatoshi)).FloatString(8),
 		"0"), ".")
 }
 
 // ToUnit implements coin.Coin.
-func (coin *Coin) ToUnit(amount coin.Amount) float64 {
+func (coin *Coin) ToUnit(amount coin.Amount, isFee bool) float64 {
 	result, _ := new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(unitSatoshi)).Float64()
 	return result
 }

--- a/backend/coins/coin/coin.go
+++ b/backend/coins/coin/coin.go
@@ -30,14 +30,15 @@ type Coin interface {
 	// // https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 	// Type() uint32
 
-	// Unit is the unit code of the string for formatting amounts.
-	Unit() string
+	// Unit is the unit code for formatting amounts, e.g. "BTC".
+	// The fee unit is usually the same as the main unit, but can differ.
+	Unit(isFee bool) string
 
 	// FormatAmount formats the given amount as a number.
-	FormatAmount(Amount) string
+	FormatAmount(amount Amount, isFee bool) string
 
 	// ToUnit returns the given amount in the unit as returned above.
-	ToUnit(Amount) float64
+	ToUnit(amount Amount, isFee bool) float64
 
 	// // Server returns the host and port of the full node used for blockchain synchronization.
 	// Server() string

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -767,11 +767,11 @@ func (handlers *Handlers) apiMiddleware(devMode bool, h func(*http.Request) (int
 	})
 }
 
-func formatAmountAsJSON(amount coin.Amount, coin coin.Coin) accountHandlers.FormattedAmount {
+func formatAmountAsJSON(amount coin.Amount, coin coin.Coin, isFee bool) accountHandlers.FormattedAmount {
 	return accountHandlers.FormattedAmount{
-		Amount:      coin.FormatAmount(amount),
-		Unit:        coin.Unit(),
-		Conversions: accountHandlers.Conversions(amount, coin),
+		Amount:      coin.FormatAmount(amount, isFee),
+		Unit:        coin.Unit(isFee),
+		Conversions: accountHandlers.Conversions(amount, coin, isFee),
 	}
 }
 
@@ -803,8 +803,8 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 			AccountCode: account.Code(),
 			Name:        account.Name(),
 			Balance: map[string]interface{}{
-				"available":   formatAmountAsJSON(balance.Available(), account.Coin()),
-				"incoming":    formatAmountAsJSON(balance.Incoming(), account.Coin()),
+				"available":   formatAmountAsJSON(balance.Available(), account.Coin(), false),
+				"incoming":    formatAmountAsJSON(balance.Incoming(), account.Coin(), false),
 				"hasIncoming": balance.Incoming().BigInt().Sign() > 0,
 			},
 		})
@@ -819,7 +819,7 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 
 	jsonTotals := make(map[string]accountHandlers.FormattedAmount)
 	for c, total := range totals {
-		jsonTotals[c.Code()] = formatAmountAsJSON(coin.NewAmount(total), c)
+		jsonTotals[c.Code()] = formatAmountAsJSON(coin.NewAmount(total), c, false)
 	}
 
 	return map[string]interface{}{


### PR DESCRIPTION
Fees can be in a different unit, so this parameter is added so coin
implementations can treat fees differently if needed (example: ERC20
Token is the main unit, ETH is the fee unit).