### PR TITLE
GetServiceInfo RPC

### DIFF
--- a/backend/bitboxbase/bitboxbase.go
+++ b/backend/bitboxbase/bitboxbase.go
@@ -131,6 +131,10 @@ type Interface interface {
 
 	// BaseInfo returns information about the Base
 	BaseInfo() (rpcmessages.GetBaseInfoResponse, error)
+
+	// ServiceInfo returns information about the services running on the Base
+	// As for example the bitcoind, electrs and ligthningd block height
+	ServiceInfo() (rpcmessages.GetServiceInfoResponse, error)
 }
 
 // SyncOption is a user provided blockchain sync option during BBB initialization
@@ -618,6 +622,22 @@ func (base *BitBoxBase) BaseInfo() (rpcmessages.GetBaseInfoResponse, error) {
 	}
 	if !reply.ErrorResponse.Success {
 		return rpcmessages.GetBaseInfoResponse{}, reply.ErrorResponse
+	}
+	return reply, nil
+}
+
+// ServiceInfo returns info about the Base contained in rpcmessages.GetServiceInfoResponse
+func (base *BitBoxBase) ServiceInfo() (rpcmessages.GetServiceInfoResponse, error) {
+	if !base.active {
+		return rpcmessages.GetServiceInfoResponse{}, errp.New("Attempted a call to non-active base")
+	}
+	base.log.Println("bitboxbase is making a GetServiceInfo call")
+	reply, err := base.rpcClient.GetServiceInfo()
+	if err != nil {
+		return rpcmessages.GetServiceInfoResponse{}, err
+	}
+	if !reply.ErrorResponse.Success {
+		return rpcmessages.GetServiceInfoResponse{}, reply.ErrorResponse
 	}
 	return reply, nil
 }

--- a/backend/bitboxbase/handlers/handlers.go
+++ b/backend/bitboxbase/handlers/handlers.go
@@ -52,6 +52,7 @@ type Base interface {
 	ShutdownBase() error
 	RebootBase() error
 	BaseInfo() (rpcmessages.GetBaseInfoResponse, error)
+	ServiceInfo() (rpcmessages.GetServiceInfoResponse, error)
 }
 
 // Handlers provides a web API to the Bitbox.
@@ -72,6 +73,7 @@ func NewHandlers(
 	handleFunc("/middleware-info", handlers.getMiddlewareInfoHandler).Methods("GET")
 	handleFunc("/verification-progress", handlers.getVerificationProgressHandler).Methods("GET")
 	handleFunc("/base-info", handlers.getBaseInfoHandler).Methods("GET")
+	handleFunc("/service-info", handlers.getServiceInfoHandler).Methods("GET")
 	handleFunc("/backup-sysconfig", handlers.postBackupSysconfigHandler).Methods("POST")
 	handleFunc("/backup-hsm-secret", handlers.postBackupHSMSecretHandler).Methods("POST")
 	handleFunc("/restore-sysconfig", handlers.postRestoreSysconfigHandler).Methods("POST")
@@ -439,5 +441,17 @@ func (handlers *Handlers) getBaseInfoHandler(_ *http.Request) (interface{}, erro
 	return map[string]interface{}{
 		"success":  true,
 		"baseInfo": baseInfo,
+	}, nil
+}
+
+func (handlers *Handlers) getServiceInfoHandler(_ *http.Request) (interface{}, error) {
+	handlers.log.Debug("Service Info")
+	baseInfo, err := handlers.base.ServiceInfo()
+	if err != nil {
+		return bbBaseError(err, handlers.log), nil
+	}
+	return map[string]interface{}{
+		"success":     true,
+		"serviceInfo": baseInfo,
 	}, nil
 }

--- a/backend/bitboxbase/rpcclient/rpcclient.go
+++ b/backend/bitboxbase/rpcclient/rpcclient.go
@@ -170,6 +170,8 @@ func (rpcClient *RPCClient) parseMessage(message []byte) {
 		rpcClient.onEvent(bitboxbasestatus.EventSampleInfoChange)
 	case rpcmessages.OpUCanHasVerificationProgress:
 		rpcClient.onEvent(bitboxbasestatus.EventVerificationProgressChange)
+	case rpcmessages.OpServiceInfoChanged:
+		rpcClient.onEvent(bitboxbasestatus.EventServiceInfoChanged)
 	case rpcmessages.OpRPCCall:
 		message := message[1:]
 		rpcClient.rpcConnection.ReadChan() <- message
@@ -422,6 +424,17 @@ func (rpcClient *RPCClient) GetBaseInfo() (rpcmessages.GetBaseInfoResponse, erro
 	err := rpcClient.client.Call("RPCServer.GetBaseInfo", true /*dummy Arg */, &reply)
 	if err != nil {
 		rpcClient.log.WithError(err).Error("GetBaseInfo RPC call failed")
+		return reply, err
+	}
+	return reply, nil
+}
+
+// GetServiceInfo makes a synchronous RPC call to the Base and returns the GetServiceInfoResponse struct
+func (rpcClient *RPCClient) GetServiceInfo() (rpcmessages.GetServiceInfoResponse, error) {
+	var reply rpcmessages.GetServiceInfoResponse
+	err := rpcClient.client.Call("RPCServer.GetServiceInfo", true /*dummy Arg */, &reply)
+	if err != nil {
+		rpcClient.log.WithError(err).Error("GetServiceInfo RPC call failed")
 		return reply, err
 	}
 	return reply, nil

--- a/backend/bitboxbase/rpcmessages/rpcmessages.go
+++ b/backend/bitboxbase/rpcmessages/rpcmessages.go
@@ -12,6 +12,8 @@ const (
 	OpUCanHasSampleInfo = "d"
 	// OpUCanHasVerificationProgress notifies when new VerificationProgress data is available.
 	OpUCanHasVerificationProgress = "v"
+	// OpServiceInfoChanged notifies when the GetServiceInfo data changed.
+	OpServiceInfoChanged = "s"
 )
 
 /*
@@ -86,6 +88,18 @@ type GetBaseInfoResponse struct {
 	BitcoindVersion     string `json:"bitcoindVersion"`
 	LightningdVersion   string `json:"lightningdVersion"`
 	ElectrsVersion      string `json:"electrsVersion"`
+}
+
+// GetServiceInfoResponse is the struct that gets sent by the RPC server during a GetServiceInfo RPC call
+type GetServiceInfoResponse struct {
+	ErrorResponse                *ErrorResponse `json:"errorResponse"`
+	BitcoindBlocks               int64          `json:"bitcoindBlocks"`
+	BitcoindHeaders              int64          `json:"bitcoindHeaders"`
+	BitcoindVerificationProgress float64        `json:"bitcoindVerificationProgress"`
+	BitcoindPeers                int64          `json:"bitcoindPeers"`
+	BitcoindIBD                  bool           `json:"bitcoindIBD"`
+	LightningdBlocks             int64          `json:"lightningdBlocks"`
+	ElectrsBlocks                int64          `json:"electrsBlocks"`
 }
 
 // ErrorResponse is a generic RPC response indicating if a RPC call was successful or not.

--- a/backend/bitboxbase/status/status.go
+++ b/backend/bitboxbase/status/status.go
@@ -52,4 +52,7 @@ const (
 
 	// EventVerificationProgressChange should be emitted whenever the rpcclient gets a new VerificationProgress notification
 	EventVerificationProgressChange Event = "verificationProgressChanged"
+
+	// EventServiceInfoChanged should be emitted whenever the rpcClient receives a 'service info changed' notification
+	EventServiceInfoChanged Event = "serviceInfoChanged"
 )


### PR DESCRIPTION
This commit adds the GetServiceInfo RPC and handler to the App.

The RPC provides the App with information about the services running on the BitBoxBase. The middleware notifies the App when the ServiceInfo change. The event is implement here as well, but not used yet.