### PR TITLE
frontend/tslint: disable no-empty-interface rule

### DIFF
--- a/frontends/web/tslint.json
+++ b/frontends/web/tslint.json
@@ -9,6 +9,7 @@
     "rules": {
         "arrow-parens": [true, "ban-single-arg-parens"],
         "interface-name": [true, "never-prefix"],
+        "no-empty-interface": false,
         "max-line-length": [false],
         "member-ordering": [false],
         "object-literal-sort-keys": [false],


### PR DESCRIPTION
It is nicer to have an `interface State { }` in a component than to
replace every `State` with `{}`, as it can be annoying / tricky to add
the State back in all the right places when you want to add a state
var.