### PR TITLE
base-settings: add basic Reboot rpc to the dashboard frontend

### DIFF
--- a/backend/bitboxbase/bitboxbase.go
+++ b/backend/bitboxbase/bitboxbase.go
@@ -608,6 +608,10 @@ func (base *BitBoxBase) RebootBase() error {
 	if !reply.Success {
 		return &reply
 	}
+	err = base.Deregister()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -270,6 +270,7 @@
         "tor": "Tor"
       },
       "system": {
+        "confirmRestart": "Your BitBoxBase will now restart and you will need to reconnect to it once ready. $t(generic.confirmToContinue)",
         "restart": "Restart",
         "shutdown": "Shutdown",
         "title": "System",
@@ -493,6 +494,9 @@
   },
   "footer": {
     "appVersion": "App version:"
+  },
+  "generic": {
+    "confirmToContinue": "Please confirm to continue."
   },
   "genericError": "An error occurred. If you notice any issues, please restart the application.",
   "goal": {

--- a/frontends/web/src/routes/bitboxbase/basesettings.tsx
+++ b/frontends/web/src/routes/bitboxbase/basesettings.tsx
@@ -15,9 +15,12 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
+import { alertUser } from '../../components/alert/Alert';
+import { confirmation } from '../../components/confirm/Confirm';
 import { Header } from '../../components/layout/header';
 import { SettingsButton } from '../../components/settingsButton/settingsButton';
 import { translate, TranslateProps } from '../../decorators/translate';
+import { apiPost } from '../../utils/request';
 import { BitBoxBaseInfo, BitBoxBaseServiceInfo } from './bitboxbase';
 import * as style from './bitboxbase.css';
 
@@ -27,6 +30,7 @@ interface SettingsProps {
     serviceInfo: BitBoxBaseServiceInfo;
     disconnect: () => void;
     connectElectrum: () => void;
+    apiPrefix: string;
 }
 
 interface State {
@@ -42,6 +46,15 @@ class BaseSettings extends Component<Props, State> {
             expandedDashboard: false,
         };
     }
+
+    private restart = () => {
+        apiPost(this.props.apiPrefix + '/reboot-base')
+                .then(response => {
+                    if (!response.success) {
+                        alertUser(response.message);
+                    }
+                });
+            }
 
     public render(
         {
@@ -229,7 +242,13 @@ class BaseSettings extends Component<Props, State> {
                                         </div>
                                         <div className="box slim divide">
                                             <SettingsButton>{t('bitboxBase.settings.system.update')}</SettingsButton>
-                                            <SettingsButton>{t('bitboxBase.settings.system.restart')}</SettingsButton>
+                                            <SettingsButton onClick={() => {
+                                                confirmation(t('bitboxBase.settings.system.confirmRestart'), confirmed => {
+                                                    if (confirmed) {
+                                                        this.restart();
+                                                    }
+                                                });
+                                            }}>{t('bitboxBase.settings.system.restart')}</SettingsButton>
                                             <SettingsButton>{t('bitboxBase.settings.system.shutdown')}</SettingsButton>
                                         </div>
                                     </div>

--- a/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
+++ b/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
@@ -399,7 +399,8 @@ class BitBoxBase extends Component<Props, State> {
                         baseInfo={baseInfo}
                         serviceInfo={serviceInfo}
                         disconnect={this.removeBitBoxBase}
-                        connectElectrum={this.connectElectrum} />
+                        connectElectrum={this.connectElectrum}
+                        apiPrefix={this.apiPrefix()} />
                 );
             }
             return (


### PR DESCRIPTION
Calls the RebootBase RPC after user confirmation.
Currently there is no automatic reconnect as the base gets
deregistered once the websocket connection shuts down. Needs
additional backend functionality to keep trying to reconnect after restart.