### PR TITLE
ci: make upload nightlies actually work for macos on travis

### DIFF
--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -5,6 +5,8 @@ WHAT="$1"
 # Because we need to compile some Go code without modules,
 # the source must be placed in a specific directory as expected by Go.
 # The path is relative to GOPATH.
+# If you change this, remember to update MACOS_BUILD in
+# travis_upload_nightlies.sh.
 GO_SRC_DIR=src/github.com/digitalbitbox/bitbox-wallet-app
 
 # The following is executed only on linux machines.

--- a/scripts/travis_upload_nightlies.sh
+++ b/scripts/travis_upload_nightlies.sh
@@ -11,10 +11,11 @@ openssl aes-256-cbc -K $encrypted_59febc5c238f_key -iv $encrypted_59febc5c238f_i
 chmod 600 travis_rsa
 mv travis_rsa ~/.ssh/id_rsa
 
+# See travis-ci.sh script for why macOS build is in a different directory.
+MACOS_BUILD=~/go/src/github.com/digitalbitbox/bitbox-wallet-app/frontends/qt/build/osx
 LINUX_BUILD=$TRAVIS_BUILD_DIR/frontends/qt/build/linux
 ANDROID_BUILD=$TRAVIS_BUILD_DIR/frontends/android/BitBoxApp/app/build/outputs/apk/debug
 UPLOADS=$TRAVIS_BUILD_DIR/uploads
-MACOS_BUILD=frontends/qt/build/osx
 UPLOAD_DIR=$1
 
 sudo mkdir $TRAVIS_BUILD_DIR/uploads


### PR DESCRIPTION
The script never actually worked. Pick any run like
https://travis-ci.org/github/digitalbitbox/bitbox-wallet-app/jobs/703697937
in which you'll see at the bottom:

    ./scripts/upload_nightlies.sh: line 33: cd: frontends/qt/build/osx:
    No such file or directory