### PR TITLE
backend/config,frontend/settings: toggle Bitcoin, Litecoin

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -308,7 +308,7 @@ func (backend *Backend) createAndAddAccount(
 			log.WithField("name", name).Info("skipping inactive erc20 token")
 			return
 		}
-	} else if !backend.arguments.Multisig() && !backend.config.AppConfig().Backend.AccountActive(code) {
+	} else if !backend.arguments.Multisig() && !backend.config.AppConfig().Backend.CoinActive(coin.Code()) {
 		log.WithField("name", name).Info("skipping inactive account")
 		return
 	}
@@ -626,10 +626,9 @@ func (backend *Backend) initDefaultAccounts() {
 			signing.ScriptTypeP2WPKH)
 
 		ETH, _ := backend.Coin(coinpkg.CodeETH)
-		const ethAccountCode = "eth"
-		backend.createAndAddAccount(ETH, ethAccountCode, "Ethereum", "m/44'/60'/0'/0", signing.ScriptTypeP2WPKH)
+		backend.createAndAddAccount(ETH, "eth", "Ethereum", "m/44'/60'/0'/0", signing.ScriptTypeP2WPKH)
 
-		if backend.config.AppConfig().Backend.AccountActive(ethAccountCode) {
+		if backend.config.AppConfig().Backend.CoinActive(coinpkg.CodeETH) {
 			for _, erc20Token := range erc20Tokens {
 				token, _ := backend.Coin(erc20Token.code)
 				backend.createAndAddAccount(token, string(erc20Token.code), erc20Token.name, "m/44'/60'/0'/0", signing.ScriptTypeP2WPKH)

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
 )
@@ -92,12 +93,9 @@ type Backend struct {
 	Proxy    proxyConfig    `json:"proxy"`
 	Services servicesConfig `json:"services"`
 
-	BitcoinP2PKHActive       bool `json:"bitcoinP2PKHActive"`
-	BitcoinP2WPKHP2SHActive  bool `json:"bitcoinP2WPKHP2SHActive"`
-	BitcoinP2WPKHActive      bool `json:"bitcoinP2WPKHActive"`
-	LitecoinP2WPKHP2SHActive bool `json:"litecoinP2WPKHP2SHActive"`
-	LitecoinP2WPKHActive     bool `json:"litecoinP2WPKHActive"`
-	EthereumActive           bool `json:"ethereumActive"`
+	BitcoinActive  bool `json:"bitcoinActive"`
+	LitecoinActive bool `json:"litecoinActive"`
+	EthereumActive bool `json:"ethereumActive"`
 
 	BTC  btcCoinConfig `json:"btc"`
 	TBTC btcCoinConfig `json:"tbtc"`
@@ -109,20 +107,14 @@ type Backend struct {
 	RETH ethCoinConfig `json:"reth"`
 }
 
-// AccountActive returns the Active setting for a coin by code.
-func (backend Backend) AccountActive(code string) bool {
+// CoinActive returns the Active setting for a coin by code.
+func (backend Backend) CoinActive(code coin.Code) bool {
 	switch code {
-	case "tbtc-p2pkh", "btc-p2pkh", "rbtc-p2pkh":
-		return backend.BitcoinP2PKHActive
-	case "tbtc-p2wpkh-p2sh", "btc-p2wpkh-p2sh", "rbtc-p2wpkh-p2sh":
-		return backend.BitcoinP2WPKHP2SHActive
-	case "tbtc-p2wpkh", "btc-p2wpkh", "rbtc-p2wpkh":
-		return backend.BitcoinP2WPKHActive
-	case "tltc-p2wpkh-p2sh", "ltc-p2wpkh-p2sh":
-		return backend.LitecoinP2WPKHP2SHActive
-	case "tltc-p2wpkh", "ltc-p2wpkh":
-		return backend.LitecoinP2WPKHActive
-	case "eth", "teth", "reth", "erc20Test":
+	case coin.CodeBTC, coin.CodeTBTC, coin.CodeRBTC:
+		return backend.BitcoinActive
+	case coin.CodeLTC, coin.CodeTLTC:
+		return backend.LitecoinActive
+	case coin.CodeETH, coin.CodeTETH, coin.CodeRETH, coin.CodeERC20TEST:
 		return backend.EthereumActive
 	default:
 		panic(fmt.Sprintf("unknown code %s", code))
@@ -184,12 +176,9 @@ func NewDefaultAppConfig() AppConfig {
 			Services: servicesConfig{
 				Safello: true,
 			},
-			BitcoinP2PKHActive:       true,
-			BitcoinP2WPKHP2SHActive:  true,
-			BitcoinP2WPKHActive:      true,
-			LitecoinP2WPKHP2SHActive: true,
-			LitecoinP2WPKHActive:     true,
-			EthereumActive:           true,
+			BitcoinActive:  true,
+			LitecoinActive: true,
+			EthereumActive: true,
 
 			BTC: btcCoinConfig{
 				ElectrumServers: []*ServerInfo{
@@ -306,8 +295,7 @@ func NewConfig(appConfigFilename string, accountsConfigFilename string) (*Config
 
 // SetBtcOnly sets non-bitcoin accounts in the config to false
 func (config *Config) SetBtcOnly() {
-	config.appConfig.Backend.LitecoinP2WPKHP2SHActive = false
-	config.appConfig.Backend.LitecoinP2WPKHActive = false
+	config.appConfig.Backend.LitecoinActive = false
 	config.appConfig.Backend.EthereumActive = false
 }
 

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1184,12 +1184,7 @@
   },
   "settings": {
     "accounts": {
-      "bitcoinP2PKH": "Bitcoin Legacy",
-      "bitcoinP2WPKH": "Bitcoin: bech32",
-      "bitcoinP2WPKHP2SH": "Bitcoin",
       "ethereum": "Ethereum",
-      "litecoinP2WPKH": "Litecoin: bech32",
-      "litecoinP2WPKHP2SH": "Litecoin",
       "title": "Active accounts"
     },
     "electrum": {

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -49,19 +49,12 @@ interface State {
 
 class Settings extends Component<Props, State> {
     private accountsList = [
-        { name: 'bitcoinP2PKHActive',
-          badges: ['BB01'],
-        },
-        { name: 'bitcoinP2WPKHActive',
+        { name: 'bitcoinActive',
+          label: 'Bitcoin',
           badges: ['BB01', 'BB02', 'BB02-BTC'],
         },
-        { name: 'bitcoinP2WPKHP2SHActive',
-          badges: ['BB01', 'BB02', 'BB02-BTC'],
-        },
-        { name: 'litecoinP2WPKHActive',
-          badges: ['BB01', 'BB02'],
-        },
-        { name: 'litecoinP2WPKHP2SHActive',
+        { name: 'litecoinActive',
+          label: 'Litecoin',
           badges: ['BB01', 'BB02'],
         },
     ];
@@ -294,7 +287,7 @@ class Settings extends Component<Props, State> {
                                                             this.accountsList.map((account, index) => (
                                                                 <div className={style.currency} key={`available-fiat-${index}`}>
                                                                     <div>
-                                                                        <p className="m-none">{t(`settings.accounts.${account.name.replace('Active', '')}`)}</p>
+                                                                        <p className="m-none">{account.label}</p>
                                                                         <p className="m-none">
                                                                             {
                                                                                 account.badges.map((badge, i) => (


### PR DESCRIPTION
Not the individual subaccount types.

For combined accounts ("Bitcoin", "Litecoin"), it just toggles the
account.

For split accounts, now either all account types are shown (Bitcoin:
bech32, Bitcoin, Bitcoin Legacy if supported), or none.

This is an acceptable trade-off, and only affects users with the
bitbox01 or users that will manually opt-in to split accounts.

The alternative would be a very hairy and granular settings screen,
which defeats the purpose of trying to simplify it.