### PR TITLE
backend: fix transaction notifier db name

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -265,7 +265,7 @@ func (backend *Backend) CreateAndAddAccount(
 	}
 
 	getNotifier := func(configurations signing.Configurations) accounts.Notifier {
-		return backend.notifier.ForAccount(fmt.Sprintf("%s-%s", configurations.Hash(), coin.Code()))
+		return backend.notifier.ForAccount(fmt.Sprintf("%s-%s", configurations.Hash(), code))
 	}
 
 	accountAdded := false


### PR DESCRIPTION
Before, the coin code was used for the database name, but it should
have been the account code all along, as the notifications work on an
account basis.

Changing this identifier now is good timing, as we just changed the
account db identifier as well (configurations hash).