### PR TITLE
ci: use correct date arguments when uploading nightly on macos

### DIFF
--- a/scripts/travis_upload_nightlies.sh
+++ b/scripts/travis_upload_nightlies.sh
@@ -41,7 +41,7 @@ fi
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     cd $MACOS_BUILD
-    NEW_ARCHIVE=$(date -I)-BitBox-macOS-$(git rev-parse --short HEAD).zip
+    NEW_ARCHIVE=$(date '+%Y-%m-%d')-BitBox-macOS-$(git rev-parse --short HEAD).zip
     zip -r $NEW_ARCHIVE BitBox.app
     scp $OPTIONS $NEW_ARCHIVE travis@$DEVSERVER_IP:/var/www/nightlies/$UPLOAD_DIR
 fi


### PR DESCRIPTION
The date command on macOS doesn't support the short -I or --iso flag:

    $  ./scripts/travis_upload_nightlies.sh
    date: illegal option -- I
    usage: date [-jnRu] [-d dst] [-r seconds] [-t west]
    [-v[+|-]val[ymwdHMS]] ...
    [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]

So, use the longer +format argument.