### PR TITLE
macOS build: minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SHELL:=/bin/bash
-WEBROOT:=`pwd`/frontends/web
+SHELL    := /bin/bash
+REPOROOT := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+WEBROOT  := $(REPOROOT)/frontends/web
+GOPATH   ?= $(HOME)/go
+PATH     := $(PATH):$(GOPATH)/bin
 
 catch:
 	@echo "Choose a make target."
@@ -26,17 +29,14 @@ envinit:
 	GO111MODULE=off go get -u github.com/jteeuwen/go-bindata/...
 	GO111MODULE=off go get -u golang.org/x/mobile/cmd/gomobile
 	gomobile init
-# This must be run in $GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app
+# Initializiation on MacOS
+#  - run make from $GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app
+#  - additional dependencies: Qt 5.11 & Xcode command line tools
+#  - add to $PATH: /usr/local/opt/go@1.13/bin
 osx-init:
-	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 	brew install yarn
-	brew install go
-	brew install qt
-	export PATH="/usr/local/opt/qt/bin:$PATH"
-	export LDFLAGS="-L/usr/local/opt/qt/lib"
-	export CPPFLAGS="-I/usr/local/opt/qt/include"
-	export GOPATH=~/go/
-	export PATH=$PATH:~/go/bin
+	brew install go@1.13	
 	$(MAKE) envinit
 servewallet:
 	go install -mod=vendor ./cmd/servewallet/... && servewallet

--- a/README.md
+++ b/README.md
@@ -45,17 +45,23 @@ The below instructions assume a unix environment.
 
 ### Requirements
 
-- [Go](https://golang.org/doc/install) version 1.13.
-- [Yarn](https://yarnpkg.com/en/) - for managing the web UI deps.
-- [Qt5](https://www.qt.io)
-  - Install via https://www.qt.io/download, also install WebEngine, and put `qmake` and `rcc` into
-    your PATH.
+The following dependencies need to be installed:
 
-Make sure `$GOPATH` is set and `$GOPATH/bin` and `$GOROOT/bin` is in your `$PATH`.
+- [Go](https://golang.org/doc/install) version 1.13
+- [Yarn](https://yarnpkg.com/en/) for managing the web UI deps
+- [Qt5](https://www.qt.io) version 5.11.3
+  - Installers for older versions can be found in [this Qt archive](https://download.qt.io/new_archive/qt/5.11/5.11.3)
+  - install Qt for your platform, including the WebEngine component
 
-Clone/move this repo to `$GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app` (`$GOPATH` is usually `~/go`).
+Make sure the following environment variables are set:
+- `$GOPATH`
+- `$PATH`: should include `$GOPATH/bin`, `$GOROOT/bin` and the location of `qmake` and `rcc`
 
-Only the first time, call `make envinit` to install the required go utilities (linters, ...).
+Clone this repository to `$GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app` (`$GOPATH` is usually `~/go`).
+
+To initialize the build environment and install the required go utilities (linters, ...), call
+* `make envinit`, or
+* on MacOS `make osx-init`
 
 ## Build the BitBoxApp
 


### PR DESCRIPTION
When building the BitBoxApp on macOS High Sierra with current software versions, there were a few issues. This pull request 
* installs 'homebrew' as recommended on brew.sh (the previous command recommends this as well in a warning)
* replaces 'pwd' with the var REPOROOT so that make can be called from outside the working directory
* moves necessary environment variables to the top of Makefile and removes the 'export' commands (that were not doing anything)
* removes 'brew install qt' as there is no reliable way to install the older version Qt 5.11 inside the script
* updates the README with more specific information about dependencies and versions