### PR TITLE
scripts/go-get: do not build the fetched package immediately

### DIFF
--- a/scripts/go-get.sh
+++ b/scripts/go-get.sh
@@ -9,7 +9,7 @@
 
 REVISION=$1
 shift
-go get -u $@
+go get -d -u $@
 cd "$GOPATH/src/$1"
 git checkout "$REVISION"
 go install ./...


### PR DESCRIPTION
The newest checkout might not build, but it doesn't need to if we're
interested in an older version.