### PR TITLE
util/socksproxy: remove excessive logging

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -145,6 +145,8 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	if err != nil {
 		return nil, errp.WithStack(err)
 	}
+	log.Infof("backend config: %+v", config.AppConfig().Backend)
+	log.Infof("frontend config: %+v", config.AppConfig().Frontend)
 	backend := &Backend{
 		arguments:   arguments,
 		environment: environment,

--- a/util/socksproxy/socksproxy.go
+++ b/util/socksproxy/socksproxy.go
@@ -46,16 +46,14 @@ func NewSocksProxy(useProxy bool, proxyAddress string) SocksProxy {
 // GetTCPProxyDialer returns a tcp connection. The connection is proxied, if useProxy is true.
 func (socksProxy *SocksProxy) GetTCPProxyDialer() proxy.Dialer {
 	if socksProxy.useProxy {
-		socksProxy.log.WithField("address", socksProxy.proxyAddress).
-			Info("Using proxy connection")
 		// Create a proxy that uses Tor's SocksPort.
 		dialer, err := proxy.SOCKS5("tcp", socksProxy.proxyAddress, nil, nil)
 		if err != nil {
-			panic("Failed to create tcp connection over socks5 proxy")
+			// TODO: Remove this panic.
+			socksProxy.log.WithError(err).Panic("Failed to create SOCKS5 TCP dialer")
 		}
 		return dialer
 	}
-	socksProxy.log.Info("Using an unproxied tcp client")
 	return &net.Dialer{}
 }
 
@@ -63,8 +61,6 @@ func (socksProxy *SocksProxy) GetTCPProxyDialer() proxy.Dialer {
 func (socksProxy *SocksProxy) GetHTTPClient() (*http.Client, error) {
 	if socksProxy.useProxy {
 		// Create a transport that uses Tor Browser's SocksPort.
-		socksProxy.log.WithField("address", socksProxy.fullProxyAddress).
-			Info("Creating new socksProxy http client")
 		tbProxyURL, err := url.Parse(socksProxy.fullProxyAddress)
 		if err != nil {
 			socksProxy.log.WithError(err).Error("Failed to parse proxy URL")
@@ -86,6 +82,5 @@ func (socksProxy *SocksProxy) GetHTTPClient() (*http.Client, error) {
 		client := &http.Client{Transport: tbTransport}
 		return client, nil
 	}
-	socksProxy.log.Info("Using an unproxied http connection")
 	return &http.Client{}, nil
 }


### PR DESCRIPTION
The "using an unproxied ..." log line does not help in any way
but it keeps repeating every time something's using it, like the
exchange rate updates. It is actually any of these and more:

    backend/update.go:
    client, err := backend.socksProxy.GetHTTPClient()

    backend/devices/bitbox/relay/request.go:
    httpClient, err := request.channel.socksProxy.GetHTTPClient()

    backend/coins/eth/etherscan/etherscan.go:
    client, err := etherScan.socksProxy.GetHTTPClient()

    backend/rates/rates.go:
    client, err := updater.socksProxy.GetHTTPClient()

    backend/backend.go:
    httpClient, err := backend.socksProxy.GetHTTPClient()

When logged, it can't be attributed to the caller.
It's a separate line and logging is typically buffered; line ordering
should not be relied upon.

Similar reasoning with when the connection is proxied.
This should be logged once, at the app startup, or by the caller of
NewSocksProxy if really necessary. This commit opts for the former.

One other part is devices/bitbox/relay but this is bb01 and the proxy
is always unused.

As an example, here's how it looked like before this commit, with https://github.com/digitalbitbox/bitbox-wallet-app/pull/916 patched in:

![image](https://user-images.githubusercontent.com/25405/86510853-e8e13f80-bdf3-11ea-9d4d-dd3de1f54fb1.png)
