### PR TITLE
frontend/settings: move legacy, bech32, segwit guide entries

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -31,7 +31,7 @@ import { apiGet, apiPost } from '../../utils/request';
 import { apiWebsocket } from '../../utils/websocket';
 import { Devices } from '../device/deviceswitch';
 import * as style from './account.css';
-import { SigningConfigurationInterface } from './info/signingconfiguration';
+import { ScriptType, SigningConfigurationInterface } from './info/signingconfiguration';
 import { isBitcoinBased } from './utils';
 
 export interface AccountInterface {
@@ -229,12 +229,12 @@ class Account extends Component<Props, State> {
         });
     }
 
-    private isLegacy = (account: AccountInterface, accountInfo?: AccountInfo): boolean => {
+    private isBTCScriptType = (scriptType: ScriptType, account: AccountInterface, accountInfo?: AccountInfo): boolean => {
         if (!accountInfo || accountInfo.signingConfigurations.length !== 1) {
             return false;
         }
         return (account.coinCode === 'btc' || account.coinCode === 'tbtc') &&
-            accountInfo.signingConfigurations[0].scriptType === 'p2pkh';
+            accountInfo.signingConfigurations[0].scriptType === scriptType;
     }
 
     private deviceIDs = (devices: Devices) => {
@@ -351,6 +351,15 @@ class Account extends Component<Props, State> {
                 </div>
                 <Guide>
                     <Entry key="accountDescription" entry={t('guide.accountDescription')} />
+                    {this.isBTCScriptType('p2pkh', account, accountInfo) && (
+                        <Entry key="guide.settings.btc-p2pkh" entry={t('guide.settings.btc-p2pkh')} />
+                    )}
+                    {this.isBTCScriptType('p2wpkh-p2sh', account, accountInfo) && (
+                        <Entry key="guide.settings.btc-p2sh" entry={t('guide.settings.btc-p2sh')} />
+                    )}
+                    {this.isBTCScriptType('p2wpkh', account, accountInfo) && (
+                    <Entry key="guide.settings.btc-p2wpkh" entry={t('guide.settings.btc-p2wpkh')} />
+                    )}
                     {balance && balance.available.amount === '0' && (
                         <Entry key="accountSendDisabled" entry={t('guide.accountSendDisabled', { unit: balance.available.unit })} />
                     )}
@@ -361,7 +370,7 @@ class Account extends Component<Props, State> {
                     {transactions !== undefined && transactions.length > 0 && (
                         <Entry key="accountTransactionTime" entry={t('guide.accountTransactionTime')} />
                     )}
-                    {this.isLegacy(account, accountInfo) && (
+                    {this.isBTCScriptType('p2pkh', account, accountInfo) && (
                         <Entry key="accountLegacyConvert" entry={t('guide.accountLegacyConvert')} />
                     )}
                     {transactions !== undefined &&  transactions.length > 0 && (

--- a/frontends/web/src/routes/account/info/signingconfiguration.tsx
+++ b/frontends/web/src/routes/account/info/signingconfiguration.tsx
@@ -29,8 +29,10 @@ interface ProvidedProps {
     signingConfigIndex: number;
 }
 
+export type ScriptType = 'p2pkh' | 'p2wpkh-p2sh' | 'p2wpkh';
+
 export interface SigningConfigurationInterface {
-    scriptType: 'p2pkh' | 'p2wpkh-p2sh' | 'p2pkh';
+    scriptType: ScriptType;
     keypath: string;
     threshold: number;
     xpubs: string[];

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -454,9 +454,6 @@ class Settings extends Component<Props, State> {
                 </div>
                 <Guide>
                     <Entry key="guide.settings.whyMultipleAccounts" entry={t('guide.settings.whyMultipleAccounts')} />
-                    <Entry key="guide.settings.btc-p2pkh" entry={t('guide.settings.btc-p2pkh')} />
-                    <Entry key="guide.settings.btc-p2sh" entry={t('guide.settings.btc-p2sh')} />
-                    <Entry key="guide.settings.btc-p2wpkh" entry={t('guide.settings.btc-p2wpkh')} />
                     <Entry key="guide.settings.servers" entry={t('guide.settings.servers')} />
                     <Entry key="guide.settings.moreCoins" entry={t('guide.settings.moreCoins')} />
                     <Entry key="guide.accountRates" entry={t('guide.accountRates')} />


### PR DESCRIPTION
Since unified accounts. there are no settings mentioning those words.

We ove it to the accounts guide, but only in split accounts, showing
the relevant part.

We might delete the entries soon altogether, as there is also the
accounts description banner that says more or less the same. Keeping
it for now though to not lose all the translations, in case we need
it.

Litecoin currently does not show them, as the text has 'Bitcoin' all
over. Not gonna fix this either.