### PR TITLE
frontend/transactions: fix buggy send/receive/self arrows

### DIFF
--- a/frontends/web/src/components/transactions/transaction.jsx
+++ b/frontends/web/src/components/transactions/transaction.jsx
@@ -67,8 +67,7 @@ export default class Transaction extends Component {
     }, {
         transactionDialog,
     }) {
-        const badge = t(`transaction.badge.${type}`);
-        const arrow =  badge === 'In' ? (
+        const arrow = type === 'receive' ? (
             <svg
                 className={[style.type, style.typeIn].join(' ')}
                 xmlns="http://www.w3.org/2000/svg"
@@ -82,7 +81,7 @@ export default class Transaction extends Component {
                 <line x1="12" y1="5" x2="12" y2="19"></line>
                 <polyline points="19 12 12 19 5 12"></polyline>
             </svg>
-        ) : badge === 'Out' ? (
+        ) : type === 'send' ? (
             <svg
                 className={[style.type, style.typeOut].join(' ')}
                 xmlns="http://www.w3.org/2000/svg"

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1265,11 +1265,6 @@
     }
   },
   "transaction": {
-    "badge": {
-      "receive": "In",
-      "send": "Out",
-      "send_to_self": "Self"
-    },
     "confirmation": "Confirmations",
     "details": {
       "address": "Address",


### PR DESCRIPTION
The arrows were switched on the translated text, which only works in
English. Of course, the type should be used directly to figure out
what it is.

The translation has been deleted too, unused.