### PR TITLE
frontend: lazy load qrreader

### DIFF
--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -28,7 +28,7 @@
     "typed-css-modules": "0.3.5"
   },
   "dependencies": {
-    "@zxing/library": "0.11.0",
+    "@zxing/library": "0.18.3",
     "i18next": "11.3.6",
     "i18next-locize-backend": "4.1.9",
     "lightweight-charts": "3.1.5",

--- a/frontends/web/src/components/qrcode/qrreader.ts
+++ b/frontends/web/src/components/qrcode/qrreader.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BrowserQRCodeReader } from '@zxing/library';
+
+export {
+    BrowserQRCodeReader
+};

--- a/frontends/web/yarn.lock
+++ b/frontends/web/yarn.lock
@@ -1367,14 +1367,19 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zxing/library@0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@zxing/library/-/library-0.11.0.tgz#35b22f46436d9ae542a4f524f22067cc8fe5f82b"
-  integrity sha512-gegxSMT0xKOjF7RkJCoq0cVguE1pNozgK8kCNrQhII7yYjJuVyu2BAOukCxjCCpqKBJY7H5b/O0m0YFGZ7bE/g==
+"@zxing/library@0.18.3":
+  version "0.18.3"
+  resolved "https://registry.yarnpkg.com/@zxing/library/-/library-0.18.3.tgz#50f20703cf3b7d357bd8801b23f27f24aa1f5e4d"
+  integrity sha512-7ny4JjUu2UfIiuyjewxeRZViXJ8GsSOoNZ+o6o0AdPvUQlaISdsGnIUVGDviJerEYeT1MKhaL7jUtjdYs3KO/Q==
   dependencies:
-    ts-custom-error "^2.2.1"
+    ts-custom-error "^3.0.0"
   optionalDependencies:
-    text-encoding "^0.7.0"
+    "@zxing/text-encoding" "~0.9.0"
+
+"@zxing/text-encoding@~0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
 
 abab@^2.0.0:
   version "2.0.2"
@@ -10567,11 +10572,6 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-encoding@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -10712,10 +10712,10 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-ts-custom-error@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-2.2.2.tgz#ee769cd6a9cf35dc2e9fedefbb3842f3a2fbceae"
-  integrity sha512-I0FEdfdatDjeigRqh1JFj67bcIKyRNm12UVGheBjs2pXgyELg2xeiQLVaWu1pVmNGXZVnz/fvycSU41moBIpOg==
+ts-custom-error@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-3.2.0.tgz#ff8f80a3812bab9dc448536312da52dce1b720fb"
+  integrity sha512-cBvC2QjtvJ9JfWLvstVnI45Y46Y5dMxIaG1TDMGAD/R87hpvqFL+7LhvUDhnRCfOnx/xitollFWWvUKKKhbN0A==
 
 ts-jest@23.10.5:
   version "23.10.5"


### PR DESCRIPTION
This should make the JavaScript main bundle.js smaller and postpone loading the zxing library until you navigate to the Send route.

![Screen Shot 2019-11-11 at 11 47 25 AM](https://user-images.githubusercontent.com/546900/68581617-10f0ec80-0479-11ea-8aea-3450b12a6aba.png)

To create a chart use `cd frontends/web && yarn build --json` that will create a `stats.json`, you can drop that into https://chrisbateman.github.io/webpack-visualizer/