### PR TITLE
frontend: suppress dialog animations when requested

### DIFF
--- a/frontends/web/src/components/dialog/dialog.css
+++ b/frontends/web/src/components/dialog/dialog.css
@@ -236,3 +236,16 @@
         padding: var(--space-half);
     }
 }
+
+/**
+ * Turn off animations when requested.
+ * On an Android phone, this is typically a "Remove animations" switch
+ * in Accessibility section.
+ */
+@media (prefers-reduced-motion) {
+    .overlay,
+    .modal {
+        animation: none;
+        opacity: 1;
+    }
+}

--- a/frontends/web/src/components/steps/steps.css
+++ b/frontends/web/src/components/steps/steps.css
@@ -406,3 +406,15 @@
         margin-bottom: var(--space-default) !important;
     }
 }
+
+/**
+ * Turn off animations when requested.
+ * On an Android phone, this is typically a "Remove animations" switch
+ * in Accessibility section.
+ */
+@media (prefers-reduced-motion) {
+    .step {
+        animation: none;
+        transition: none;
+    }
+}

--- a/frontends/web/src/utils/animation.ts
+++ b/frontends/web/src/utils/animation.ts
@@ -1,8 +1,29 @@
+import { debug } from './env';
+
+const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+let reduceMotion = mq.matches;
+try {
+    // experimental https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList
+    // @ts-ignore
+    mq.addListener(e => reduceMotion = e.matches);
+} catch (e) {
+    if (debug) {
+        // tslint:disable-next-line: no-console
+        console.log(e);
+    }
+}
+
 export function animate(
     el: Element,
     effect: string,
     callback?: () => void,
 ) {
+    if (reduceMotion) {
+        if (callback) {
+            callback();
+        }
+        return;
+    }
     el.addEventListener('animationend', onAnimationEnd, false);
     function onAnimationEnd() {
         el.classList.remove('animated', 'faster', effect);


### PR DESCRIPTION
Popup animations prevent dialogs from showing up at all, at least on
Android devices where animations are disabled.

Being able to completely turn off animations is an accessibility
feature in most phones these days.

To reproduce the current issue on Android, go to Accessibility settings
and enable "Remove animations". Close the app completely and reopen.
Navigate to Settings, Connect your own full node, tap on "Check" for
any row in the Servers list. You'll see nothing and unable to scroll
up/down anymore. Expected: a dialog with the check status.

Trial and error has shown that Android WebView adheres to "Disable
Animations" accessibility setting and honors prefers-reduced-motion
@media CSS query, in which we suppress dialog animations.

See
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
for more details about the @media query.