### PR TITLE
backend/btc: export function to create a pubkey script hash

### DIFF
--- a/backend/coins/btc/addresses/address.go
+++ b/backend/coins/btc/addresses/address.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -156,7 +155,7 @@ func (address *AccountAddress) PubkeyScript() []byte {
 // PubkeyScriptHashHex returns the hash of the pubkey script in hex format.
 // It is used to subscribe to notifications at the ElectrumX server.
 func (address *AccountAddress) PubkeyScriptHashHex() blockchain.ScriptHashHex {
-	return blockchain.ScriptHashHex(chainhash.HashH(address.PubkeyScript()).String())
+	return blockchain.NewScriptHashHex(address.PubkeyScript())
 }
 
 // ScriptForHashToSign returns whether this address is a segwit output and the script used when

--- a/backend/coins/btc/blockchain/blockchain.go
+++ b/backend/coins/btc/blockchain/blockchain.go
@@ -80,6 +80,11 @@ func (history TxHistory) Status() string {
 // ScriptHashHex is the hash of a pkScript in reverse hex format. Always 64 chars.
 type ScriptHashHex string
 
+// NewScriptHashHex creates the hash of a pubkeyScript.
+func NewScriptHashHex(pkScript []byte) ScriptHashHex {
+	return ScriptHashHex(chainhash.HashH(pkScript).String())
+}
+
 // Header is returned by HeadersSubscribe().
 type Header struct {
 	BlockHeight int

--- a/backend/coins/btc/transactions/transactions.go
+++ b/backend/coins/btc/transactions/transactions.go
@@ -46,7 +46,7 @@ func (txOut *SpendableOutput) ScriptHashHex() blockchain.ScriptHashHex {
 }
 
 func getScriptHashHex(txOut *wire.TxOut) blockchain.ScriptHashHex {
-	return blockchain.ScriptHashHex(chainhash.HashH(txOut.PkScript).String())
+	return blockchain.NewScriptHashHex(txOut.PkScript)
 }
 
 // Transactions handles wallet transactions: keeping an index of the transactions, inputs, (unspent)


### PR DESCRIPTION
Code de-duplication, and it will be used from another package to get
the input configuration when creating a new tx.