### PR TITLE
frontend: upgrade preact to 8.5.2, fix TypeScript

### DIFF
--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -40,7 +40,7 @@
     "i18next-locize-backend": "1.6.0",
     "linkstate": "1.1.1",
     "locize-editor": "1.7.0",
-    "preact": "8.4.2",
+    "preact": "8.5.2",
     "preact-compat": "3.18.0",
     "preact-router": "2.6.1",
     "react-i18next": "7.9.0"

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -170,7 +170,7 @@ class App extends Component<Props, State> {
     }
 
     private toggleSidebar = () => {
-        this.setState(({ activeSidebar }) => ({ activeSidebar: !activeSidebar }));
+        panelStore.setState({ activeSidebar: !panelStore.state.activeSidebar });
     }
 
     public render(

--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -50,7 +50,7 @@ export class Entry extends Component<Props, State> {
     }
 
     private toggle = () => {
-        this.setState((state: State): State => ({
+        this.setState(state => ({
             shown: !state.shown,
             highlighted: false,
         }));

--- a/frontends/web/src/decorators/subscribe.tsx
+++ b/frontends/web/src/decorators/subscribe.tsx
@@ -67,13 +67,13 @@ export function subscribe<LoadedProps extends ObjectButNotFunction, ProvidedProp
                         this.setState({ [key]: event.object } as Pick<LoadedProps, keyof LoadedProps>);
                         break;
                     case 'prepend':
-                        this.setState((state: LoadedProps) => ({ [key]: [event.object, ...state[key] as any] }));
+                        this.setState(state => ({ [key]: [event.object, ...state[key] as any] } as any));
                         break;
                     case 'append':
-                        this.setState((state: LoadedProps) => ({ [key]: [...state[key] as any, event.object] }));
+                        this.setState(state => ({ [key]: [...state[key] as any, event.object] } as any));
                         break;
                     case 'remove':
-                        this.setState((state: LoadedProps) => ({ [key]: (state[key] as any).filter((item: any) => !equal(item, event.object)) }));
+                        this.setState(state => ({ [key]: (state[key] as any).filter((item: any) => !equal(item, event.object)) } as any));
                         break;
                     case 'reload':
                         apiGet(event.subject).then(object => this.setState({ [key]: object } as Pick<LoadedProps, keyof LoadedProps>));

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -91,7 +91,7 @@ interface State {
     amountError?: string;
     dataError?: string;
     paired?: boolean;
-    noMobileChannelError: boolean;
+    noMobileChannelError?: boolean;
     signProgress?: SignProgress;
     // show visual BitBox in dialog when instructed to sign.
     // can't be undefined because of the default touchConfirm param in the wait dialog.

--- a/frontends/web/yarn.lock
+++ b/frontends/web/yarn.lock
@@ -7401,7 +7401,12 @@ preact-transition-group@^1.1.0, preact-transition-group@^1.1.1:
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
   integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
 
-preact@8.4.2, preact@^8.1.0:
+preact@8.5.2:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.2.tgz#2f532da485287c07369e08150cf4d23921a09789"
+  integrity sha512-37tlDJGq5IQKqGUbqPZ7qPtsTOWFyxe+ojAOFfzKo0dEPreenqrqgJuS83zGpeGAqD9h9L9Yr7QuxH2W4ZrKxg==
+
+preact@^8.1.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
   integrity sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A==


### PR DESCRIPTION
As far as I can judge, the preact update exposed problems that we already had before but which TypeScript didn't detect because it could pick the wrong method declaration and basically opt out of type checking. I fixed the issues but
- @originalblend337: Please review and test the change in `app.tsx` to the guide toggler (the behavior should have been broken before and I haven't tested the effect of my fix).
- @benma: Please check and test the change in `send.tsx`. The problem was more or less that `boolean | undefined` could not be assigned to `boolean` so I made `noMobileChannelError` optional as well.