### PR TITLE
frontend: fix double routing

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -72,7 +72,7 @@ class App extends Component<Props, State> {
         if (panelStore.state.activeSidebar) {
             toggleSidebar();
         }
-        this.maybeRoute();
+        setTimeout(this.maybeRoute);
     }
 
     public componentDidMount() {


### PR DESCRIPTION
The BitBoxLogo redirect to / was added so users can get back to the
device waiting screen if they for example go to the Settings.

When you click the BitBoxApp logo, we are routing to / and then with
maybeRoute() straight back to the first account, if there is one.

This seems to be broken with the current preact or
preact-router. Instead, the whole page reloads, with broken react
state (e.g. showing 'Connection lost' in the account...).

Inspired by https://github.com/preactjs/preact-router/issues/302, I
just randomly tried defering the routing via setTimeout (0 timeout),
which seems to fix the issue.