### PR TITLE
unified-accounts: resolve TODO, receive screen

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -24,6 +24,9 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 )
 
+// AddressList is a list of addresses.
+type AddressList []Address
+
 // Interface is the API of a Account.
 type Interface interface {
 	Info() *Info
@@ -53,7 +56,10 @@ type Interface interface {
 	FeeTargets() ([]FeeTarget, FeeTargetCode)
 	TxProposal(string, coin.SendAmount, FeeTargetCode, map[wire.OutPoint]struct{}, []byte) (
 		coin.Amount, coin.Amount, coin.Amount, error)
-	GetUnusedReceiveAddresses() []Address
+	// GetUnusedReceiveAddresses gets a list of list of receive addresses. The result can be one
+	// list of addresses, or if there are multiple types of addresses (e.g. `bc1...` vs `3...`), a
+	// list of lists.
+	GetUnusedReceiveAddresses() []AddressList
 	CanVerifyAddresses() (bool, bool, error)
 	VerifyAddress(addressID string) (bool, error)
 	Keystores() *keystore.Keystores

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -737,20 +737,21 @@ func (account *Account) Transactions() ([]accounts.Transaction, error) {
 }
 
 // GetUnusedReceiveAddresses returns a number of unused addresses.
-func (account *Account) GetUnusedReceiveAddresses() []accounts.Address {
+func (account *Account) GetUnusedReceiveAddresses() []accounts.AddressList {
 	account.synchronizer.WaitSynchronized()
 	defer account.RLock()()
 	account.log.Debug("Get unused receive address")
-	var addresses []accounts.Address
-	// TODO unified-accounts
-	for idx, address := range account.subaccounts[0].receiveAddresses.GetUnused() {
-		if idx >= receiveAddressesLimit {
-			// Limit to gap limit for receive addresses, even if the actual limit is higher when
-			// scanning.
-			break
-		}
+	addresses := make([]accounts.AddressList, len(account.subaccounts))
+	for subaccIdx, subacc := range account.subaccounts {
+		for idx, address := range subacc.receiveAddresses.GetUnused() {
+			if idx >= receiveAddressesLimit {
+				// Limit to gap limit for receive addresses, even if the actual limit is higher when
+				// scanning.
+				break
+			}
 
-		addresses = append(addresses, address)
+			addresses[subaccIdx] = append(addresses[subaccIdx], address)
+		}
 	}
 	return addresses
 }

--- a/backend/coins/btc/exchange.go
+++ b/backend/coins/btc/exchange.go
@@ -32,10 +32,10 @@ func (account *Account) SafelloBuySupported() bool {
 func (account *Account) SafelloBuy() *safello.Buy {
 	switch account.coin.Net().Net {
 	case chaincfg.MainNetParams.Net:
-		address := account.GetUnusedReceiveAddresses()[0]
+		address := account.GetUnusedReceiveAddresses()[0][0]
 		return safello.NewBuy(false, address.ID(), address.EncodeForHumans())
 	case chaincfg.TestNet3Params.Net:
-		address := account.GetUnusedReceiveAddresses()[0]
+		address := account.GetUnusedReceiveAddresses()[0][0]
 		return safello.NewBuy(true, address.ID(), address.EncodeForHumans())
 	default:
 		panic("SafelloBuy is not supported by this account")

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -443,18 +443,24 @@ func (handlers *Handlers) getAccountStatus(_ *http.Request) (interface{}, error)
 	return status, nil
 }
 
+type jsonAddress struct {
+	Address   string `json:"address"`
+	AddressID string `json:"addressID"`
+}
+
 func (handlers *Handlers) getReceiveAddresses(_ *http.Request) (interface{}, error) {
-	addresses := []interface{}{}
-	for _, address := range handlers.account.GetUnusedReceiveAddresses() {
-		addresses = append(addresses, struct {
-			Address   string `json:"address"`
-			AddressID string `json:"addressID"`
-		}{
-			Address:   address.EncodeForHumans(),
-			AddressID: address.ID(),
-		})
+	var addressesList [][]jsonAddress
+	for _, addresses := range handlers.account.GetUnusedReceiveAddresses() {
+		addrs := []jsonAddress{}
+		for _, address := range addresses {
+			addrs = append(addrs, jsonAddress{
+				Address:   address.EncodeForHumans(),
+				AddressID: address.ID(),
+			})
+		}
+		addressesList = append(addressesList, addrs)
 	}
-	return addresses, nil
+	return addressesList, nil
 }
 
 func (handlers *Handlers) postVerifyAddress(r *http.Request) (interface{}, error) {

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -683,8 +683,10 @@ func (account *Account) TxProposal(
 }
 
 // GetUnusedReceiveAddresses implements accounts.Interface.
-func (account *Account) GetUnusedReceiveAddresses() []accounts.Address {
-	return []accounts.Address{account.address}
+func (account *Account) GetUnusedReceiveAddresses() []accounts.AddressList {
+	return []accounts.AddressList{
+		[]accounts.Address{account.address},
+	}
 }
 
 // VerifyAddress implements accounts.Interface.


### PR DESCRIPTION
The backend now sends unused addresses of each subaccount to the
frontend.

Frontend now only shows, as before, the addresses from the first
subaccount. Work needs to be done to allow the user to cycle through
the address types (see TODO).