### PR TITLE
base-backend: refactor initial connection and noise pairing

### DIFF
--- a/backend/bitboxbase/bitboxbase.go
+++ b/backend/bitboxbase/bitboxbase.go
@@ -39,6 +39,9 @@ type Interface interface {
 	// Identifier returns the bitboxBaseID.
 	Identifier() string
 
+	// ConnectRPCClient connects to the RPC client of the Base whose initial connection has already been established
+	ConnectRPCClient() error
+
 	// GetRPCClient returns the rpcClient so we can listen to its events.
 	RPCClient() *rpcclient.RPCClient
 
@@ -204,6 +207,14 @@ func NewBitBoxBase(address string,
 // Self returns the current bitbox base instance.
 func (base *BitBoxBase) Self() *BitBoxBase {
 	return base
+}
+
+// EstablishConnection establishes initial websocket connection with the middleware
+func (base *BitBoxBase) EstablishConnection() error {
+	if err := base.rpcClient.EstablishConnection(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ConnectRPCClient starts the connection with the remote bitbox base middleware

--- a/backend/bitboxbase/handlers/handlers.go
+++ b/backend/bitboxbase/handlers/handlers.go
@@ -27,6 +27,7 @@ import (
 
 // Base models the api of the base middleware
 type Base interface {
+	ConnectRPCClient() error
 	BaseUpdateProgress() (rpcmessages.GetBaseUpdateProgressResponse, error)
 	ConnectElectrum() error
 	Status() bitboxbasestatus.Status
@@ -77,6 +78,7 @@ func NewHandlers(
 	handleFunc("/service-info", handlers.getServiceInfoHandler).Methods("GET")
 	handleFunc("/base-update-progress", handlers.getBaseUpdateProgressHandler).Methods("GET")
 	handleFunc("/update-info", handlers.getUpdateInfoHandler).Methods("GET")
+	handleFunc("/connect-base", handlers.postConnectBaseHandler).Methods("POST")
 	handleFunc("/backup-sysconfig", handlers.postBackupSysconfigHandler).Methods("POST")
 	handleFunc("/backup-hsm-secret", handlers.postBackupHSMSecretHandler).Methods("POST")
 	handleFunc("/restore-sysconfig", handlers.postRestoreSysconfigHandler).Methods("POST")
@@ -131,6 +133,17 @@ func bbBaseError(err error, log *logrus.Entry) map[string]interface{} {
 		"code":    "UNEXPECTED_ERROR",
 		"message": err.Error,
 	}
+}
+
+func (handlers *Handlers) postConnectBaseHandler(r *http.Request) (interface{}, error) {
+	handlers.log.Println("Connecting base...")
+	err := handlers.base.ConnectRPCClient()
+	if err != nil {
+		return bbBaseError(err, handlers.log), nil
+	}
+	return map[string]interface{}{
+		"success": true,
+	}, nil
 }
 
 func (handlers *Handlers) postDisconnectBaseHandler(r *http.Request) (interface{}, error) {

--- a/backend/bitboxbase/mdns/manager.go
+++ b/backend/bitboxbase/mdns/manager.go
@@ -121,7 +121,7 @@ func (manager *Manager) TryMakeNewBase(address string) (bool, error) {
 		return false, err
 	}
 
-	if err = baseDevice.ConnectRPCClient(); err != nil {
+	if err = baseDevice.EstablishConnection(); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -195,7 +195,7 @@ func NewHandlers(
 	getAPIRouter(apiRouter)("/coins/btc/headers/status", handlers.getHeadersStatus("btc")).Methods("GET")
 	getAPIRouter(apiRouter)("/certs/download", handlers.postCertsDownloadHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/certs/check", handlers.postCertsCheckHandler).Methods("POST")
-	getAPIRouter(apiRouter)("/bitboxbases/connectbase", handlers.postConnectBaseHandler).Methods("POST")
+	getAPIRouter(apiRouter)("/bitboxbases/establish-connection", handlers.postEstablishConnectionHandler).Methods("POST")
 
 	devicesRouter := getAPIRouter(apiRouter.PathPrefix("/devices").Subrouter())
 	bitboxBasesRouter := getAPIRouter(apiRouter.PathPrefix("/bitboxbases").Subrouter())
@@ -649,7 +649,7 @@ func (handlers *Handlers) postCertsCheckHandler(r *http.Request) (interface{}, e
 	}, nil
 }
 
-func (handlers *Handlers) postConnectBaseHandler(r *http.Request) (interface{}, error) {
+func (handlers *Handlers) postEstablishConnectionHandler(r *http.Request) (interface{}, error) {
 	jsonBody := map[string]string{}
 	if err := json.NewDecoder(r.Body).Decode(&jsonBody); err != nil {
 		return nil, errp.WithStack(err)

--- a/frontends/web/src/routes/bitboxbase/bitboxbase.css
+++ b/frontends/web/src/routes/bitboxbase/bitboxbase.css
@@ -256,3 +256,8 @@ The svg draws a line which forms a minus (-).
 .loadingText {
     color: var(--color-gray-alt)
 }
+
+.noHash {
+    color: var(--color-gray-alt);
+    letter-spacing: 2px;
+}

--- a/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
+++ b/frontends/web/src/routes/bitboxbase/bitboxbase.tsx
@@ -100,6 +100,10 @@ enum NetworkOptions {
     ClearnetIBD = 'enable-clearnet-ibd',
 }
 
+// Displays one-letter-wide blocks as placeholders if pairing code not available yet
+const noPairingPlaceholder = '\u2588\u2588\u2588\u2588\u2588 \u2588\u2588\u2588\u2588\u2588\n' +
+                             '\u2588\u2588\u2588\u2588\u2588 \u2588\u2588\u2588\u2588\u2588';
+
 interface State {
     baseInfo?: BitBoxBaseInfo;
     serviceInfo?: BitBoxBaseServiceInfo;
@@ -465,7 +469,9 @@ class BitBoxBase extends Component<Props, State> {
                                 width={540}>
                                 <div className={stepStyle.stepContext}>
                                     <p>{t('bitboxBaseWizard.pairing.unpaired')}</p>
-                                    <pre>{hash}</pre>
+                                    <pre className={!hash ? style.noHash : ''}>
+                                        {hash ? hash : noPairingPlaceholder}
+                                    </pre>
                                     <div className={['buttons text-center', stepStyle.fullWidth].join(' ')}>
                                         <Button
                                             primary


### PR DESCRIPTION
Because:
Previously, the '/connectbase' endpoint would not succeed until after
the noise pairing hash was confirmed by the user. This means that when
connecting to the Base, the user would not be routed to the setup
wizard until after the pairing had succeeded (which happens
automatically now, but in final implementation would mean the user
would never be routed to the wizard)

This commit:
Refactors the intial rpc client ping and websocket dial to a separate
function which succeeds on initial connection. Only after this is the
noise pairing initialized.