### PR TITLE
frontends/qt: enable HiDPI auto-scaling on Windows

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -109,13 +109,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-    // note: doesn't work as expected. Users with hidpi enabled should set the environment flag themselves
-    // turn on the DPI support**
-// #if QT_VERSION >= QT_VERSION_CHECK(5,6,0)
-//     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-// #else
-//     qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", QByteArray("1"));
-// #endif // QT_VERSION
+// Enable auto HiDPI scaling on Windows only for now.
+// Historically, auto scaling did not work as expected on other platforms
+// before Qt v5.14 but we're at 5.11 due to older systems support.
+#if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,6,0)
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
 
 // QT configuration parameters which change the attack surface for memory
 // corruption vulnerabilities


### PR DESCRIPTION
This makes the app scale well with the rest of the display
when the scaling factor is greater than 100%, especially font sizes.

Only Windows because there has been unexpected behavior on other
platforms in the past, at least on Qt versions before 5.14.
But we are currently stuck at 5.11 due to various dependencies and
older platforms support. Will reconsider and possibly upgrade to 5.14
in about a year.

See more about Qt HiDPI here:
https://doc.qt.io/qt-5/highdpi.html