### PR TITLE
Handle Disconnects of the RPC Connection

### DIFF
--- a/backend/bitboxbase/handlers/handlers.go
+++ b/backend/bitboxbase/handlers/handlers.go
@@ -17,6 +17,7 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/bitboxbase/rpcclient"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/jsonp"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
@@ -24,7 +25,7 @@ import (
 
 //Base models the api of the base middleware
 type Base interface {
-	MiddlewareInfo() interface{}
+	MiddlewareInfo() (rpcclient.SampleInfoResponse, error)
 	ConnectElectrum() error
 }
 
@@ -61,8 +62,12 @@ func (handlers *Handlers) Uninit() {
 }
 
 func (handlers *Handlers) getMiddlewareInfoHandler(_ *http.Request) (interface{}, error) {
-	handlers.log.Debug("Block Info")
-	return jsonp.MustMarshal(handlers.base.MiddlewareInfo()), nil
+	handlers.log.Debug("Middleware Info")
+	middlewareInfo, err := handlers.base.MiddlewareInfo()
+	if err != nil {
+		return nil, err
+	}
+	return jsonp.MustMarshal(middlewareInfo), nil
 }
 
 func (handlers *Handlers) postConnectElectrumHandler(r *http.Request) (interface{}, error) {

--- a/backend/bitboxbase/rpcclient/rpcclient.go
+++ b/backend/bitboxbase/rpcclient/rpcclient.go
@@ -136,12 +136,12 @@ func NewRPCClient(address string, bitboxBaseConfigDir string, onUnregister func(
 func (rpcClient *RPCClient) Ping() (bool, error) {
 	response, err := http.Get("http://" + rpcClient.address + "/")
 	if err != nil {
-		rpcClient.log.Println("No response from middleware", err)
+		rpcClient.log.WithError(err).Error("No response from middleware")
 		return false, err
 	}
 
 	if response.StatusCode != http.StatusOK {
-		rpcClient.log.Println("Received http status code from middleware other than 200")
+		rpcClient.log.Error("Received http status code from middleware other than 200")
 		return false, nil
 	}
 	return true, nil
@@ -151,7 +151,7 @@ func (rpcClient *RPCClient) Ping() (bool, error) {
 // then establishing a websocket connection, then authenticating and encrypting all further traffic with noise.
 func (rpcClient *RPCClient) Connect(bitboxBaseID string) error {
 	rpcClient.bitboxBaseID = bitboxBaseID
-	rpcClient.log.Printf("connecting to base websocket")
+	rpcClient.log.Infof("connecting to bitbox base websocket with id %q", bitboxBaseID)
 	connected, err := rpcClient.Ping()
 	if err != nil {
 		return err
@@ -173,45 +173,55 @@ func (rpcClient *RPCClient) Connect(bitboxBaseID string) error {
 
 func (rpcClient *RPCClient) parseMessage(message []byte) {
 	if len(message) == 0 {
-		rpcClient.log.Println("Received empty message")
+		rpcClient.log.Error("Received empty message, dropping.")
 		return
 	}
 	opCode := message[0]
 	switch opCode {
 	case opUCanHasDemo:
-		go rpcClient.SampleInfo()
+		go func() {
+			_, err := rpcClient.SampleInfo()
+			if err != nil {
+				rpcClient.log.WithError(err).Error("GetSampleInfo notification triggered rpc call failed")
+			}
+		}()
 	case opRPCCall:
 		message := message[1:]
 		rpcClient.rpcConnection.ReadChan() <- message
 	default:
-		rpcClient.log.Println("Received message without opCode")
+		rpcClient.log.Error("Received message without opCode, dropping.")
 	}
 }
 
 // Stop shuts down the websocket connection with the base
 func (rpcClient *RPCClient) Stop() {
-	rpcClient.client.Close()
+	err := rpcClient.client.Close()
+	if err != nil {
+		rpcClient.log.WithError(err).Error("failed to close rpc client")
+	}
 }
 
 // GetEnv makes a synchronous rpc call to the base and returns the network type and electrs rpc port
-func (rpcClient *RPCClient) GetEnv() (string, string) {
+func (rpcClient *RPCClient) GetEnv() (GetEnvResponse, error) {
 	var reply GetEnvResponse
 	request := 1
 	err := rpcClient.client.Call("RPCServer.GetSystemEnv", request, &reply)
 	if err != nil {
-		rpcClient.log.Printf("Failed with: %v", err)
+		rpcClient.log.WithError(err).Error("GetSystemEnv RPC call failed")
+		return reply, err
 	}
-	return reply.Network, reply.ElectrsRPCPort
+	return reply, nil
 }
 
 // SampleInfo make a synchronous rpc call to the base, emits an event containing the SampleInfo struct
 // to the frontend and returns the SampleInfo struct
-func (rpcClient *RPCClient) SampleInfo() SampleInfoResponse {
+func (rpcClient *RPCClient) SampleInfo() (SampleInfoResponse, error) {
 	var reply SampleInfoResponse
 	request := 1
 	err := rpcClient.client.Call("RPCServer.GetSampleInfo", request, &reply)
 	if err != nil {
-		rpcClient.log.Printf("Failed with: %v", err)
+		rpcClient.log.WithError(err).Error("GetSampleInfo RPC call failed")
+		return reply, err
 	}
 	rpcClient.Notify(observable.Event{
 		Subject: fmt.Sprintf("/bitboxbases/%s/middlewareinfo", rpcClient.bitboxBaseID),
@@ -219,5 +229,5 @@ func (rpcClient *RPCClient) SampleInfo() SampleInfoResponse {
 		Object:  reply,
 	})
 
-	return reply
+	return reply, nil
 }


### PR DESCRIPTION
The backend now passes a callback to properly unregister through the manager and bitboxbase package to the rpcclient. In case the websocket connection fails, the callback is called and both read and write websocket loops are closed.
Fix the ordering of the close channel to make sure that no double closing, or writing into a closed websocket connection occurs.
The rpc methods now return proper errors and need to get handled based
on their purpose. Also print the errors in their proper logging format.