### PR TITLE
frontend: account default routing refactor

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -178,6 +178,12 @@ class App extends Component<Props, State> {
                 if (inAccounts && !accounts.some(account => getCurrentUrl().startsWith('/account/' + account.code))) {
                     route('/', true);
                 }
+
+                if (getCurrentUrl().match(/^\/account$/)) {
+                    if (accounts && accounts.length) {
+                        route(`/account/${accounts[0].code}`, true);
+                    }
+                }
             });
         });
     }
@@ -216,7 +222,7 @@ class App extends Component<Props, State> {
                             path="/account/:code/info"
                             accounts={accounts} />
                         <Account
-                            path="/account/:code?"
+                            path="/account/:code"
                             code={'' /* dummy to satisfy TS */}
                             devices={devices}
                             accounts={accounts} />

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -15,7 +15,6 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
-import { route } from 'preact-router';
 import { Balance, BalanceInterface } from '../../components/balance/balance';
 import { Entry } from '../../components/guide/entry';
 import { Guide } from '../../components/guide/guide';
@@ -101,9 +100,6 @@ class Account extends Component<Props, State> {
 
     public componentDidUpdate(prevProps) {
         if (!this.props.code) {
-            if (this.props.accounts && this.props.accounts.length) {
-                route(`/account/${this.props.accounts[0].code}`, true);
-            }
             return;
         }
         if (this.props.code !== prevProps.code) {


### PR DESCRIPTION
The Account component is invoked for `/account`, only for the routing
to happen. It's cleaner to invoke Account only for an actual account,
and do the routing in app.tsx closer to the other routing.