### PR TITLE
backend/rates: avoid excessive logging and drop go-spew

### DIFF
--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable/action"
@@ -106,7 +105,6 @@ func (updater *RateUpdater) update() {
 	}
 
 	updater.last = rates
-	updater.log.WithField("data", spew.Sprintf("%v", rates)).Debug("Exchange rates changed.")
 	updater.Notify(observable.Event{
 		Subject: "rates",
 		Action:  action.Replace,

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/cloudfoundry-attic/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
 	github.com/coreos/bbolt v1.3.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/digitalbitbox/bitbox02-api-go v0.0.0-20200623201452-8e5a24b5a32f
 	github.com/edsrzf/mmap-go v1.0.0 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,7 +46,6 @@ github.com/cloudfoundry-attic/jibber_jabber
 ## explicit
 github.com/coreos/bbolt
 # github.com/davecgh/go-spew v1.1.1
-## explicit
 github.com/davecgh/go-spew/spew
 # github.com/deckarep/golang-set v1.7.1
 ## explicit


### PR DESCRIPTION
I find it very annoying, seeing nothing except "exchange rates changed"
messages in the logs. Hard to look for anything else.

Apart from the usual "no news is good news" reasoning, if exchange rate
update fails, it should be surfaced to the app UI in some way because
noone reads the logs except us. But it's beyond this simple commit.

Turns out spew package was used only in that one place.
Hence, vendor/modules.txt removes '## explicit' but the package is
still there because it's used by some others.