### PR TITLE
backend/coins/btc/headers: try to fix transient error

### DIFF
--- a/backend/coins/btc/headers/headers_test.go
+++ b/backend/coins/btc/headers/headers_test.go
@@ -40,7 +40,7 @@ func TestClose(t *testing.T) {
 	require.NoError(t, headers.Close())
 	select {
 	case <-didFinish:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		require.Fail(t, "did not shut down")
 	}
 


### PR DESCRIPTION
Sometimes CI would run into the timeout.