### PR TITLE
ci: add missing space in travis_upload_nightlies

### DIFF
--- a/scripts/travis_upload_nightlies.sh
+++ b/scripts/travis_upload_nightlies.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Don't upload anything unless it's a push commit to the master branch.
-if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master"]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
The bash installed on Travis CI VMs apparently requires spaces between
brackets in "if [ expression ]". If missing, it results in:

    ./scripts/travis_upload_nightlies.sh: line 6: [: missing `]'

Somehow I missed it when copying in 00227bb and the bash I have
installed locally accepts both. So, didn't catch it earlier.