### PR TITLE
backend/keystore: don't pass full signing config to CanVerifyAddress

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -752,8 +752,7 @@ func (account *Account) VerifyAddress(addressID string) (bool, error) {
 	if address == nil {
 		return false, errp.New("unknown address not found")
 	}
-	canVerifyAddress, _, err := account.Keystores().CanVerifyAddresses(
-		account.signingConfiguration.Multisig(), account.Coin())
+	canVerifyAddress, _, err := account.Keystores().CanVerifyAddresses(account.Coin())
 	if err != nil {
 		return false, err
 	}
@@ -768,7 +767,7 @@ func (account *Account) CanVerifyAddresses() (bool, bool, error) {
 	if account.signingConfiguration == nil {
 		return false, false, errp.New("account must be initialized")
 	}
-	return account.Keystores().CanVerifyAddresses(account.signingConfiguration.Multisig(), account.Coin())
+	return account.Keystores().CanVerifyAddresses(account.Coin())
 }
 
 // Keystores returns the keystores of the account.

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -752,7 +752,8 @@ func (account *Account) VerifyAddress(addressID string) (bool, error) {
 	if address == nil {
 		return false, errp.New("unknown address not found")
 	}
-	canVerifyAddress, _, err := account.Keystores().CanVerifyAddresses(account.signingConfiguration, account.Coin())
+	canVerifyAddress, _, err := account.Keystores().CanVerifyAddresses(
+		account.signingConfiguration.Multisig(), account.Coin())
 	if err != nil {
 		return false, err
 	}
@@ -767,7 +768,7 @@ func (account *Account) CanVerifyAddresses() (bool, bool, error) {
 	if account.signingConfiguration == nil {
 		return false, false, errp.New("account must be initialized")
 	}
-	return account.Keystores().CanVerifyAddresses(account.signingConfiguration, account.Coin())
+	return account.Keystores().CanVerifyAddresses(account.signingConfiguration.Multisig(), account.Coin())
 }
 
 // Keystores returns the keystores of the account.

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -700,8 +700,7 @@ func (account *Account) VerifyAddress(addressID string) (bool, error) {
 	}
 	account.synchronizer.WaitSynchronized()
 	defer account.RLock()()
-	canVerifyAddress, _, err := account.Keystores().CanVerifyAddresses(
-		account.signingConfiguration.Multisig(), account.Coin())
+	canVerifyAddress, _, err := account.Keystores().CanVerifyAddresses(account.Coin())
 	if err != nil {
 		return false, err
 	}
@@ -716,8 +715,7 @@ func (account *Account) CanVerifyAddresses() (bool, bool, error) {
 	if account.signingConfiguration == nil {
 		return false, false, errp.New("account must be initialized")
 	}
-	return account.Keystores().CanVerifyAddresses(
-		account.signingConfiguration.Multisig(), account.Coin())
+	return account.Keystores().CanVerifyAddresses(account.Coin())
 }
 
 // Keystores implements accounts.Interface.

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -701,7 +701,7 @@ func (account *Account) VerifyAddress(addressID string) (bool, error) {
 	account.synchronizer.WaitSynchronized()
 	defer account.RLock()()
 	canVerifyAddress, _, err := account.Keystores().CanVerifyAddresses(
-		account.signingConfiguration, account.Coin())
+		account.signingConfiguration.Multisig(), account.Coin())
 	if err != nil {
 		return false, err
 	}
@@ -716,7 +716,8 @@ func (account *Account) CanVerifyAddresses() (bool, bool, error) {
 	if account.signingConfiguration == nil {
 		return false, false, errp.New("account must be initialized")
 	}
-	return account.Keystores().CanVerifyAddresses(account.signingConfiguration, account.Coin())
+	return account.Keystores().CanVerifyAddresses(
+		account.signingConfiguration.Multisig(), account.Coin())
 }
 
 // Keystores implements accounts.Interface.

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -59,19 +59,19 @@ func (keystore *keystore) SupportsAccount(
 
 // CanVerifyAddress implements keystore.Keystore.
 func (keystore *keystore) CanVerifyAddress(
-	configuration *signing.Configuration, coin coin.Coin) (bool, bool, error) {
+	multisig bool, coin coin.Coin) (bool, bool, error) {
 	deviceInfo, err := keystore.dbb.DeviceInfo()
 	if err != nil {
 		return false, false, err
 	}
 	optional := true
-	return deviceInfo.Pairing && keystore.dbb.HasMobileChannel() && configuration.Singlesig(), optional, nil
+	return deviceInfo.Pairing && keystore.dbb.HasMobileChannel() && !multisig, optional, nil
 }
 
 // VerifyAddress implements keystore.Keystore.
 func (keystore *keystore) VerifyAddress(
 	configuration *signing.Configuration, coin coin.Coin) error {
-	canVerifyAddress, _, err := keystore.CanVerifyAddress(configuration, coin)
+	canVerifyAddress, _, err := keystore.CanVerifyAddress(configuration.Multisig(), coin)
 	if err != nil {
 		return err
 	}

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -64,7 +64,7 @@ func (keystore *keystore) CanVerifyAddress(
 	if err != nil {
 		return false, false, err
 	}
-	optional := true
+	const optional = true
 	return deviceInfo.Pairing && keystore.dbb.HasMobileChannel() && !multisig, optional, nil
 }
 

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -51,27 +51,26 @@ func (keystore *keystore) SupportsAccount(
 	coin coin.Coin, multisig bool, meta interface{}) bool {
 	switch coin.(type) {
 	case *btc.Coin:
-		return true
+		return !multisig
 	default:
 		return false
 	}
 }
 
 // CanVerifyAddress implements keystore.Keystore.
-func (keystore *keystore) CanVerifyAddress(
-	multisig bool, coin coin.Coin) (bool, bool, error) {
+func (keystore *keystore) CanVerifyAddress(coin coin.Coin) (bool, bool, error) {
 	deviceInfo, err := keystore.dbb.DeviceInfo()
 	if err != nil {
 		return false, false, err
 	}
 	const optional = true
-	return deviceInfo.Pairing && keystore.dbb.HasMobileChannel() && !multisig, optional, nil
+	return deviceInfo.Pairing && keystore.dbb.HasMobileChannel(), optional, nil
 }
 
 // VerifyAddress implements keystore.Keystore.
 func (keystore *keystore) VerifyAddress(
 	configuration *signing.Configuration, coin coin.Coin) error {
-	canVerifyAddress, _, err := keystore.CanVerifyAddress(configuration.Multisig(), coin)
+	canVerifyAddress, _, err := keystore.CanVerifyAddress(coin)
 	if err != nil {
 		return err
 	}

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -74,7 +74,7 @@ func (keystore *keystore) SupportsAccount(
 }
 
 // CanVerifyAddress implements keystore.Keystore.
-func (keystore *keystore) CanVerifyAddress(configuration *signing.Configuration, coin coinpkg.Coin) (bool, bool, error) {
+func (keystore *keystore) CanVerifyAddress(multisig bool, coin coinpkg.Coin) (bool, bool, error) {
 	optional := false
 	switch coin.(type) {
 	case *btc.Coin:
@@ -90,7 +90,7 @@ func (keystore *keystore) CanVerifyAddress(configuration *signing.Configuration,
 // VerifyAddress implements keystore.Keystore.
 func (keystore *keystore) VerifyAddress(
 	configuration *signing.Configuration, coin coinpkg.Coin) error {
-	canVerifyAddress, _, err := keystore.CanVerifyAddress(configuration, coin)
+	canVerifyAddress, _, err := keystore.CanVerifyAddress(configuration.Multisig(), coin)
 	if err != nil {
 		return err
 	}

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -75,7 +75,7 @@ func (keystore *keystore) SupportsAccount(
 
 // CanVerifyAddress implements keystore.Keystore.
 func (keystore *keystore) CanVerifyAddress(multisig bool, coin coinpkg.Coin) (bool, bool, error) {
-	optional := false
+	const optional = false
 	switch coin.(type) {
 	case *btc.Coin:
 		_, ok := btcMsgCoinMap[coin.Code()]

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -74,7 +74,7 @@ func (keystore *keystore) SupportsAccount(
 }
 
 // CanVerifyAddress implements keystore.Keystore.
-func (keystore *keystore) CanVerifyAddress(multisig bool, coin coinpkg.Coin) (bool, bool, error) {
+func (keystore *keystore) CanVerifyAddress(coin coinpkg.Coin) (bool, bool, error) {
 	const optional = false
 	switch coin.(type) {
 	case *btc.Coin:
@@ -90,7 +90,7 @@ func (keystore *keystore) CanVerifyAddress(multisig bool, coin coinpkg.Coin) (bo
 // VerifyAddress implements keystore.Keystore.
 func (keystore *keystore) VerifyAddress(
 	configuration *signing.Configuration, coin coinpkg.Coin) error {
-	canVerifyAddress, _, err := keystore.CanVerifyAddress(configuration.Multisig(), coin)
+	canVerifyAddress, _, err := keystore.CanVerifyAddress(coin)
 	if err != nil {
 		return err
 	}

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -53,8 +53,8 @@ type Keystore interface {
 	// This is typically done through a screen on the device or through a paired mobile phone.
 	// optional is true if the user can skip verification, and false if they should be incentivized
 	// or forced to verify.
-	// The passed configuration is the account-level configuration.
-	CanVerifyAddress(*signing.Configuration, coin.Coin) (secureOutput bool, optional bool, err error)
+	// multisig is true when verifying multisig addresses.
+	CanVerifyAddress(multisig bool, c coin.Coin) (secureOutput bool, optional bool, err error)
 
 	// VerifyAddress outputs the public key at the given configuration for the given coin.
 	// Please note that this is only supported if the keystore has a secure output channel.

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -53,8 +53,7 @@ type Keystore interface {
 	// This is typically done through a screen on the device or through a paired mobile phone.
 	// optional is true if the user can skip verification, and false if they should be forced to
 	// verify.
-	// multisig is true when verifying multisig addresses.
-	CanVerifyAddress(multisig bool, c coin.Coin) (secureOutput bool, optional bool, err error)
+	CanVerifyAddress(coin.Coin) (secureOutput bool, optional bool, err error)
 
 	// VerifyAddress outputs the public key at the given configuration for the given coin.
 	// Please note that this is only supported if the keystore has a secure output channel.

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -51,8 +51,8 @@ type Keystore interface {
 
 	// CanVerifyAddress returns whether the keystore supports to output an address securely.
 	// This is typically done through a screen on the device or through a paired mobile phone.
-	// optional is true if the user can skip verification, and false if they should be incentivized
-	// or forced to verify.
+	// optional is true if the user can skip verification, and false if they should be forced to
+	// verify.
 	// multisig is true when verifying multisig addresses.
 	CanVerifyAddress(multisig bool, c coin.Coin) (secureOutput bool, optional bool, err error)
 

--- a/backend/keystore/keystores.go
+++ b/backend/keystore/keystores.go
@@ -66,9 +66,9 @@ func (keystores *Keystores) Remove(keystore Keystore) error {
 }
 
 // CanVerifyAddresses returns whether any of the keystores can verify an address.
-func (keystores *Keystores) CanVerifyAddresses(multisig bool, coin coin.Coin) (bool, bool, error) {
+func (keystores *Keystores) CanVerifyAddresses(coin coin.Coin) (bool, bool, error) {
 	for _, keystore := range keystores.keystores {
-		canVerifyAddress, optional, err := keystore.CanVerifyAddress(multisig, coin)
+		canVerifyAddress, optional, err := keystore.CanVerifyAddress(coin)
 		if err != nil {
 			return false, false, err
 		}
@@ -87,7 +87,7 @@ func (keystores *Keystores) VerifyAddress(
 ) error {
 	found := false
 	for _, keystore := range keystores.keystores {
-		canVerifyAddress, _, err := keystore.CanVerifyAddress(configuration.Multisig(), coin)
+		canVerifyAddress, _, err := keystore.CanVerifyAddress(coin)
 		if err != nil {
 			return err
 		}

--- a/backend/keystore/keystores.go
+++ b/backend/keystore/keystores.go
@@ -66,10 +66,9 @@ func (keystores *Keystores) Remove(keystore Keystore) error {
 }
 
 // CanVerifyAddresses returns whether any of the keystores can verify an address.
-func (keystores *Keystores) CanVerifyAddresses(
-	configuration *signing.Configuration, coin coin.Coin) (bool, bool, error) {
+func (keystores *Keystores) CanVerifyAddresses(multisig bool, coin coin.Coin) (bool, bool, error) {
 	for _, keystore := range keystores.keystores {
-		canVerifyAddress, optional, err := keystore.CanVerifyAddress(configuration, coin)
+		canVerifyAddress, optional, err := keystore.CanVerifyAddress(multisig, coin)
 		if err != nil {
 			return false, false, err
 		}
@@ -88,7 +87,7 @@ func (keystores *Keystores) VerifyAddress(
 ) error {
 	found := false
 	for _, keystore := range keystores.keystores {
-		canVerifyAddress, _, err := keystore.CanVerifyAddress(configuration, coin)
+		canVerifyAddress, _, err := keystore.CanVerifyAddress(configuration.Multisig(), coin)
 		if err != nil {
 			return err
 		}

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -98,7 +98,7 @@ func (keystore *Keystore) Identifier() (string, error) {
 }
 
 // CanVerifyAddress implements keystore.Keystore.
-func (keystore *Keystore) CanVerifyAddress(*signing.Configuration, coin.Coin) (bool, bool, error) {
+func (keystore *Keystore) CanVerifyAddress(bool, coin.Coin) (bool, bool, error) {
 	return false, false, nil
 }
 

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -98,7 +98,7 @@ func (keystore *Keystore) Identifier() (string, error) {
 }
 
 // CanVerifyAddress implements keystore.Keystore.
-func (keystore *Keystore) CanVerifyAddress(bool, coin.Coin) (bool, bool, error) {
+func (keystore *Keystore) CanVerifyAddress(coin.Coin) (bool, bool, error) {
 	return false, false, nil
 }
 


### PR DESCRIPTION
Only the multisig flag is needed (and only in the bitbox01).

Multisig in the app is a simple demo of p2sh-multisig with multiple
bitbox01, so it is technical debt in a sense.

When combining accounts, it is currently simpler to assume that a
device can verify the addresses of all supported types (see
SupportsAccount()), which is true for all supported devices and
account types. Multisig is the only exception, where the bitbox01 can
sign it, but the app does not implement verifying the addresses on the
2fa app.