### PR TITLE
frontend: fix "show password" checkbox which was too large

### DIFF
--- a/frontends/web/src/components/forms/input.css
+++ b/frontends/web/src/components/forms/input.css
@@ -54,3 +54,8 @@
 .errorText > span > span {
     margin-left: 5px;
 }
+
+.input input[type=checkbox] {
+    width: auto;
+    height: auto;
+}


### PR DESCRIPTION
In the PasswordSingleInput component, the checkbox for showing the
password was too large, running out of bounds of a dialog and being
clickable from a large area

![checkbox](https://user-images.githubusercontent.com/14039565/68678406-2f7ce380-055e-11ea-8c94-ec3a820065ba.gif)