### PR TITLE
backend/config: option to force split accounts

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -99,6 +99,10 @@ type Backend struct {
 	LitecoinP2WPKHActive     bool `json:"litecoinP2WPKHActive"`
 	EthereumActive           bool `json:"ethereumActive"`
 
+	// Whether Bitcoin, Litecoin should be shown in multiple accounts - one per script type -
+	// instead of a combined account.
+	SplitAccounts bool `json:"splitAccounts"`
+
 	BTC  btcCoinConfig `json:"btc"`
 	TBTC btcCoinConfig `json:"tbtc"`
 	RBTC btcCoinConfig `json:"rbtc"`
@@ -190,6 +194,8 @@ func NewDefaultAppConfig() AppConfig {
 			LitecoinP2WPKHP2SHActive: true,
 			LitecoinP2WPKHActive:     true,
 			EthereumActive:           true,
+
+			SplitAccounts: false,
 
 			BTC: btcCoinConfig{
 				ElectrumServers: []*ServerInfo{

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1226,6 +1226,7 @@
         "title": "Connect your own full node"
       },
       "setProxyAddress": "Set proxy address",
+      "splitAccounts": "One account per address type",
       "title": "Expert settings",
       "useProxy": "Enable tor proxy"
     },

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -356,6 +356,21 @@ class Settings extends Component<Props, State> {
                                                     <div className="box slim divide">
                                                         <div className={style.currency}>
                                                             <div>
+                                                                <p className="m-none">{t('settings.expert.splitAccounts')}</p>
+                                                                <p className="m-none">
+                                                                    <Badge type="primary">BB02</Badge>
+                                                                    <Badge type="secondary" className="m-left-quarter">BB02-BTC</Badge>
+                                                                    <Badge type="generic" className="m-left-quarter">BTC</Badge>
+                                                                    <Badge type="generic" className="m-left-quarter">LTC</Badge>
+                                                                </p>
+                                                            </div>
+                                                            <Toggle
+                                                                id="splitAccounts"
+                                                                checked={config.backend.splitAccounts}
+                                                                onChange={this.handleToggleAccount} />
+                                                        </div>
+                                                        <div className={style.currency}>
+                                                            <div>
                                                                 <p className="m-none">{t('settings.expert.coinControl')}</p>
                                                                 <p className="m-none">
                                                                     <Badge type="generic">BTC</Badge>


### PR DESCRIPTION
For the time being, we allow the user to go back to one account per
address/script type in the expert settings, like it was before unified
accounts.