### PR TITLE
base-setup: fix presync bug

### DIFF
--- a/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
+++ b/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
@@ -268,7 +268,7 @@ class BitBoxBase extends Component<Props, State> {
         .then(response => {
             if (response.success) {
                 if (this.state.syncingOption === SyncingOptions.Presync) {
-                    this.setState({ activeStep: ActiveStep.Backup });
+                    this.setState({ activeStep: ActiveStep.Backup, waitDialog: undefined });
                 } else {
                     this.setSyncingOption();
                 }


### PR DESCRIPTION
When continuing from presynced state, wait dialog was not removed on success