### PR TITLE
Remove the BitBoxBase Interface

### DIFF
--- a/backend/bitboxbase/bitboxbase.go
+++ b/backend/bitboxbase/bitboxbase.go
@@ -33,121 +33,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Interface represents bitbox base.
-type Interface interface {
-
-	// Identifier returns the bitboxBaseID.
-	Identifier() string
-
-	// ConnectRPCClient connects to the RPC client of the Base whose initial connection has already been established
-	ConnectRPCClient() error
-
-	// GetRPCClient returns the rpcClient so we can listen to its events.
-	RPCClient() *rpcclient.RPCClient
-
-	// Close tells the bitboxbase to close all connections.
-	Close()
-
-	// GetRegisterTime implements a getter for the timestamp of when the bitboxBase was registered
-	GetRegisterTime() time.Time
-
-	// ConnectElectrum connects to the electrs server on the base and configures the backend accordingly
-	ConnectElectrum() error
-
-	// Ping sends a get requset to the bitbox base middleware root handler and returns true if successful
-	Ping() (bool, error)
-
-	// Self returns an instance of the base
-	Self() *BitBoxBase
-
-	// Status returns the current status of the base
-	Status() bitboxbasestatus.Status
-
-	// ChannelHash returns the hash of the noise channel
-	ChannelHash() (string, bool)
-
-	// Deregister calls the backend's BitBoxBase Deregister callback and sends a notification to the frontend, if bitboxbase is active.
-	// If bitboxbase is not active, an error is returned.
-	Deregister() error
-
-	// ReindexBitcoin starts a bitcoin reindex on the base.
-	ReindexBitcoin() error
-
-	// ResyncBitcoin starts a bitcoin resync on the base.
-	ResyncBitcoin() error
-
-	// SetHostname sets the hostname of the BitBox Base
-	SetHostname(string) error
-
-	// UserChangePassword sets a new password for a given user
-	UserChangePassword(string, string, string) error
-
-	// UserAuthenticate returns is the authentication with a username and password was successful
-	UserAuthenticate(string, string) error
-
-	// BackupSysconfig backs up the system config to the flashdrive
-	BackupSysconfig() error
-
-	// BackupHSMSecret backs up the lightning hsm_secret
-	BackupHSMSecret() error
-
-	// RestoreSysconfig restores the system config from the flashdrive
-	RestoreSysconfig() error
-
-	// RestoreHSMSecret restores the lightning hsm_secret
-	RestoreHSMSecret() error
-
-	// EnableTor enables/disables Tor
-	EnableTor(rpcmessages.ToggleSettingArgs) error
-
-	// EnableTorMiddleware enables/disables Tor for the middleware
-	EnableTorMiddleware(rpcmessages.ToggleSettingArgs) error
-
-	// EnableTorElectrs enables/disables Tor for electrs
-	EnableTorElectrs(rpcmessages.ToggleSettingArgs) error
-
-	// EnableTorSSH enables/disables Tor for SSH
-	EnableTorSSH(rpcmessages.ToggleSettingArgs) error
-
-	// EnableClearnetIBD configures bitcoind to run over clearnet while in IBD
-	EnableClearnetIBD(rpcmessages.ToggleSettingArgs) error
-
-	// EnableRootLogin enables/disables login via the root user/password
-	EnableRootLogin(rpcmessages.ToggleSettingArgs) error
-
-	// EnableSSHPasswordLogin enables/disables the ssh login with a password
-	EnableSSHPasswordLogin(rpcmessages.ToggleSettingArgs) error
-
-	// SetRootPassword sets the systems root password
-	SetLoginPassword(string) error
-
-	// ShutdownBase initiates a `shutdown now` call via the bbb-cmd.sh script
-	ShutdownBase() error
-
-	// RebootBase initiates a `reboot` call via the bbb-cmd.sh script
-	RebootBase() error
-
-	// UpdateBase performs an update of the Base firmware to a passed version.
-	UpdateBase(rpcmessages.UpdateBaseArgs) error
-
-	// BaseUpdateProgress returns the Base Update progress.
-	// This should be called when then middleware notifies the App that the update progress changed.
-	BaseUpdateProgress() (rpcmessages.GetBaseUpdateProgressResponse, error)
-
-	// BaseInfo returns information about the Base
-	BaseInfo() (rpcmessages.GetBaseInfoResponse, error)
-
-	// FinalizeSetupWizard calls the FinalizeSetupWizard RPC to enable bitcoin and start bitcoin services
-	FinalizeSetupWizard() error
-
-	// ServiceInfo returns information about the services running on the Base
-	// As for example the bitcoind, electrs and ligthningd block height
-	ServiceInfo() (rpcmessages.GetServiceInfoResponse, error)
-
-	// UpdateInfo returns whether an update is available, and if so, version, description and severity information
-	UpdateInfo() (rpcmessages.IsBaseUpdateAvailableResponse, error)
-}
-
 // SyncOption is a user provided blockchain sync option during BBB initialization
 type SyncOption string
 
@@ -202,11 +87,6 @@ func NewBitBoxBase(address string,
 	bitboxBase.rpcClient = rpcClient
 
 	return bitboxBase, err
-}
-
-// Self returns the current bitbox base instance.
-func (base *BitBoxBase) Self() *BitBoxBase {
-	return base
 }
 
 // EstablishConnection establishes initial websocket connection with the middleware

--- a/backend/bitboxbase/handlers/handlers.go
+++ b/backend/bitboxbase/handlers/handlers.go
@@ -18,50 +18,16 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/bitboxbase"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/bitboxbase/rpcmessages"
-	bitboxbasestatus "github.com/digitalbitbox/bitbox-wallet-app/backend/bitboxbase/status"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 )
 
-// Base models the api of the base middleware
-type Base interface {
-	ConnectRPCClient() error
-	BaseUpdateProgress() (rpcmessages.GetBaseUpdateProgressResponse, error)
-	ConnectElectrum() error
-	Status() bitboxbasestatus.Status
-	ChannelHash() (string, bool)
-	Deregister() error
-	ReindexBitcoin() error
-	ResyncBitcoin() error
-	SetHostname(string) error
-	UserAuthenticate(string, string) error
-	UserChangePassword(string, string, string) error
-	BackupSysconfig() error
-	BackupHSMSecret() error
-	RestoreSysconfig() error
-	RestoreHSMSecret() error
-	EnableTor(rpcmessages.ToggleSettingArgs) error
-	EnableTorMiddleware(rpcmessages.ToggleSettingArgs) error
-	EnableTorElectrs(rpcmessages.ToggleSettingArgs) error
-	EnableTorSSH(rpcmessages.ToggleSettingArgs) error
-	EnableClearnetIBD(rpcmessages.ToggleSettingArgs) error
-	EnableRootLogin(rpcmessages.ToggleSettingArgs) error
-	EnableSSHPasswordLogin(rpcmessages.ToggleSettingArgs) error
-	SetLoginPassword(string) error
-	ShutdownBase() error
-	RebootBase() error
-	UpdateBase(rpcmessages.UpdateBaseArgs) error
-	BaseInfo() (rpcmessages.GetBaseInfoResponse, error)
-	ServiceInfo() (rpcmessages.GetServiceInfoResponse, error)
-	UpdateInfo() (rpcmessages.IsBaseUpdateAvailableResponse, error)
-	FinalizeSetupWizard() error
-}
-
 // Handlers provides a web API to the Bitbox.
 type Handlers struct {
-	base Base
+	base *bitboxbase.BitBoxBase
 	log  *logrus.Entry
 }
 
@@ -108,7 +74,7 @@ func NewHandlers(
 
 // Init installs a bitboxbase as a base for the web api. This needs to be called before any requests
 // are made.
-func (handlers *Handlers) Init(base Base) {
+func (handlers *Handlers) Init(base *bitboxbase.BitBoxBase) {
 	handlers.log.Debug("Init")
 	handlers.base = base
 }

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -85,10 +85,10 @@ type Backend interface {
 	OnDeviceInit(f func(device.Interface))
 	OnDeviceUninit(f func(deviceID string))
 	DevicesRegistered() map[string]device.Interface
-	OnBitBoxBaseInit(f func(bitboxbase.Interface))
+	OnBitBoxBaseInit(f func(*bitboxbase.BitBoxBase))
 	OnBitBoxBaseUninit(f func(bitboxBaseID string))
 	BitBoxBasesDetected() map[string]string
-	BitBoxBasesRegistered() map[string]bitboxbase.Interface
+	BitBoxBasesRegistered() map[string]*bitboxbase.BitBoxBase
 	Start() <-chan interface{}
 	RegisterKeystore(keystore.Keystore)
 	DeregisterKeystore()
@@ -284,7 +284,7 @@ func NewHandlers(
 		getDeviceHandlers(deviceID).Uninit()
 	})
 
-	backend.OnBitBoxBaseInit(func(baseDevice bitboxbase.Interface) {
+	backend.OnBitBoxBaseInit(func(baseDevice *bitboxbase.BitBoxBase) {
 		getBaseHandlers(baseDevice.Identifier()).Init(baseDevice)
 	})
 	backend.OnBitBoxBaseUninit(func(bitboxBaseID string) {


### PR DESCRIPTION
This was initially required to to hook up the events from the BitBoxBase struct to the backend. A direct reference to the BitBoxBase can be used though, since the BitBoxBase struct is defined then.
Should replace https://github.com/digitalbitbox/bitbox-wallet-app/pull/691