### PR TITLE
backend/handlers: set appropriate JSON mime type

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -754,7 +754,7 @@ func (handlers *Handlers) apiMiddleware(devMode bool, h func(*http.Request) (int
 			}
 		}()
 
-		w.Header().Set("Content-Type", "text/json")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if devMode {
 			// This enables us to run a server on a different port serving just the UI, while still
 			// allowing it to access the API.


### PR DESCRIPTION
There's no such thing as text/json. It may have used to be an
unofficial alternative a few years back but application/json is what's
set by IANA: https://www.iana.org/assignments/media-types/

This has no impact on the app except for maybe charset=utf8 when in
servewallet+webdev mode using an older browser, in which case it
actually makes them correctly interpret responses in UTF-8.

The reason I actually bothered is I started looking into the system language detection and one of the things I looked at was /api/config which is hard to read without correct mime-type. With it, beauty!

![image](https://user-images.githubusercontent.com/25405/86506918-3baaff00-bdd4-11ea-8173-ba710867a904.png)

 (on firefox)