### PR TITLE
ci: add github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# See reference docs at
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+name: ci
+on: [push, pull_request]
+
+jobs:
+  linux-docker:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Clone the repo
+        uses: actions/checkout@v2
+      - name: Run CI script
+        run: ./scripts/travis-ci.sh
+        env:
+          TRAVIS_OS_NAME: linux
+          TRAVIS_BUILD_DIR: ${{github.workspace}}
+  macos:
+    runs-on: macos-10.15
+    steps:
+      - name: Clone the repo
+        uses: actions/checkout@v2
+      - name: Run CI script
+        run: ./scripts/travis-ci.sh
+        env:
+          TRAVIS_OS_NAME: osx
+          TRAVIS_BUILD_DIR: ${{github.workspace}}

--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -52,7 +52,7 @@ osx:
 	mv build/BitBox.app build/osx/
 	cp resources/MacOS/Info.plist build/osx/BitBox.app/Contents/
 	cp resources/MacOS/icon.icns build/osx/BitBox.app/Contents/Resources/
-	macdeployqt build/osx/BitBox.app/
+	macdeployqt build/osx/BitBox.app
 	cp server/libserver.so build/osx/BitBox.app/Contents/Frameworks
 	cp build/assets.rcc build/osx/BitBox.app/Contents/MacOS/
 	install_name_tool -change libserver.so @executable_path/../Frameworks/libserver.so build/osx/BitBox.app/Contents/MacOS/BitBox

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -16,8 +16,12 @@ fi
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     export HOMEBREW_NO_AUTO_UPDATE=1
     brew outdated go || brew upgrade go
-    brew install yarn
+    go version
     brew install qt
+    # Install yarn only if it isn't already.
+    # GitHub runners already have node and yarn installed which makes homebrew
+    # fail due to conflicting files.
+    type yarn > /dev/null || brew install yarn
     brew install nvm
     source /usr/local/opt/nvm/nvm.sh
     nvm install 10.16.3 # install this node version
@@ -27,8 +31,12 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     export GOPATH=~/go/
     export PATH=$PATH:~/go/bin
     mkdir -p $GOPATH/src/github.com/digitalbitbox/
-    cd ../ && mv bitbox-wallet-app $GOPATH/src/github.com/digitalbitbox/
+    # GitHub checkout action (git clone) seem to require current work dir
+    # to be the root of the repo during its clean up phase. So, we push it
+    # here and pop in the end.
+    pushd ../ && cp -a bitbox-wallet-app $GOPATH/src/github.com/digitalbitbox/
     cd $GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app/
     make envinit
     make qt-osx
+    popd
 fi


### PR DESCRIPTION
Alternative to Travis CI.
Runs the same scripts except SSH for nightly builds.