### PR TITLE
backend/eth: query gasLimit also for the ETH account

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -570,14 +570,10 @@ func (account *Account) newTx(
 			}
 		}
 	}
-	gasLimit := uint64(21000) // gas limit for standard ethereum transactions
-	if account.coin.erc20Token != nil {
-		n, err := account.coin.client.EstimateGas(context.TODO(), message)
-		if err != nil {
-			account.log.WithError(err).Error("Could not estimate the gas limit.")
-			return nil, errp.WithStack(errors.ErrInvalidData)
-		}
-		gasLimit = n
+	gasLimit, err := account.coin.client.EstimateGas(context.TODO(), message)
+	if err != nil {
+		account.log.WithError(err).Error("Could not estimate the gas limit.")
+		return nil, errp.WithStack(errors.ErrInvalidData)
 	}
 
 	fee := new(big.Int).Mul(new(big.Int).SetUint64(gasLimit), suggestedGasPrice)


### PR DESCRIPTION
With a premature optimization, the gasLimit for the ETH account was
hardcoded to 21000. When sending regular ETH to a contract, the gas
limit can be higher, leading to rejected/cancelled transactions.