### PR TITLE
android: add a logcat "helper" make target

### DIFF
--- a/frontends/android/Makefile
+++ b/frontends/android/Makefile
@@ -11,3 +11,13 @@ prepare-android:
 	mkdir -p BitBoxApp/app/src/main/assets/web && cp -aR ../web/build/* BitBoxApp/app/src/main/assets/web/
 	cd goserver && ${MAKE} build
 	cp goserver/goserver.aar BitBoxApp/goserver/
+logcat:
+	adb logcat -s \
+		GoLog \
+		ch.shiftcrypto.bitboxapp \
+		ActivityManager \
+		InputDispatcher \
+		libprocessgroup \
+		SurfaceFlinger \
+		WindowManager \
+		Zygote


### PR DESCRIPTION
This just makes it a little easier to watch adb's logcat logs
pertinent to the app.

The current filter does catch slightly more than just the app
yet the log output isn't cluttered and allows one to follow
the life of the app with enough comfort from command line.