### PR TITLE
backend/config: enable bech32 and legacy accounts by default

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -170,11 +170,11 @@ func NewDefaultAppConfig() AppConfig {
 				UseProxy:     false,
 				ProxyAddress: defaultProxyAddress,
 			},
-			BitcoinP2PKHActive:       false,
+			BitcoinP2PKHActive:       true,
 			BitcoinP2WPKHP2SHActive:  true,
-			BitcoinP2WPKHActive:      false,
+			BitcoinP2WPKHActive:      true,
 			LitecoinP2WPKHP2SHActive: true,
-			LitecoinP2WPKHActive:     false,
+			LitecoinP2WPKHActive:     true,
 			EthereumActive:           true,
 
 			BTC: btcCoinConfig{


### PR DESCRIPTION
Until we have a better account discovery, this makes it easier for
upgraded users to find their legacy account funds.

Also enable bech32 by default, as exchange support now is pretty good.