### PR TITLE
base-settings: add button functionality

### DIFF
--- a/backend/bitboxbase/bitboxbase.go
+++ b/backend/bitboxbase/bitboxbase.go
@@ -615,6 +615,11 @@ func (base *BitBoxBase) ShutdownBase() error {
 	if !reply.Success {
 		return &reply
 	}
+	// FIXME: Change backend node management to status: offline
+	err = base.Deregister()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -631,6 +636,7 @@ func (base *BitBoxBase) RebootBase() error {
 	if !reply.Success {
 		return &reply
 	}
+	// FIXME: Change backend node management to status: rebooting
 	err = base.Deregister()
 	if err != nil {
 		return err

--- a/backend/bitboxbase/rpcmessages/rpcmessages.go
+++ b/backend/bitboxbase/rpcmessages/rpcmessages.go
@@ -125,21 +125,21 @@ type GetBaseUpdateProgressResponse struct {
 
 // GetBaseInfoResponse is the struct that gets sent by the RPC server during a GetBaseInfo RPC call
 type GetBaseInfoResponse struct {
-	ErrorResponse       *ErrorResponse
-	Status              string `json:"status"`
-	Hostname            string `json:"hostname"`
-	MiddlewareLocalIP   string `json:"middlewareLocalIP"`
-	MiddlewareLocalPort string `json:"middlewareLocalPort"`
-	MiddlewareTorOnion  string `json:"middlewareTorOnion"`
-	MiddlewareTorPort   string `json:"middlewareTorPort"`
-	IsTorEnabled        bool   `json:"isTorEnabled"`
-	IsBitcoindListening bool   `json:"isBitcoindListening"`
-	FreeDiskspace       int64  `json:"freeDiskspace"`  // in Byte
-	TotalDiskspace      int64  `json:"totalDiskspace"` // in Byte
-	BaseVersion         string `json:"baseVersion"`
-	BitcoindVersion     string `json:"bitcoindVersion"`
-	LightningdVersion   string `json:"lightningdVersion"`
-	ElectrsVersion      string `json:"electrsVersion"`
+	ErrorResponse             *ErrorResponse
+	Status                    string `json:"status"`
+	Hostname                  string `json:"hostname"`
+	MiddlewareLocalIP         string `json:"middlewareLocalIP"`
+	MiddlewarePort            string `json:"middlewarePort"`
+	MiddlewareTorOnion        string `json:"middlewareTorOnion"`
+	IsTorEnabled              bool   `json:"isTorEnabled"`
+	IsBitcoindListening       bool   `json:"isBitcoindListening"`
+	IsSSHPasswordLoginEnabled bool   `json:"IsSSHPasswordLoginEnabled"`
+	FreeDiskspace             int64  `json:"freeDiskspace"`  // in Byte
+	TotalDiskspace            int64  `json:"totalDiskspace"` // in Byte
+	BaseVersion               string `json:"baseVersion"`
+	BitcoindVersion           string `json:"bitcoindVersion"`
+	LightningdVersion         string `json:"lightningdVersion"`
+	ElectrsVersion            string `json:"electrsVersion"`
 }
 
 // GetServiceInfoResponse is the struct that gets sent by the RPC server during a GetServiceInfo RPC call

--- a/backend/bitboxbase/rpcmessages/rpcmessages.go
+++ b/backend/bitboxbase/rpcmessages/rpcmessages.go
@@ -134,6 +134,7 @@ type GetBaseInfoResponse struct {
 	IsTorEnabled              bool   `json:"isTorEnabled"`
 	IsBitcoindListening       bool   `json:"isBitcoindListening"`
 	IsSSHPasswordLoginEnabled bool   `json:"IsSSHPasswordLoginEnabled"`
+	LightningActiveChannels   int64  `json:"lightningActiveChannels"`
 	FreeDiskspace             int64  `json:"freeDiskspace"`  // in Byte
 	TotalDiskspace            int64  `json:"totalDiskspace"` // in Byte
 	BaseVersion               string `json:"baseVersion"`

--- a/frontends/web/src/components/bitboxbase/changebasehostname.tsx
+++ b/frontends/web/src/components/bitboxbase/changebasehostname.tsx
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2019 Shift Devices AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { translate, TranslateProps } from '../../decorators/translate';
+import { apiPost } from '../../utils/request';
+import { alertUser } from '../alert/Alert';
+import { Dialog } from '../dialog/dialog';
+import { Button, Input } from '../forms';
+import { SettingsButton } from '../settingsButton/settingsButton';
+
+interface ChangeBaseHostnameProps {
+    apiPrefix: string;
+    currentHostname: string;
+    getBaseInfo: () => void;
+}
+
+interface State {
+    active: boolean;
+    inProgress: boolean;
+    newHostname: string;
+    validHostname: boolean;
+}
+
+const hostnamePattern = '^[a-z][a-z0-9-]{0,22}[a-z0-9]$';
+
+type Props = ChangeBaseHostnameProps & TranslateProps;
+
+class ChangeBaseHostname extends Component<Props, State> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            active: false,
+            inProgress: false,
+            newHostname: '',
+            validHostname: false,
+        };
+    }
+
+    private setHostname = () => {
+        this.setState({inProgress: true});
+        apiPost(this.props.apiPrefix + '/set-hostname', {hostname: this.state.newHostname})
+        .then(response => {
+            if (response.success) {
+                this.props.getBaseInfo(); // FIXME: there should be a notification from the middleware when BaseInfo changes instead of having to call it manually
+                this.setState({ active: false, inProgress: false, newHostname: '' });
+            } else {
+                this.setState({ active: false, inProgress: false, newHostname: '' });
+                alertUser(response.message);
+            }
+        });
+    }
+
+    private showDialog = () => {
+        this.setState({
+            active: true,
+            newHostname: '',
+        });
+    }
+
+    private handleNameInput = (event: Event) => {
+        const target = (event.target as HTMLInputElement);
+        const newHostname: string = target.value;
+        if (newHostname.match(hostnamePattern) !== null) {
+            this.setState({ newHostname, validHostname: true });
+        } else {
+            this.setState({ newHostname, validHostname: false });
+        }
+    }
+
+    private abort = () => {
+        this.setState({
+            active: false,
+        });
+    }
+
+    public render(
+        {
+            t,
+            currentHostname,
+        }: RenderableProps<Props>,
+        {
+            active,
+            inProgress,
+            validHostname,
+            newHostname,
+        }: State,
+    ) {
+        return (
+            <div>
+                <SettingsButton onClick={this.showDialog} optionalText={currentHostname}>
+                    {t('bitboxBase.settings.node.changeName')}
+                </SettingsButton>
+                {
+                    active ? (
+                        <Dialog onClose={this.abort} title={t('bitboxBase.settings.node.changeNameTitle')} small>
+                            <div className="columnsContainer half">
+                                <div className="columns half">
+                                    <div className="column">
+                                        <h2 className="flex flex-row flex-center m-bottom-half m-top-quarter">{currentHostname}</h2>
+                                    </div>
+                                    <div className="column">
+                                        <Input
+                                            pattern={hostnamePattern}
+                                            label={t('bitboxBase.settings.node.newName')}
+                                            placeholder={t('bitboxBaseWizard.hostname.placeholder')}
+                                            type="text"
+                                            title={t('bitboxBaseWizard.hostname.tooltip')}
+                                            value={newHostname}
+                                            onInput={this.handleNameInput} />
+                                    </div>
+                                </div>
+                            </div>
+                            <div className="buttons text-center m-top-none">
+                                <Button
+                                    primary
+                                    onClick={this.setHostname}
+                                    disabled={!validHostname || inProgress}>
+                                    {t('button.continue')}
+                                </Button>
+                            </div>
+                        </Dialog>
+                    ) : null
+                }
+            </div>
+        );
+    }
+}
+
+const HOC = translate<ChangeBaseHostnameProps>()(ChangeBaseHostname);
+export { HOC as ChangeBaseHostname};

--- a/frontends/web/src/components/bitboxbase/changebasepassword.tsx
+++ b/frontends/web/src/components/bitboxbase/changebasepassword.tsx
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2019 Shift Devices AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { translate, TranslateProps } from '../../decorators/translate';
+import { apiPost } from '../../utils/request';
+import { alertUser } from '../alert/Alert';
+import { Dialog } from '../dialog/dialog';
+import { Button  } from '../forms';
+import { PasswordRepeatInput, PasswordSingleInput } from '../password';
+import { SettingsButton } from '../settingsButton/settingsButton';
+
+interface ChangeBasePasswordProps {
+    apiPrefix: string;
+}
+
+interface State {
+    active: boolean;
+    inProgress: boolean;
+    authenticated: boolean;
+    oldPassword?: string;
+    newPassword?: string;
+    username: string;
+}
+
+type PasswordKind = 'oldPassword' | 'newPassword';
+
+type Props = ChangeBasePasswordProps & TranslateProps;
+
+class ChangeBasePassword extends Component<Props, State> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            active: false,
+            inProgress: false,
+            authenticated: false,
+            username: 'admin',
+        };
+    }
+
+    private submitOldPassword = (event: Event) => {
+        event.preventDefault();
+        this.setState({ inProgress: true });
+        if (!this.validate('oldPassword')) {
+            return;
+        }
+        apiPost(this.props.apiPrefix + '/user-authenticate', {username: this.state.username, password: this.state.oldPassword })
+        .then(response => {
+            if (response.success) {
+                this.setState({ authenticated: true });
+            } else {
+                alertUser(response.message);
+            }
+            this.setState({ inProgress: false });
+        });
+    }
+
+    private submitChangePassword = (event: Event) => {
+        event.preventDefault();
+        this.setState({ inProgress: true });
+        if (!this.validate('newPassword')) {
+            return;
+        }
+        apiPost(this.props.apiPrefix + '/user-change-password', {username: 'admin', password: this.state.oldPassword, newPassword: this.state.newPassword})
+        .then(response => {
+            if (response.success) {
+                alertUser('Password changed successfully.');
+            } else {
+                alertUser(response.message);
+            }
+            this.setState({ authenticated: false, active: false, inProgress: false });
+        });
+        this.setState({ oldPassword: '', newPassword: '' });
+    }
+
+    private validate = (passwordKind: PasswordKind) => {
+        return this.state[passwordKind] !== '';
+    }
+
+    private setValidOldPassword = (oldPassword: string) => {
+        this.setState({ oldPassword });
+    }
+
+    private setValidNewPassword = (newPassword: string) => {
+        this.setState({ newPassword });
+    }
+
+    private showDialog = () => {
+        this.setState({
+            active: true,
+        });
+    }
+
+    private abort = () => {
+        this.setState({
+            active: false,
+            authenticated: false,
+            oldPassword: '',
+        });
+    }
+
+    public render(
+        {
+            t,
+        }: RenderableProps<Props>,
+        {
+            active,
+            inProgress,
+            authenticated,
+            newPassword,
+        }: State,
+    ) {
+        return (
+            <div>
+                <SettingsButton onClick={this.showDialog}>
+                    {t('bitboxBase.settings.node.password')}
+                </SettingsButton>
+                {
+                    active && !authenticated &&
+                    <Dialog onClose={this.abort} title={t('bitboxBase.settings.node.password')} medium>
+                        <div class="box medium">
+                            <form onSubmit={this.submitOldPassword}>
+                                <div>
+                                    <PasswordSingleInput
+                                        id="password"
+                                        type="password"
+                                        label={t('changePin.oldLabel')}
+                                        showLabel= " "
+                                        onValidPassword={this.setValidOldPassword} />
+                                </div>
+                                <div className="buttons">
+                                    <Button
+                                        primary
+                                        disabled={inProgress}
+                                        type="submit">
+                                        {t('button.continue')}
+                                    </Button>
+                                </div>
+                            </form>
+                        </div>
+                    </Dialog>
+                }
+                {
+                    active && authenticated &&
+                    <Dialog onClose={this.abort} title={t('bitboxBase.settings.node.password')} medium>
+                        <div class="box medium">
+                            <form onSubmit={this.submitChangePassword}>
+                                <PasswordRepeatInput
+                                    label={t('changePin.newTitle')}
+                                    repeatLabel={t('initialize.input.labelRepeat')}
+                                    showLabel=" "
+                                    onValidPassword={this.setValidNewPassword} />
+                                <div className={'buttons text-center'}>
+                                    <Button
+                                        disabled={!newPassword || inProgress}
+                                        primary
+                                        type="submit">
+                                        {t('bitboxBase.settings.node.password')}
+                                    </Button>
+                                </div>
+                            </form>
+                        </div>
+                    </Dialog>
+                }
+            </div>
+        );
+    }
+}
+
+const HOC = translate<ChangeBasePasswordProps>()(ChangeBasePassword);
+export { HOC as ChangeBasePassword};

--- a/frontends/web/src/components/bitboxbase/confirmbaserpc.tsx
+++ b/frontends/web/src/components/bitboxbase/confirmbaserpc.tsx
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2019 Shift Devices AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /**
+  * This is a generic modal dialog for the BitBoxBase for RPC calls whose result the user should be informed about
+  * e.g. create backup, or toggle ssh access.
+  * It prompts the user to confirm the action, has a pending state while the RPC is being executed and displays
+  * the result.
+  * It should be provided via the props with the text for all the states relevant to the action being executed
+  * as well as one of pre-defined API endpoints to call.
+  */
+
+import { Component, h, RenderableProps } from 'preact';
+import { translate, TranslateProps } from '../../decorators/translate';
+import { apiPost } from '../../utils/request';
+import { Dialog } from '../dialog/dialog';
+import { Button  } from '../forms';
+
+// Endpoints whose functionality is supported by the format of this component
+type ConfirmBaseRPCEndpoint = '/backup-sysconfig' | '/enable-ssh-password-login';
+
+interface ConfirmBaseRPCProps {
+    apiPrefix: string;
+    apiEndpoint: ConfirmBaseRPCEndpoint;
+    confirmText: string;
+    inProgressText: string;
+    successText: string;
+    dialogTitle: string;
+    toggleDialog: () => void;
+}
+
+interface State {
+    inProgress: boolean;
+    success?: boolean;
+    failureMessage?: string;
+}
+
+type Props = ConfirmBaseRPCProps & TranslateProps;
+
+class ConfirmBaseRPC extends Component<Props, State> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            inProgress: false,
+            success: undefined,
+        };
+    }
+
+    private apiCall = (event: Event) => {
+        event.preventDefault();
+        this.setState({ inProgress: true });
+        apiPost(this.props.apiPrefix + this.props.apiEndpoint)
+        .then(response => {
+            if (response.success) {
+                this.setState({ success: true });
+            } else {
+                this.setState({ success: false, failureMessage: response.message });
+            }
+            this.setState({ inProgress: false });
+        });
+    }
+
+    private abort = () => {
+        this.props.toggleDialog();
+        this.setState({
+            inProgress: false,
+            success: undefined,
+        });
+    }
+
+    public render(
+        {
+            confirmText,
+            inProgressText,
+            successText,
+            dialogTitle,
+            t,
+        }: RenderableProps<Props>,
+        {
+            inProgress,
+            success,
+            failureMessage,
+        }: State,
+    ) {
+        return (
+            <div>
+                <Dialog onClose={this.abort} title={dialogTitle} small>
+                    <div class="box medium p-top-none">
+                        <form onSubmit={success ? this.abort : this.apiCall}>
+                            <div>
+                                {
+                                    !success && !inProgress &&
+                                    <p>{confirmText}</p>
+                                }
+                                {
+                                    success && <p>{successText}</p>
+                                }
+                                {
+                                    inProgress && !success && <p>{inProgressText}</p>
+                                }
+                                {
+                                    // TODO: Look up user facing message from locales file based on error code
+                                    failureMessage && <p>{failureMessage}</p>
+                                }
+                            </div>
+                            <div className="buttons">
+                                <Button
+                                    primary
+                                    disabled={inProgress}
+                                    type="submit">
+                                    {t('button.ok')}
+                                </Button>
+                            </div>
+                        </form>
+                    </div>
+                </Dialog>
+            </div>
+        );
+    }
+}
+
+const HOC = translate<ConfirmBaseRPCProps>()(ConfirmBaseRPC);
+export { HOC as ConfirmBaseRPC};

--- a/frontends/web/src/components/bitboxbase/confirmbaserpc.tsx
+++ b/frontends/web/src/components/bitboxbase/confirmbaserpc.tsx
@@ -21,6 +21,7 @@
   * the result.
   * It should be provided via the props with the text for all the states relevant to the action being executed
   * as well as one of pre-defined API endpoints to call.
+  * If it is a POST request which requires arguments, provide them in 'args' on the props
   */
 
 import { Component, h, RenderableProps } from 'preact';
@@ -39,7 +40,9 @@ interface ConfirmBaseRPCProps {
     inProgressText: string;
     successText: string;
     dialogTitle: string;
+    args?: any;
     toggleDialog: () => void;
+    onSuccess?: () => void;
 }
 
 interface State {
@@ -62,9 +65,11 @@ class ConfirmBaseRPC extends Component<Props, State> {
     private apiCall = (event: Event) => {
         event.preventDefault();
         this.setState({ inProgress: true });
-        apiPost(this.props.apiPrefix + this.props.apiEndpoint)
+        apiPost(this.props.apiPrefix + this.props.apiEndpoint, this.props.args)
         .then(response => {
             if (response.success) {
+                // tslint:disable-next-line: no-unused-expression
+                this.props.onSuccess && this.props.onSuccess();
                 this.setState({ success: true });
             } else {
                 this.setState({ success: false, failureMessage: response.message });

--- a/frontends/web/src/components/bitboxbase/createbasebackup.tsx
+++ b/frontends/web/src/components/bitboxbase/createbasebackup.tsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2019 Shift Devices AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { ConfirmBaseRPC } from '../../components/bitboxbase/confirmbaserpc';
+import { translate, TranslateProps } from '../../decorators/translate';
+import { SettingsButton } from '../settingsButton/settingsButton';
+
+interface CreateBaseBackupProps {
+    apiPrefix: string;
+}
+
+interface State {
+    active: boolean;
+}
+
+type Props = CreateBaseBackupProps & TranslateProps;
+
+class CreateBaseBackup extends Component<Props, State> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            active: false,
+        };
+    }
+
+    private toggleDialog = () => {
+        this.setState({
+            active: !this.state.active,
+        });
+    }
+
+    public render(
+        {
+            apiPrefix,
+            t,
+        }: RenderableProps<Props>,
+        {
+            active,
+        }: State,
+    ) {
+        return (
+            <div>
+                <SettingsButton onClick={this.toggleDialog}>
+                    {t('bitboxBase.settings.backups.create')}
+                </SettingsButton>
+                {
+                    active &&
+                    <ConfirmBaseRPC
+                        apiPrefix={apiPrefix}
+                        apiEndpoint="/backup-sysconfig"
+                        confirmText={t('bitboxBase.settings.backups.confirmBackup')}
+                        inProgressText={t('bitboxBase.settings.backups.creating')}
+                        successText={t('bitboxBase.settings.backups.created')}
+                        dialogTitle={t('bitboxBase.settings.backups.create')}
+                        toggleDialog={this.toggleDialog} />
+                }
+            </div>
+        );
+    }
+}
+
+const HOC = translate<CreateBaseBackupProps>()(CreateBaseBackup);
+export { HOC as CreateBaseBackup};

--- a/frontends/web/src/components/bitboxbase/enablesshlogin.tsx
+++ b/frontends/web/src/components/bitboxbase/enablesshlogin.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2019 Shift Devices AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { ConfirmBaseRPC } from '../../components/bitboxbase/confirmbaserpc';
+import { translate, TranslateProps } from '../../decorators/translate';
+import { SettingsButton } from '../settingsButton/settingsButton';
+
+interface EnableSSHLoginProps {
+    apiPrefix: string;
+    enabled?: boolean;
+    onSuccess: () => void; // GetBaseInfo() onSuccess to reflect the successful change
+}
+
+interface State {
+    active: boolean;
+}
+
+type Props = EnableSSHLoginProps & TranslateProps;
+
+class EnableSSHLogin extends Component<Props, State> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            active: false,
+        };
+    }
+
+    private toggleDialog = () => {
+        this.setState({
+            active: !this.state.active,
+        });
+    }
+
+    public render(
+        {
+            apiPrefix,
+            enabled,
+            onSuccess,
+            t,
+        }: RenderableProps<Props>,
+        {
+            active,
+        }: State,
+    ) {
+        return (
+            <div>
+                <SettingsButton onClick={this.toggleDialog} optionalText={t(`generic.enabled.${enabled}`)}>
+                    {t('bitboxBase.settings.advanced.sshAccess.button')}
+                </SettingsButton>
+                {
+                    active &&
+                    <ConfirmBaseRPC
+                        apiPrefix={apiPrefix}
+                        apiEndpoint="/enable-ssh-password-login"
+                        confirmText={t('bitboxBase.settings.advanced.sshAccess.confirm', { toggle: t(`generic.enable.${enabled}`)})}
+                        inProgressText={t('bitboxBase.settings.advanced.sshAccess.inProgress')}
+                        successText={t('bitboxBase.settings.advanced.sshAccess.success', {enabled: (t(`generic.enabled.${enabled}`).toLowerCase())})}
+                        dialogTitle={t('bitboxBase.settings.advanced.sshAccess.title')}
+                        args={!enabled}
+                        toggleDialog={this.toggleDialog}
+                        onSuccess={onSuccess} />
+                }
+            </div>
+        );
+    }
+}
+
+const HOC = translate<EnableSSHLoginProps>()(EnableSSHLogin);
+export { HOC as EnableSSHLogin};

--- a/frontends/web/src/components/bitboxbase/setbasesystempassword.tsx
+++ b/frontends/web/src/components/bitboxbase/setbasesystempassword.tsx
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2019 Shift Devices AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { translate, TranslateProps } from '../../decorators/translate';
+import { apiPost } from '../../utils/request';
+import { alertUser } from '../alert/Alert';
+import { confirmation } from '../confirm/Confirm';
+import { Dialog } from '../dialog/dialog';
+import { Button  } from '../forms';
+import { PasswordRepeatInput } from '../password';
+import { SettingsButton } from '../settingsButton/settingsButton';
+
+interface SetBaseSystemPasswordProps {
+    apiPrefix: string;
+}
+
+interface State {
+    active: boolean;
+    inProgress: boolean;
+    password?: string;
+}
+
+type Props = SetBaseSystemPasswordProps & TranslateProps;
+
+class SetBaseSystemPassword extends Component<Props, State> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            active: false,
+            inProgress: false,
+        };
+    }
+
+    private submitPassword = (event: Event) => {
+        event.preventDefault();
+        this.setState({ inProgress: true });
+        if (!this.validate()) {
+            return;
+        }
+        apiPost(this.props.apiPrefix + '/set-login-password', {password: this.state.password })
+        .then(response => {
+            if (response.success) {
+                alertUser(this.props.t('bitboxBase.settings.advanced.systemPasswordSuccess'));
+            } else {
+                alertUser(response.message);
+            }
+            this.setState({ inProgress: false, active: false, password: undefined });
+        });
+    }
+
+    private validate = () => {
+        return this.state.password !== '';
+    }
+
+    private setValidPassword = (password: string) => {
+        this.setState({ password });
+    }
+
+    private showDialog = () => {
+        this.setState({
+            active: true,
+        });
+    }
+
+    private abort = () => {
+        this.setState({
+            active: false,
+            password: undefined,
+        });
+    }
+
+    public render(
+        {
+            t,
+        }: RenderableProps<Props>,
+        {
+            active,
+            inProgress,
+            password,
+        }: State,
+    ) {
+        return (
+            <div>
+                <SettingsButton onClick={() => {
+                    confirmation(t('bitboxBase.settings.advanced.confirmSystemPassword'), confirmed => {
+                        // tslint:disable-next-line: no-unused-expression
+                        confirmed && this.showDialog();
+                    });
+                }}>
+                    {t('bitboxBase.settings.advanced.systemPassword')}
+                </SettingsButton>
+                {
+                    active &&
+                    <Dialog onClose={this.abort} title={t('bitboxBase.settings.advanced.systemPassword')} medium>
+                        <div class="box medium">
+                            <form onSubmit={this.submitPassword}>
+                                <PasswordRepeatInput
+                                    label={t('changePin.newTitle')}
+                                    repeatLabel={t('initialize.input.labelRepeat')}
+                                    showLabel=" "
+                                    onValidPassword={this.setValidPassword} />
+                                <div className={'buttons text-center'}>
+                                    <Button
+                                        disabled={!password || inProgress}
+                                        primary
+                                        type="submit">
+                                        {t('bitboxBase.settings.advanced.systemPassword')}
+                                    </Button>
+                                </div>
+                            </form>
+                        </div>
+                    </Dialog>
+                }
+            </div>
+        );
+    }
+}
+
+const HOC = translate<SetBaseSystemPasswordProps>()(SetBaseSystemPassword);
+export { HOC as SetBaseSystemPassword};

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -265,11 +265,13 @@
       "node": {
         "bitcoinRestarting": "Base services are restarting...",
         "changeName": "Change name",
+        "changeNameTitle": "Change BitBoxBase hostname",
         "confirmTorEnabled": {
           "false": "Are you sure you want to <strong>enable</strong> Tor?\n $t(bitboxBase.settings.node.warning)",
           "true": "Are you sure you want to <strong>disable</strong> Tor?\n This can have serious and irreversible implications regarding privacy and is not recommended.\n $t(bitboxBase.settings.node.warning)"
         },
         "disconnect": "Disconnect",
+        "newName": "Enter new hostname",
         "password": "Change password",
         "title": "Node",
         "tor": "Tor",

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -263,11 +263,17 @@
         "title": "Backups"
       },
       "node": {
+        "bitcoinRestarting": "Base services are restarting...",
         "changeName": "Change name",
+        "confirmTorEnabled": {
+          "false": "Are you sure you want to <strong>enable</strong> Tor?\n $t(bitboxBase.settings.node.warning)",
+          "true": "Are you sure you want to <strong>disable</strong> Tor?\n This can have serious and irreversible implications regarding privacy and is not recommended.\n $t(bitboxBase.settings.node.warning)"
+        },
         "disconnect": "Disconnect",
         "password": "Change password",
         "title": "Node",
-        "tor": "Tor"
+        "tor": "Tor",
+        "warning": "Please allow 1-2 minutes for changes to take effect."
       },
       "system": {
         "confirmRestart": "Your BitBoxBase will now restart and you will need to reconnect to it once ready. $t(generic.confirmToContinue)",
@@ -509,8 +515,13 @@
     "appVersion": "App version:"
   },
   "generic": {
+    "applying": "Applying configuration",
     "confirmToContinue": "Please confirm to continue.",
-    "description": "Description"
+    "description": "Description",
+    "enabled": {
+      "false": "Disabled",
+      "true": "Enabled"
+    }
   },
   "genericError": "An error occurred. If you notice any issues, please restart the application.",
   "goal": {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -278,7 +278,8 @@
         "warning": "Please allow 1-2 minutes for changes to take effect."
       },
       "system": {
-        "confirmRestart": "Your BitBoxBase will now restart and you will need to reconnect to it once ready. $t(generic.confirmToContinue)",
+        "confirmRestart": "Your BitBoxBase will now <strong>restart</strong> and you will need to reconnect to it once ready.\n $t(generic.confirmToContinue)",
+        "confirmShutdown": "Your BitBoxBase will now <strong>shut down</strong> and you will have to turn it back on manually.\n $t(generic.confirmToContinue)",
         "confirmUpdate": "Would you like to update your BitBoxBase from version {{current}} to {{newVersion}}?",
         "restart": "Restart",
         "shutdown": "Shutdown",

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -246,7 +246,13 @@
         "manual": "Manual update",
         "port": "Port",
         "reset": "Reset to factory settings",
-        "sshAccess": "SSH access",
+        "sshAccess": {
+          "button": "SSH password login",
+          "confirm": "Would you like to {{toggle}} SSH password authentication?",
+          "inProgress": "Toggling SSH password authentication",
+          "success": "SSH password authentication {{enabled}}",
+          "title": "SSH access"
+        },
         "subheaders": {
           "bitcoin": "Bitcoin Core",
           "electrs": "Electrs",
@@ -524,6 +530,10 @@
     "applying": "Applying configuration",
     "confirmToContinue": "Please confirm to continue.",
     "description": "Description",
+    "enable": {
+      "true": "disable",
+      "false": "enable"
+    },
     "enabled": {
       "false": "Disabled",
       "true": "Enabled"

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -241,6 +241,7 @@
     "new": "New BitBoxBase",
     "settings": {
       "advanced": {
+        "confirmSystemPassword": "This will set the BitBoxBase system password to use for <strong>ssh authentication and sudo access.</strong>\n$t(generic.confirmToContinue)",
         "connectElectrum": "Connect Electrum",
         "ipAddress": "IP address",
         "manual": "Manual update",
@@ -260,6 +261,8 @@
           "networking": "Networking"
         },
         "syncOptions": "Sync options",
+        "systemPassword": "Set system password",
+        "systemPasswordSuccess": "BitBoxBase system password set successfully.",
         "title": "Advanced"
       },
       "backups": {
@@ -531,8 +534,8 @@
     "confirmToContinue": "Please confirm to continue.",
     "description": "Description",
     "enable": {
-      "true": "disable",
-      "false": "enable"
+      "false": "enable",
+      "true": "disable"
     },
     "enabled": {
       "false": "Disabled",

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -257,7 +257,10 @@
         "title": "Advanced"
       },
       "backups": {
+        "confirmBackup": "Would you like to create a new backup?",
         "create": "Create backup",
+        "created": "Backup created successfully.",
+        "creating": "Creating backup...",
         "manage": "Manage backups",
         "restore": "Restore backup",
         "title": "Backups"

--- a/frontends/web/src/routes/bitboxbase/basesettings.tsx
+++ b/frontends/web/src/routes/bitboxbase/basesettings.tsx
@@ -16,6 +16,7 @@
 
 import { Component, h, RenderableProps } from 'preact';
 import { alertUser } from '../../components/alert/Alert';
+import { ChangeBaseHostname } from '../../components/bitboxbase/changebasehostname';
 import { UpdateBaseButton } from '../../components/bitboxbase/updatebasebutton';
 import { CenteredContent } from '../../components/centeredcontent/centeredcontent';
 import { confirmation } from '../../components/confirm/Confirm';
@@ -159,6 +160,7 @@ class BaseSettings extends Component<Props, State> {
             updateInfo,
             updateAvailable,
             apiPrefix,
+            getBaseInfo,
         }: RenderableProps<Props>,
         {
             expandedDashboard,
@@ -365,7 +367,10 @@ class BaseSettings extends Component<Props, State> {
                                                 </div>
                                             </div>
                                             <div className="box slim divide">
-                                            <SettingsButton>{t('bitboxBase.settings.node.changeName')}</SettingsButton>
+                                            <ChangeBaseHostname
+                                                apiPrefix={apiPrefix}
+                                                currentHostname={baseInfo.hostname}
+                                                getBaseInfo={getBaseInfo} />
                                             <SettingsButton>{t('bitboxBase.settings.node.password')}</SettingsButton>
                                             <SettingsButton
                                                 optionalText={t(`generic.enabled.${baseInfo.isTorEnabled}`)}

--- a/frontends/web/src/routes/bitboxbase/basesettings.tsx
+++ b/frontends/web/src/routes/bitboxbase/basesettings.tsx
@@ -17,6 +17,7 @@
 import { Component, h, RenderableProps } from 'preact';
 import { alertUser } from '../../components/alert/Alert';
 import { ChangeBaseHostname } from '../../components/bitboxbase/changebasehostname';
+import { ChangeBasePassword } from '../../components/bitboxbase/changebasepassword';
 import { UpdateBaseButton } from '../../components/bitboxbase/updatebasebutton';
 import { CenteredContent } from '../../components/centeredcontent/centeredcontent';
 import { confirmation } from '../../components/confirm/Confirm';
@@ -371,7 +372,7 @@ class BaseSettings extends Component<Props, State> {
                                                 apiPrefix={apiPrefix}
                                                 currentHostname={baseInfo.hostname}
                                                 getBaseInfo={getBaseInfo} />
-                                            <SettingsButton>{t('bitboxBase.settings.node.password')}</SettingsButton>
+                                            <ChangeBasePassword apiPrefix={apiPrefix} />
                                             <SettingsButton
                                                 optionalText={t(`generic.enabled.${baseInfo.isTorEnabled}`)}
                                                 onClick={() => {

--- a/frontends/web/src/routes/bitboxbase/basesettings.tsx
+++ b/frontends/web/src/routes/bitboxbase/basesettings.tsx
@@ -19,6 +19,7 @@ import { alertUser } from '../../components/alert/Alert';
 import { ChangeBaseHostname } from '../../components/bitboxbase/changebasehostname';
 import { ChangeBasePassword } from '../../components/bitboxbase/changebasepassword';
 import { CreateBaseBackup } from '../../components/bitboxbase/createbasebackup';
+import { EnableSSHLogin } from '../../components/bitboxbase/enablesshlogin';
 import { UpdateBaseButton } from '../../components/bitboxbase/updatebasebutton';
 import { CenteredContent } from '../../components/centeredcontent/centeredcontent';
 import { confirmation } from '../../components/confirm/Confirm';
@@ -454,7 +455,10 @@ class BaseSettings extends Component<Props, State> {
                                                         {t('bitboxBase.settings.advanced.title')}
                                                     </summary>
                                                     <div className="box slim divide">
-                                                        <SettingsButton optionalText="Disabled">{t('bitboxBase.settings.advanced.sshAccess')}</SettingsButton>
+                                                        <EnableSSHLogin
+                                                            apiPrefix={apiPrefix}
+                                                            enabled={baseInfo.IsSSHPasswordLoginEnabled}
+                                                            onSuccess={getBaseInfo} />
                                                         <SettingsButton onClick={connectElectrum}>{t('bitboxBase.settings.advanced.connectElectrum')}</SettingsButton>
                                                         <SettingsButton>{t('bitboxBase.settings.advanced.syncOptions')}</SettingsButton>
                                                         <SettingsButton>{t('bitboxBase.settings.advanced.manual')}</SettingsButton>

--- a/frontends/web/src/routes/bitboxbase/basesettings.tsx
+++ b/frontends/web/src/routes/bitboxbase/basesettings.tsx
@@ -18,6 +18,7 @@ import { Component, h, RenderableProps } from 'preact';
 import { alertUser } from '../../components/alert/Alert';
 import { ChangeBaseHostname } from '../../components/bitboxbase/changebasehostname';
 import { ChangeBasePassword } from '../../components/bitboxbase/changebasepassword';
+import { CreateBaseBackup } from '../../components/bitboxbase/createbasebackup';
 import { UpdateBaseButton } from '../../components/bitboxbase/updatebasebutton';
 import { CenteredContent } from '../../components/centeredcontent/centeredcontent';
 import { confirmation } from '../../components/confirm/Confirm';
@@ -439,7 +440,7 @@ class BaseSettings extends Component<Props, State> {
                                                 </div>
                                             </div>
                                             <div className="box slim divide">
-                                                <SettingsButton>{t('bitboxBase.settings.backups.create')}</SettingsButton>
+                                                <CreateBaseBackup apiPrefix={apiPrefix} />
                                                 <SettingsButton>{t('bitboxBase.settings.backups.restore')}</SettingsButton>
                                             </div>
                                         </div>

--- a/frontends/web/src/routes/bitboxbase/basesettings.tsx
+++ b/frontends/web/src/routes/bitboxbase/basesettings.tsx
@@ -222,7 +222,7 @@ class BaseSettings extends Component<Props, State> {
                                     </div>
                                     <div className={style.item}>
                                         <div className={style.dashboardItem}>
-                                            <p>TODO</p>
+                                            <p>{baseInfo.lightningActiveChannels}</p>
                                             <p>Lightning channels</p>
                                         </div>
                                     </div>

--- a/frontends/web/src/routes/bitboxbase/basesettings.tsx
+++ b/frontends/web/src/routes/bitboxbase/basesettings.tsx
@@ -20,6 +20,7 @@ import { ChangeBaseHostname } from '../../components/bitboxbase/changebasehostna
 import { ChangeBasePassword } from '../../components/bitboxbase/changebasepassword';
 import { CreateBaseBackup } from '../../components/bitboxbase/createbasebackup';
 import { EnableSSHLogin } from '../../components/bitboxbase/enablesshlogin';
+import { SetBaseSystemPassword } from '../../components/bitboxbase/setbasesystempassword';
 import { UpdateBaseButton } from '../../components/bitboxbase/updatebasebutton';
 import { CenteredContent } from '../../components/centeredcontent/centeredcontent';
 import { confirmation } from '../../components/confirm/Confirm';
@@ -459,6 +460,7 @@ class BaseSettings extends Component<Props, State> {
                                                             apiPrefix={apiPrefix}
                                                             enabled={baseInfo.IsSSHPasswordLoginEnabled}
                                                             onSuccess={getBaseInfo} />
+                                                        <SetBaseSystemPassword apiPrefix={apiPrefix} />
                                                         <SettingsButton onClick={connectElectrum}>{t('bitboxBase.settings.advanced.connectElectrum')}</SettingsButton>
                                                         <SettingsButton>{t('bitboxBase.settings.advanced.syncOptions')}</SettingsButton>
                                                         <SettingsButton>{t('bitboxBase.settings.advanced.manual')}</SettingsButton>

--- a/frontends/web/src/routes/bitboxbase/basesettings.tsx
+++ b/frontends/web/src/routes/bitboxbase/basesettings.tsx
@@ -120,6 +120,15 @@ class BaseSettings extends Component<Props, State> {
                 });
             }
 
+    private shutdown = () => {
+        apiPost(this.props.apiPrefix + '/shutdown-base')
+                .then(response => {
+                    if (!response.success) {
+                        alertUser(response.message);
+                    }
+                });
+            }
+
     private updateBase = (version: string) => {
         this.setState({ updating: true });
         apiPost(this.props.apiPrefix + '/update-base', {version})
@@ -414,7 +423,13 @@ class BaseSettings extends Component<Props, State> {
                                                         }
                                                     });
                                                 }}>{t('bitboxBase.settings.system.restart')}</SettingsButton>
-                                                <SettingsButton>{t('bitboxBase.settings.system.shutdown')}</SettingsButton>
+                                                <SettingsButton onClick={() => {
+                                                    confirmation(t('bitboxBase.settings.system.confirmShutdown'), confirmed => {
+                                                        if (confirmed) {
+                                                            this.shutdown();
+                                                        }
+                                                    });
+                                                }}>{t('bitboxBase.settings.system.shutdown')}</SettingsButton>
                                             </div>
                                         </div>
                                         <div className="column column-1-3">

--- a/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
+++ b/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
@@ -431,7 +431,8 @@ class BitBoxBase extends Component<Props, State> {
                         connectElectrum={this.connectElectrum}
                         apiPrefix={this.apiPrefix()}
                         updateAvailable={updateAvailable}
-                        updateInfo={updateInfo} />
+                        updateInfo={updateInfo}
+                        getBaseInfo={this.getBaseInfo} />
                 );
             }
             return (

--- a/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
+++ b/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
@@ -48,6 +48,7 @@ export interface BitBoxBaseInfo {
     isTorEnabled: boolean;
     isBitcoindListening: boolean;
     IsSSHPasswordLoginEnabled: boolean;
+    lightningActiveChannels: number;
     freeDiskspace: number;
     totalDiskspace: number;
     baseVersion: string;

--- a/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
+++ b/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
@@ -47,6 +47,7 @@ export interface BitBoxBaseInfo {
     middlewareTorPort: string;
     isTorEnabled: boolean;
     isBitcoindListening: boolean;
+    IsSSHPasswordLoginEnabled: boolean;
     freeDiskspace: number;
     totalDiskspace: number;
     baseVersion: string;


### PR DESCRIPTION
This PR implements functionality for these settings buttons:
- Enable/Disable Tor
- Change hostname
- Change password
- Shut down
- Create backup
- Enable ssh password authentication
- Set system password

Additionally:
- Add number of active lightning channels