### PR TITLE
Makefile: fix REPOROOT / make buildweb on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 SHELL    := /bin/bash
-REPOROOT := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+REPOROOT := `dirname $(realpath $(lastword $(MAKEFILE_LIST)))`
 WEBROOT  := $(REPOROOT)/frontends/web
 GOPATH   ?= $(HOME)/go
 PATH     := $(PATH):$(GOPATH)/bin
@@ -36,7 +36,7 @@ envinit:
 osx-init:
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 	brew install yarn
-	brew install go@1.13	
+	brew install go@1.13
 	$(MAKE) envinit
 servewallet:
 	go install -mod=vendor ./cmd/servewallet/... && servewallet


### PR DESCRIPTION
make buildweb on windows (mingw, gnu make 4.0) failed with:

```
$ make buildweb
rm -rf C:/Users/<user>/go/src/github.com/digitalbitbox/bitbox-wallet-app/frontends/web/build
yarn --cwd=C:/Users/<user>/go/src/github.com/digitalbitbox/bitbox-wallet-app/frontends/web install
yarn install v1.22.4
info No lockfile found.
```

Copy pasting the yarn install cmd into the shell worked. Hardcoding
the path in the `--cwd` flag in the Makefile also failed.

This is a fix by trial and error, the backtick env var is passed
unevaluated to yarn. Why this is works better then a passing the
absolute path directly is a mystery.