### PR TITLE
backend/eth: hardcode gas limit for standard eth txs

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -564,10 +564,14 @@ func (account *Account) newTx(
 			}
 		}
 	}
-	gasLimit, err := account.coin.client.EstimateGas(context.TODO(), message)
-	if err != nil {
-		account.log.WithError(err).Error("Could not estimate the gas limit.")
-		return nil, errp.WithStack(errors.ErrInvalidData)
+	gasLimit := uint64(21000) // gas limit for standard ethereum transactions
+	if account.coin.erc20Token != nil {
+		n, err := account.coin.client.EstimateGas(context.TODO(), message)
+		if err != nil {
+			account.log.WithError(err).Error("Could not estimate the gas limit.")
+			return nil, errp.WithStack(errors.ErrInvalidData)
+		}
+		gasLimit = n
 	}
 
 	fee := new(big.Int).Mul(new(big.Int).SetUint64(gasLimit), suggestedGasPrice)


### PR DESCRIPTION
Which is 21000. This saves a network request to estimate the gas
limit. It is more robust as the gas estimation api call has been
unstable lately.