### PR TITLE
backend/btc: bundle address chains and signing config in one struct

### DIFF
--- a/backend/coins/btc/maketx/maketx.go
+++ b/backend/coins/btc/maketx/maketx.go
@@ -110,7 +110,6 @@ func toInputConfigurations(
 // NewTxSpendAll creates a transaction which spends all available unspent outputs.
 func NewTxSpendAll(
 	coin coin.Coin,
-	inputConfiguration *signing.Configuration,
 	spendableOutputs map[wire.OutPoint]UTXO,
 	outputPkScript []byte,
 	feePerKb btcutil.Amount,
@@ -156,7 +155,6 @@ func NewTxSpendAll(
 // changeAddress: a change output to this address is added if needed.
 func NewTx(
 	coin coin.Coin,
-	inputConfiguration *signing.Configuration,
 	spendableOutputs map[wire.OutPoint]UTXO,
 	output *wire.TxOut,
 	feePerKb btcutil.Amount,

--- a/backend/coins/btc/maketx/maketx_test.go
+++ b/backend/coins/btc/maketx/maketx_test.go
@@ -95,7 +95,6 @@ func (s *newTxSuite) newTx(
 	utxo map[wire.OutPoint]maketx.UTXO) (*maketx.TxProposal, error) {
 	return maketx.NewTx(
 		tbtc,
-		s.inputConfiguration,
 		utxo,
 		s.output(amount),
 		feePerKb,

--- a/backend/coins/btc/sign.go
+++ b/backend/coins/btc/sign.go
@@ -49,8 +49,9 @@ func (account *Account) signTransaction(
 	getPrevTx func(chainhash.Hash) *wire.MsgTx,
 ) error {
 	proposedTransaction := &ProposedTransaction{
-		TXProposal:                   txProposal,
-		AccountSigningConfigurations: []*signing.Configuration{account.signingConfiguration},
+		TXProposal: txProposal,
+		// TODO unified-accounts
+		AccountSigningConfigurations: []*signing.Configuration{account.subaccounts[0].signingConfiguration},
 		PreviousOutputs:              previousOutputs,
 		GetAddress:                   account.getAddress,
 		GetPrevTx:                    getPrevTx,

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -110,7 +110,8 @@ func (account *Account) newTx(
 			wireUTXO,
 			wire.NewTxOut(parsedAmountInt64, pkScript),
 			*feeTarget.feeRatePerKb,
-			account.changeAddresses.GetUnused()[0],
+			// TODO unified-accounts
+			account.subaccounts[0].changeAddresses.GetUnused()[0],
 			account.log,
 		)
 		if err != nil {
@@ -123,10 +124,11 @@ func (account *Account) newTx(
 }
 
 func (account *Account) getAddress(scriptHashHex blockchain.ScriptHashHex) *addresses.AccountAddress {
-	if address := account.receiveAddresses.LookupByScriptHashHex(scriptHashHex); address != nil {
+	// TODO: unified-accounts
+	if address := account.subaccounts[0].receiveAddresses.LookupByScriptHashHex(scriptHashHex); address != nil {
 		return address
 	}
-	if address := account.changeAddresses.LookupByScriptHashHex(scriptHashHex); address != nil {
+	if address := account.subaccounts[0].changeAddresses.LookupByScriptHashHex(scriptHashHex); address != nil {
 		return address
 	}
 	panic("address must be present")

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -87,7 +87,6 @@ func (account *Account) newTx(
 	if amount.SendAll() {
 		txProposal, err = maketx.NewTxSpendAll(
 			account.coin,
-			account.signingConfiguration,
 			wireUTXO,
 			pkScript,
 			*feeTarget.feeRatePerKb,
@@ -108,7 +107,6 @@ func (account *Account) newTx(
 		}
 		txProposal, err = maketx.NewTx(
 			account.coin,
-			account.signingConfiguration,
 			wireUTXO,
 			wire.NewTxOut(parsedAmountInt64, pkScript),
 			*feeTarget.feeRatePerKb,


### PR DESCRIPTION
In preparation for unifying account types into one account.

I already make this a slice, but with only one element, so it behaves
the same as before.

When unifying e.g. Bitcoin Legacy, Segwit and Native Segwit accounts,
there would be one entry per such signing configuration.

Each accesss is marked with:

// TODO unified-accounts

with each following commit fixing one of those. This hopefully results
in smaller and easier to review commits.