### PR TITLE
frontend/dialog: increase width to fit bc1.. address

### DIFF
--- a/frontends/web/src/components/dialog/dialog.css
+++ b/frontends/web/src/components/dialog/dialog.css
@@ -43,7 +43,8 @@
 }
 
 .modal.medium {
-    max-width: 450px;
+    /* long enough to fit a bc1... address in the receive screen on desktop */
+    max-width: 452px;
     width: 100%;
 }
 


### PR DESCRIPTION
On linux, the address was still split on two lines by one char.