### PR TITLE
frontend/eth: warning to only receive only the current coin

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -614,6 +614,7 @@ func (backend *Backend) initDefaultAccounts() {
 
 			ETH, _ := backend.Coin(coinETH)
 			const ethAccountCode = "eth"
+			// Once the BETA label is removed, also remove the 'BETA' string replace in receive.jsx
 			backend.createAndAddAccount(ETH, ethAccountCode, "Ethereum BETA", "m/44'/60'/0'/0/0", signing.ScriptTypeP2WPKH)
 
 			if backend.config.AppConfig().Backend.AccountActive(ethAccountCode) {

--- a/backend/erc20.go
+++ b/backend/erc20.go
@@ -24,6 +24,8 @@ type erc20Token struct {
 }
 
 var erc20Tokens = []erc20Token{
+	// Note: if you change the coinCode from eth-erc20- to something else, make sure to check for
+	// instances of it in the frontend.
 	{
 		code:  "eth-erc20-usdt",
 		name:  "Tether USD BETA",

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -719,6 +719,10 @@
       "info": "Litecoin is transitioning from addresses starting with '3' to addresses starting with an 'M'.",
       "result": "Legacy format of {{address}}:\n{{legacyAddress}}"
     },
+    "onlyThisCoin": {
+      "description": "To receive other tokens, enable them in the settings. If you deposit other tokens, they might not be accessible.",
+      "warning": "Make sure to only receive {{accountName}} on this address."
+    },
     "showFull": "Show and verify full address on device",
     "title": "Get {{accountName}}",
     "verify": "Verify address securely",

--- a/frontends/web/src/routes/account/receive/receive.jsx
+++ b/frontends/web/src/routes/account/receive/receive.jsx
@@ -17,6 +17,7 @@
 import { Component, h } from 'preact';
 import { route } from 'preact-router';
 import { translate } from 'react-i18next';
+import { isEthereumBased } from '../utils';
 import { apiGet, apiPost } from '../../../utils/request';
 import { Button, ButtonLink } from '../../../components/forms';
 import { Dialog } from '../../../components/dialog/dialog';
@@ -298,6 +299,15 @@ export default class Receive extends Component {
                             disableEscape={true}
                             medium centered>
                             <div className="text-center">
+                                {
+                                    isEthereumBased(account.coinCode) &&
+                                    <p>
+                                        <strong>
+                                            {t('receive.onlyThisCoin.warning', { accountName: account.name.replace(' BETA', '') })}
+                                        </strong><br />
+                                        {t('receive.onlyThisCoin.description')}
+                                    </p>
+                                }
                                 <QRCode data={uriPrefix + address} />
                                 <p>{t('receive.verifyInstruction')}</p>
                             </div>

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -25,3 +25,7 @@ export function isBitcoinBased(coinCode: string): boolean {
         return false;
     }
 }
+
+export function isEthereumBased(coinCode: string): boolean {
+    return coinCode === 'eth' || coinCode.startsWith('eth-erc20-');
+}


### PR DESCRIPTION
In the receive tab, when verifying. Reason: we currently do not
support all erc-20 tokens. This guides the user to activate the token
they want in the settings.