### PR TITLE
backend/keystore: simplify VerifyExtendedPublicKey() signature

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -846,7 +846,6 @@ func (account *Account) VerifyExtendedPublicKey(signingConfigIndex, xpubIndex in
 	if keystore.CanVerifyExtendedPublicKey() {
 		return true, keystore.VerifyExtendedPublicKey(
 			account.Coin(),
-			account.subaccounts[signingConfigIndex].signingConfiguration.AbsoluteKeypath(),
 			account.subaccounts[signingConfigIndex].signingConfiguration,
 		)
 	}

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -93,7 +93,7 @@ func (keystore *keystore) CanVerifyExtendedPublicKey() bool {
 }
 
 // VerifyExtendedPublicKey implements keystore.Keystore.
-func (keystore *keystore) VerifyExtendedPublicKey(coin coin.Coin, keyPath signing.AbsoluteKeypath, configuration *signing.Configuration) error {
+func (keystore *keystore) VerifyExtendedPublicKey(coin coin.Coin, configuration *signing.Configuration) error {
 	keystore.log.Panic("BitBox v1 does not have a screen to verify the xpub")
 	return nil
 }

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -154,7 +154,7 @@ func (keystore *keystore) CanVerifyExtendedPublicKey() bool {
 }
 
 func (keystore *keystore) VerifyExtendedPublicKey(
-	coin coinpkg.Coin, keyPath signing.AbsoluteKeypath, configuration *signing.Configuration) error {
+	coin coinpkg.Coin, configuration *signing.Configuration) error {
 	if !keystore.CanVerifyExtendedPublicKey() {
 		panic("CanVerifyExtendedPublicKey must be true")
 	}
@@ -181,7 +181,7 @@ func (keystore *keystore) VerifyExtendedPublicKey(
 			msgXPubType = messages.BTCPubRequest_XPUB
 		}
 		_, err := keystore.device.BTCXPub(
-			msgCoin, keyPath.ToUInt32(), msgXPubType, true)
+			msgCoin, configuration.AbsoluteKeypath().ToUInt32(), msgXPubType, true)
 		if firmware.IsErrorAbort(err) {
 			// No special action taken on user abort.
 			return nil

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -69,7 +69,7 @@ type Keystore interface {
 	CanVerifyExtendedPublicKey() bool
 
 	// VerifyExtendedPublicKey displays the public key on the device for verification
-	VerifyExtendedPublicKey(coin.Coin, signing.AbsoluteKeypath, *signing.Configuration) error
+	VerifyExtendedPublicKey(coin.Coin, *signing.Configuration) error
 
 	// ExtendedPublicKey returns the extended public key at the given absolute keypath.
 	ExtendedPublicKey(coin.Coin, signing.AbsoluteKeypath) (*hdkeychain.ExtendedKey, error)

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -119,7 +119,7 @@ func (keystore *Keystore) CanVerifyExtendedPublicKey() bool {
 }
 
 // VerifyExtendedPublicKey implements keystore.Keystore.
-func (keystore *Keystore) VerifyExtendedPublicKey(coin coin.Coin, keyPath signing.AbsoluteKeypath, configuration *signing.Configuration) error {
+func (keystore *Keystore) VerifyExtendedPublicKey(coin coin.Coin, configuration *signing.Configuration) error {
 	return errp.New("The software-based keystore has no secure output to display the public key.")
 }
 


### PR DESCRIPTION
keypath is directly derived from configuratio and redundant.