### PR TITLE
backend/btc/maketx: remove unnecessary callback

### DIFF
--- a/backend/coins/btc/maketx/maketx.go
+++ b/backend/coins/btc/maketx/maketx.go
@@ -147,14 +147,16 @@ func NewTxSpendAll(
 }
 
 // NewTx creates a transaction from a set of unspent outputs, targeting an output value. A subset of
-// the unspent outputs is selected to cover the needed amount. A change output is added if needed.
+// the unspent outputs is selected to cover the needed amount.
+//
+// changeAddress: a change output to this address is added if needed.
 func NewTx(
 	coin coin.Coin,
 	inputConfiguration *signing.Configuration,
 	spendableOutputs map[wire.OutPoint]*wire.TxOut,
 	output *wire.TxOut,
 	feePerKb btcutil.Amount,
-	getChangeAddress func() *addresses.AccountAddress,
+	changeAddress *addresses.AccountAddress,
 	log *logrus.Entry,
 ) (*TxProposal, error) {
 	targetAmount := btcutil.Amount(output.Value)
@@ -162,7 +164,6 @@ func NewTx(
 		panic("amount must be positive")
 	}
 	outputs := []*wire.TxOut{output}
-	changeAddress := getChangeAddress()
 	changePKScript := changeAddress.PubkeyScript()
 
 	estimatedSize := estimateTxSize(

--- a/backend/coins/btc/maketx/maketx_test.go
+++ b/backend/coins/btc/maketx/maketx_test.go
@@ -67,7 +67,6 @@ type newTxSuite struct {
 	someAddresses      []*addresses.AccountAddress
 	inputConfiguration *signing.Configuration
 	changeAddress      *addresses.AccountAddress
-	getChangeAddress   func() *addresses.AccountAddress
 	outputPkScript     []byte
 
 	log *logrus.Entry
@@ -79,9 +78,6 @@ func (s *newTxSuite) SetupTest() {
 	someAddresses := s.addressChain.EnsureAddresses()
 	s.outputPkScript = someAddresses[1].PubkeyScript()
 	s.changeAddress = someAddresses[0]
-	s.getChangeAddress = func() *addresses.AccountAddress {
-		return s.changeAddress
-	}
 	s.someAddresses = someAddresses[2:]
 }
 
@@ -103,7 +99,7 @@ func (s *newTxSuite) newTx(
 		utxo,
 		s.output(amount),
 		feePerKb,
-		s.getChangeAddress,
+		s.changeAddress,
 		s.log,
 	)
 }

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -108,9 +108,7 @@ func (account *Account) newTx(
 			wireUTXO,
 			wire.NewTxOut(parsedAmountInt64, pkScript),
 			*feeTarget.feeRatePerKb,
-			func() *addresses.AccountAddress {
-				return account.changeAddresses.GetUnused()[0]
-			},
+			account.changeAddresses.GetUnused()[0],
 			account.log,
 		)
 		if err != nil {


### PR DESCRIPTION
Can just pass the value directly instead.