### PR TITLE
frontend: improve upgrade firmware screen UI

### DIFF
--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -42,7 +42,6 @@ interface State {
         upgradeSuccessful: boolean;
         rebootSeconds: number;
     };
-    advancedSettings: boolean;
 }
 
 class BitBox02Bootloader extends Component<Props, State> {
@@ -56,7 +55,6 @@ class BitBox02Bootloader extends Component<Props, State> {
                 upgradeSuccessful: false,
                 rebootSeconds: 0,
             },
-            advancedSettings: false,
         };
     }
 
@@ -108,7 +106,6 @@ class BitBox02Bootloader extends Component<Props, State> {
           erased,
         }: RenderableProps<Props>,
         { status,
-          advancedSettings,
         }: State,
     ) {
         let contents;
@@ -132,7 +129,7 @@ class BitBox02Bootloader extends Component<Props, State> {
             }
         } else {
             contents = (
-                <div className="box large">
+                <div className="box large" style="min-height: 390px">
                     <div className="buttons">
                         <Button
                             primary
@@ -147,7 +144,7 @@ class BitBox02Bootloader extends Component<Props, State> {
                             </Button>
                         )}
                     </div>
-                    <div>
+                    <div className="flex flex-center" style="margin-top: 32px">
                         {t('bb02Bootloader.orientation')}&nbsp;
                         <a
                             onClick={this.screenRotate}
@@ -156,19 +153,15 @@ class BitBox02Bootloader extends Component<Props, State> {
                         </a>
                     </div>
                     <hr/>
-                    <div>
-                        <a
-                            onClick={() => { this.setState({ advancedSettings: !advancedSettings }); }}
-                            style="text-decoration: underline; cursor: pointer;" >
-                            { advancedSettings ? '-' : '+' } Advanced Settings
-                        </a>
-                    </div>
-                    { advancedSettings && (
+                    <details>
+                        <summary>
+                            {t('bb02Bootloader.advanced.label')}
+                        </summary>
                           <div>
                               <br />
                               <ToggleShowFirmwareHash deviceID={deviceID} />
                           </div>
-                    )}
+                    </details>
                 </div>
             );
         }

--- a/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
@@ -18,7 +18,7 @@ import { Component, h, RenderableProps } from 'preact';
 import { load } from '../../../decorators/load';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiPost } from '../../../utils/request';
-import { Checkbox } from '../../forms';
+import { Toggle } from '../../toggle/toggle';
 
 interface ToggleProps {
     deviceID: string;
@@ -30,7 +30,7 @@ interface LoadedProps {
 
 type Props = ToggleProps & LoadedProps & TranslateProps;
 
-class Toggle extends Component<Props, {}> {
+class ToggleFWHash extends Component<Props, {}> {
     private handleToggle = event => {
         apiPost(
             'devices/bitbox02-bootloader/' + this.props.deviceID + '/set-firmware-hash-enabled',
@@ -45,16 +45,20 @@ class Toggle extends Component<Props, {}> {
         {}: {},
     ) {
         return (
-            <Checkbox
-                checked={enabled}
-                id="togggle-show-firmware-hash"
-                onChange={this.handleToggle}
-                label={t('bb02Bootloader.advanced.toggleShowFirmwareHash')}
-                className="text-medium" />
+            <div className="box slim divide">
+                <div class="flex flex-row flex-between flex-items-center">
+                    <p className="m-none">{t('bb02Bootloader.advanced.toggleShowFirmwareHash')}</p>
+                    <Toggle
+                        checked={enabled}
+                        id="togggle-show-firmware-hash"
+                        onChange={this.handleToggle}
+                        className="text-medium" />
+                </div>
+            </div>
         );
     }
 }
 
-const loadHOC = load<LoadedProps, ToggleProps & TranslateProps>(({ deviceID }) => ({ enabled: 'devices/bitbox02-bootloader/' + deviceID + '/show-firmware-hash-enabled' }))(Toggle);
+const loadHOC = load<LoadedProps, ToggleProps & TranslateProps>(({ deviceID }) => ({ enabled: 'devices/bitbox02-bootloader/' + deviceID + '/show-firmware-hash-enabled' }))(ToggleFWHash);
 const HOC = translate<ToggleProps>()(loadHOC);
 export { HOC as ToggleShowFirmwareHash };

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -114,6 +114,7 @@
   "bb02Bootloader": {
     "abort": "Don't upgrade – Take me back",
     "advanced": {
+      "label": "Advanced Settings",
       "toggleShowFirmwareHash": "Show the firmware hash every time on startup"
     },
     "flipscreen": "Flip screen",


### PR DESCRIPTION
- Improves the update firmware screen with our new toggle button.
- Makes the content box fixed size so it doesn't jump with the added checkbox div (which also moved the Advanced Settings link, making the user unable to open/close without moving cursor)
- Center and add margin to "Device oriented the wrong way"

Before:
![Screencast2019-09-23131651](https://user-images.githubusercontent.com/14039565/65422171-06658f80-de06-11e9-9487-892b1eb3a201.gif)

After:
![Screencast2019-09-23131508](https://user-images.githubusercontent.com/14039565/65422182-0b2a4380-de06-11e9-87e0-407e2d4dd254.gif)

