### PR TITLE
backend: add Close()

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -962,3 +962,9 @@ func (backend *Backend) SystemOpen(url string) error {
 	return backend.environment.SystemOpen(url)
 
 }
+
+// Close shuts down the backend.
+func (backend *Backend) Close() error {
+	return backend.notifier.Close()
+	// TODO: wind down goroutines, all accounts, etc.
+}

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -159,6 +159,12 @@ func Serve(
 
 	events := backend.Events()
 	go func() {
+		defer func() {
+			if err := backend.Close(); err != nil {
+				log.WithError(err).Error("backend.Close failed")
+			}
+		}()
+
 		for {
 			select {
 			case <-quitChan:

--- a/backend/bridgecommon/bridgecommon_test.go
+++ b/backend/bridgecommon/bridgecommon_test.go
@@ -1,0 +1,63 @@
+// Copyright 2018 Shift Devices AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridgecommon_test
+
+import (
+	"log"
+	"testing"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/bridgecommon"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/usb"
+)
+
+type communication struct{}
+
+func (c communication) Respond(queryID int, response string) {
+	log.Println("Respond:", queryID, response)
+}
+
+func (c communication) PushNotify(msg string) {
+	log.Println("PushNotify:", msg)
+}
+
+type environment struct{}
+
+func (e environment) NotifyUser(msg string) {
+	log.Println("NotfiyUser:", msg)
+}
+
+func (e environment) DeviceInfos() []usb.DeviceInfo {
+	return []usb.DeviceInfo{}
+}
+
+func (e environment) SystemOpen(url string) error {
+	log.Println("SystemOpen:", url)
+	return nil
+}
+
+// TestServeShutdownServe checks that you can call Serve twice in a row.
+func TestServeShutdownServe(t *testing.T) {
+	bridgecommon.Serve(
+		false,
+		communication{},
+		environment{},
+	)
+	bridgecommon.Shutdown()
+	bridgecommon.Serve(
+		false,
+		communication{},
+		environment{},
+	)
+}

--- a/backend/notifier.go
+++ b/backend/notifier.go
@@ -41,6 +41,11 @@ func NewNotifier(dbFilename string) (*Notifier, error) {
 	return &Notifier{db: db}, nil
 }
 
+// Close closes the notifier database.
+func (notifier *Notifier) Close() error {
+	return notifier.db.Close()
+}
+
 type notifierForAccount struct {
 	db          *bbolt.DB
 	accountCode string

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -15,7 +15,7 @@
 
 # This script has to be called from the project root directory.
 go build -mod=vendor ./...
-go test -mod=vendor ./... -v
+go test -mod=vendor ./... -count=1 -v
 golangci-lint run
 
 yarn --cwd=frontends/web install # needed to install the eslint dev dep.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -15,8 +15,7 @@
 
 # This script has to be called from the project root directory.
 go build -mod=vendor ./...
-go test -mod=vendor ./...
-
+go test -mod=vendor ./... -v
 golangci-lint run
 
 yarn --cwd=frontends/web install # needed to install the eslint dev dep.


### PR DESCRIPTION
Call it after bridgecommon.Shutdown(). Otherwise running Serve() again
can lead to undesired behavior, like opening a database twice and
hanging.

This commit is a partial solution, as we need to close all resources.