### PR TITLE
base-rpc: add Base Update RPCs

### DIFF
--- a/backend/bitboxbase/rpcclient/rpcclient.go
+++ b/backend/bitboxbase/rpcclient/rpcclient.go
@@ -191,6 +191,8 @@ func (rpcClient *RPCClient) parseMessage(message []byte) {
 		rpcClient.onEvent(bitboxbasestatus.EventVerificationProgressChange)
 	case rpcmessages.OpServiceInfoChanged:
 		rpcClient.onEvent(bitboxbasestatus.EventServiceInfoChanged)
+	case rpcmessages.OpBaseUpdateProgressChanged:
+		rpcClient.onEvent(bitboxbasestatus.EventBaseUpdateProgressChange)
 	case rpcmessages.OpRPCCall:
 		message := message[1:]
 		rpcClient.rpcConnection.ReadChan() <- message
@@ -455,6 +457,31 @@ func (rpcClient *RPCClient) RebootBase() (rpcmessages.ErrorResponse, error) {
 	err := rpcClient.client.Call("RPCServer.RebootBase", rpcmessages.AuthGenericRequest{Token: rpcClient.jwtToken}, &reply)
 	if err != nil {
 		return rpcmessages.ErrorResponse{}, errp.WithStack(err)
+	}
+	return reply, nil
+}
+
+// UpdateBase makes an rpc call to BitBoxBase that updates the Base to the passed version.
+// The Base is restarted after a successful RPC call.
+func (rpcClient *RPCClient) UpdateBase(args rpcmessages.UpdateBaseArgs) (rpcmessages.ErrorResponse, error) {
+	rpcClient.log.Println("Executing UpdateBase rpc call")
+	args.Token = rpcClient.jwtToken
+	var reply rpcmessages.ErrorResponse
+	err := rpcClient.client.Call("RPCServer.UpdateBase", args, &reply)
+	if err != nil {
+		return rpcmessages.ErrorResponse{}, errp.WithStack(err)
+	}
+	return reply, nil
+}
+
+// GetBaseUpdateProgress returns the current Base update progress.
+// This RPC should be called when the middleware sends a notification that the Base update progress changed.
+func (rpcClient *RPCClient) GetBaseUpdateProgress() (rpcmessages.GetBaseUpdateProgressResponse, error) {
+	var reply rpcmessages.GetBaseUpdateProgressResponse
+	err := rpcClient.client.Call("RPCServer.GetBaseUpdateProgress", rpcmessages.AuthGenericRequest{Token: rpcClient.jwtToken}, &reply)
+	if err != nil {
+		rpcClient.log.WithError(err).Error("GetBaseUpdateProgress RPC call failed")
+		return reply, err
 	}
 	return reply, nil
 }

--- a/backend/bitboxbase/rpcmessages/errorcodes.go
+++ b/backend/bitboxbase/rpcmessages/errorcodes.go
@@ -5,8 +5,9 @@ type ErrorCode string
 
 const (
 
-	// ErrorScriptNotFound is thrown if either the bbb-cmd.sh or bbb-config.sh scripts are not found
-	ErrorScriptNotFound ErrorCode = "SCRIPT_NOT_FOUND"
+	// ExecutableNotFound is thrown when a executable is not found.
+	// This can for example be a script (e.g. bbb-cmd.sh or bbb-config.sh) or a executable like `reboot`
+	ExecutableNotFound ErrorCode = "EXECUTABLE_NOT_FOUND"
 
 	// ErrorScriptNotSuperuser is thrown if a run scripts need to be run as superuser.
 	ErrorScriptNotSuperuser ErrorCode = "SCRIPT_NOT_RUN_AS_SUPERUSER"
@@ -22,7 +23,7 @@ const (
 	// There is no differentiation of Prometheus errors because the front-end most likely handles them similar.
 	ErrorPrometheusError ErrorCode = "PROMETHEUS_ERROR"
 
-	// ErrorUnexpected is thrown when a a unknown/unhandled/unexpected error occurrs.
+	// ErrorUnexpected is thrown when a a unknown/unhandled/unexpected error occurs.
 	// It's a catch-all error.
 	ErrorUnexpected ErrorCode = "UNEXPECTED_ERROR"
 )
@@ -36,7 +37,7 @@ const (
 	/* bbb-cmd.sh flashdrive check
 	-------------------------------*/
 
-	// ErrorFlashdriveCheckMultiple is thrown if multiple USB flashdrives are found. Needs exacly one.
+	// ErrorFlashdriveCheckMultiple is thrown if multiple USB flashdrives are found. Needs exactly one.
 	ErrorFlashdriveCheckMultiple ErrorCode = "FLASHDRIVE_CHECK_MULTI"
 	// ErrorFlashdriveCheckNone is thrown if no USB flashdrive is found.
 	ErrorFlashdriveCheckNone ErrorCode = "FLASHDRIVE_CHECK_NONE"
@@ -87,6 +88,9 @@ const (
 	// ErrorMenderUpdateInvalidVersion is thrown if an invalid firmware version passed to the script.
 	ErrorMenderUpdateInvalidVersion ErrorCode = "MENDER_UPDATE_INVALID_VERSION"
 
+	// ErrorMenderUpdateAlreadyInProgress is thrown by the middleware, if an update is already in progress.
+	ErrorMenderUpdateAlreadyInProgress ErrorCode = "MENDER_UPDATE_ALREADY_IN_PROGRESS"
+
 	/* bbb-cmd.sh mender-update commit
 	-----------------------------------*/
 
@@ -132,7 +136,7 @@ const (
 )
 
 const (
-	// ErrorDummyAuthenticationNotSuccessful is thrown if the dummy autentication is not successful.
+	// ErrorDummyAuthenticationNotSuccessful is thrown if the dummy authentication is not successful.
 	ErrorDummyAuthenticationNotSuccessful ErrorCode = "DUMMY_AUTHENTICATION_NOT_SUCCESSFUL"
 
 	// ErrorDummyPasswordTooShort is thrown if the provided password is too short.

--- a/backend/bitboxbase/rpcmessages/rpcmessages.go
+++ b/backend/bitboxbase/rpcmessages/rpcmessages.go
@@ -14,13 +14,15 @@ const (
 	OpUCanHasVerificationProgress = "v"
 	// OpServiceInfoChanged notifies when the GetServiceInfo data changed.
 	OpServiceInfoChanged = "s"
+	// OpBaseUpdateProgressChanged notifies when the BaseUpdateProgress changes while performing a Base Update.
+	OpBaseUpdateProgressChanged = "u"
 )
 
 /*
 Put Incoming Args below this line. They should have the format of 'RPC Method Name' + 'Args'.
 */
 
-// UserAuthenticateArgs is a struct that holds the arguments for the UserAuthenticate RPC call. The first rpc call should always authenticate first
+// UserAuthenticateArgs is a struct that holds the arguments for the UserAuthenticate RPC call
 type UserAuthenticateArgs struct {
 	Username string
 	Password string
@@ -31,7 +33,7 @@ type AuthGenericRequest struct {
 	Token string
 }
 
-// UserChangePasswordArgs is a struct that holds the arguments for the UserChangePassword RPC call
+// UserChangePasswordArgs is an struct that holds the arguments for the UserChangePassword RPC call
 type UserChangePasswordArgs struct {
 	Username    string
 	Password    string
@@ -55,6 +57,12 @@ type SetRootPasswordArgs struct {
 type ToggleSettingArgs struct {
 	ToggleSetting bool
 	Token         string
+}
+
+// UpdateBaseArgs is a struct that holds the Base version that should be updated to
+type UpdateBaseArgs struct {
+	Version string
+	Token   string
 }
 
 /*
@@ -94,7 +102,30 @@ type VerificationProgressResponse struct {
 	VerificationProgress float64 `json:"verificationProgress"`
 }
 
-// GetBaseInfoResponse is the struct that get sent by the rpc server during a GetBaseInfo rpc call
+// BaseUpdateState is the type used to hold the current state for a Base update.
+type BaseUpdateState int
+
+// The possible values of BaseUpdateState.
+// Representing the states that can be reached in a BaseUpdate RPC call.
+const (
+	UpdateNotInProgress BaseUpdateState = iota + 1
+	UpdateDownloading
+	UpdateFailed
+	UpdateApplying
+	UpdateRebooting
+)
+
+// GetBaseUpdateProgressResponse is the response to a GetBaseUpdateProgress RPC call.
+// The app is notified over a changed middleware state calls the GetBaseUpdateProgress
+// RPC which returns GetBaseUpdateProgressResponse.
+type GetBaseUpdateProgressResponse struct {
+	ErrorResponse         *ErrorResponse
+	State                 BaseUpdateState
+	ProgressPercentage    int
+	ProgressDownloadedKiB int
+}
+
+// GetBaseInfoResponse is the struct that gets sent by the RPC server during a GetBaseInfo RPC call
 type GetBaseInfoResponse struct {
 	ErrorResponse       *ErrorResponse
 	Status              string `json:"status"`
@@ -135,10 +166,10 @@ type ErrorResponse struct {
 }
 
 // Error formats the ErrorResponse in the following two formats:
-// If no error occoured:
+// If no error occurred:
 //  ErrorResponse: Success: true
 //
-// If an error occoured:
+// If an error occurred:
 // 	ErrorResponse:
 // 		Success: false
 // 		Code: <ERROR_CODE>

--- a/backend/bitboxbase/status/status.go
+++ b/backend/bitboxbase/status/status.go
@@ -65,4 +65,7 @@ const (
 	// EventUserAuthenticated emits an event when a user successfully authenticates with the Base
 	// so that the frontend knows it can now fetch BaseInfo
 	EventUserAuthenticated Event = "userAuthenticated"
+
+	// EventBaseUpdateProgressChange is emitted whenever the rpcClient gets a BaseUpdateProgress changed notification
+	EventBaseUpdateProgressChange Event = "baseUpdateProgressChanged"
 )


### PR DESCRIPTION
This PR adds the counterparts to the UpdateBase and GetBaseUpdateProgress RPCs added in https://github.com/digitalbitbox/bitbox-base/pull/228 to the App. Next to the RPCs a event for a BaseUpdateProgressChanged notification is added.
