### PR TITLE
backend/eth: propagate errors from EstimateGas()

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -567,7 +567,7 @@ func (account *Account) newTx(
 	gasLimit, err := account.coin.client.EstimateGas(context.TODO(), message)
 	if err != nil {
 		account.log.WithError(err).Error("Could not estimate the gas limit.")
-		return nil, errp.WithStack(errors.ErrInvalidData)
+		return nil, errp.WithStack(errors.TxValidationError(err.Error()))
 	}
 
 	fee := new(big.Int).Mul(new(big.Int).SetUint64(gasLimit), suggestedGasPrice)

--- a/backend/coins/eth/etherscan/etherscan.go
+++ b/backend/coins/eth/etherscan/etherscan.go
@@ -370,16 +370,18 @@ func (etherScan *EtherScan) rpcCall(params url.Values, result interface{}) error
 	params.Set("module", "proxy")
 
 	var wrapped struct {
-		JSONRPC string           `json:"jsonrpc"`
-		ID      int              `json:"id"`
-		Error   *json.RawMessage `json:"error"`
-		Result  *json.RawMessage `json:"result"`
+		JSONRPC string `json:"jsonrpc"`
+		ID      int    `json:"id"`
+		Error   *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		Result *json.RawMessage `json:"result"`
 	}
 	if err := etherScan.call(params, &wrapped); err != nil {
 		return err
 	}
 	if wrapped.Error != nil {
-		return errp.WithMessage(errp.New("unexpected error"), string(*wrapped.Error))
+		return errp.New(wrapped.Error.Message)
 	}
 	if result == nil {
 		return nil


### PR DESCRIPTION
When the transaction is invalid (e.g. a contract destination without
any data input), EstimateGas() returns an error.

Before, the error would be swallowed (only logged) and in the frontend
nothing would happen. Now we propagate it as is from EtherScan (it
does not provide any useful error code, just -32000 which stands for
server-error)