### PR TITLE
ci: preserve symlinks while zipping macos app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Archive app
         run: >
           pushd ~/go/src/github.com/digitalbitbox/bitbox-wallet-app/frontends/qt/build/osx;
-          zip -r ${{github.workspace}}/BitBoxApp-macos.zip BitBox.app;
+          ditto -c -k --keepParent BitBox.app ${{github.workspace}}/BitBoxApp-macos.zip;
           popd;
       - name: Upload app
         uses: actions/upload-artifact@v2

--- a/scripts/travis_upload_nightlies.sh
+++ b/scripts/travis_upload_nightlies.sh
@@ -41,6 +41,6 @@ fi
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     cd $MACOS_BUILD
     NEW_ARCHIVE=$(date -I)-BitBox-macOS-$(git rev-parse --short HEAD).zip
-    zip -r $NEW_ARCHIVE BitBox.app
+    ditto -c -k --keepParent BitBox.app $NEW_ARCHIVE
     scp $OPTIONS $NEW_ARCHIVE travis@$DEVSERVER_IP:/var/www/nightlies/$UPLOAD_DIR
 fi


### PR DESCRIPTION
See build docs https://github.com/digitalbitbox/bitbox-wallet-app/blob/673708a/docs/BUILD.md#signing--notarization and #903.