### PR TITLE
ci: make golangci-lint great again

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,9 @@ run:
   # include test files or not, default is true
   tests: true
 
+  # ignore go.mod and use vendor dir instead
+  modules-download-mode: vendor
+
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
-github.com/btcsuite/btcd v0.20.0-beta h1:DnZGUjFbRkpytojHWwy6nfUSA7vFrzWXDLpFNzt74ZA=
+github.com/btcsuite/btcd v0.20.0-beta h1:PamBMopnHxO2nEIsU89ibVVnqnXR2yFTgGNc+PdG68o=
 github.com/btcsuite/btcd v0.20.0-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=


### PR DESCRIPTION
This resolves the following error

    + golangci-lint run
    level=error msg="Running error: context loading failed:
    no go files to analyze"
    Makefile:79: recipe for target 'ci' failed

I believe this is because of a recent golangci-lint upgrade.
It seems to be running with the default go modules support now,
which in turn tries downloading all the package dependencies.

Unfortunately, one package dep was added to go.sum at the time
where package checksums were computed incorrectly in certain conditions.
More on that can be found in golang/go issue 29278.

This went unnoticed for quite some time because vendored dir is used
instead of go.mod. Since the upgrade of golangci-lint, it started
using go.mod.

This change updates go.mod checksum, even though it isn't used,
and makes golangci-lint use vendored dir as it should.