### PR TITLE
Scripts/Regtest: Remove obsolete electrumx env vars

### DIFF
--- a/backend/coins/btc/electrum/client/client.go
+++ b/backend/coins/btc/electrum/client/client.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	clientVersion         = "0.0.1"
+	clientVersion         = "3.3.8"
 	clientProtocolVersion = "1.2"
 )
 

--- a/scripts/run_regtest.sh
+++ b/scripts/run_regtest.sh
@@ -60,14 +60,11 @@ docker run \
        -e DAEMON_URL="dbb:dbb@${DOCKER_IP}:10332" \
        -e COIN=BitcoinSegwit \
        -e NET=regtest \
-       -e RPC_PORT=10002 \
        -e PEER_DISCOVERY= \
-       -e HOST=0.0.0.0 \
-       -e RPC_HOST=0.0.0.0 \
-       -e TCP_PORT=52001 \
-       -e SSL_PORT=52002 \
        -p 52001:52001 \
+       -e REQUEST_SLEEP=0 \
        -p 10002:10002 \
+       -e SERVICES=rpc://0.0.0.0:10002,tcp://0.0.0.0:52001,ssl://0.0.0.0:52002 \
        --name=electrumx-regtest \
        lukechilds/electrumx &
 


### PR DESCRIPTION
With the current version I get `electrumx.lib.env_base.EnvBase.Error: remove obsolete environment variables ['HOST', 'TCP_PORT', 'SSL_PORT', 'RPC_HOST', 'RPC_PORT']`