### PR TITLE
frontend: remove t(settings.accounts.ethereum)

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1184,7 +1184,6 @@
   },
   "settings": {
     "accounts": {
-      "ethereum": "Ethereum",
       "title": "Active accounts"
     },
     "electrum": {

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -313,7 +313,7 @@ class Settings extends Component<Props, State> {
                                                 <div className="column column-1-3">
                                                     <div class="subHeaderContainer withToggler">
                                                         <div class="subHeader">
-                                                            <h3>{t('settings.accounts.ethereum')}</h3>
+                                                            <h3>Ethereum</h3>
                                                             <Badge type="primary" className="m-left-quarter">BB02</Badge>
                                                         </div>
                                                         <div className="subHeaderToggler">


### PR DESCRIPTION
No point in translating a constant name.