### PR TITLE
Frontend: fixes account info cropped on linux

### DIFF
--- a/frontends/web/src/routes/account/info/info.jsx
+++ b/frontends/web/src/routes/account/info/info.jsx
@@ -73,7 +73,7 @@ export default class Info extends Component {
                 <div class="container">
                     <Header title={<h2>{t('accountInfo.title')}</h2>} />
                     <div class="innerContainer scrollableContainer">
-                        <div class="content padded flex flex-column flex-center">
+                        <div class="content padded">
                             <div class={[style.infoContent, 'box large'].join(' ')}>
                                 {
                                     info.signingConfigurations.map((config, index) => (


### PR DESCRIPTION
Removed classes that were previously used to vertically center
the address. Unfortunatelly this issue was not reproducible in
the macOS app. The addresses do not have to be vertically centered
anymore so removing the flex classes is fine.