### PR TITLE
Base pairing

### DIFF
--- a/backend/bitboxbase/handlers/handlers.go
+++ b/backend/bitboxbase/handlers/handlers.go
@@ -97,7 +97,7 @@ func bbBaseError(err error, log *logrus.Entry) map[string]interface{} {
 	return map[string]interface{}{
 		"success": false,
 		"code":    "UNEXPECTED_ERROR",
-		"message": err.Error,
+		"message": err.Error(),
 	}
 }
 

--- a/backend/bitboxbase/mdns/manager.go
+++ b/backend/bitboxbase/mdns/manager.go
@@ -55,6 +55,7 @@ type Manager struct {
 
 	onRegister   func(*bitboxbase.BitBoxBase) error
 	onUnregister func(string)
+	onRemove     func(string)
 
 	log                 *logrus.Entry
 	config              *config.Config
@@ -68,6 +69,7 @@ func NewManager(
 	onDetect func(),
 	onRegister func(*bitboxbase.BitBoxBase) error,
 	onUnregister func(string),
+	onRemove func(string),
 	config *config.Config,
 	bitboxBaseConfigDir string,
 	socksProxy socksproxy.SocksProxy,
@@ -78,6 +80,7 @@ func NewManager(
 		detectedBases:        map[string]string{},
 		onRegister:           onRegister,
 		onUnregister:         onUnregister,
+		onRemove:             onRemove,
 		config:               config,
 		bitboxBaseConfigDir:  bitboxBaseConfigDir,
 		socksProxy:           socksProxy,
@@ -108,7 +111,7 @@ func (manager *Manager) TryMakeNewBase(address string) (bool, error) {
 	}
 
 	manager.log.WithField("host", manager.detectedBases[address]).WithField("address", address)
-	baseDevice, err := bitboxbase.NewBitBoxBase(address, bitboxBaseID, manager.config, manager.bitboxBaseConfigDir, manager.onUnregister, manager.socksProxy)
+	baseDevice, err := bitboxbase.NewBitBoxBase(address, bitboxBaseID, manager.config, manager.bitboxBaseConfigDir, manager.onUnregister, manager.onRemove, manager.socksProxy)
 
 	if err != nil {
 		manager.log.WithError(err).Error("Failed to register Base")

--- a/backend/bitboxbase/rpcclient/websocket.go
+++ b/backend/bitboxbase/rpcclient/websocket.go
@@ -16,6 +16,7 @@ package rpcclient
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base32"
 	"fmt"
 
@@ -201,7 +202,9 @@ func (rpcClient *RPCClient) initializeNoise(client *websocket.Conn) error {
 
 	// Do the user verification of the channel binding hash if either the app or base require it
 	if pairingVerificationRequiredByBase || pairingVerificationRequiredByApp {
-		channelHashBase32 := base32.StdEncoding.EncodeToString(handshake.ChannelBinding())
+		sha256PairingHash32byte := sha256.Sum256(handshake.ChannelBinding())
+		sha256PairingHash := sha256PairingHash32byte[:]
+		channelHashBase32 := base32.StdEncoding.EncodeToString(sha256PairingHash)
 		rpcClient.channelHash = fmt.Sprintf(
 			"%s %s\n%s %s",
 			channelHashBase32[:5],

--- a/frontends/web/src/routes/bitboxbase/bitboxbaseconnect.tsx
+++ b/frontends/web/src/routes/bitboxbase/bitboxbaseconnect.tsx
@@ -128,7 +128,11 @@ class BitBoxBaseConnect extends Component<Props, State> {
         apiPost(`bitboxbases/${ip}/connect-base`)
         .then(response => {
             if (!response.success) {
-                alertUser(`Could not connect to the BitBoxBase RPC client at ${ip}`);
+                if (response.message) {
+                    alertUser(response.message);
+                } else {
+                    alertUser(`Could not connect to the BitBoxBase RPC client at ${ip}`);
+                }
             }
         });
     }


### PR DESCRIPTION
@KasparEtter could you please take a look at this commit: https://github.com/digitalbitbox/bitbox-wallet-app/commit/76545637be7633cbade7e4698d427f679bfe120b

specifically: https://github.com/Tomasvrba/bitbox-wallet-app/blob/e4696353cbc1b4b4d23313d381593eb6b5abef4d/frontends/web/src/routes/bitboxbase/bitboxbase.tsx#L94

I had to type the `registeredBases[baseID]` as `any` because the `RegisteredBases` interface includes a boolean:
```
interface RegisteredBases {
    [ID: string]: {
        paired?: boolean;
        status?: BaseStatus;
    };
}
```
This is because:
```
type T1 = number & string;  // number & string
type T2 = string & boolean;  // never
```

If there is no boolean field in the `RegisteredBases` interface, then `newState.registeredBases[baseID][key] = value;` works fine. But with the boolean, it's a `never` type. So I'm wondering if you have a clever way to do this without typing it as any :)

See https://github.com/microsoft/TypeScript/issues/31663 for context.
