### PR TITLE
ci: speed bump by running builds in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,23 +2,65 @@
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
 name: ci
 on: [push, pull_request]
+env:
+  # Use alternative image when running on GitHub workflows CI to avoid potential
+  # rate limiting when executing jobs in parallel: they can't cache docker images
+  # and always pull.
+  #
+  # To update this image, generate a personal token with write:packages scope
+  # on https://github.com/settings/tokens and authenticate yourself locally with
+  # "docker login https://docker.pkg.github.com -u <github-username>" using the
+  # newly generated token as password.
+  # Once logged in, tag an new image:
+  #   docker tag shiftcrypto/bitbox-wallet-app:VERSION \
+  #   docker.pkg.github.com/digitalbitbox/bitbox-wallet-app/ci-builder:VERSION
+  # and push as usual:
+  #   docker push docker.pkg.github.com/digitalbitbox/bitbox-wallet-app/ci-builder:VERSION
+  # Lastly, update the next line to use the newly pushed image version.
+  # See docs for more details:
+  # https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages
+  CI_IMAGE: docker.pkg.github.com/digitalbitbox/bitbox-wallet-app/ci-builder:5
+  TRAVIS_BUILD_DIR: ${{github.workspace}}
 
 jobs:
-  linux-docker:
+  test-lint:
     runs-on: ubuntu-18.04
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2
+      - name: Docker login
+        run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
       - name: Run CI script
-        run: ./scripts/travis-ci.sh
+        run: ./scripts/travis-ci.sh ci
         env:
           TRAVIS_OS_NAME: linux
-          TRAVIS_BUILD_DIR: ${{github.workspace}}
-      - name: Upload Android
+  android:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Clone the repo
+        uses: actions/checkout@v2
+      - name: Docker login
+        run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
+      - name: Build Android
+        run: ./scripts/travis-ci.sh android
+        env:
+          TRAVIS_OS_NAME: linux
+      - name: Upload APK
         uses: actions/upload-artifact@v2
         with:
           path: frontends/android/BitBoxApp/app/build/outputs/apk/debug/app-debug.apk
           name: BitBoxApp-android-${{github.sha}}.apk
+  qt-linux:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Clone the repo
+        uses: actions/checkout@v2
+      - name: Docker login
+        run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
+      - name: Build Qt-Linux
+        run: ./scripts/travis-ci.sh qt-linux
+        env:
+          TRAVIS_OS_NAME: linux
       - name: Upload AppImage
         uses: actions/upload-artifact@v2
         with:
@@ -39,11 +81,10 @@ jobs:
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2
-      - name: Run CI script
-        run: ./scripts/travis-ci.sh
+      - name: Build macOS app
+        run: ./scripts/travis-ci.sh qt-osx
         env:
           TRAVIS_OS_NAME: osx
-          TRAVIS_BUILD_DIR: ${{github.workspace}}
       - name: Archive app
         run: >
           pushd ~/go/src/github.com/digitalbitbox/bitbox-wallet-app/frontends/qt/build/osx;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
-dist: trusty
-
-sudo: true
+# See reference docs for details:
+# https://config.travis-ci.com.
+dist: bionic
 
 services:
   - docker
-
-os:
-  - linux
-  - osx
 
 language: go
 go: 1.14.x
@@ -17,13 +13,17 @@ addons:
     packages:
       - make
 
-before_install:
-  - bash ./scripts/travis_ssh.sh
-
-script:
-  - ./scripts/travis-ci.sh
-
-after_success:
-  # Run uploads only on non-PRs since PRs sent from forked repositories do not have access to encrypted variables
-  # Also run uploads only on staging and master branches
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && ([ "$TRAVIS_BRANCH" = "master" ] || [ "$TRAVIS_BRANCH" = "staging" ]); then bash ./scripts/upload_nightlies.sh $TRAVIS_BRANCH; fi
+jobs:
+  include:
+    - stage: Linux
+      os: linux
+      script:
+        - ./scripts/travis-ci.sh ci
+        - ./scripts/travis-ci.sh android
+        - ./scripts/travis-ci.sh qt-linux
+        - ./scripts/travis_upload_nightlies.sh
+    - stage: macOS
+      os: osx
+      script:
+        - ./scripts/travis-ci.sh qt-osx
+        - ./scripts/travis_upload_nightlies.sh

--- a/scripts/travis_ssh.sh
+++ b/scripts/travis_ssh.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -e
-
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    openssl aes-256-cbc -K $encrypted_59febc5c238f_key -iv $encrypted_59febc5c238f_iv -in travis_rsa.enc -out travis_rsa -d
-    chmod 600 travis_rsa
-    mv travis_rsa ~/.ssh/id_rsa
-fi

--- a/scripts/travis_upload_nightlies.sh
+++ b/scripts/travis_upload_nightlies.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+# Don't upload anything unless it's a push commit to the master branch.
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master"]; then
+    exit 0
+fi
+
+openssl aes-256-cbc -K $encrypted_59febc5c238f_key -iv $encrypted_59febc5c238f_iv -in travis_rsa.enc -out travis_rsa -d
+chmod 600 travis_rsa
+mv travis_rsa ~/.ssh/id_rsa
+
 LINUX_BUILD=$TRAVIS_BUILD_DIR/frontends/qt/build/linux
 ANDROID_BUILD=$TRAVIS_BUILD_DIR/frontends/android/BitBoxApp/app/build/outputs/apk/debug
 UPLOADS=$TRAVIS_BUILD_DIR/uploads


### PR DESCRIPTION
This cuts overall run to about a half: 17min vs 9min on average.
And the test/lint job typically requires only ~5min.

Because Docker Hub may rate limit "docker pulls", use alternative image
stored in GitHub's docker.pkg.github.com registry.

https://docs.docker.com/docker-hub/download-rate-limit/ specifies that

> Docker will gradually impose download rate limits with an eventual
> limit of 300 downloads per six hours for anonymous users.

With the current CI image of 13 layers, it would limit us to 1 PR per
hour at the least. Add some typo corrections which trigger CI builds
and we may hit rate limiting quite fast.

Plus, it's always good to have a separate copy of the CI image for
times when DockerHub is inaccessible.

See ci.yml in .github/workflows for how to update this image in
the GitHub's registry.

On Travis CI however jobs are still run serially. I believe they have a
limitation of 1 "concurrent" job for free open-source projects. So, it
wouldn't help splitting CI tasks into separate jobs.

Also, some nits:
- removed sudo from Travis CI since it's a noop these days
- switch to bionic dist from trusty; the latter is a very old Ubuntu
  14.04.
- don't bother with "staging" branches; it's been unused for a long
  time now
- merge travis_ssh.sh content into upload_nightlies for easier
  maintenance