### PR TITLE
frontend/web: minor transaction styles improvements

### DIFF
--- a/frontends/web/src/components/rates/rates.css
+++ b/frontends/web/src/components/rates/rates.css
@@ -5,7 +5,8 @@
     line-height: 1;
 }
 
-.unit {
+.unit,
+.unitAction {
 	color: var(--color-secondary);
 	position: relative;
 }
@@ -25,7 +26,7 @@
 	position: relative;
 }
 
-.unit::after,
+.unitAction::after,
 .availableFiatUnit::after {
 	border-bottom: dotted 1px var(--color-softblack);
 	content: "";

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -154,12 +154,12 @@ function Conversion({
             {' '}
             {
                 !skipUnit && !noAction && (
-                    <span className={style.unit} onClick={rotateFiat}>{active}</span>
+                    <span className={style.unitAction} onClick={rotateFiat}>{active}</span>
                 )
             }
             {
                 !skipUnit && noAction && (
-                    <span>{active}</span>
+                    <span className={style.unit}>{active}</span>
                 )
             }
         </span>

--- a/frontends/web/src/components/transactions/transaction.css
+++ b/frontends/web/src/components/transactions/transaction.css
@@ -83,6 +83,10 @@
 
 }
 
+.currencyUnit {
+    color: var(--color-secondary);
+}
+
 .action {
     display: flex;
     flex-direction: column;

--- a/frontends/web/src/components/transactions/transaction.css
+++ b/frontends/web/src/components/transactions/transaction.css
@@ -79,6 +79,10 @@
     color: var(--color-softred) !important;
 }
 
+.receive {
+    color: var(--color-success);
+}
+
 .currency {
 
 }

--- a/frontends/web/src/components/transactions/transaction.jsx
+++ b/frontends/web/src/components/transactions/transaction.jsx
@@ -195,12 +195,12 @@ export default class Transaction extends Component {
                         </div>
                         <div className={parentStyle.fiat}>
                             <span className={[style.fiat, type === 'send' && style.send].join(' ')}>
-                                <FiatConversion amount={amount} noAction>{type === 'send' && sign}</FiatConversion>
+                                <FiatConversion amount={amount} noAction>{sign}</FiatConversion>
                             </span>
                         </div>
                         <div className={parentStyle.currency}>
                             <span className={[style.currency, type === 'send' && style.send].join(' ')}>
-                                {type === 'send' && sign}{amount.amount}
+                                {sign}{amount.amount}
                                 {' '}
                                 <span className={style.currencyUnit}>{amount.unit}</span>
                             </span>

--- a/frontends/web/src/components/transactions/transaction.jsx
+++ b/frontends/web/src/components/transactions/transaction.jsx
@@ -284,22 +284,30 @@ export default class Transaction extends Component {
                             <div className={style.detail}>
                                 <label>{t('transaction.details.fiat')}</label>
                                 <p>
-                                    <span className={[style.fiat, type === 'send' && style.send].join(' ')}>
-                                        <FiatConversion amount={amount} noAction>{type === 'send' && sign} </FiatConversion>
+                                    <span className={`${style.fiat} ${typeClassName}`}>
+                                        <FiatConversion amount={amount} noAction>{sign}</FiatConversion>
                                     </span>
                                 </p>
                             </div>
                             <div className={style.detail}>
                                 <label>{t('transaction.details.amount')}</label>
                                 <p>
-                                    <span className={[style.currency, type === 'send' && style.send].join(' ')}>{type === 'send' && sign} {amount.amount} {amount.unit}</span>
+                                    <span className={`${style.currency} ${typeClassName}`}>
+                                        {sign}{amount.amount}
+                                        {' '}
+                                        <span className={style.currencyUnit}>{amount.unit}</span>
+                                    </span>
                                 </p>
                             </div>
                             <div className={style.detail}>
                                 <label>{t('transaction.fee')}</label>
                                 {
                                     fee && fee.amount ? (
-                                        <p title={feeRatePerKb.amount ? feeRatePerKb.amount + ' ' + feeRatePerKb.unit + '/Kb' : ''}>{fee.amount} {fee.unit}</p>
+                                        <p title={feeRatePerKb.amount ? feeRatePerKb.amount + ' ' + feeRatePerKb.unit + '/Kb' : ''}>
+                                            {fee.amount}
+                                            {' '}
+                                            <span className={style.currencyUnit}>{fee.unit}</span>
+                                        </p>
                                     ) : (
                                         <p>---</p>
                                     )
@@ -327,7 +335,11 @@ export default class Transaction extends Component {
                                 weight ? (
                                     <div className={style.detail}>
                                         <label>{t('transaction.weight')}</label>
-                                        <p>{weight}</p>
+                                        <p>
+                                            {weight}
+                                            {' '}
+                                            <span className={style.currencyUnit}>WU</span>
+                                        </p>
                                     </div>
                                 ) : null
                             }
@@ -335,7 +347,11 @@ export default class Transaction extends Component {
                                 vsize ? (
                                     <div className={style.detail}>
                                         <label>{t('transaction.vsize')}</label>
-                                        <p>{vsize}</p>
+                                        <p>
+                                            {vsize}
+                                            {' '}
+                                            <span className={style.currencyUnit}>b</span>
+                                        </p>
                                     </div>
                                 ) : null
                             }
@@ -343,7 +359,11 @@ export default class Transaction extends Component {
                                 size ? (
                                     <div className={style.detail}>
                                         <label>{t('transaction.size')}</label>
-                                        <p>{size}</p>
+                                        <p>
+                                            {size}
+                                            {' '}
+                                            <span className={style.currencyUnit}>b</span>
+                                        </p>
                                     </div>
                                 ) : null
                             }

--- a/frontends/web/src/components/transactions/transaction.jsx
+++ b/frontends/web/src/components/transactions/transaction.jsx
@@ -200,7 +200,9 @@ export default class Transaction extends Component {
                         </div>
                         <div className={parentStyle.currency}>
                             <span className={[style.currency, type === 'send' && style.send].join(' ')}>
-                                {type === 'send' && sign}{amount.amount} {amount.unit}
+                                {type === 'send' && sign}{amount.amount}
+                                {' '}
+                                <span className={style.currencyUnit}>{amount.unit}</span>
                             </span>
                         </div>
                         <div className={[parentStyle.action, parentStyle.showOnMedium].join(' ')}>

--- a/frontends/web/src/components/transactions/transaction.jsx
+++ b/frontends/web/src/components/transactions/transaction.jsx
@@ -195,11 +195,13 @@ export default class Transaction extends Component {
                         </div>
                         <div className={parentStyle.fiat}>
                             <span className={[style.fiat, type === 'send' && style.send].join(' ')}>
-                                <FiatConversion amount={amount} noAction>{type === 'send' && sign} </FiatConversion>
+                                <FiatConversion amount={amount} noAction>{type === 'send' && sign}</FiatConversion>
                             </span>
                         </div>
                         <div className={parentStyle.currency}>
-                            <span className={[style.currency, type === 'send' && style.send].join(' ')}>{type === 'send' && sign} {amount.amount} {amount.unit}</span>
+                            <span className={[style.currency, type === 'send' && style.send].join(' ')}>
+                                {type === 'send' && sign}{amount.amount} {amount.unit}
+                            </span>
                         </div>
                         <div className={[parentStyle.action, parentStyle.showOnMedium].join(' ')}>
                             <a href="#" className={style.action} onClick={this.showDetails}>

--- a/frontends/web/src/components/transactions/transaction.jsx
+++ b/frontends/web/src/components/transactions/transaction.jsx
@@ -112,6 +112,7 @@ export default class Transaction extends Component {
             </svg>
         );
         const sign = ((type === 'send') && '−') || ((type === 'receive') && '+') || null;
+        const typeClassName = (type === 'send' && style.send) || (type === 'receive' && style.receive) || '';
         const sDate = time ? this.parseTimeShort(time) : '---';
         const statusText = {
             complete: t('transaction.status.complete'),
@@ -194,12 +195,12 @@ export default class Transaction extends Component {
                             <span className={style.status}>{statusText}</span>
                         </div>
                         <div className={parentStyle.fiat}>
-                            <span className={[style.fiat, type === 'send' && style.send].join(' ')}>
+                            <span className={`${style.fiat} ${typeClassName}`}>
                                 <FiatConversion amount={amount} noAction>{sign}</FiatConversion>
                             </span>
                         </div>
                         <div className={parentStyle.currency}>
-                            <span className={[style.currency, type === 'send' && style.send].join(' ')}>
+                            <span className={`${style.currency} ${typeClassName}`}>
                                 {sign}{amount.amount}
                                 {' '}
                                 <span className={style.currencyUnit}>{amount.unit}</span>


### PR DESCRIPTION
Few minor changes, this PR:
- removes space between sign and value (e.g `−1.234`)
- uses secondary grayish font color for the unit (CHF, BTC)
- uses green for incoming tx (not sure if that green is acceptable, but the red is very soft too)
- adds units (WU and b) to the tx detail view

![Screen Shot 2020-05-04 at 9 14 58 AM](https://user-images.githubusercontent.com/546900/80944023-ddb86600-8de8-11ea-8efe-20d20bd961f3.png)

![Screen Shot 2020-05-04 at 9 37 32 AM](https://user-images.githubusercontent.com/546900/80944941-f6298000-8dea-11ea-86fd-14318de87c87.png)
