### PR TITLE
backend/account: rename Initialized() -> Synced()

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -38,9 +38,10 @@ type Interface interface {
 	Coin() coin.Coin
 	// Name returns a human readable long name.
 	Name() string
-	// Initialize only starts the initialization, the account is not initialized right afterwards.
+	// Initialize only starts the synchronization, the account is not synced right afterwards.
 	Initialize() error
-	Initialized() bool
+	// Synced indicates whether the account has loaded and finished the initial sync.
+	Synced() bool
 	Offline() bool
 	FatalError() bool
 	Close()

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -88,7 +88,9 @@ type Account struct {
 
 	feeTargets []*FeeTarget
 
-	initialized bool
+	// synced indicates whether the account has loaded and finished the initial sync of the
+	// addresses.
+	synced      bool
 	offline     bool
 	fatalError  bool
 	onEvent     func(accounts.Event)
@@ -160,7 +162,7 @@ func NewAccount(
 		},
 		// initializing to false, to prevent flashing of offline notification in the frontend
 		offline:     false,
-		initialized: false,
+		synced:      false,
 		onEvent:     onEvent,
 		log:         log,
 		rateUpdater: rateUpdater,
@@ -168,8 +170,8 @@ func NewAccount(
 	account.synchronizer = synchronizer.NewSynchronizer(
 		func() { onEvent(accounts.EventSyncStarted) },
 		func() {
-			if !account.initialized {
-				account.initialized = true
+			if !account.synced {
+				account.synced = true
 				onEvent(accounts.EventStatusChanged)
 			}
 			onEvent(accounts.EventSyncDone)
@@ -342,7 +344,7 @@ func (account *Account) Initialize() error {
 		case blockchain.CONNECTED:
 			// when we have previously been offline, the initial sync status is set back
 			// as we need to synchronize with the new backend.
-			account.initialized = false
+			account.synced = false
 			account.offline = false
 			account.onEvent(accounts.EventStatusChanged)
 			account.log.Debug("Connection to blockchain backend established")
@@ -469,10 +471,9 @@ func (account *Account) Offline() bool {
 	return account.offline
 }
 
-// Initialized indicates whether the account has loaded and finished the initial sync of the
-// addresses.
-func (account *Account) Initialized() bool {
-	return account.initialized
+// Synced implements accounts.Interface.
+func (account *Account) Synced() bool {
+	return account.synced
 }
 
 // FatalError returns true if the account had a fatal error.
@@ -500,7 +501,7 @@ func (account *Account) Close() {
 	}
 	// TODO: deregister from json RPC client. The client can be closed when no account uses
 	// the client any longer.
-	account.initialized = false
+	account.synced = false
 	if account.transactions != nil {
 		account.transactions.Close()
 	}

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -72,9 +72,9 @@ func TestAccount(t *testing.T) {
 		logging.Get().WithGroup("account_test"),
 		nil,
 	)
-	require.False(t, account.Initialized())
+	require.False(t, account.Synced())
 	require.NoError(t, account.Initialize())
-	require.True(t, account.Initialized())
+	require.True(t, account.Synced())
 
 	balance, err := account.Balance()
 	require.NoError(t, err)

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -428,7 +428,7 @@ func (handlers *Handlers) getAccountStatus(_ *http.Request) (interface{}, error)
 	if handlers.account == nil {
 		status = append(status, btc.AccountDisabled)
 	} else {
-		if handlers.account.Initialized() {
+		if handlers.account.Synced() {
 			status = append(status, btc.AccountSynced)
 		}
 


### PR DESCRIPTION
Because that's what it really means. This is to disambiguate with the
Initialize() function and the `alreadyInitialized` var used inside,
which are unrelated.