### PR TITLE
backend,backend/btc: pass signingConfigurations (plural)

### DIFF
--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -51,7 +51,7 @@ func TestAccount(t *testing.T) {
 
 	coin.TstSetMakeBlockchain(func() blockchain.Interface { return blockchainMock })
 
-	getSigningConfiguration := func() (*signing.Configuration, error) {
+	getSigningConfigurations := func() (signing.Configurations, error) {
 		keypath, err := signing.NewAbsoluteKeypath("m/49'/1'/0'")
 		require.NoError(t, err)
 		xpub, err := hdkeychain.NewMaster(make([]byte, 32), net)
@@ -59,15 +59,15 @@ func TestAccount(t *testing.T) {
 		xpub, err = xpub.Neuter()
 		require.NoError(t, err)
 
-		return signing.NewSinglesigConfiguration(
+		return signing.Configurations{signing.NewSinglesigConfiguration(
 			signing.ScriptTypeP2WPKHP2SH,
 			keypath,
 			xpub,
-		), nil
+		)}, nil
 	}
 	account := btc.NewAccount(
-		coin, dbFolder, "accountcode", "accountname", nil, getSigningConfiguration, nil,
-		func(*signing.Configuration) accounts.Notifier { return nil },
+		coin, dbFolder, "accountcode", "accountname", nil, getSigningConfigurations, nil,
+		func(signing.Configurations) accounts.Notifier { return nil },
 		func(accounts.Event) {},
 		logging.Get().WithGroup("account_test"),
 		nil,

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -65,7 +65,7 @@ type Account struct {
 	getSigningConfiguration func() (*signing.Configuration, error)
 	signingConfiguration    *signing.Configuration
 	keystores               *keystore.Keystores
-	getNotifier             func(*signing.Configuration) accounts.Notifier
+	getNotifier             func(signing.Configurations) accounts.Notifier
 	notifier                accounts.Notifier
 	offline                 bool
 	onEvent                 func(accounts.Event)
@@ -102,7 +102,7 @@ func NewAccount(
 	name string,
 	getSigningConfiguration func() (*signing.Configuration, error),
 	keystores *keystore.Keystores,
-	getNotifier func(*signing.Configuration) accounts.Notifier,
+	getNotifier func(signing.Configurations) accounts.Notifier,
 	onEvent func(accounts.Event),
 	log *logrus.Entry,
 	rateUpdater *rates.RateUpdater,
@@ -202,7 +202,7 @@ func (account *Account) Initialize() error {
 		return err
 	}
 	account.signingConfiguration = signingConfiguration
-	account.notifier = account.getNotifier(signingConfiguration)
+	account.notifier = account.getNotifier(signing.Configurations{signingConfiguration})
 
 	accountIdentifier := fmt.Sprintf("account-%s-%s", account.signingConfiguration.Hash(), account.code)
 	account.dbSubfolder = path.Join(account.dbFolder, accountIdentifier)

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -80,7 +80,7 @@ type Backend interface {
 		coin coinpkg.Coin,
 		code string,
 		name string,
-		getSigningConfiguration func() (*signing.Configuration, error),
+		getSigningConfigurations func() (signing.Configurations, error),
 		persist bool,
 		emitEvent bool,
 	) error
@@ -460,12 +460,12 @@ func (handlers *Handlers) postAddAccountHandler(r *http.Request) (interface{}, e
 		configuration = signing.NewSinglesigConfiguration(scriptType, keypath, extendedPublicKey)
 	}
 
-	getSigningConfiguration := func() (*signing.Configuration, error) {
-		return configuration, nil
+	getSigningConfigurations := func() (signing.Configurations, error) {
+		return signing.Configurations{configuration}, nil
 	}
 	accountCode := fmt.Sprintf("%s-%s", configuration.Hash(), coin.Code())
 	err = handlers.backend.CreateAndAddAccount(
-		coin, accountCode, jsonAccountName, getSigningConfiguration, true, true)
+		coin, accountCode, jsonAccountName, getSigningConfigurations, true, true)
 	if errp.Cause(err) == backend.ErrAccountAlreadyExists {
 		return map[string]interface{}{"success": false, "errorCode": "alreadyExists"}, nil
 	}


### PR DESCRIPTION
Actual use in the following commit; but this allows the backend to
create multiple signingConfigs in a btc coin, to enable combining the
account types into one combined account.