### PR TITLE
ci: enable caching to avoid intermittent build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Docker login
         run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
+      - name: Enable caching
+        uses: actions/cache@v2
+        with:
+          key: ${{runner.os}}-test-lint
+          path: frontends/web/node_modules
       - name: Run CI script
         run: ./scripts/travis-ci.sh ci
         env:
@@ -41,6 +46,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Docker login
         run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
+      - name: Enable caching
+        uses: actions/cache@v2
+        with:
+          key: ${{runner.os}}-android
+          path: |
+            frontends/web/node_modules
+            ~/.gradle/caches
+            ~/.gradle/wrapper
       - name: Build Android
         run: ./scripts/travis-ci.sh android
         env:
@@ -57,6 +70,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Docker login
         run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
+      - name: Enable caching
+        uses: actions/cache@v2
+        with:
+          key: ${{runner.os}}-qt-linux
+          path: frontends/web/node_modules
       - name: Build Qt-Linux
         run: ./scripts/travis-ci.sh qt-linux
         env:
@@ -81,6 +99,13 @@ jobs:
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2
+      - name: Enable caching
+        uses: actions/cache@v2
+        with:
+          key: ${{runner.os}}-qt-osx
+          path: |
+            frontends/web/node_modules
+            ~/Library/Caches/Homebrew
       - name: Build macOS app
         run: ./scripts/travis-ci.sh qt-osx
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,14 @@ addons:
     packages:
       - make
 
+cache:
+  yarn: true
+  directories:
+    - ./frontends/web/node_modules
+    - $HOME/.gradle/caches
+    - $HOME/.gradle/wrapper
+    - $HOME/Library/Caches/Homebrew
+
 jobs:
   include:
     - stage: Linux

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -17,7 +17,9 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     # Time image pull to compare in the future.
     time docker pull "$CI_IMAGE"
 
+    # .gradle dir is mapped to preserve cache.
     docker run --privileged \
+           -v $HOME/.gradle:/root/.gradle \
            -v ${TRAVIS_BUILD_DIR}:/opt/go/${GO_SRC_DIR}/ \
            -i "${CI_IMAGE}" \
            bash -c "make -C \$GOPATH/${GO_SRC_DIR} ${WHAT}"
@@ -39,7 +41,7 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     export PATH="/usr/local/opt/qt/bin:$PATH"
     export LDFLAGS="-L/usr/local/opt/qt/lib"
     export CPPFLAGS="-I/usr/local/opt/qt/include"
-    export GOPATH=~/go/
+    export GOPATH=~/go
     export PATH=$PATH:~/go/bin
     mkdir -p $GOPATH/$(dirname $GO_SRC_DIR)
     # GitHub checkout action (git clone) seem to require current work dir
@@ -49,4 +51,8 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     cd $GOPATH/$GO_SRC_DIR
     make "$WHAT"
     popd
+    # Bring cacheable artifacts back to the original directory.
+    # Some CIs are picky and don't allow caching outside.
+    rsync -a --delete $GOPATH/$GO_SRC_DIR/frontends/web/node_modules/ \
+      frontends/web/node_modules/
 fi


### PR DESCRIPTION
Sometimes yarn install command fails with a network error.
Gradle and Homebrew do too but less often.
This will hopefully make the builds more stable.

Most recent run failed due to network: https://github.com/digitalbitbox/bitbox-wallet-app/runs/835012963, but there are more if you go back in build history, on both travis and github.

To invalidate the cache on GitHub, it is sufficient to change the cache key. Reference docs:
https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy.
Travis has an option in their UI: https://docs.travis-ci.com/user/caching/#clearing-caches

Both Travis and GitHub cache node modules, gradle and homebrew.
Some rough cache size numbers at the time of this commit:

- node modules: 37Mb
- gradle: 380Mb
- homebrew: 3.4Gb on github but it's the whole setup, not just ours;
  github cache is capped at 5Gb
- travis-ci says total cache size ~455Mb; cap is unknown