### PR TITLE
qt: remove CopyLinkToClipboard from context menu

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -64,7 +64,6 @@ public:
             page()->action(QWebEnginePage::Undo),
             page()->action(QWebEnginePage::Redo),
             page()->action(QWebEnginePage::SelectAll),
-            page()->action(QWebEnginePage::CopyLinkToClipboard),
             page()->action(QWebEnginePage::Unselect),
         };
         QMenu *menu = page()->createStandardContextMenu();


### PR DESCRIPTION
It appears in unexpected places like in the context menu of
`Settings`, which copies an internal qrc:/ link.