### PR TITLE
qt/macOS: fix and document notarization

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -39,6 +39,21 @@ Build the QT frontend for MacOS:
 Build artifacts:
 * `frontends/qt/build/osx/BitBox.app`
 
+### Signing & Notarization
+
+Requires Xcode 10+ and macOS 10.13.6+.
+
+```
+$ cd frontends/qt/build/osx/
+$ # Sign with hardened runtime:
+$ codesign -f --deep --strict --timestamp -o runtime --entitlements ../../resources/MacOS/entitlements.plist -s CODESIGN_IDENTITY BitBox.app
+$ /usr/bin/ditto -c -k --keepParent BitBox.app BitBox.zip
+$ # Notarize
+$ xcrun altool --notarize-app --primary-bundle-id "ch.shiftcrypto.bitboxapp" --username "APPLE_ID" --password "PASSWORD" --file BitBox.zip
+$ # Check notarization status
+$  xcrun altool --notarization-info NOTARIZATION_ID --username "APPLE_ID" --password "PASSWORD"
+```
+
 ## Windows
 
 The build requires `mingw-w64`, `bash`, `make`, `Microsoft Visual Studio 2017`, `go 1.10`, `yarn`,

--- a/frontends/qt/resources/MacOS/entitlements.plist
+++ b/frontends/qt/resources/MacOS/entitlements.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- needed for QtWebEngine, otherwise there is a gray screen at launch -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- needed for USB HID access, who knows why -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+
+    <!-- the QR code scanner works even without this. We add it just in case it might be enforced on some systems or in the future. -->
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <!-- the USB HID access works even without this. We add it just in case it might be enforced on some systems or in the future. -->
+    <key>com.apple.security.device.usb</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
Notarization requires a hardened runtime. The app had two issues with
this:

- Gray screen at launch - fixed by whitelisting unsigned memory
execution in for QtWebEngine

- Couldn't open the HID device - fixed by
`allow-dyld-environment-variables`, by trial and error.