### PR TITLE
BitBoxBase: Move ToggleSetting to a Struct

### DIFF
--- a/backend/bitboxbase/bitboxbase.go
+++ b/backend/bitboxbase/bitboxbase.go
@@ -103,22 +103,22 @@ type Interface interface {
 	RestoreHSMSecret() error
 
 	// EnableTor enables/disables Tor
-	EnableTor(rpcmessages.ToggleSetting) error
+	EnableTor(rpcmessages.ToggleSettingArgs) error
 
 	// EnableTorMiddleware enables/disables Tor for the middleware
-	EnableTorMiddleware(rpcmessages.ToggleSetting) error
+	EnableTorMiddleware(rpcmessages.ToggleSettingArgs) error
 
 	// EnableTorElectrs enables/disables Tor for electrs
-	EnableTorElectrs(rpcmessages.ToggleSetting) error
+	EnableTorElectrs(rpcmessages.ToggleSettingArgs) error
 
 	// EnableTorSSH enables/disables Tor for SSH
-	EnableTorSSH(rpcmessages.ToggleSetting) error
+	EnableTorSSH(rpcmessages.ToggleSettingArgs) error
 
 	// EnableClearnetIBD configures bitcoind to run over clearnet while in IBD
-	EnableClearnetIBD(rpcmessages.ToggleSetting) error
+	EnableClearnetIBD(rpcmessages.ToggleSettingArgs) error
 
 	// EnableRootLogin enables/disables login via the root user/password
-	EnableRootLogin(rpcmessages.ToggleSetting) error
+	EnableRootLogin(rpcmessages.ToggleSettingArgs) error
 
 	// SetRootPassword sets the systems root password
 	SetRootPassword(string) error
@@ -452,8 +452,8 @@ func (base *BitBoxBase) RestoreSysconfig() error {
 	return nil
 }
 
-// EnableTor enables/disables Tor with rpcmessages.ToggleSettingEnable/Disable
-func (base *BitBoxBase) EnableTor(toggleAction rpcmessages.ToggleSetting) error {
+// EnableTor enables/disables Tor with rpcmessages.ToggleSettingArgs Enable/Disable
+func (base *BitBoxBase) EnableTor(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
 	}
@@ -469,8 +469,8 @@ func (base *BitBoxBase) EnableTor(toggleAction rpcmessages.ToggleSetting) error 
 	return nil
 }
 
-// EnableTorMiddleware enables/disables Tor for the middleware with rpcmessages.ToggleSettingEnable/Disable
-func (base *BitBoxBase) EnableTorMiddleware(toggleAction rpcmessages.ToggleSetting) error {
+// EnableTorMiddleware enables/disables Tor for the middleware with rpcmessages.ToggleSettingArgs Enable/Disable
+func (base *BitBoxBase) EnableTorMiddleware(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
 	}
@@ -486,8 +486,8 @@ func (base *BitBoxBase) EnableTorMiddleware(toggleAction rpcmessages.ToggleSetti
 	return nil
 }
 
-// EnableTorElectrs enables/disables Tor for electrs with rpcmessages.ToggleSettingEnable/Disable
-func (base *BitBoxBase) EnableTorElectrs(toggleAction rpcmessages.ToggleSetting) error {
+// EnableTorElectrs enables/disables Tor for electrs with rpcmessages.ToggleSettingArgs Enable/Disable
+func (base *BitBoxBase) EnableTorElectrs(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
 	}
@@ -503,8 +503,8 @@ func (base *BitBoxBase) EnableTorElectrs(toggleAction rpcmessages.ToggleSetting)
 	return nil
 }
 
-// EnableTorSSH enables/disables Tor for SSH with rpcmessages.ToggleSettingEnable/Disable
-func (base *BitBoxBase) EnableTorSSH(toggleAction rpcmessages.ToggleSetting) error {
+// EnableTorSSH enables/disables Tor for SSH with rpcmessages.ToggleSettingArgs Enable/Disable
+func (base *BitBoxBase) EnableTorSSH(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
 	}
@@ -520,8 +520,8 @@ func (base *BitBoxBase) EnableTorSSH(toggleAction rpcmessages.ToggleSetting) err
 	return nil
 }
 
-// EnableClearnetIBD configures bitcoind to run over clearnet while in IBD with rpcmessages.ToggleSettingEnable/Disable
-func (base *BitBoxBase) EnableClearnetIBD(toggleAction rpcmessages.ToggleSetting) error {
+// EnableClearnetIBD configures bitcoind to run over clearnet while in IBD with rpcmessages.ToggleSettingArgs Enable/Disable
+func (base *BitBoxBase) EnableClearnetIBD(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
 	}
@@ -537,8 +537,8 @@ func (base *BitBoxBase) EnableClearnetIBD(toggleAction rpcmessages.ToggleSetting
 	return nil
 }
 
-// EnableRootLogin enables/disables login via the root user/password with rpcmessages.ToggleSettingEnable/Disable
-func (base *BitBoxBase) EnableRootLogin(toggleAction rpcmessages.ToggleSetting) error {
+// EnableRootLogin enables/disables login via the root user/password with rpcmessages.ToggleSettingArgs Enable/Disable
+func (base *BitBoxBase) EnableRootLogin(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
 	}

--- a/backend/bitboxbase/handlers/handlers.go
+++ b/backend/bitboxbase/handlers/handlers.go
@@ -42,12 +42,12 @@ type Base interface {
 	BackupHSMSecret() error
 	RestoreSysconfig() error
 	RestoreHSMSecret() error
-	EnableTor(rpcmessages.ToggleSetting) error
-	EnableTorMiddleware(rpcmessages.ToggleSetting) error
-	EnableTorElectrs(rpcmessages.ToggleSetting) error
-	EnableTorSSH(rpcmessages.ToggleSetting) error
-	EnableClearnetIBD(rpcmessages.ToggleSetting) error
-	EnableRootLogin(rpcmessages.ToggleSetting) error
+	EnableTor(rpcmessages.ToggleSettingArgs) error
+	EnableTorMiddleware(rpcmessages.ToggleSettingArgs) error
+	EnableTorElectrs(rpcmessages.ToggleSettingArgs) error
+	EnableTorSSH(rpcmessages.ToggleSettingArgs) error
+	EnableClearnetIBD(rpcmessages.ToggleSettingArgs) error
+	EnableRootLogin(rpcmessages.ToggleSettingArgs) error
 	SetRootPassword(string) error
 	ShutdownBase() error
 	RebootBase() error
@@ -300,11 +300,12 @@ func (handlers *Handlers) postReindexBitcoinHandler(_ *http.Request) (interface{
 
 func (handlers *Handlers) postEnableTorHandler(r *http.Request) (interface{}, error) {
 	handlers.log.Debug("Enable Tor")
-	var toggleAction rpcmessages.ToggleSetting
+	var toggleAction bool
 	if err := json.NewDecoder(r.Body).Decode(&toggleAction); err != nil {
 		return nil, errp.WithStack(err)
 	}
-	if err := handlers.base.EnableTor(toggleAction); err != nil {
+	toggleActionArgs := rpcmessages.ToggleSettingArgs{ToggleSetting: toggleAction}
+	if err := handlers.base.EnableTor(toggleActionArgs); err != nil {
 		return bbBaseError(err, handlers.log), nil
 	}
 	return map[string]interface{}{
@@ -314,11 +315,12 @@ func (handlers *Handlers) postEnableTorHandler(r *http.Request) (interface{}, er
 
 func (handlers *Handlers) postEnableTorMiddlewareHandler(r *http.Request) (interface{}, error) {
 	handlers.log.Debug("Enable Tor for middleware")
-	var toggleAction rpcmessages.ToggleSetting
+	var toggleAction bool
 	if err := json.NewDecoder(r.Body).Decode(&toggleAction); err != nil {
 		return nil, errp.WithStack(err)
 	}
-	if err := handlers.base.EnableTorMiddleware(toggleAction); err != nil {
+	toggleActionArgs := rpcmessages.ToggleSettingArgs{ToggleSetting: toggleAction}
+	if err := handlers.base.EnableTorMiddleware(toggleActionArgs); err != nil {
 		return bbBaseError(err, handlers.log), nil
 	}
 	return map[string]interface{}{
@@ -328,11 +330,12 @@ func (handlers *Handlers) postEnableTorMiddlewareHandler(r *http.Request) (inter
 
 func (handlers *Handlers) postEnableTorElectrsHandler(r *http.Request) (interface{}, error) {
 	handlers.log.Debug("Enable Tor for electrs")
-	var toggleAction rpcmessages.ToggleSetting
+	var toggleAction bool
 	if err := json.NewDecoder(r.Body).Decode(&toggleAction); err != nil {
 		return nil, errp.WithStack(err)
 	}
-	if err := handlers.base.EnableTorElectrs(toggleAction); err != nil {
+	toggleActionArgs := rpcmessages.ToggleSettingArgs{ToggleSetting: toggleAction}
+	if err := handlers.base.EnableTorElectrs(toggleActionArgs); err != nil {
 		return bbBaseError(err, handlers.log), nil
 	}
 	return map[string]interface{}{
@@ -342,11 +345,12 @@ func (handlers *Handlers) postEnableTorElectrsHandler(r *http.Request) (interfac
 
 func (handlers *Handlers) postEnableTorSSHHandler(r *http.Request) (interface{}, error) {
 	handlers.log.Debug("Enable Tor for SSH")
-	var toggleAction rpcmessages.ToggleSetting
+	var toggleAction bool
 	if err := json.NewDecoder(r.Body).Decode(&toggleAction); err != nil {
 		return nil, errp.WithStack(err)
 	}
-	if err := handlers.base.EnableTorSSH(toggleAction); err != nil {
+	toggleActionArgs := rpcmessages.ToggleSettingArgs{ToggleSetting: toggleAction}
+	if err := handlers.base.EnableTorSSH(toggleActionArgs); err != nil {
 		return bbBaseError(err, handlers.log), nil
 	}
 	return map[string]interface{}{
@@ -356,11 +360,12 @@ func (handlers *Handlers) postEnableTorSSHHandler(r *http.Request) (interface{},
 
 func (handlers *Handlers) postEnableClearnetIBDHandler(r *http.Request) (interface{}, error) {
 	handlers.log.Debug("Enable clearnet for IBD")
-	var toggleAction rpcmessages.ToggleSetting
+	var toggleAction bool
 	if err := json.NewDecoder(r.Body).Decode(&toggleAction); err != nil {
 		return nil, errp.WithStack(err)
 	}
-	if err := handlers.base.EnableClearnetIBD(toggleAction); err != nil {
+	toggleActionArgs := rpcmessages.ToggleSettingArgs{ToggleSetting: toggleAction}
+	if err := handlers.base.EnableClearnetIBD(toggleActionArgs); err != nil {
 		return bbBaseError(err, handlers.log), nil
 	}
 	return map[string]interface{}{
@@ -370,11 +375,12 @@ func (handlers *Handlers) postEnableClearnetIBDHandler(r *http.Request) (interfa
 
 func (handlers *Handlers) postEnableRootLoginHandler(r *http.Request) (interface{}, error) {
 	handlers.log.Debug("Enable root login")
-	var toggleAction rpcmessages.ToggleSetting
+	var toggleAction bool
 	if err := json.NewDecoder(r.Body).Decode(&toggleAction); err != nil {
 		return nil, errp.WithStack(err)
 	}
-	if err := handlers.base.EnableRootLogin(toggleAction); err != nil {
+	toggleActionArgs := rpcmessages.ToggleSettingArgs{ToggleSetting: toggleAction}
+	if err := handlers.base.EnableRootLogin(toggleActionArgs); err != nil {
 		return bbBaseError(err, handlers.log), nil
 	}
 	return map[string]interface{}{

--- a/backend/bitboxbase/rpcclient/rpcclient.go
+++ b/backend/bitboxbase/rpcclient/rpcclient.go
@@ -317,8 +317,8 @@ func (rpcClient *RPCClient) RestoreHSMSecret() (rpcmessages.ErrorResponse, error
 	return reply, nil
 }
 
-// EnableTor makes an rpc call to the Base that enables/disables the tor.service based on rpcmessages.ToggleSettingEnable/Disable
-func (rpcClient *RPCClient) EnableTor(toggleAction rpcmessages.ToggleSetting) (rpcmessages.ErrorResponse, error) {
+// EnableTor makes an rpc call to the Base that enables/disables the tor.service based on rpcmessages.ToggleSettingArgs Enable/Disable
+func (rpcClient *RPCClient) EnableTor(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableTorTor: %t' rpc call\n", toggleAction)
 	var reply rpcmessages.ErrorResponse
 	err := rpcClient.client.Call("RPCServer.EnableTor", toggleAction, &reply)
@@ -328,8 +328,8 @@ func (rpcClient *RPCClient) EnableTor(toggleAction rpcmessages.ToggleSetting) (r
 	return reply, nil
 }
 
-// EnableTorMiddleware makes an rpc call to BitBoxBase that enables/disables the Tor hidden service for the middleware based on rpcmessages.ToggleSettingEnable/Disable
-func (rpcClient *RPCClient) EnableTorMiddleware(toggleAction rpcmessages.ToggleSetting) (rpcmessages.ErrorResponse, error) {
+// EnableTorMiddleware makes an rpc call to BitBoxBase that enables/disables the Tor hidden service for the middleware based on rpcmessages.ToggleSettingArgs Enable/Disable
+func (rpcClient *RPCClient) EnableTorMiddleware(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableTorMiddleware: %t' rpc call\n", toggleAction)
 	var reply rpcmessages.ErrorResponse
 	err := rpcClient.client.Call("RPCServer.EnableTorMiddleware", toggleAction, &reply)
@@ -339,8 +339,8 @@ func (rpcClient *RPCClient) EnableTorMiddleware(toggleAction rpcmessages.ToggleS
 	return reply, nil
 }
 
-// EnableTorElectrs makes an rpc call to BitBoxBase that enables/disables the Tor hidden service for electrs based on rpcmessages.ToggleSettingEnable/Disable
-func (rpcClient *RPCClient) EnableTorElectrs(toggleAction rpcmessages.ToggleSetting) (rpcmessages.ErrorResponse, error) {
+// EnableTorElectrs makes an rpc call to BitBoxBase that enables/disables the Tor hidden service for electrs based on rpcmessages.ToggleSettingArgs Enable/Disable
+func (rpcClient *RPCClient) EnableTorElectrs(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableTorElectrs: %t' rpc call\n", toggleAction)
 	var reply rpcmessages.ErrorResponse
 	err := rpcClient.client.Call("RPCServer.EnableTorElectrs", toggleAction, &reply)
@@ -350,8 +350,8 @@ func (rpcClient *RPCClient) EnableTorElectrs(toggleAction rpcmessages.ToggleSett
 	return reply, nil
 }
 
-// EnableTorSSH makes an rpc call to BitBoxBase that enables/disables the tor hidden service for SSH based on rpcmessages.ToggleSettingEnable/Disable
-func (rpcClient *RPCClient) EnableTorSSH(toggleAction rpcmessages.ToggleSetting) (rpcmessages.ErrorResponse, error) {
+// EnableTorSSH makes an rpc call to BitBoxBase that enables/disables the tor hidden service for SSH based on rpcmessages.ToggleSettingArgs Enable/Disable
+func (rpcClient *RPCClient) EnableTorSSH(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableTorSSH: %t' rpc call\n", toggleAction)
 	var reply rpcmessages.ErrorResponse
 	err := rpcClient.client.Call("RPCServer.EnableTorSSH", toggleAction, &reply)
@@ -361,8 +361,8 @@ func (rpcClient *RPCClient) EnableTorSSH(toggleAction rpcmessages.ToggleSetting)
 	return reply, nil
 }
 
-// EnableClearnetIBD makes an rpc call to BitBoxBase that configures bitcoind to run over clearnet while in IBD mode based on rpcmessages.ToggleSettingEnable/Disable
-func (rpcClient *RPCClient) EnableClearnetIBD(toggleAction rpcmessages.ToggleSetting) (rpcmessages.ErrorResponse, error) {
+// EnableClearnetIBD makes an rpc call to BitBoxBase that configures bitcoind to run over clearnet while in IBD mode based on rpcmessages.ToggleSettingArgs Enable/Disable
+func (rpcClient *RPCClient) EnableClearnetIBD(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableClearnetIBD: %t' rpc call\n", toggleAction)
 	var reply rpcmessages.ErrorResponse
 	err := rpcClient.client.Call("RPCServer.EnableClearnetIBD", toggleAction, &reply)
@@ -372,8 +372,8 @@ func (rpcClient *RPCClient) EnableClearnetIBD(toggleAction rpcmessages.ToggleSet
 	return reply, nil
 }
 
-// EnableRootLogin makes an rpc call to BitBoxBase that enables/disables login via the root user/password based on rpcmessages.ToggleSettingEnable/Disable
-func (rpcClient *RPCClient) EnableRootLogin(toggleAction rpcmessages.ToggleSetting) (rpcmessages.ErrorResponse, error) {
+// EnableRootLogin makes an rpc call to BitBoxBase that enables/disables login via the root user/password based on rpcmessages.ToggleSettingArgs Enable/Disable
+func (rpcClient *RPCClient) EnableRootLogin(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableRootLogin: %t' rpc call\n", toggleAction)
 	var reply rpcmessages.ErrorResponse
 	err := rpcClient.client.Call("RPCServer.EnableRootLogin", toggleAction, &reply)

--- a/backend/bitboxbase/rpcmessages/rpcmessages.go
+++ b/backend/bitboxbase/rpcmessages/rpcmessages.go
@@ -40,8 +40,10 @@ type SetRootPasswordArgs struct {
 	RootPassword string
 }
 
-// ToggleSetting is a generic message for settings that can be enabled or disabled
-type ToggleSetting bool
+// ToggleSettingArgs is a generic message for settings that can be enabled or disabled
+type ToggleSettingArgs struct {
+	ToggleSetting bool
+}
 
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.


### PR DESCRIPTION
In preperation for adding JSON Web Tokens to the rpc message structs, move standalone values to a struct.
@0xB10C corresponding pull request to https://github.com/digitalbitbox/bitbox-base/pull/226