### PR TITLE
Improve Mobile Pairing Error Messages

### DIFF
--- a/backend/devices/bitbox/events.go
+++ b/backend/devices/bitbox/events.go
@@ -25,6 +25,12 @@ const (
 	// EventPairingTimedout is fired when the pairing timed out.
 	EventPairingTimedout event.Event = "pairingTimedout"
 
+	// EventPullFailed is fired when a message cannot be pulled through the pairing relay server.
+	EventPairingPullMessageFailed event.Event = "pairingPullMessageFailed"
+
+	// EventPairingScanningFailed is fired when the mobile does not respond with success after scanning the pairing code.
+	EventPairingScanningFailed event.Event = "pairingScanningFailed"
+
 	// EventPairingAborted is fired when the pairing aborted.
 	EventPairingAborted event.Event = "pairingAborted"
 

--- a/backend/devices/bitbox/relay/request.go
+++ b/backend/devices/bitbox/relay/request.go
@@ -18,7 +18,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"strings"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 )
 
 // request models a request to the relay server.
@@ -77,6 +80,9 @@ func (request *request) send() (*response, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+	if httpResponse.StatusCode != http.StatusOK {
+		return nil, errp.New("Proxy Server did not respond with OK http status code, it is probably offline")
 	}
 	defer func() { _ = httpResponse.Body.Close() }()
 	body, err := ioutil.ReadAll(httpResponse.Body)

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -845,8 +845,16 @@
       "text": "Something went wrong. Please start again.",
       "title": "Error"
     },
+    "pullFailed": {
+      "text": "Failed to pull a message from your mobile through the relay server. The relay server might be offline, please contact support.",
+      "title": "Pull failed"
+    },
     "reconnectOnly": {
       "button": "Reconnect mobile app"
+    },
+    "scanningFailed": {
+      "text": "Mobile was not able to scan the message successfully. Please try again.",
+      "title": "Scanning Failed"
     },
     "start": {
       "hideAppQRCode": "Hide QR code",

--- a/frontends/web/src/routes/device/settings/components/mobile-pairing.tsx
+++ b/frontends/web/src/routes/device/settings/components/mobile-pairing.tsx
@@ -84,6 +84,12 @@ class MobilePairing extends Component<Props, State> {
                     this.setState({ status: 'timeout' });
                 }
                 break;
+            case 'pairingPullMessageFailed':
+                this.setState({ status: 'pullFailed' });
+                break;
+            case 'pairingScanningFailed':
+                this.setState({ status: 'scanningFailed' });
+                break;
             case 'pairingAborted':
                 this.setState({ status: 'aborted' });
                 break;


### PR DESCRIPTION
When the relay server is not reachable, the frontend just displays a timeout message, while the backend logs an unrelated error. This commit attempts to improve this by displaying a separate message in the frontend when messages are not relayed correctly and improves the logging in the backend.