### PR TITLE
frontend: fix height in dialog for long addresses

### DIFF
--- a/frontends/web/src/components/copy/Copy.css
+++ b/frontends/web/src/components/copy/Copy.css
@@ -45,7 +45,7 @@
     font-weight: 400;
     min-width: 200px !important;
     width: 100%;
-    padding: var(--space-half) calc(var(--space-half) * 3) var(--space-half) var(--space-half);
+    padding: var(--space-half) calc(var(--space-default) * 1.2) var(--space-half) calc(var(--space-half) * .5);
     height: 52px;
     border-radius: 2px;
     border: solid 1px var(--color-lightgray);

--- a/frontends/web/src/components/dialog/dialog.css
+++ b/frontends/web/src/components/dialog/dialog.css
@@ -44,7 +44,7 @@
 
 .modal.medium {
     /* long enough to fit a bc1... address in the receive screen on desktop */
-    max-width: 452px;
+    max-width: 455px;
     width: 100%;
 }
 

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -313,7 +313,7 @@ class Receive extends Component<Props, State> {
                                 <p>{t('receive.verifyInstruction')}</p>
                             </div>
                             <div className="m-bottom-half">
-                                <CopyableInput value={address} />
+                                <CopyableInput value={address} flexibleHeight />
                             </div>
                         </Dialog>
                     )


### PR DESCRIPTION
Long address can still break onto two lines, but this change
fixes the ugly tiny scrollbar by adding flexibleHeight prop.
The padding of the copy box is smaller and the width of the
dialog little wider so it should fit a few more letter in
one line.