### PR TITLE
frontend: enforce state type

### DIFF
--- a/frontends/web/src/components/backups/restore.tsx
+++ b/frontends/web/src/components/backups/restore.tsx
@@ -45,7 +45,7 @@ interface State {
 }
 
 class Restore extends Component<Props, State> {
-    public state = {
+    public readonly state: State = {
         isConfirming: false,
         activeDialog: false,
         isLoading: false,

--- a/frontends/web/src/components/devices/bitbox02/checkbackup.tsx
+++ b/frontends/web/src/components/devices/bitbox02/checkbackup.tsx
@@ -38,7 +38,7 @@ interface State {
 }
 
 class Check extends Component<Props, State> {
-    public state = {
+    public readonly state: State = {
         activeDialog: false,
         message: '',
         foundBackup: undefined,

--- a/frontends/web/src/components/devices/bitbox02/createbackup.tsx
+++ b/frontends/web/src/components/devices/bitbox02/createbackup.tsx
@@ -34,7 +34,7 @@ interface State {
 }
 
 class Create extends Component<Props, State> {
-    public state = {
+    public readonly state: State = {
         creatingBackup: false,
         disabled: false,
     };

--- a/frontends/web/src/components/devices/bitbox02/reset.tsx
+++ b/frontends/web/src/components/devices/bitbox02/reset.tsx
@@ -37,7 +37,7 @@ interface State {
 }
 
 class Reset extends Component<Props, State> {
-    public state = {
+    public readonly state: State = {
         understand: false,
         isConfirming: false,
         activeDialog: false,

--- a/frontends/web/src/components/devices/bitbox02/showmnemonic.tsx
+++ b/frontends/web/src/components/devices/bitbox02/showmnemonic.tsx
@@ -33,7 +33,7 @@ interface State {
 }
 
 class ShowMnemonic extends Component<Props, State> {
-    public state = {
+    public readonly state: State = {
         inProgress: false,
     };
 

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -69,7 +69,7 @@ interface State {
 type Props = LoadedAccountProps & AccountProps & TranslateProps;
 
 class Account extends Component<Props, State> {
-    public state = {
+    public readonly state: State = {
         initialized: false,
         connected: false,
         transactions: undefined,

--- a/frontends/web/src/routes/device/skipfortesting.tsx
+++ b/frontends/web/src/routes/device/skipfortesting.tsx
@@ -28,7 +28,7 @@ interface SkipForTestingState {
 }
 
 export class SkipForTesting extends Component<SkipForTestingProps, SkipForTestingState> {
-    public state = {
+    public readonly state: SkipForTestingState = {
         testPIN: '',
     };
 


### PR DESCRIPTION
Otherwise a non-state var could sneak in.

Readonly because the state is supposed to be set via setState().