### PR TITLE
BitBoxBase: Add Authentication with JWT

### DIFF
--- a/backend/bitboxbase/handlers/handlers.go
+++ b/backend/bitboxbase/handlers/handlers.go
@@ -37,7 +37,7 @@ type Base interface {
 	ResyncBitcoin() error
 	SetHostname(string) error
 	UserAuthenticate(string, string) error
-	UserChangePassword(string, string) error
+	UserChangePassword(string, string, string) error
 	BackupSysconfig() error
 	BackupHSMSecret() error
 	RestoreSysconfig() error
@@ -227,13 +227,14 @@ func (handlers *Handlers) postUserAuthenticate(r *http.Request) (interface{}, er
 func (handlers *Handlers) postUserChangePassword(r *http.Request) (interface{}, error) {
 	payload := struct {
 		Username    string `json:"username"`
+		Password    string `json:"password"`
 		NewPassword string `json:"newPassword"`
 	}{}
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		return bbBaseError(err, handlers.log), nil
 	}
 
-	err := handlers.base.UserChangePassword(payload.Username, payload.NewPassword)
+	err := handlers.base.UserChangePassword(payload.Username, payload.Password, payload.NewPassword)
 	if err != nil {
 		return bbBaseError(err, handlers.log), nil
 	}

--- a/backend/bitboxbase/rpcclient/websocket.go
+++ b/backend/bitboxbase/rpcclient/websocket.go
@@ -235,14 +235,12 @@ func (rpcClient *RPCClient) initializeNoise(client *websocket.Conn) error {
 			return errp.New("pairing with BitBox Base failed")
 		}
 		rpcClient.channelHashAppVerified = true
-		rpcClient.onChangeStatus(bitboxbasestatus.StatusBitcoinPre)
 	} else {
 		err = client.WriteMessage(websocket.BinaryMessage, []byte(responseSuccess))
 		if err != nil {
 			return errp.New("the websocket failed writing the success message at the verification stage of the noise handshake")
 		}
 		rpcClient.channelHashAppVerified = true
-		rpcClient.onChangeStatus(bitboxbasestatus.StatusInitialized)
 	}
 
 	return nil

--- a/backend/bitboxbase/rpcmessages/rpcmessages.go
+++ b/backend/bitboxbase/rpcmessages/rpcmessages.go
@@ -20,36 +20,59 @@ const (
 Put Incoming Args below this line. They should have the format of 'RPC Method Name' + 'Args'.
 */
 
-// UserAuthenticateArgs is an struct that holds the arguments for the UserAuthenticate RPC call
+// UserAuthenticateArgs is a struct that holds the arguments for the UserAuthenticate RPC call. The first rpc call should always authenticate first
 type UserAuthenticateArgs struct {
 	Username string
 	Password string
 }
 
-// UserChangePasswordArgs is an struct that holds the arguments for the UserChangePassword RPC call
+// AuthGenericRequest is a struct that acts as a generic request struct
+type AuthGenericRequest struct {
+	Token string
+}
+
+// UserChangePasswordArgs is a struct that holds the arguments for the UserChangePassword RPC call
 type UserChangePasswordArgs struct {
 	Username    string
+	Password    string
 	NewPassword string
+	Token       string
 }
 
 // SetHostnameArgs is a struct that holds the to be set hostname
 type SetHostnameArgs struct {
 	Hostname string
+	Token    string
 }
 
 // SetRootPasswordArgs is a struct that holds the to be set root password
 type SetRootPasswordArgs struct {
 	RootPassword string
+	Token        string
 }
 
 // ToggleSettingArgs is a generic message for settings that can be enabled or disabled
 type ToggleSettingArgs struct {
 	ToggleSetting bool
+	Token         string
 }
 
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.
 */
+
+// SetupStatusResponse is the struct that gets sent by the rpc server during a SetupStatus rpc call.
+// This call is not authenticated and serves as indicator for what to show during the base setup wizzard.
+type SetupStatusResponse struct {
+	MiddlewarePasswordSet bool
+	BaseSetup             bool
+}
+
+// UserAuthenticateResponse is the struct that gets sent by the rpc server during a UserAuthenticate call. It contains the session's jwt token.
+type UserAuthenticateResponse struct {
+	ErrorResponse *ErrorResponse
+	Token         string
+}
 
 // GetEnvResponse is the struct that gets sent by the rpc server during a GetSystemEnv call
 type GetEnvResponse struct {

--- a/backend/bitboxbase/status/status.go
+++ b/backend/bitboxbase/status/status.go
@@ -29,8 +29,14 @@ const (
 	// StatusPairingFailed is when the pairing code was rejected on the app or on the BitBox Base.
 	StatusPairingFailed Status = "pairingFailed"
 
+	// StatusPasswordNotSet is after status unpaired, if the Base has not been initialized before.
+	StatusPasswordNotSet Status = "passwordNotSet"
+
 	// StatusBitcoinPre is after status unpaired, if the Base has not been initialized before.
 	StatusBitcoinPre Status = "bitcoinPre"
+
+	// StatusLocked is before status initialized and after unpairs, passwordNotSet or bitcoinPre
+	StatusLocked Status = "locked"
 
 	// StatusInitialized means the BitBox Base has verfied the pairing
 	StatusInitialized Status = "initialized"

--- a/frontends/web/src/components/bitboxbase/unlockbitboxbase.tsx
+++ b/frontends/web/src/components/bitboxbase/unlockbitboxbase.tsx
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2019 Shift Devices AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { alertUser } from '../../components/alert/Alert';
+import { Button } from '../../components/forms';
+import { AppLogo, SwissMadeOpenSource } from '../../components/icon/logo';
+import { Footer, Header } from '../../components/layout';
+import { PasswordSingleInput } from '../../components/password';
+import { translate, TranslateProps } from '../../decorators/translate';
+import { apiPost } from '../../utils/request';
+
+interface UnlockBitBoxBaseProps {
+    bitboxBaseID: string | null;
+}
+
+interface State {
+    password?: string;
+    username: string;
+}
+
+type Props = UnlockBitBoxBaseProps & TranslateProps;
+
+class UnlockBitBoxBase extends Component<Props, State> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            password: undefined,
+            username: 'admin',
+        };
+    }
+
+    private apiPrefix = () => {
+        return 'bitboxbases/' + this.props.bitboxBaseID;
+    }
+
+    private handleFormChange = password => {
+        this.setState({ password });
+    }
+
+    private validate = () => {
+        return this.state.password !== '';
+    }
+
+    private handleSubmit = event => {
+        event.preventDefault();
+        if (!this.validate()) {
+            return;
+        }
+        apiPost(this.apiPrefix() + '/user-authenticate', {username: 'admin', password: this.state.password })
+        .then(response => {
+            if (!response.success) {
+                // TODO: Once error codes are implemented on the base, add them with corresponding text to app.json for translation
+                alertUser(response.message);
+            }
+        });
+        this.setState({ password: '' });
+    }
+
+    public render(
+        {
+            t,
+        }: RenderableProps<Props>,
+        {
+            password,
+        }: State,
+    ) {
+        return (
+            <div class="contentWithGuide">
+                <div className="container">
+                    <Header title={<h2>{t('welcome.title')}</h2>} />
+                    <div className="innerContainer scrollableContainer">
+                        <div className="content narrow padded isVerticallyCentered">
+                            <AppLogo />
+                            <div class="box large">
+                                {
+                                    <form onSubmit={this.handleSubmit}>
+                                        <div className="m-top-default">
+                                            <PasswordSingleInput
+                                                autoFocus
+                                                id="password"
+                                                type="password"
+                                                label="Password"
+                                                placeholder={t('bitboxBaseUnlock.placeholder')}
+                                                onValidPassword={this.handleFormChange}
+                                                value={password} />
+                                        </div>
+                                        <div className="buttons">
+                                            <Button
+                                                primary
+                                                type="submit">
+                                                {t('button.unlock')}
+                                            </Button>
+                                        </div>
+                                    </form>
+                                }
+                            </div>
+                        </div>
+                        <Footer>
+                            <SwissMadeOpenSource />
+                        </Footer>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+const HOC = translate<UnlockBitBoxBaseProps>()(UnlockBitBoxBase);
+export { HOC as UnlockBitBoxBase};

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -237,6 +237,9 @@
     "manualInput": "Can't see your BitBoxBase? Connect manually below:",
     "title": "BitBoxBase"
   },
+  "bitboxBaseUnlock": {
+    "placeholder": "Enter your BitBoxBase password to unlock"
+  },
   "bitboxBaseWizard": {
     "bitcoin": {
       "pre": "Start syncing from pre-synced state",


### PR DESCRIPTION
All rpc calls now need to be authenticated with a token. A new token is received by calling the UserAuthenticate rpc method with the users's password and username.

This commit also re-works the setup wizzard for the BitBox Base to make sure that the authentication is run correctly and that the wizzard is not left in a state from which it cannot recover.

This PR needs to be tested against https://github.com/digitalbitbox/bitbox-base/pull/227