### PR TITLE
frontend/send: don't overwrite amount when scanning a QR code

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -430,9 +430,11 @@ class Send extends Component<Props, State> {
         this.setState({
             recipientAddress: address,
             sendAll: false,
-            amount,
             fiatAmount: undefined,
         });
+        if (amount) {
+            this.setState({ amount });
+        }
         // TODO: similar to handleFormChange(). Refactor.
         if (amount !== undefined) {
             this.convertToFiat(amount);


### PR DESCRIPTION
If you first enter the amount, then scan an address from a QR code,
the amount would be deleted. Now it is preserved.

If the QR code encodes an amount as well, the amount is overwritten
with the amount from the QR code.