### PR TITLE
backend/btc/maketx: extend estimateTxSize to allow mixed inputs

### DIFF
--- a/backend/coins/btc/maketx/maketx_test.go
+++ b/backend/coins/btc/maketx/maketx_test.go
@@ -181,9 +181,15 @@ func (s *newTxSuite) check(
 	txFee := btcutil.Amount(inputSum-output.Value) - expectedChange
 	// At the moment, the fee is based on the assumption of the tx having two outputs always, even
 	// if the change output is not there.
+
+	inputConfigurations := make([]*signing.Configuration, len(tx.TxIn))
+	for i := range inputConfigurations {
+		inputConfigurations[i] = s.inputConfiguration
+	}
+
 	expectedFee := maketx.TstFeeForSerializeSize(
 		feePerKb,
-		maketx.TstEstimateTxSize(len(tx.TxIn), s.inputConfiguration, len(output.PkScript), len(s.changeAddress.PubkeyScript())),
+		maketx.TstEstimateTxSize(inputConfigurations, len(output.PkScript), len(s.changeAddress.PubkeyScript())),
 		s.log) + expectedDustDonation
 	require.Equal(s.T(), expectedFee, txFee)
 	require.Equal(s.T(), expectedFee, txProposal.Fee)

--- a/backend/coins/btc/maketx/txsize.go
+++ b/backend/coins/btc/maketx/txsize.go
@@ -32,7 +32,9 @@ func outputSize(pkScriptSize int) int {
 	return 8 + wire.VarIntSerializeSize(uint64(pkScriptSize)) + pkScriptSize
 }
 
-// estimateTxSize gives the worst case tx size estimate.
+// estimateTxSize gives the worst case tx size estimate. The unit of the result is vbyte (virtual
+// bytes), for the purpose of fee calculation.
+// https://en.bitcoin.it/wiki/Weight_units
 //
 // Witnesses, if present, are assumed to have the following format:
 // <serialized sig> <serialized compressed pubkey>
@@ -53,7 +55,8 @@ func estimateTxSize(
 	const (
 		versionSize  = 4
 		lockTimeSize = 4
-		nonWitness   = 4 // factor for non-witness fields
+		// factor for non-witness fields, https://en.bitcoin.it/wiki/Weight_units#Weight_for_legacy_transactions
+		nonWitness = 4
 	)
 
 	txWeight := nonWitness * (versionSize + lockTimeSize + wire.VarIntSerializeSize(uint64(len(inputConfigurations))) +

--- a/backend/coins/btc/maketx/txsize.go
+++ b/backend/coins/btc/maketx/txsize.go
@@ -45,8 +45,12 @@ func estimateTxSize(
 	inputConfigurations []*signing.Configuration,
 	outputPkScriptSize int,
 	changePkScriptSize int) int {
+	outputCount := 2 // 1 output + 1 change output
+	if changePkScriptSize == 0 {
+		outputCount = 1
+	}
+
 	const (
-		outputCount  = 2 // 1 output + 1 change output
 		versionSize  = 4
 		lockTimeSize = 4
 		nonWitness   = 4 // factor for non-witness fields

--- a/backend/coins/btc/maketx/txsize.go
+++ b/backend/coins/btc/maketx/txsize.go
@@ -32,16 +32,17 @@ func outputSize(pkScriptSize int) int {
 	return 8 + wire.VarIntSerializeSize(uint64(pkScriptSize)) + pkScriptSize
 }
 
-// estimateTxSize gives the worst case tx size estimate. All inputs are assumed to be of the same
-// structure.
-// inputCount is the number of inputs in the tx.
-// inputConfiguration defines the structure of every input.
+// estimateTxSize gives the worst case tx size estimate.
+//
+// Witnesses, if present, are assumed to have the following format:
+// <serialized sig> <serialized compressed pubkey>
+//
+// inputConfigurations defines the number of inputs and the input configurations in the tx.
 // outputPkScriptSize is the size of the output pkScript. One output is assumed (apart from change).
 // changePkScriptSize  is the size of the change pkScript. A value of 0 means that there is no change output.
 // This function computes the virtual size of a transaction, taking segwit discount into account.
 func estimateTxSize(
-	inputCount int,
-	inputConfiguration *signing.Configuration,
+	inputConfigurations []*signing.Configuration,
 	outputPkScriptSize int,
 	changePkScriptSize int) int {
 	const (
@@ -50,25 +51,45 @@ func estimateTxSize(
 		lockTimeSize = 4
 		nonWitness   = 4 // factor for non-witness fields
 	)
-	sigScriptSize, hasWitness := addresses.SigScriptWitnessSize(inputConfiguration)
-	inputSize := calcInputSize(sigScriptSize)
 
-	txWeight := nonWitness * (versionSize + lockTimeSize + wire.VarIntSerializeSize(uint64(inputCount)) +
+	txWeight := nonWitness * (versionSize + lockTimeSize + wire.VarIntSerializeSize(uint64(len(inputConfigurations))) +
 		wire.VarIntSerializeSize(uint64(outputCount)) +
-		inputCount*inputSize +
 		outputSize(outputPkScriptSize) +
 		outputSize(changePkScriptSize))
-	if hasWitness {
-		// For now, every input has a witness serialization of this format:
-		// <serialized sig> <serialized compressed pubkey>
-		const (
-			signatureSize = 73 // including SIGHASH op
-			pubkeySize    = 33
-		)
-		witnessSize := wire.VarIntSerializeSize(2) +
-			wire.VarIntSerializeSize(signatureSize) + signatureSize +
-			wire.VarIntSerializeSize(pubkeySize) + pubkeySize
-		txWeight += inputCount * witnessSize
+
+	isSegwitTx := false
+	for _, inputConfiguration := range inputConfigurations {
+		_, hasWitness := addresses.SigScriptWitnessSize(inputConfiguration)
+		if hasWitness {
+			isSegwitTx = true
+			break
+		}
+	}
+
+	for _, inputConfiguration := range inputConfigurations {
+		sigScriptSize, hasWitness := addresses.SigScriptWitnessSize(inputConfiguration)
+		txWeight += nonWitness * calcInputSize(sigScriptSize)
+		if isSegwitTx {
+			const (
+				// Including SIGHASH op. Assumes signatures follow the low-S requirement.
+				// See https://en.bitcoin.it/wiki/BIP_0062#DER_encoding
+				signatureSize = 72
+				pubkeySize    = 33
+			)
+			if hasWitness {
+				// For now, every input has a witness serialization of this format:
+				// <serialized sig> <serialized compressed pubkey>
+				txWeight += wire.VarIntSerializeSize(2) +
+					wire.VarIntSerializeSize(signatureSize) + signatureSize +
+					wire.VarIntSerializeSize(pubkeySize) + pubkeySize
+			} else {
+				// "Empty script witnesses are encoded as a zero byte"
+				// https://github.com/bitcoin/bips/blob/d8a56c9f2b521bf4af5d588f217e7618cc44952c/bip-0144.mediawiki
+				txWeight += wire.VarIntSerializeSize(0)
+			}
+		}
+	}
+	if isSegwitTx {
 		txWeight += 2 // segwit marker + segwit flag
 	}
 	// return txWeight/4 rounded up.

--- a/backend/coins/btc/maketx/txsize_export_test.go
+++ b/backend/coins/btc/maketx/txsize_export_test.go
@@ -16,12 +16,12 @@ package maketx
 
 import "github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 
-func TstEstimateTxSize(inputCount int,
-	inputConfiguration *signing.Configuration,
+func TstEstimateTxSize(
+	inputConfigurations []*signing.Configuration,
 	outputPkScriptSize int,
 	changePkScriptSize int) int {
-	return estimateTxSize(inputCount,
-		inputConfiguration,
+	return estimateTxSize(
+		inputConfigurations,
 		outputPkScriptSize,
 		changePkScriptSize)
 }

--- a/backend/coins/btc/maketx/txsize_internal_test.go
+++ b/backend/coins/btc/maketx/txsize_internal_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEstimateTxSize(t *testing.T) {
+func testEstimateTxSize(
+	t *testing.T, useSegwit bool, outputScriptType signing.ScriptType, changeScriptType *signing.ScriptType) {
+
 	// A signature can be 70 or 71 bytes (excluding sighash op).
 	// We take one that has 71 bytes, as the size function returns the maximum possible size.
 	sigBytes, err := hex.DecodeString(
@@ -37,75 +39,78 @@ func TestEstimateTxSize(t *testing.T) {
 	sig, err := btcec.ParseDERSignature(sigBytes, btcec.S256())
 	require.NoError(t, err)
 
-	scriptTypeP2PKH := signing.ScriptTypeP2PKH
-	scriptTypeP2WPKHP2SH := signing.ScriptTypeP2WPKHP2SH
-	scriptTypeP2WPKH := signing.ScriptTypeP2WPKH
-	scriptTypes := []signing.ScriptType{scriptTypeP2PKH, scriptTypeP2WPKHP2SH, scriptTypeP2WPKH}
+	inputScriptTypes := []signing.ScriptType{
+		signing.ScriptTypeP2PKH,
+		signing.ScriptTypeP2WPKHP2SH,
+		signing.ScriptTypeP2WPKH,
+	}
+	if !useSegwit {
+		inputScriptTypes = []signing.ScriptType{signing.ScriptTypeP2PKH}
+	}
 
-	test := func(useSegwit bool, outputScriptType signing.ScriptType, changeScriptType *signing.ScriptType) {
-		changeStr := "noChange"
-		if changeScriptType != nil {
-			changeStr = string(*changeScriptType)
-		}
-		t.Run(fmt.Sprintf("%s/%s/%v", outputScriptType, changeStr, useSegwit),
-			func(t *testing.T) {
-				inputScriptTypes := []signing.ScriptType{scriptTypeP2PKH, scriptTypeP2WPKHP2SH, scriptTypeP2WPKH}
-				if !useSegwit {
-					inputScriptTypes = []signing.ScriptType{scriptTypeP2PKH}
-				}
+	outputPkScript := addressesTest.GetAddress(outputScriptType).PubkeyScript()
+	tx := &wire.MsgTx{
+		Version: wire.TxVersion,
+		// One output and one change.
+		TxOut: []*wire.TxOut{
+			{
+				Value:    1,
+				PkScript: outputPkScript,
+			},
+		},
+		LockTime: 0,
+	}
 
-				outputPkScript := addressesTest.GetAddress(outputScriptType).PubkeyScript()
-				tx := &wire.MsgTx{
-					Version: wire.TxVersion,
-					// One output and one change.
-					TxOut: []*wire.TxOut{
-						{
-							Value:    1,
-							PkScript: outputPkScript,
-						},
-					},
-					LockTime: 0,
-				}
-
-				var inputConfigurations []*signing.Configuration
-				// Add each type of input, multiple times.  Only once might not catch errors that
-				// are smoothed over by the rounding (ceiling) of the tx weight.
-				for counter := 0; counter < 10; counter++ {
-					for _, inputScriptType := range inputScriptTypes {
-						inputAddress := addressesTest.GetAddress(inputScriptType)
-						sigScript, witness := inputAddress.SignatureScript([]*btcec.Signature{sig})
-						tx.TxIn = append(tx.TxIn, &wire.TxIn{
-							SignatureScript: sigScript,
-							Witness:         witness,
-							Sequence:        0,
-						})
-						inputConfigurations = append(inputConfigurations, inputAddress.Configuration)
-					}
-				}
-				changePkScriptSize := 0
-				if changeScriptType != nil {
-					// add change
-					changePkScript := addressesTest.GetAddress(*changeScriptType).PubkeyScript()
-					tx.TxOut = append(tx.TxOut, &wire.TxOut{
-						Value:    1,
-						PkScript: changePkScript,
-					})
-					changePkScriptSize = len(changePkScript)
-				}
-
-				estimatedSize := estimateTxSize(
-					inputConfigurations,
-					len(outputPkScript), changePkScriptSize)
-				require.Equal(t, mempool.GetTxVirtualSize(btcutil.NewTx(tx)), int64(estimatedSize))
+	var inputConfigurations []*signing.Configuration
+	// Add each type of input, multiple times.  Only once might not catch errors that
+	// are smoothed over by the rounding (ceiling) of the tx weight.
+	for counter := 0; counter < 10; counter++ {
+		for _, inputScriptType := range inputScriptTypes {
+			inputAddress := addressesTest.GetAddress(inputScriptType)
+			sigScript, witness := inputAddress.SignatureScript([]*btcec.Signature{sig})
+			tx.TxIn = append(tx.TxIn, &wire.TxIn{
+				SignatureScript: sigScript,
+				Witness:         witness,
+				Sequence:        0,
 			})
+			inputConfigurations = append(inputConfigurations, inputAddress.Configuration)
+		}
+	}
+	changePkScriptSize := 0
+	if changeScriptType != nil {
+		// add change
+		changePkScript := addressesTest.GetAddress(*changeScriptType).PubkeyScript()
+		tx.TxOut = append(tx.TxOut, &wire.TxOut{
+			Value:    1,
+			PkScript: changePkScript,
+		})
+		changePkScriptSize = len(changePkScript)
+	}
+
+	estimatedSize := estimateTxSize(
+		inputConfigurations,
+		len(outputPkScript), changePkScriptSize)
+	require.Equal(t, mempool.GetTxVirtualSize(btcutil.NewTx(tx)), int64(estimatedSize))
+
+}
+
+func TestEstimateTxSize(t *testing.T) {
+	scriptTypes := []signing.ScriptType{
+		signing.ScriptTypeP2PKH,
+		signing.ScriptTypeP2WPKHP2SH,
+		signing.ScriptTypeP2WPKH,
 	}
 
 	for _, useSegwit := range []bool{false, true} {
 		for _, outputScriptType := range scriptTypes {
-			test(useSegwit, outputScriptType, nil)
+			t.Run(fmt.Sprintf("output=%s,noChange,segwit=%v", outputScriptType, useSegwit), func(t *testing.T) {
+				testEstimateTxSize(t, useSegwit, outputScriptType, nil)
+			})
 			for _, changeScriptType := range scriptTypes {
 				changeScriptType := changeScriptType // avoids referencing the same variable across loop iterations
-				test(useSegwit, outputScriptType, &changeScriptType)
+				t.Run(fmt.Sprintf("output=%s,change=%s,segwit=%v", outputScriptType, changeScriptType, useSegwit), func(t *testing.T) {
+					testEstimateTxSize(t, useSegwit, outputScriptType, &changeScriptType)
+				})
 			}
 		}
 	}

--- a/backend/coins/btc/maketx/txsize_internal_test.go
+++ b/backend/coins/btc/maketx/txsize_internal_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 func testEstimateTxSize(
-	t *testing.T, useSegwit bool, outputScriptType signing.ScriptType, changeScriptType *signing.ScriptType) {
-
+	t *testing.T, useSegwit bool, outputScriptType, changeScriptType signing.ScriptType) {
 	// A signature can be 70 or 71 bytes (excluding sighash op).
 	// We take one that has 71 bytes, as the size function returns the maximum possible size.
 	sigBytes, err := hex.DecodeString(
@@ -77,9 +76,9 @@ func testEstimateTxSize(
 		}
 	}
 	changePkScriptSize := 0
-	if changeScriptType != nil {
+	if changeScriptType != "" {
 		// add change
-		changePkScript := addressesTest.GetAddress(*changeScriptType).PubkeyScript()
+		changePkScript := addressesTest.GetAddress(changeScriptType).PubkeyScript()
 		tx.TxOut = append(tx.TxOut, &wire.TxOut{
 			Value:    1,
 			PkScript: changePkScript,
@@ -102,14 +101,16 @@ func TestEstimateTxSize(t *testing.T) {
 	}
 
 	for _, useSegwit := range []bool{false, true} {
+		useSegwit := useSegwit
 		for _, outputScriptType := range scriptTypes {
+			outputScriptType := outputScriptType
 			t.Run(fmt.Sprintf("output=%s,noChange,segwit=%v", outputScriptType, useSegwit), func(t *testing.T) {
-				testEstimateTxSize(t, useSegwit, outputScriptType, nil)
+				testEstimateTxSize(t, useSegwit, outputScriptType, "")
 			})
 			for _, changeScriptType := range scriptTypes {
-				changeScriptType := changeScriptType // avoids referencing the same variable across loop iterations
+				changeScriptType := changeScriptType
 				t.Run(fmt.Sprintf("output=%s,change=%s,segwit=%v", outputScriptType, changeScriptType, useSegwit), func(t *testing.T) {
-					testEstimateTxSize(t, useSegwit, outputScriptType, &changeScriptType)
+					testEstimateTxSize(t, useSegwit, outputScriptType, changeScriptType)
 				})
 			}
 		}


### PR DESCRIPTION
estimateTxSize assumed that all inputs in a tx are of the same
type (signing configuration in BitBoxApp terminology), e.g. version 0
native segwit.

It is extended to correctly handle transactions with mixed input
types. This will be needed when combining the different account
subtypes (e.g. Bitcoin Legacy, Segwit, Native Segwit) into one
account.

This is done by providing the input configuration for each input.

Testing this uncovered a bug:

signatureSize = 73 was wrong, signatureSize = 72 is correct (see
comments in the code). The unit test didn't catch it as it had too few
inputs, so by rounding the tx weight, the result was the same.

When mixing non segwit and segwit inputs, there is an empty witness
that has to be accounted for for each non-segwit input.

Tx construction, which uses this function to estimate the fees, is
still accepting only one configuration for all inputs, so it is just
repeated for now. In the next commit, mixed inputs will be allowed,
and the correct configuration per input will be used.