### PR TITLE
frontend: fix settings without rates

### DIFF
--- a/frontends/web/src/components/fiat/fiat.tsx
+++ b/frontends/web/src/components/fiat/fiat.tsx
@@ -17,7 +17,7 @@
 import { h, RenderableProps } from 'preact';
 import { share } from '../../decorators/share';
 import { translate, TranslateProps } from '../../decorators/translate';
-import { Fiat, selectFiat, setActiveFiat, SharedProps, store, unselectFiat } from '../rates/rates';
+import { currencies, Fiat, selectFiat, setActiveFiat, SharedProps, store, unselectFiat } from '../rates/rates';
 import { Toggle } from '../toggle/toggle';
 import * as style from './fiat.css';
 
@@ -40,14 +40,9 @@ type Props = SharedProps & TranslateProps;
 
 function Selection({
     t,
-    rates,
     active,
     selected,
 }: RenderableProps<Props>): JSX.Element | null {
-    if (!rates) {
-        return null;
-    }
-    const currencies = Object.keys(rates.BTC) as Fiat[];
     return (
         <div>
             <div class="subHeaderContainer first">

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -43,6 +43,8 @@ export interface SharedProps {
     selected: Fiat[];
 }
 
+export const currencies: Fiat[] = ['CAD', 'CHF', 'CNY', 'EUR', 'GBP', 'JPY', 'KRW', 'RUB', 'USD'];
+
 export const store = new Store<SharedProps>({
     rates: undefined,
     active: 'CHF',


### PR DESCRIPTION
If you navigate to the settings page before the rates have been
fetched, or the rates could not be fetched, you'd have an error or an
empty screen.