### PR TITLE
ci: don't run envinit on macOS

### DIFF
--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -36,7 +36,6 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     # here and pop in the end.
     pushd ../ && cp -a bitbox-wallet-app $GOPATH/src/github.com/digitalbitbox/
     cd $GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app/
-    make envinit
     make qt-osx
     popd
 fi


### PR DESCRIPTION
The CI on macOS requires no tools installed in envinit make target.
This speeds it up a bit and avoids failures when upstream moves tools
source code around because we install with "go get".

Ideally, to fix the latter, we would install tools at specific release
versions in GO111MODULE=on mode. While this would probably work for
most, gomobile doesn't support "go build -mod=vendor" and regardless,
Go modules seem to make this more complicated and confusing. Also,
see https://github.com/golang/go/issues/25922.