### PR TITLE
backend,frontend: add event-based banners

### DIFF
--- a/backend/banners/banners.go
+++ b/backend/banners/banners.go
@@ -1,0 +1,121 @@
+// Copyright 2018 Shift Devices AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package banners
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable/action"
+	"github.com/sirupsen/logrus"
+)
+
+const bannersURL = "https://shiftcrypto.ch/updates/banners.json"
+
+// MessageKey enumerates the possible keys in the banners json.
+type MessageKey string
+
+const (
+	// KeyBitBox01 is the message key for the event when a BitBox01 gets connected.
+	KeyBitBox01 MessageKey = "bitbox01"
+)
+
+// Message is one entry in the banners json.
+type Message struct {
+	// map of language code to message.
+	Message map[string]string `json:"message"`
+	// ID is a unique id of the message.
+	ID string `json:"id"`
+	// Link, if present, will be appended to the message.
+	Link *struct {
+		Href string `json:"href"`
+	} `json:"link"`
+}
+
+// Banners fetches banner information from remote.
+type Banners struct {
+	observable.Implementation
+
+	url     string
+	banners struct {
+		BitBox01 *Message `json:"bitbox01"`
+	}
+
+	active map[MessageKey]struct{}
+
+	log *logrus.Entry
+}
+
+// NewBanners makes a new Banners instance.
+func NewBanners() *Banners {
+	return &Banners{
+		url:    bannersURL,
+		active: map[MessageKey]struct{}{},
+		log:    logging.Get().WithGroup("banners"),
+	}
+}
+
+func (banners *Banners) init(httpClient *http.Client) error {
+	response, err := httpClient.Get(banners.url)
+	if err != nil {
+		return errp.WithStack(err)
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if err := json.NewDecoder(response.Body).Decode(&banners.banners); err != nil {
+		return errp.WithStack(err)
+	}
+	return nil
+}
+
+// Init fetches the remote banners info. Should be called in a go-routine to be non-blocking.
+func (banners *Banners) Init(httpClient *http.Client) {
+	if err := banners.init(httpClient); err != nil {
+		banners.log.WithError(err).Warn("Check for banners failed.")
+	}
+}
+
+// Activate invokes showing the message for the given key.
+func (banners *Banners) Activate(key MessageKey) {
+	banners.active[key] = struct{}{}
+	banners.Notify(observable.Event{
+		Subject: "banners/" + string(key),
+		Action:  action.Replace,
+		Object:  banners.getMessage(key),
+	})
+}
+
+func (banners *Banners) getMessage(key MessageKey) *Message {
+	switch key {
+	case KeyBitBox01:
+		return banners.banners.BitBox01
+	default:
+		banners.log.Errorf("unrecognized key: %s", key)
+		return nil
+	}
+}
+
+// GetMessage gets a message for a key if it was activated. nil otherwise, or if no msg exists.
+func (banners *Banners) GetMessage(key MessageKey) *Message {
+	_, active := banners.active[key]
+	if !active {
+		return nil
+	}
+	return banners.getMessage(key)
+}

--- a/backend/banners/banners_test.go
+++ b/backend/banners/banners_test.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Shift Devices AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package banners
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable/action"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Test request parameters
+		_, err := rw.Write([]byte(`
+{
+    "bitbox01": {
+        "id": "some-id",
+        "message": {
+            "en": "some-msg"
+        },
+        "link": {
+            "href": "some-link"
+        }
+    }
+}
+		`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	banners := NewBanners()
+	banners.url = server.URL
+	banners.Init(server.Client())
+	require.Nil(t, banners.GetMessage(KeyBitBox01))
+	banners.Activate(KeyBitBox01)
+	msg := banners.GetMessage(KeyBitBox01)
+
+	banners.Observe(func(event observable.Event) {
+		require.Equal(
+			t,
+			observable.Event{
+				Subject: "banners/bitbox01",
+				Action:  action.Replace,
+				Object:  msg,
+			},
+			event,
+		)
+	})
+
+	require.Equal(t, "some-id", msg.ID)
+	require.Equal(t, map[string]string{"en": "some-msg"}, msg.Message)
+	require.NotNil(t, msg.Link)
+	require.Equal(t, "some-link", msg.Link.Href)
+
+}

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/banners"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/bitboxbase"
 	baseHandlers "github.com/digitalbitbox/bitbox-wallet-app/backend/bitboxbase/handlers"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
@@ -103,6 +104,7 @@ type Backend interface {
 	SystemOpen(string) error
 	ReinitializeAccounts()
 	CheckForUpdateIgnoringErrors() *backend.UpdateFile
+	Banners() *banners.Banners
 }
 
 // Handlers provides a web api to the backend.
@@ -173,6 +175,7 @@ func NewHandlers(
 	getAPIRouter(apiRouter)("/notify-user", handlers.postNotifyHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/open", handlers.postOpenHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/update", handlers.getUpdateHandler).Methods("GET")
+	getAPIRouter(apiRouter)("/banners/{key}", handlers.getBannersHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/version", handlers.getVersionHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/testing", handlers.getTestingHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/account-add", handlers.postAddAccountHandler).Methods("POST")
@@ -351,6 +354,10 @@ func (handlers *Handlers) postOpenHandler(r *http.Request) (interface{}, error) 
 
 func (handlers *Handlers) getUpdateHandler(_ *http.Request) (interface{}, error) {
 	return handlers.backend.CheckForUpdateIgnoringErrors(), nil
+}
+
+func (handlers *Handlers) getBannersHandler(r *http.Request) (interface{}, error) {
+	return handlers.backend.Banners().GetMessage(banners.MessageKey(mux.Vars(r)["key"])), nil
 }
 
 func (handlers *Handlers) getVersionHandler(_ *http.Request) (interface{}, error) {

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -17,6 +17,7 @@
 import { Component, h, RenderableProps } from 'preact';
 import { getCurrentUrl, route } from 'preact-router';
 import { Alert } from './components/alert/Alert';
+import { Banner } from './components/banner/banner';
 import { Confirm } from './components/confirm/Confirm';
 import { Container } from './components/container/container';
 import { store as panelStore } from './components/guide/guide';
@@ -187,6 +188,7 @@ class App extends Component<Props, State> {
                     accountsInitialized={accountsInitialized} />
                 <div class="appContent flex-column flex-1" style="min-width: 0;">
                     <Update />
+                    <Banner msgKey="bitbox01" />
                     <Container toggleSidebar={this.toggleSidebar} onChange={this.handleRoute}>
                         <Send
                             path="/account/:code/send"

--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2018 Shift Devices AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { h, RenderableProps } from 'preact';
+import { subscribe } from '../../decorators/subscribe';
+import { translate, TranslateProps } from '../../decorators/translate';
+import A from '../anchor/anchor';
+import Status from '../status/status';
+
+interface BannerInfo {
+    id: string;
+    message: { [key: string]: string; };
+    link?: {
+        href: string;
+        text: string;
+    };
+}
+
+interface LoadedProps {
+    banner: BannerInfo | null;
+}
+
+interface BannerProps {
+    msgKey: 'bitbox01';
+}
+
+type Props = LoadedProps & BannerProps & TranslateProps;
+
+function Banner({ msgKey, banner, i18n, t }: RenderableProps<Props>): JSX.Element | null {
+    if (!i18n.options.fallbackLng) {
+        return null;
+    }
+    return banner && (
+        <Status dismissable keyName={`banner-${msgKey}-${banner.id}`} type="info">
+            { banner.message[i18n.language] || banner.message[i18n.options.fallbackLng[0]] }&nbsp;
+            { banner.link && (
+                <A href={banner.link.href}>
+                    {t('clickHere')}
+                </A>
+            )}
+        </Status>
+    );
+}
+
+const HOC = translate<BannerProps>()(
+    subscribe<LoadedProps, BannerProps & TranslateProps>(
+        ({ msgKey }) => ({ banner: 'banners/' + msgKey }),
+        true,
+        false,
+    )(Banner),
+);
+
+export { HOC as Banner };

--- a/frontends/web/src/decorators/translate.ts
+++ b/frontends/web/src/decorators/translate.ts
@@ -52,6 +52,7 @@ export type Translate = (i18nKey: string, values?: TranslateOptions) => any;
  */
 export interface TranslateProps {
     t: Translate;
+    i18n: any;
 }
 
 interface HOCOptions {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -415,6 +415,7 @@
     "oldLabel": "Current device password"
   },
   "checkSDcard": "checking microSD card",
+  "clickHere": "Click here.",
   "confirm": {
     "abortInfo": "Tap to ",
     "abortInfoRedText": "abort",


### PR DESCRIPTION
Initial use-case: alert BitBox01 users of BitBox02's existence when
they plug in their BitBox01.

The banner information is fetched from shiftcrypto.ch.