### PR TITLE
Makefile: fix make envinit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ catch:
 envinit:
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.19.1
 	GO111MODULE=off go get -u github.com/stretchr/testify # needed for mockery
-	GO111MODULE=off go get -u github.com/vektra/mockery/cmd/mockery
+	GO111MODULE=off go get -u github.com/vektra/mockery/...
 	GO111MODULE=off go get -u github.com/goware/modvendor
 	GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 	GO111MODULE=off go get -u github.com/jteeuwen/go-bindata/...


### PR DESCRIPTION
Getting mockery failed:

$ GO111MODULE=off go get github.com/vektra/mockery/cmd/mockery
package github.com/vektra/mockery/cmd/mockery: cannot find package "github.com/vektra/mockery/cmd/mockery" in any of:
        /usr/local/go/src/github.com/vektra/mockery/cmd/mockery (from $GOROOT)
        /home/<user>/go/src/github.com/vektra/mockery/cmd/mockery (from $GOPATH)