### PR TITLE
backend/coins/eth: fix address level derivation

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -183,6 +183,15 @@ func (account *Account) Initialize() error {
 		if err != nil {
 			return false, err
 		}
+		// Derive m/0, first account.
+		relKeyPath, err := signing.NewRelativeKeypath("0")
+		if err != nil {
+			return false, err
+		}
+		signingConfiguration, err = signingConfiguration.Derive(relKeyPath)
+		if err != nil {
+			return false, err
+		}
 		account.signingConfiguration = signingConfiguration
 		account.notifier = account.getNotifier(signingConfiguration)
 		return false, nil


### PR DESCRIPTION
Regression of 5249d64c9e4dbff4cd0c94d1fc8b0588b188cdb4 -> /0 removed
in one place but not added in the other.