### PR TITLE
unified-accounts: resolve TODO, pick change

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -126,7 +126,11 @@ const (
 )
 
 // NewAccount creates a new account.
+//
 // forceGaplimits: if not nil, these limits will be used and persisted for future use.
+//
+// getSigningConfigurations: defines the script types used in this account. The first one is used as
+// a default for receive addresses, and always used for change.
 func NewAccount(
 	coin *Coin,
 	dbFolder string,

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -110,7 +110,7 @@ func (account *Account) newTx(
 			wireUTXO,
 			wire.NewTxOut(parsedAmountInt64, pkScript),
 			*feeTarget.feeRatePerKb,
-			// TODO unified-accounts
+			// Change address is of the first subaccount, always.
 			account.subaccounts[0].changeAddresses.GetUnused()[0],
 			account.log,
 		)


### PR DESCRIPTION
For now we always use native segwit for change.

If it does not match the input types, it might even be a small privacy
benefit, as change is usually assumed to be the output that matches
the inputs type.