### PR TITLE
unified-accounts: resolve TODO, bb02 signing

### DIFF
--- a/backend/coins/btc/sign.go
+++ b/backend/coins/btc/sign.go
@@ -48,10 +48,13 @@ func (account *Account) signTransaction(
 	previousOutputs map[wire.OutPoint]*transactions.SpendableOutput,
 	getPrevTx func(chainhash.Hash) *wire.MsgTx,
 ) error {
+	signingConfigs := make([]*signing.Configuration, len(account.subaccounts))
+	for i, subacc := range account.subaccounts {
+		signingConfigs[i] = subacc.signingConfiguration
+	}
 	proposedTransaction := &ProposedTransaction{
-		TXProposal: txProposal,
-		// TODO unified-accounts
-		AccountSigningConfigurations: []*signing.Configuration{account.subaccounts[0].signingConfiguration},
+		TXProposal:                   txProposal,
+		AccountSigningConfigurations: signingConfigs,
 		PreviousOutputs:              previousOutputs,
 		GetAddress:                   account.getAddress,
 		GetPrevTx:                    getPrevTx,

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -269,15 +269,26 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 				PubkeyScript: prevTxOut.PkScript,
 			}
 		}
+		inputAddress := btcProposedTx.GetAddress(prevOut.ScriptHashHex())
+
+		// Find the script config index. Assumption: there is only one entry per script type, so we
+		// don't have to check that the keypath prefix matches.
+		var scriptConfigIndex uint32
+		for i, cfg := range btcProposedTx.AccountSigningConfigurations {
+			if cfg.ScriptType() == inputAddress.Configuration.ScriptType() {
+				scriptConfigIndex = uint32(i)
+				break
+			}
+		}
 
 		inputs[inputIndex] = &firmware.BTCTxInput{
 			Input: &messages.BTCSignInputRequest{
-				PrevOutHash:  txIn.PreviousOutPoint.Hash[:],
-				PrevOutIndex: txIn.PreviousOutPoint.Index,
-				PrevOutValue: uint64(prevOut.Value),
-				Sequence:     txIn.Sequence,
-				Keypath: btcProposedTx.GetAddress(prevOut.ScriptHashHex()).
-					Configuration.AbsoluteKeypath().ToUInt32(),
+				PrevOutHash:       txIn.PreviousOutPoint.Hash[:],
+				PrevOutIndex:      txIn.PreviousOutPoint.Index,
+				PrevOutValue:      uint64(prevOut.Value),
+				Sequence:          txIn.Sequence,
+				Keypath:           inputAddress.Configuration.AbsoluteKeypath().ToUInt32(),
+				ScriptConfigIndex: scriptConfigIndex,
 			},
 			PrevTx: &firmware.BTCPrevTx{
 				Version:  uint32(prevTx.Version),


### PR DESCRIPTION
- Pass all signing configs to the keystore
- Apply them in the bitbox02 keystore to correctly sign tx with mixed inputs.