### PR TITLE
backend/account: fix fee mismatch between confirm dialog and device

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -1,4 +1,5 @@
 // Copyright 2018 Shift Devices AG
+// Copyright 2020 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,9 +47,8 @@ type Interface interface {
 	Notifier() Notifier
 	Transactions() ([]Transaction, error)
 	Balance() (*Balance, error)
-	// Creates, signs and broadcasts a transaction. Returns keystore.ErrSigningAborted on user
-	// abort.
-	SendTx(string, coin.SendAmount, FeeTargetCode, map[wire.OutPoint]struct{}, []byte) error
+	// SendTx signs and sends the active tx proposal, set by TxProposal. Errors if none available.
+	SendTx() error
 	FeeTargets() ([]FeeTarget, FeeTargetCode)
 	TxProposal(string, coin.SendAmount, FeeTargetCode, map[wire.OutPoint]struct{}, []byte) (
 		coin.Amount, coin.Amount, coin.Amount, error)

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -31,6 +31,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/blockchain"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/db/transactionsdb"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/maketx"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/synchronizer"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/transactions"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/types"
@@ -78,6 +79,10 @@ type Account struct {
 	changeAddresses  AddressChain
 
 	transactions *transactions.Transactions
+
+	// if not nil, SendTx() will sign and send this transaction. Set by TxProposal().
+	activeTxProposal     *maketx.TxProposal
+	activeTxProposalLock locker.Locker
 
 	synchronizer *synchronizer.Synchronizer
 

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2020 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,7 +209,7 @@ class Send extends Component<Props, State> {
             return;
         }
         this.setState({ signProgress: undefined, isConfirming: true });
-        apiPost('account/' + this.getAccount()!.code + '/sendtx', this.txInput()).then(result => {
+        apiPost('account/' + this.getAccount()!.code + '/sendtx').then(result => {
             if (result.success) {
                 this.setState({
                     sendAll: false,


### PR DESCRIPTION
When entering the tx details, on each form change, a /tx-proposal
backend call is made that creates the tx, including fee computation,
and returns the computed details to the frontend for display (fee,
total).

When clicking Review, the /sendtx backend call is called with the same
inputs, and the tx is re-created. With some bad timing, the fee rates
could have updated in the meantime, leading to a different fee than
the user sees in the app.

This commit fixes it in a general way: the tx proposal is persisted in
RAM, and /sendtx signs and sends that proposal instead of recreating
it.