### PR TITLE
frontend/send: fix devmode send to self

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -376,7 +376,7 @@ class Send extends Component<Props, State> {
 
     private sendToSelf = (event: Event) => {
         apiGet('account/' + this.getAccount()!.code + '/receive-addresses').then(receiveAddresses => {
-            this.setState({ recipientAddress: receiveAddresses[0].address });
+            this.setState({ recipientAddress: receiveAddresses[0][0].address });
             this.handleFormChange(event);
         });
     }


### PR DESCRIPTION
Addresses are now a multi-dimensional array with potentially multiple
address types. For the purpose of getting a quick address in dev mode,
always getting the first format works.