### PR TITLE
ci: upgrade golangci-lint to v1.27 and make it happy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,22 @@ env:
   # Lastly, update the next line to use the newly pushed image version.
   # See docs for more details:
   # https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages
-  CI_IMAGE: docker.pkg.github.com/digitalbitbox/bitbox-wallet-app/ci-builder:5
+  #
+  # Keep this in sync with default in scripts/travis-ci.sh.
+  CI_IMAGE: docker.pkg.github.com/digitalbitbox/bitbox-wallet-app/ci-builder:6
   TRAVIS_BUILD_DIR: ${{github.workspace}}
 
 jobs:
+  golangci:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Clone the repo
+        uses: actions/checkout@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          # Keep this in sync with the version in envinit make target.
+          version: v1.27
   test-lint:
     runs-on: ubuntu-18.04
     steps:
@@ -31,6 +43,8 @@ jobs:
       - name: Docker login
         run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
       - name: Run CI script
+        # The script also runs golang-ci but it's ok: doesn't take too long and may be useful
+        # to keep its linter errors in this log, too.
         run: ./scripts/travis-ci.sh ci
         env:
           TRAVIS_OS_NAME: linux

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
-# This file contains all available configuration options
-# with their default values.
+# See reference docs for details:
+# https://golangci-lint.run/usage/configuration/
 
 # options for analysis running
 run:
@@ -36,8 +36,9 @@ linters-settings:
     enabled-checks:
       - assignOp
       - builtinShadow
-      - caseOrder
       - captLocal
+      - caseOrder
+      - defaultCaseOrder
       - dupArg
       - dupBranchBody
       - dupCase
@@ -55,7 +56,6 @@ linters-settings:
       - underef
       - unlambda
       - unslice
-      - defaultCaseOrder
   gocyclo:
     min-complexity: 25
   maligned:
@@ -80,25 +80,27 @@ linters-settings:
     line-length: 120
     # allow long comments.
     exclude: '//'
-    # tab width in spaces. Default to 1.
-    tab-width: 4
-
 
 linters:
   enable-all: true
   disable:
-    - maligned
-    - prealloc
-    - lll
-    - gochecknoinits
-    - gochecknoglobals
-    - godox
-    - funlen
-    - dogsled
-    - whitespace
     - bodyclose
-    - stylecheck
+    - dogsled
     - dupl
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - godox
+    - goerr113 # can't switch to errors.Is due to GopherJS still on go1.12
+    - gomnd
+    - lll
+    - maligned
+    - nestif
+    - prealloc
+    - stylecheck
+    - whitespace
+    - wsl
   disable-all: false
 
 issues:
@@ -107,12 +109,17 @@ issues:
   # it can be disabled by `exclude-use-default: false`. To list all
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
-    # TLS `InsecureSkipVerify` set true. (gas)
-    - G402
-    # Potential hardcoded credentials (gas)
-    - G101
-    # gas: Duplicated errcheck checks
-    - G104
   # Use linters in their original configuration. golangci-linter changes the default config, for
   # example skipping the docstring comment checks of golint.
   exclude-use-default: false
+
+  # Excluding configuration per-path, per-linter, per-text and per-source.
+  exclude-rules:
+    # In addition to always disalbed linters above, exclude some more in tests.
+    - path: _test\.go
+      linters:
+        - errcheck
+        - gocyclo
+        - godot
+        - gosec
+        - testpackage

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ PATH     := $(PATH):$(GOPATH)/bin
 catch:
 	@echo "Choose a make target."
 envinit:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.19.1
+	# Keep golangci-lint version in sync with what's in .github/workflows/ci.yml.
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.27.0
 	GO111MODULE=off go get -u github.com/stretchr/testify # needed for mockery
 	GO111MODULE=off go get -u github.com/vektra/mockery/...
 	GO111MODULE=off go get -u github.com/goware/modvendor

--- a/backend/accounts/feetarget.go
+++ b/backend/accounts/feetarget.go
@@ -19,7 +19,7 @@ import (
 )
 
 // FeeTarget interface has priority codes.
-// Coin specific methods are implemented in corresponding coins
+// Coin specific methods are implemented in corresponding coins.
 type FeeTarget interface {
 	Code() FeeTargetCode
 }

--- a/backend/accounts/safello/safello.go
+++ b/backend/accounts/safello/safello.go
@@ -75,5 +75,5 @@ func StoreCallbackJSONMessage(filename string, message map[string]json.RawMessag
 	if err != nil {
 		return errp.WithStack(err)
 	}
-	return ioutil.WriteFile(filename, writeJSONBytes, 0700)
+	return ioutil.WriteFile(filename, writeJSONBytes, 0600)
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -471,7 +471,7 @@ func (backend *Backend) Config() *config.Config {
 	return backend.config
 }
 
-// DefaultAppConfig returns the default app config.y
+// DefaultAppConfig returns the default app config.
 func (backend *Backend) DefaultAppConfig() config.AppConfig {
 	return config.NewDefaultAppConfig()
 }
@@ -874,7 +874,7 @@ func (backend *Backend) Start() <-chan interface{} {
 	return backend.events
 }
 
-// TryMakeNewBase calls TryMakeNewBase() in the manager with the given ip
+// TryMakeNewBase calls TryMakeNewBase() in the manager with the given ip.
 func (backend *Backend) TryMakeNewBase(ip string) (bool, error) {
 	return backend.baseManager.TryMakeNewBase(ip)
 }
@@ -894,12 +894,12 @@ func (backend *Backend) BitBoxBasesDetected() map[string]string {
 	return backend.baseManager.GetDetectedBases()
 }
 
-// EmitBitBoxBaseDetected notifies the frontend that the manager.detectedBases has changed
+// EmitBitBoxBaseDetected notifies the frontend that the manager.detectedBases has changed.
 func (backend *Backend) EmitBitBoxBaseDetected() {
 	backend.events <- backendEvent{Type: "bitboxbases", Data: "detectedChanged"}
 }
 
-// EmitBitBoxBaseReconnected notifies the frontend that a previously registered Base has successfully reconnected
+// EmitBitBoxBaseReconnected notifies the frontend that a previously registered Base has successfully reconnected.
 func (backend *Backend) EmitBitBoxBaseReconnected(bitboxBaseID string) {
 	backend.events <- backendEvent{Type: "bitboxbases", Data: "reconnected", Meta: map[string]interface{}{
 		"ID": bitboxBaseID,
@@ -926,7 +926,7 @@ func (backend *Backend) bitBoxBaseRegister(theBase *bitboxbase.BitBoxBase, hostn
 }
 
 // BitBoxBaseRemove removes a Base from the backend in the case it has not been fully connected
-// i.e., if the noise pairing wasn't completed and so the RPC connection not established
+// i.e., if the noise pairing wasn't completed and so the RPC connection not established.
 func (backend *Backend) BitBoxBaseRemove(bitboxBaseID string) {
 	backend.baseManager.RemoveBase(bitboxBaseID)
 	delete(backend.bitboxBases, bitboxBaseID)
@@ -1072,7 +1072,7 @@ func (backend *Backend) Deregister(deviceID string) {
 	}
 }
 
-// RatesUpdater returns the backend's ratesUpdater instance
+// RatesUpdater returns the backend's ratesUpdater instance.
 func (backend *Backend) RatesUpdater() *rates.RateUpdater {
 	return backend.ratesUpdater
 }

--- a/backend/bitboxbase/bbbconfig/bbbconfig.go
+++ b/backend/bitboxbase/bbbconfig/bbbconfig.go
@@ -24,7 +24,7 @@ import (
 
 const configFilename = "bitboxbase.json"
 
-// RegisteredBase has information about BitBoxBases registered with the backend
+// RegisteredBase has information about BitBoxBases registered with the backend.
 type RegisteredBase struct {
 	BaseID   string `json:"baseID"`
 	Hostname string `json:"hostname"`
@@ -36,7 +36,7 @@ type BBBConfig struct {
 	configDir string
 }
 
-//TODO(TheCharlatan) refactor this into a shared interface with the bitbox02 implmentation, for example in util/noiseconfig
+// TODO: refactor this into a shared interface with the bitbox02 implmentation, for example in util/noiseconfig.
 type noiseKeypair struct {
 	Private []byte `json:"private"`
 	Public  []byte `json:"public"`
@@ -71,7 +71,7 @@ func (bbbconfig *BBBConfig) storeConfig(conf *ConfigData) error {
 	return configFile.WriteJSON(conf)
 }
 
-// ContainsBaseStaticPubkey implements BBBConfigurationInterface
+// ContainsBaseStaticPubkey implements BBBConfigurationInterface.
 func (bbbconfig *BBBConfig) ContainsBaseStaticPubkey(pubkey []byte) bool {
 	bbbconfig.mu.RLock()
 	defer bbbconfig.mu.RUnlock()
@@ -84,7 +84,7 @@ func (bbbconfig *BBBConfig) ContainsBaseStaticPubkey(pubkey []byte) bool {
 	return false
 }
 
-// AddBaseStaticPubkey implements BBBConfigurationInterface
+// AddBaseStaticPubkey implements BBBConfigurationInterface.
 func (bbbconfig *BBBConfig) AddBaseStaticPubkey(pubkey []byte) error {
 	if bbbconfig.ContainsBaseStaticPubkey(pubkey) {
 		// Don't add again if already present.
@@ -99,7 +99,7 @@ func (bbbconfig *BBBConfig) AddBaseStaticPubkey(pubkey []byte) error {
 	return bbbconfig.storeConfig(configData)
 }
 
-// GetAppNoiseStaticKeypair implements BBBConfigurationInterface
+// GetAppNoiseStaticKeypair implements BBBConfigurationInterface.
 func (bbbconfig *BBBConfig) GetAppNoiseStaticKeypair() *noise.DHKey {
 	bbbconfig.mu.RLock()
 	defer bbbconfig.mu.RUnlock()
@@ -114,7 +114,7 @@ func (bbbconfig *BBBConfig) GetAppNoiseStaticKeypair() *noise.DHKey {
 	}
 }
 
-// SetAppNoiseStaticKeypair implements BBBConfigurationInterface
+// SetAppNoiseStaticKeypair implements BBBConfigurationInterface.
 func (bbbconfig *BBBConfig) SetAppNoiseStaticKeypair(key *noise.DHKey) error {
 	bbbconfig.mu.Lock()
 	defer bbbconfig.mu.Unlock()
@@ -127,7 +127,7 @@ func (bbbconfig *BBBConfig) SetAppNoiseStaticKeypair(key *noise.DHKey) error {
 	return bbbconfig.storeConfig(configData)
 }
 
-// ContainsRegisteredBase implements BBBConfigurationInterface
+// ContainsRegisteredBase implements BBBConfigurationInterface.
 func (bbbconfig *BBBConfig) ContainsRegisteredBase(baseID string) bool {
 	bbbconfig.mu.RLock()
 	defer bbbconfig.mu.RUnlock()
@@ -140,7 +140,7 @@ func (bbbconfig *BBBConfig) ContainsRegisteredBase(baseID string) bool {
 	return false
 }
 
-// AddRegisteredBase implements BBBConfigurationInterface
+// AddRegisteredBase implements BBBConfigurationInterface.
 func (bbbconfig *BBBConfig) AddRegisteredBase(baseID string, hostname string) error {
 	if bbbconfig.ContainsRegisteredBase(baseID) {
 		return nil
@@ -158,7 +158,7 @@ func (bbbconfig *BBBConfig) AddRegisteredBase(baseID string, hostname string) er
 	return bbbconfig.storeConfig(configData)
 }
 
-// RegisteredBases implements BBBConfigurationInterface
+// RegisteredBases implements BBBConfigurationInterface.
 func (bbbconfig *BBBConfig) RegisteredBases() []RegisteredBase {
 	bbbconfig.mu.RLock()
 	defer bbbconfig.mu.RUnlock()
@@ -166,7 +166,7 @@ func (bbbconfig *BBBConfig) RegisteredBases() []RegisteredBase {
 	return bbbconfig.readConfig().RegisteredBases
 }
 
-// RemoveRegisteredBase implements BBBConfigurationInterface
+// RemoveRegisteredBase implements BBBConfigurationInterface.
 func (bbbconfig *BBBConfig) RemoveRegisteredBase(baseID string) error {
 	if !bbbconfig.ContainsRegisteredBase(baseID) {
 		return nil
@@ -185,7 +185,7 @@ func (bbbconfig *BBBConfig) RemoveRegisteredBase(baseID string) error {
 	return bbbconfig.storeConfig(configData)
 }
 
-// UpdateRegisteredBaseHostname implements BBBConfigurationInterface
+// UpdateRegisteredBaseHostname implements BBBConfigurationInterface.
 func (bbbconfig *BBBConfig) UpdateRegisteredBaseHostname(baseID string, hostname string) error {
 	if !bbbconfig.ContainsRegisteredBase(baseID) {
 		return nil

--- a/backend/bitboxbase/bitboxbase.go
+++ b/backend/bitboxbase/bitboxbase.go
@@ -38,25 +38,25 @@ import (
 )
 
 // DisconnectType indicates the type of disconnect that should be passed to Disconnect() to determine if we set the Base
-// status to 'offline' or 'reconnecting' which determines subsequent behavior of the backend
+// status to 'offline' or 'reconnecting' which determines subsequent behavior of the backend.
 type DisconnectType int
 
-// DisconnectType currently has three possibilities, reboot, shutdown and disconnect
-// DisconnectTypeReboot changes status to StatusReconnecting to tell the backend to attempt to reconnect
-// DisconnectTypeShutdown changes status StatusOffline
+// DisconnectType currently has three possibilities: reboot, shutdown and disconnect.
+// DisconnectTypeReboot changes status to StatusReconnecting to tell the backend to attempt to reconnect.
+// DisconnectTypeShutdown changes status StatusOffline.
 // DisconnectTypeDisconnect changes status StatusDisconnected to indicate that the Base is online, but not connected to
-// the App backend
+// the App backend.
 const (
 	DisconnectTypeReboot     DisconnectType = 0
 	DisconnectTypeShutdown   DisconnectType = 1
 	DisconnectTypeDisconnect DisconnectType = 2
 )
 
-// BitBoxBase provides the dictated bitboxbase api to communicate with the base
+// BitBoxBase provides the dictated bitboxbase api to communicate with the base.
 type BitBoxBase struct {
 	observable.Implementation
 
-	bitboxBaseID   string //This is just the ip currently
+	bitboxBaseID   string // this is just the ip currently
 	registerTime   time.Time
 	address        string
 	port           string
@@ -68,7 +68,7 @@ type BitBoxBase struct {
 	appConfig      *appConfig.Config
 	bbbConfig      *bbbconfig.BBBConfig
 	status         bitboxbasestatus.Status
-	active         bool //this indicates if the bitboxbase is in use, or being disconnected
+	active         bool // this indicates if the bitboxbase is in use, or being disconnected
 
 	onUnregister  func(string)
 	onRemove      func(string)
@@ -76,7 +76,7 @@ type BitBoxBase struct {
 	socksProxy    socksproxy.SocksProxy
 }
 
-//NewBitBoxBase creates a new bitboxBase instance
+// NewBitBoxBase creates a new bitboxBase instance.
 func NewBitBoxBase(address string,
 	id string,
 	hostname string,
@@ -109,7 +109,7 @@ func NewBitBoxBase(address string,
 	return bitboxBase, err
 }
 
-// EstablishConnection establishes initial websocket connection with the middleware
+// EstablishConnection establishes initial websocket connection with the middleware.
 func (base *BitBoxBase) EstablishConnection() error {
 	if err := base.rpcClient.EstablishConnection(); err != nil {
 		return err
@@ -117,7 +117,7 @@ func (base *BitBoxBase) EstablishConnection() error {
 	return nil
 }
 
-// ConnectRPCClient starts the connection with the remote bitbox base middleware
+// ConnectRPCClient starts the connection with the remote bitbox base middleware.
 func (base *BitBoxBase) ConnectRPCClient() error {
 	if err := base.rpcClient.Connect(); err != nil {
 		fmt.Println("Removing")
@@ -134,7 +134,7 @@ func (base *BitBoxBase) ConnectRPCClient() error {
 	return nil
 }
 
-// ConnectElectrum connects to the electrs server on the base and configures the backend accordingly
+// ConnectElectrum connects to the electrs server on the base and configures the backend accordingly.
 func (base *BitBoxBase) ConnectElectrum() error {
 	if !base.active {
 		return errp.New("Attempted call to non-active base")
@@ -188,9 +188,9 @@ func (base *BitBoxBase) Deregister() error {
 	return nil
 }
 
-// Remove calls the backend's BitBoxBaseRemove callback and sends a notification to the frontend
-// Remove should only be used in the case the Base has not been fully connected
-// i.e., if the noise pairing wasn't completed and so the RPC connection not established
+// Remove calls the backend's BitBoxBaseRemove callback and sends a notification to the frontend.
+// Remove should only be used in the case the Base has not been fully connected,
+// i.e. if the noise pairing wasn't completed and so the RPC connection not established.
 func (base *BitBoxBase) Remove() {
 	base.fireEvent("disconnect")
 	base.onRemove(base.bitboxBaseID)
@@ -200,7 +200,7 @@ func (base *BitBoxBase) Remove() {
 	base.active = false
 }
 
-// Disconnect changes the Base status and takes appropriate action based on DisconnectType
+// Disconnect changes the Base status and takes appropriate action based on DisconnectType.
 func (base *BitBoxBase) Disconnect(disconnectType DisconnectType) error {
 	if !base.active {
 		return errp.New("Attempted call to non-active base")
@@ -223,7 +223,7 @@ func (base *BitBoxBase) Disconnect(disconnectType DisconnectType) error {
 	return nil
 }
 
-// ChannelHash returns the bitboxbase's rpcClient noise channel hash
+// ChannelHash returns the bitboxbase's rpcClient noise channel hash.
 func (base *BitBoxBase) ChannelHash() (string, bool) {
 	return base.rpcClient.ChannelHash()
 }
@@ -233,7 +233,7 @@ func (base *BitBoxBase) Status() bitboxbasestatus.Status {
 	return base.status
 }
 
-// fireEvent notifies the frontend of an event in the bitboxbase
+// fireEvent notifies the frontend of an event in the bitboxbase.
 func (base *BitBoxBase) fireEvent(event bitboxbasestatus.Event) {
 	base.Notify(observable.Event{
 		Subject: fmt.Sprintf("/bitboxbases/%s/event", base.bitboxBaseID),
@@ -247,12 +247,12 @@ func (base *BitBoxBase) changeStatus(status bitboxbasestatus.Status) {
 	base.fireEvent(bitboxbasestatus.EventStatusChange)
 }
 
-// RPCClient returns ths current instance of the rpcClient
+// RPCClient returns ths current instance of the rpcClient.
 func (base *BitBoxBase) RPCClient() *rpcclient.RPCClient {
 	return base.rpcClient
 }
 
-// ReindexBitcoin returns true if the chosen sync option was executed successfully
+// ReindexBitcoin returns true if the chosen sync option was executed successfully.
 func (base *BitBoxBase) ReindexBitcoin() error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -268,7 +268,7 @@ func (base *BitBoxBase) ReindexBitcoin() error {
 	return nil
 }
 
-// ResyncBitcoin returns true if the chosen sync option was executed successfully
+// ResyncBitcoin returns true if the chosen sync option was executed successfully.
 func (base *BitBoxBase) ResyncBitcoin() error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -284,7 +284,7 @@ func (base *BitBoxBase) ResyncBitcoin() error {
 	return nil
 }
 
-// SetHostname sets the hostname of the physical BitBoxBase device
+// SetHostname sets the hostname of the physical BitBoxBase device.
 func (base *BitBoxBase) SetHostname(hostname string) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -301,20 +301,20 @@ func (base *BitBoxBase) SetHostname(hostname string) error {
 	return nil
 }
 
-// SetLocalHostname sets hostname field in the BitBoxBase struct
+// SetLocalHostname sets hostname field in the BitBoxBase struct.
 // This is necessary for example when restoring Bases from persisted config file
-// when we don't yet have access to authenticated BaseInfo() RPC
+// when we don't yet have access to authenticated BaseInfo() RPC.
 func (base *BitBoxBase) SetLocalHostname(hostname string) {
 	base.hostname = hostname
 }
 
-// GetLocalHostname gets the hostname from the hostname field in the BitBoxBase struct
-// Necessary for the same reasons as setLocalHostname
+// GetLocalHostname gets the hostname from the hostname field in the BitBoxBase struct.
+// Necessary for the same reasons as setLocalHostname.
 func (base *BitBoxBase) GetLocalHostname() string {
 	return base.hostname
 }
 
-// UserAuthenticate returns if a given Username and Password are valid
+// UserAuthenticate returns if a given Username and Password are valid.
 func (base *BitBoxBase) UserAuthenticate(username string, password string) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -341,7 +341,7 @@ func (base *BitBoxBase) UserAuthenticate(username string, password string) error
 	return nil
 }
 
-// UserChangePassword returns if the password change for a username was successful
+// UserChangePassword returns if the password change for a username was successful.
 func (base *BitBoxBase) UserChangePassword(username string, password, newPassword string) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -368,7 +368,7 @@ func (base *BitBoxBase) UserChangePassword(username string, password, newPasswor
 	return nil
 }
 
-// BackupSysconfig backs up the system config to the flashdrive
+// BackupSysconfig backs up the system config to the flashdrive.
 func (base *BitBoxBase) BackupSysconfig() error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -384,7 +384,7 @@ func (base *BitBoxBase) BackupSysconfig() error {
 	return nil
 }
 
-// BackupHSMSecret backs up the lightning hsm_secret
+// BackupHSMSecret backs up the lightning hsm_secret.
 func (base *BitBoxBase) BackupHSMSecret() error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -400,7 +400,7 @@ func (base *BitBoxBase) BackupHSMSecret() error {
 	return nil
 }
 
-// RestoreHSMSecret restores the lightning hsm_secret
+// RestoreHSMSecret restores the lightning hsm_secret.
 func (base *BitBoxBase) RestoreHSMSecret() error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -416,7 +416,7 @@ func (base *BitBoxBase) RestoreHSMSecret() error {
 	return nil
 }
 
-// RestoreSysconfig restores the system config from the flashdrive
+// RestoreSysconfig restores the system config from the flashdrive.
 func (base *BitBoxBase) RestoreSysconfig() error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -432,7 +432,7 @@ func (base *BitBoxBase) RestoreSysconfig() error {
 	return nil
 }
 
-// EnableTor enables/disables Tor with rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableTor enables/disables Tor with rpcmessages.ToggleSettingArgs Enable/Disable.
 func (base *BitBoxBase) EnableTor(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -449,7 +449,7 @@ func (base *BitBoxBase) EnableTor(toggleAction rpcmessages.ToggleSettingArgs) er
 	return nil
 }
 
-// EnableTorMiddleware enables/disables Tor for the middleware with rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableTorMiddleware enables/disables Tor for the middleware with rpcmessages.ToggleSettingArgs Enable/Disable.
 func (base *BitBoxBase) EnableTorMiddleware(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -466,7 +466,7 @@ func (base *BitBoxBase) EnableTorMiddleware(toggleAction rpcmessages.ToggleSetti
 	return nil
 }
 
-// EnableTorElectrs enables/disables Tor for electrs with rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableTorElectrs enables/disables Tor for electrs with rpcmessages.ToggleSettingArgs Enable/Disable.
 func (base *BitBoxBase) EnableTorElectrs(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -483,7 +483,7 @@ func (base *BitBoxBase) EnableTorElectrs(toggleAction rpcmessages.ToggleSettingA
 	return nil
 }
 
-// EnableTorSSH enables/disables Tor for SSH with rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableTorSSH enables/disables Tor for SSH with rpcmessages.ToggleSettingArgs Enable/Disable.
 func (base *BitBoxBase) EnableTorSSH(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -500,7 +500,7 @@ func (base *BitBoxBase) EnableTorSSH(toggleAction rpcmessages.ToggleSettingArgs)
 	return nil
 }
 
-// EnableClearnetIBD configures bitcoind to run over clearnet while in IBD with rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableClearnetIBD configures bitcoind to run over clearnet while in IBD with rpcmessages.ToggleSettingArgs Enable/Disable.
 func (base *BitBoxBase) EnableClearnetIBD(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -517,7 +517,7 @@ func (base *BitBoxBase) EnableClearnetIBD(toggleAction rpcmessages.ToggleSetting
 	return nil
 }
 
-// EnableRootLogin enables/disables login via the root user/password with rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableRootLogin enables/disables login via the root user/password with rpcmessages.ToggleSettingArgs Enable/Disable.
 func (base *BitBoxBase) EnableRootLogin(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -534,7 +534,7 @@ func (base *BitBoxBase) EnableRootLogin(toggleAction rpcmessages.ToggleSettingAr
 	return nil
 }
 
-// EnableSSHPasswordLogin enables/disables the ssh login with a password
+// EnableSSHPasswordLogin enables/disables the ssh login with a password.
 func (base *BitBoxBase) EnableSSHPasswordLogin(toggleAction rpcmessages.ToggleSettingArgs) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -551,7 +551,7 @@ func (base *BitBoxBase) EnableSSHPasswordLogin(toggleAction rpcmessages.ToggleSe
 	return nil
 }
 
-// SetLoginPassword sets the systems root password
+// SetLoginPassword sets the systems root password.
 func (base *BitBoxBase) SetLoginPassword(password string) error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -567,7 +567,7 @@ func (base *BitBoxBase) SetLoginPassword(password string) error {
 	return nil
 }
 
-// ShutdownBase initiates a `shutdown now` call via the bbb-cmd.sh script
+// ShutdownBase initiates a `shutdown now` call via the bbb-cmd.sh script.
 func (base *BitBoxBase) ShutdownBase() error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -587,7 +587,7 @@ func (base *BitBoxBase) ShutdownBase() error {
 	return nil
 }
 
-// RebootBase initiates a `reboot` call via the bbb-cmd.sh script
+// RebootBase initiates a `reboot` call via the bbb-cmd.sh script.
 func (base *BitBoxBase) RebootBase() error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -627,7 +627,7 @@ func (base *BitBoxBase) UpdateBase(args rpcmessages.UpdateBaseArgs) error {
 	return nil
 }
 
-// BaseInfo returns info about the Base contained in rpcmessages.GetBaseInfoResponse
+// BaseInfo returns info about the Base contained in rpcmessages.GetBaseInfoResponse.
 func (base *BitBoxBase) BaseInfo() (rpcmessages.GetBaseInfoResponse, error) {
 	if !base.active {
 		return rpcmessages.GetBaseInfoResponse{}, errp.New("Attempted a call to non-active base")
@@ -648,7 +648,7 @@ func (base *BitBoxBase) BaseInfo() (rpcmessages.GetBaseInfoResponse, error) {
 	return reply, nil
 }
 
-// ServiceInfo returns info about the Base contained in rpcmessages.GetServiceInfoResponse
+// ServiceInfo returns info about the Base contained in rpcmessages.GetServiceInfoResponse.
 func (base *BitBoxBase) ServiceInfo() (rpcmessages.GetServiceInfoResponse, error) {
 	if !base.active {
 		return rpcmessages.GetServiceInfoResponse{}, errp.New("Attempted a call to non-active base")
@@ -677,7 +677,7 @@ func (base *BitBoxBase) BaseUpdateProgress() (rpcmessages.GetBaseUpdateProgressR
 	return reply, nil
 }
 
-// UpdateInfo returns whether an update is available, and if so, version, description and severity information
+// UpdateInfo returns whether an update is available, and if so, version, description and severity information.
 func (base *BitBoxBase) UpdateInfo() (rpcmessages.IsBaseUpdateAvailableResponse, error) {
 	if !base.active {
 		return rpcmessages.IsBaseUpdateAvailableResponse{}, errp.New("Attempted a call to non-active base")
@@ -693,7 +693,7 @@ func (base *BitBoxBase) UpdateInfo() (rpcmessages.IsBaseUpdateAvailableResponse,
 	return reply, nil
 }
 
-// FinalizeSetupWizard calls the FinalizeSetupWizard RPC to enable bitcoin and start bitcoin services
+// FinalizeSetupWizard calls the FinalizeSetupWizard RPC to enable bitcoin and start bitcoin services.
 func (base *BitBoxBase) FinalizeSetupWizard() error {
 	if !base.active {
 		return errp.New("Attempted a call to non-active base")
@@ -710,32 +710,32 @@ func (base *BitBoxBase) FinalizeSetupWizard() error {
 	return nil
 }
 
-// Identifier implements a getter for the bitboxBase ID
+// Identifier implements a getter for the bitboxBase ID.
 func (base *BitBoxBase) Identifier() string {
 	return base.bitboxBaseID
 }
 
-// Config returns the Base's configuration
+// Config returns the Base's configuration.
 func (base *BitBoxBase) Config() *bbbconfig.BBBConfig {
 	return base.bbbConfig
 }
 
-// GetRegisterTime implements a getter for the timestamp of when the bitbox base was registered
+// GetRegisterTime implements a getter for the timestamp of when the bitbox base was registered.
 func (base *BitBoxBase) GetRegisterTime() time.Time {
 	return base.registerTime
 }
 
-// isTestnet returns a boolean that is true when connected to a base serving testnet and false otherwise
+// isTestnet returns a boolean that is true when connected to a base serving testnet and false otherwise.
 func (base *BitBoxBase) isTestnet() bool {
 	return base.network == "testnet"
 }
 
-// Close implements a method to unset the bitboxBase
+// Close implements a method to unset the bitboxBase.
 func (base *BitBoxBase) Close() {
 	base.rpcClient.Stop()
 }
 
-// Ping sends a get request to the BitBoxBase middleware root handler and returns true if successful
+// Ping sends a get request to the BitBoxBase middleware root handler and returns true if successful.
 func (base *BitBoxBase) Ping() (bool, error) {
 	response, err := http.Get("http://" + base.address + ":" + base.port + "/")
 	if err != nil {
@@ -750,9 +750,9 @@ func (base *BitBoxBase) Ping() (bool, error) {
 	return true, nil
 }
 
-// attemptReconnectLoop attempts to reconnect to a rebooting base
+// attemptReconnectLoop attempts to reconnect to a rebooting base.
 func (base *BitBoxBase) attemptReconnectLoop() {
-	time.Sleep(15 * time.Second) // Wait for Base to shut down before attempting to reconnect
+	time.Sleep(15 * time.Second) // wait for Base to shut down before attempting to reconnect
 	for {
 		reply, err := base.Ping()
 		if err != nil {

--- a/backend/bitboxbase/mdns/manager.go
+++ b/backend/bitboxbase/mdns/manager.go
@@ -42,7 +42,7 @@ const (
 	discoveryDuration = time.Second * 10
 )
 
-// BaseDeviceInfo contains the IPv4s and Hostname of a discovered BitBox Base
+// BaseDeviceInfo contains the IPv4s and Hostname of a discovered BitBox Base.
 type BaseDeviceInfo struct {
 	Hostname string
 	IPv4     string
@@ -154,7 +154,7 @@ func (manager *Manager) RemoveBase(bitboxBaseID string) {
 	delete(manager.baseDeviceBitBoxBase, bitboxBaseID)
 }
 
-// GetDetectedBases returns bases detected by the manager with the mDNS scan
+// GetDetectedBases returns bases detected by the manager with the mDNS scan.
 func (manager *Manager) GetDetectedBases() map[string]string {
 	return manager.detectedBases
 }

--- a/backend/bitboxbase/rpcclient/rpcclient.go
+++ b/backend/bitboxbase/rpcclient/rpcclient.go
@@ -78,7 +78,7 @@ func (conn *rpcConn) Close() error {
 	return nil
 }
 
-// RPCClient handles communication with the BitBox Base's rpc server
+// RPCClient handles communication with the BitBox Base's rpc server.
 type RPCClient struct {
 	log       *logrus.Entry
 	address   string
@@ -121,7 +121,7 @@ func NewRPCClient(address string,
 	return rpcClient, nil
 }
 
-// ChannelHash returns the noise channel and a boolean to indicate if it is verified
+// ChannelHash returns the noise channel and a boolean to indicate if it is verified.
 func (rpcClient *RPCClient) ChannelHash() (string, bool) {
 	return rpcClient.channelHash, rpcClient.channelHashBitBoxBaseVerified
 }
@@ -142,7 +142,7 @@ func (rpcClient *RPCClient) EstablishConnection() error {
 }
 
 // Connect initializes the noise pairing after a successful websocket connection had already been established,
-// it then sets the appropriate authentication status based on SetupStatus
+// it then sets the appropriate authentication status based on SetupStatus.
 func (rpcClient *RPCClient) Connect() error {
 	rpcClient.log.Printf("initializing noise pairing")
 	if err := rpcClient.initializeNoise(rpcClient.webSocketConnection); err != nil {
@@ -192,7 +192,7 @@ func (rpcClient *RPCClient) parseMessage(message []byte) {
 	}
 }
 
-// Stop shuts down the websocket connection with the base
+// Stop shuts down the websocket connection with the base.
 func (rpcClient *RPCClient) Stop() {
 	err := rpcClient.client.Close()
 	if err != nil {
@@ -212,7 +212,7 @@ func (rpcClient *RPCClient) GetSetupStatus() (rpcmessages.SetupStatusResponse, e
 	return reply, nil
 }
 
-// GetEnv makes a synchronous rpc call to the base and returns the network type and electrs rpc port
+// GetEnv makes a synchronous rpc call to the base and returns the network type and electrs rpc port.
 func (rpcClient *RPCClient) GetEnv() (rpcmessages.GetEnvResponse, error) {
 	var reply rpcmessages.GetEnvResponse
 	err := rpcClient.client.Call("RPCServer.GetSystemEnv", rpcmessages.AuthGenericRequest{Token: rpcClient.jwtToken}, &reply)
@@ -325,7 +325,7 @@ func (rpcClient *RPCClient) RestoreHSMSecret() (rpcmessages.ErrorResponse, error
 	return reply, nil
 }
 
-// EnableTor makes an rpc call to the Base that enables/disables the tor.service based on rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableTor makes an rpc call to the Base that enables/disables the tor.service based on rpcmessages.ToggleSettingArgs Enable/Disable.
 func (rpcClient *RPCClient) EnableTor(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableTorTor: %v' rpc call\n", toggleAction)
 	var reply rpcmessages.ErrorResponse
@@ -337,7 +337,7 @@ func (rpcClient *RPCClient) EnableTor(toggleAction rpcmessages.ToggleSettingArgs
 	return reply, nil
 }
 
-// EnableTorMiddleware makes an rpc call to BitBoxBase that enables/disables the Tor hidden service for the middleware based on rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableTorMiddleware makes an rpc call to BitBoxBase that enables/disables the Tor hidden service for the middleware based on rpcmessages.ToggleSettingArgs Enable/Disable.
 func (rpcClient *RPCClient) EnableTorMiddleware(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableTorMiddleware: %v' rpc call\n", toggleAction)
 	toggleAction.Token = rpcClient.jwtToken
@@ -349,7 +349,7 @@ func (rpcClient *RPCClient) EnableTorMiddleware(toggleAction rpcmessages.ToggleS
 	return reply, nil
 }
 
-// EnableTorElectrs makes an rpc call to BitBoxBase that enables/disables the Tor hidden service for electrs based on rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableTorElectrs makes an rpc call to BitBoxBase that enables/disables the Tor hidden service for electrs based on rpcmessages.ToggleSettingArgs Enable/Disable.
 func (rpcClient *RPCClient) EnableTorElectrs(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableTorElectrs: %v' rpc call\n", toggleAction)
 	toggleAction.Token = rpcClient.jwtToken
@@ -361,7 +361,7 @@ func (rpcClient *RPCClient) EnableTorElectrs(toggleAction rpcmessages.ToggleSett
 	return reply, nil
 }
 
-// EnableTorSSH makes an rpc call to BitBoxBase that enables/disables the tor hidden service for SSH based on rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableTorSSH makes an rpc call to BitBoxBase that enables/disables the tor hidden service for SSH based on rpcmessages.ToggleSettingArgs Enable/Disable.
 func (rpcClient *RPCClient) EnableTorSSH(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableTorSSH: %v' rpc call\n", toggleAction)
 	toggleAction.Token = rpcClient.jwtToken
@@ -373,7 +373,7 @@ func (rpcClient *RPCClient) EnableTorSSH(toggleAction rpcmessages.ToggleSettingA
 	return reply, nil
 }
 
-// EnableClearnetIBD makes an rpc call to BitBoxBase that configures bitcoind to run over clearnet while in IBD mode based on rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableClearnetIBD makes an rpc call to BitBoxBase that configures bitcoind to run over clearnet while in IBD mode based on rpcmessages.ToggleSettingArgs Enable/Disable.
 func (rpcClient *RPCClient) EnableClearnetIBD(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableClearnetIBD: %v' rpc call\n", toggleAction)
 	toggleAction.Token = rpcClient.jwtToken
@@ -385,7 +385,7 @@ func (rpcClient *RPCClient) EnableClearnetIBD(toggleAction rpcmessages.ToggleSet
 	return reply, nil
 }
 
-// EnableRootLogin makes an rpc call to BitBoxBase that enables/disables login via the root user/password based on rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableRootLogin makes an rpc call to BitBoxBase that enables/disables login via the root user/password based on rpcmessages.ToggleSettingArgs Enable/Disable.
 func (rpcClient *RPCClient) EnableRootLogin(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableRootLogin: %v' rpc call\n", toggleAction)
 	toggleAction.Token = rpcClient.jwtToken
@@ -397,7 +397,7 @@ func (rpcClient *RPCClient) EnableRootLogin(toggleAction rpcmessages.ToggleSetti
 	return reply, nil
 }
 
-// EnableSSHPasswordLogin makes an rpc call to BitBoxBase that enables/disables the ssh login with a password based on rpcmessages.ToggleSettingArgs Enable/Disable
+// EnableSSHPasswordLogin makes an rpc call to BitBoxBase that enables/disables the ssh login with a password based on rpcmessages.ToggleSettingArgs Enable/Disable.
 func (rpcClient *RPCClient) EnableSSHPasswordLogin(toggleAction rpcmessages.ToggleSettingArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Printf("Executing 'EnableSSHPasswordLogin: %v' rpc call\n", toggleAction)
 	toggleAction.Token = rpcClient.jwtToken
@@ -409,7 +409,7 @@ func (rpcClient *RPCClient) EnableSSHPasswordLogin(toggleAction rpcmessages.Togg
 	return reply, nil
 }
 
-// SetLoginPassword makes an rpc call to BitBoxBase that sets the system main ssh/login password
+// SetLoginPassword makes an rpc call to BitBoxBase that sets the system main ssh/login password.
 func (rpcClient *RPCClient) SetLoginPassword(args rpcmessages.SetLoginPasswordArgs) (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Println("Executing SetLoginPassword rpc call")
 	args.Token = rpcClient.jwtToken
@@ -421,7 +421,7 @@ func (rpcClient *RPCClient) SetLoginPassword(args rpcmessages.SetLoginPasswordAr
 	return reply, nil
 }
 
-// ShutdownBase makes an rpc call to BitBoxBase that calls the bbb-cmd.sh script which initiates a `shutdown now`
+// ShutdownBase makes an rpc call to BitBoxBase that calls the bbb-cmd.sh script which initiates a `shutdown now`.
 func (rpcClient *RPCClient) ShutdownBase() (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Println("Executing ShutdownBase rpc call")
 	var reply rpcmessages.ErrorResponse
@@ -432,7 +432,7 @@ func (rpcClient *RPCClient) ShutdownBase() (rpcmessages.ErrorResponse, error) {
 	return reply, nil
 }
 
-// RebootBase makes an rpc call to BitBoxBase that calls the bbb-cmd.sh script which initiates a `reboot`
+// RebootBase makes an rpc call to BitBoxBase that calls the bbb-cmd.sh script which initiates a `reboot`.
 func (rpcClient *RPCClient) RebootBase() (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Println("Executing RebootBase rpc call")
 	var reply rpcmessages.ErrorResponse
@@ -468,7 +468,7 @@ func (rpcClient *RPCClient) GetBaseUpdateProgress() (rpcmessages.GetBaseUpdatePr
 	return reply, nil
 }
 
-// GetBaseInfo makes a synchronous rpc call to the base and returns the GetBaseInfoResponse struct
+// GetBaseInfo makes a synchronous rpc call to the base and returns the GetBaseInfoResponse struct.
 func (rpcClient *RPCClient) GetBaseInfo() (rpcmessages.GetBaseInfoResponse, error) {
 	var reply rpcmessages.GetBaseInfoResponse
 	err := rpcClient.client.Call("RPCServer.GetBaseInfo", rpcmessages.AuthGenericRequest{Token: rpcClient.jwtToken}, &reply)
@@ -479,7 +479,7 @@ func (rpcClient *RPCClient) GetBaseInfo() (rpcmessages.GetBaseInfoResponse, erro
 	return reply, nil
 }
 
-// GetServiceInfo makes a synchronous RPC call to the Base and returns the GetServiceInfoResponse struct
+// GetServiceInfo makes a synchronous RPC call to the Base and returns the GetServiceInfoResponse struct.
 func (rpcClient *RPCClient) GetServiceInfo() (rpcmessages.GetServiceInfoResponse, error) {
 	var reply rpcmessages.GetServiceInfoResponse
 	err := rpcClient.client.Call("RPCServer.GetServiceInfo", rpcmessages.AuthGenericRequest{Token: rpcClient.jwtToken}, &reply)
@@ -491,7 +491,7 @@ func (rpcClient *RPCClient) GetServiceInfo() (rpcmessages.GetServiceInfoResponse
 }
 
 // GetBaseUpdateInfo makes a synchronous RPC call to the Base and returns the IsBaseUpdateAvailable struct
-// with corresponding UpdateInfo
+// with corresponding UpdateInfo.
 func (rpcClient *RPCClient) GetBaseUpdateInfo() (rpcmessages.IsBaseUpdateAvailableResponse, error) {
 	var reply rpcmessages.IsBaseUpdateAvailableResponse
 	err := rpcClient.client.Call("RPCServer.IsBaseUpdateAvailable", rpcmessages.AuthGenericRequest{Token: rpcClient.jwtToken}, &reply)
@@ -503,7 +503,7 @@ func (rpcClient *RPCClient) GetBaseUpdateInfo() (rpcmessages.IsBaseUpdateAvailab
 }
 
 // FinalizeSetupWizard makes an rpc that calls the bbb-config.sh script to enable bitcoin services and the
-// bbb-systemctl.sh to start the services
+// bbb-systemctl.sh to start the services.
 func (rpcClient *RPCClient) FinalizeSetupWizard() (rpcmessages.ErrorResponse, error) {
 	rpcClient.log.Println("Executing FinalizeSetupWizard RPC")
 	var reply rpcmessages.ErrorResponse

--- a/backend/bitboxbase/rpcmessages/errorcodes.go
+++ b/backend/bitboxbase/rpcmessages/errorcodes.go
@@ -1,6 +1,6 @@
 package rpcmessages
 
-// ErrorCode is a unique and short string code represeting an Error
+// ErrorCode is a unique and short string code represeting an Error.
 type ErrorCode string
 
 const (

--- a/backend/bitboxbase/rpcmessages/rpcmessages.go
+++ b/backend/bitboxbase/rpcmessages/rpcmessages.go
@@ -20,18 +20,18 @@ const (
 Put Incoming Args below this line. They should have the format of 'RPC Method Name' + 'Args'.
 */
 
-// UserAuthenticateArgs is a struct that holds the arguments for the UserAuthenticate RPC call
+// UserAuthenticateArgs is a struct that holds the arguments for the UserAuthenticate RPC call.
 type UserAuthenticateArgs struct {
 	Username string
 	Password string
 }
 
-// AuthGenericRequest is a struct that acts as a generic request struct
+// AuthGenericRequest is a struct that acts as a generic request struct.
 type AuthGenericRequest struct {
 	Token string
 }
 
-// UserChangePasswordArgs is an struct that holds the arguments for the UserChangePassword RPC call
+// UserChangePasswordArgs is an struct that holds the arguments for the UserChangePassword RPC call.
 type UserChangePasswordArgs struct {
 	Username    string
 	Password    string
@@ -39,25 +39,25 @@ type UserChangePasswordArgs struct {
 	Token       string
 }
 
-// SetHostnameArgs is a struct that holds the to be set hostname
+// SetHostnameArgs is a struct that holds the to be set hostname.
 type SetHostnameArgs struct {
 	Hostname string
 	Token    string
 }
 
-// SetLoginPasswordArgs is a struct that holds the to be set login password
+// SetLoginPasswordArgs is a struct that holds the to be set login password.
 type SetLoginPasswordArgs struct {
 	LoginPassword string
 	Token         string
 }
 
-// ToggleSettingArgs is a generic message for settings that can be enabled or disabled
+// ToggleSettingArgs is a generic message for settings that can be enabled or disabled.
 type ToggleSettingArgs struct {
 	ToggleSetting bool
 	Token         string
 }
 
-// UpdateBaseArgs is a struct that holds the Base version that should be updated to
+// UpdateBaseArgs is a struct that holds the Base version that should be updated to.
 type UpdateBaseArgs struct {
 	Version string
 	Token   string
@@ -80,13 +80,13 @@ type UserAuthenticateResponse struct {
 	Token         string
 }
 
-// GetEnvResponse is the struct that gets sent by the rpc server during a GetSystemEnv call
+// GetEnvResponse is the struct that gets sent by the rpc server during a GetSystemEnv call.
 type GetEnvResponse struct {
 	Network        string
 	ElectrsRPCPort string
 }
 
-// UpdateInfo holds information about a available Base image update
+// UpdateInfo holds information about a available Base image update.
 type UpdateInfo struct {
 	Description string `json:"description"`
 	Version     string `json:"version"`
@@ -123,7 +123,7 @@ type GetBaseUpdateProgressResponse struct {
 	ProgressDownloadedKiB int             `json:"updateKBDownloaded"`
 }
 
-// GetBaseInfoResponse is the struct that gets sent by the RPC server during a GetBaseInfo RPC call
+// GetBaseInfoResponse is the struct that gets sent by the RPC server during a GetBaseInfo RPC call.
 type GetBaseInfoResponse struct {
 	ErrorResponse             *ErrorResponse
 	Status                    string `json:"status"`
@@ -142,7 +142,7 @@ type GetBaseInfoResponse struct {
 	ElectrsVersion            string `json:"electrsVersion"`
 }
 
-// GetServiceInfoResponse is the struct that gets sent by the RPC server during a GetServiceInfo RPC call
+// GetServiceInfoResponse is the struct that gets sent by the RPC server during a GetServiceInfo RPC call.
 type GetServiceInfoResponse struct {
 	ErrorResponse                *ErrorResponse `json:"errorResponse"`
 	BitcoindBlocks               int64          `json:"bitcoindBlocks"`

--- a/backend/bitboxbase/status/status.go
+++ b/backend/bitboxbase/status/status.go
@@ -54,7 +54,7 @@ const (
 	StatusReconnecting Status = "reconnecting"
 )
 
-// Event represents state change events
+// Event represents state change events.
 type Event string
 
 const (

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -131,14 +131,14 @@ type BackendEnvironment struct {
 	UsingMobileDataFunc func() bool
 }
 
-// NotifyUser implements backend.Environment
+// NotifyUser implements backend.Environment.
 func (env *BackendEnvironment) NotifyUser(text string) {
 	if env.NotifyUserFunc != nil {
 		env.NotifyUserFunc(text)
 	}
 }
 
-// DeviceInfos implements backend.Environment
+// DeviceInfos implements backend.Environment.
 func (env *BackendEnvironment) DeviceInfos() []usb.DeviceInfo {
 	if env.DeviceInfosFunc != nil {
 		return env.DeviceInfosFunc()
@@ -146,7 +146,7 @@ func (env *BackendEnvironment) DeviceInfos() []usb.DeviceInfo {
 	return nil
 }
 
-// SystemOpen implements backend.Environment
+// SystemOpen implements backend.Environment.
 func (env *BackendEnvironment) SystemOpen(url string) error {
 	if env.SystemOpenFunc != nil {
 		return env.SystemOpenFunc(url)
@@ -154,7 +154,7 @@ func (env *BackendEnvironment) SystemOpen(url string) error {
 	return nil
 }
 
-// UsingMobileData implements backend.Environment
+// UsingMobileData implements backend.Environment.
 func (env *BackendEnvironment) UsingMobileData() bool {
 	if env.UsingMobileDataFunc != nil {
 		return env.UsingMobileDataFunc()

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -416,7 +416,7 @@ func (account *Account) Initialize() error {
 	return nil
 }
 
-// RateUpdater implements interface
+// RateUpdater implements interface.
 func (account *Account) RateUpdater() *rates.RateUpdater {
 	return account.rateUpdater
 }
@@ -739,7 +739,7 @@ func (account *Account) subscribeAddress(
 	return nil
 }
 
-// Transactions wraps transaction.Transactions.Transactions()
+// Transactions wraps transaction.Transactions.Transactions().
 func (account *Account) Transactions() ([]accounts.Transaction, error) {
 	if account.fatalError {
 		return nil, errp.New("can't call Transactions() after a fatal error")
@@ -854,7 +854,7 @@ func (account *Account) SpendableOutputs() []*SpendableOutput {
 	return result
 }
 
-// CanVerifyExtendedPublicKey returns the indices of the keystores that support secure verification
+// CanVerifyExtendedPublicKey returns the indices of the keystores that support secure verification.
 func (account *Account) CanVerifyExtendedPublicKey() []int {
 	return account.Keystores().CanVerifyExtendedPublicKeys()
 }

--- a/backend/coins/btc/addresschain.go
+++ b/backend/coins/btc/addresschain.go
@@ -19,7 +19,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/blockchain"
 )
 
-// AddressChain is the interface for AddressChains
+// AddressChain is the interface for AddressChains.
 type AddressChain interface {
 	GetUnused() []*addresses.AccountAddress
 	EnsureAddresses() []*addresses.AccountAddress

--- a/backend/coins/btc/addresses/singleaddress.go
+++ b/backend/coins/btc/addresses/singleaddress.go
@@ -44,7 +44,7 @@ func NewSingleAddress(
 	}
 }
 
-// GetUnused returns the address
+// GetUnused returns the address.
 func (addresses *SingleAddress) GetUnused() []*AccountAddress {
 	if addresses.address == nil {
 		addresses.log.Panic("Concurrency error: Address not synced correctly")
@@ -61,7 +61,7 @@ func (addresses *SingleAddress) LookupByScriptHashHex(hashHex blockchain.ScriptH
 	return addresses.address
 }
 
-// EnsureAddresses returns the address
+// EnsureAddresses returns the address.
 func (addresses *SingleAddress) EnsureAddresses() []*AccountAddress {
 	if addresses.address == nil {
 		addresses.address = NewAccountAddress(

--- a/backend/coins/btc/blockchain/blockchain.go
+++ b/backend/coins/btc/blockchain/blockchain.go
@@ -90,7 +90,7 @@ type Header struct {
 	BlockHeight int
 }
 
-// Status is the connection status to the blockchain node
+// Status is the connection status to the blockchain node.
 type Status int
 
 const (

--- a/backend/coins/btc/electrum/electrum.go
+++ b/backend/coins/btc/electrum/electrum.go
@@ -64,8 +64,10 @@ func newTLSConnection(address string, rootCert string, dialer proxy.Dialer) (*tl
 		return nil, errp.WithStack(err)
 	}
 	tlsConn := tls.Client(conn, &tls.Config{
-		RootCAs:            caCertPool,
-		InsecureSkipVerify: true, // Not actually skipping, we check the cert in VerifyPeerCertificate
+		RootCAs: caCertPool,
+		// Expecting a self-signed cert.
+		// See custom verification against a rootCert in VerifyPeerCertificate.
+		InsecureSkipVerify: true, //nolint:gosec
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			// Code copy/pasted and adapted from
 			// https://github.com/golang/go/blob/81555cb4f3521b53f9de4ce15f64b77cc9df61b9/src/crypto/tls/handshake_client.go#L327-L344, but adapted to skip the hostname verification.
@@ -147,6 +149,9 @@ func DownloadCert(server string, socksProxy socksproxy.SocksProxy) (string, erro
 	}
 
 	tlsConn := tls.Client(conn, &tls.Config{
+		// Just fetching the cert. No need to verify.
+		// newTLSConnection is where the actual connection happens and the cert is verified.
+		InsecureSkipVerify: true, //nolint:gosec
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			if len(rawCerts) == 0 {
 				return errp.New("no remote certs")
@@ -160,7 +165,6 @@ func DownloadCert(server string, socksProxy socksproxy.SocksProxy) (string, erro
 			pemCert = certificatePEMBytes.Bytes()
 			return nil
 		},
-		InsecureSkipVerify: true,
 	})
 	err = tlsConn.Handshake()
 	if err != nil {

--- a/backend/coins/btc/feetarget.go
+++ b/backend/coins/btc/feetarget.go
@@ -32,7 +32,7 @@ type FeeTarget struct {
 	feeRatePerKb *btcutil.Amount
 }
 
-// Code returns the btc fee target
+// Code returns the btc fee target.
 func (feeTarget *FeeTarget) Code() accounts.FeeTargetCode {
 	return feeTarget.code
 }

--- a/backend/coins/btc/headers/headers.go
+++ b/backend/coins/btc/headers/headers.go
@@ -155,7 +155,7 @@ func (headers *Headers) checkpoint() chaincfg.Checkpoint {
 
 // SubscribeEvent subscribes to header events. The provided callback will be notified of events. The
 // returned function unsubscribes.
-// FIXME: not thread-safe
+// FIXME: Unsafe for concurrent use.
 func (headers *Headers) SubscribeEvent(f func(event Event)) func() {
 	headers.eventCallbacks = append(headers.eventCallbacks, f)
 	index := len(headers.eventCallbacks) - 1

--- a/backend/coins/btc/transactions/transactions.go
+++ b/backend/coins/btc/transactions/transactions.go
@@ -329,7 +329,7 @@ func (transactions *Transactions) UpdateAddressHistory(scriptHashHex blockchain.
 	}
 }
 
-// requires transactions lock
+// getTransactionsCached requires transactions lock.
 func (transactions *Transactions) getTransactionCached(
 	dbTx DBTxInterface,
 	txHash chainhash.Hash,

--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -17,7 +17,7 @@ func formatAsCurrency(amount float64) string {
 	return formatted
 }
 
-// Conversions handles fiat conversions
+// Conversions handles fiat conversions.
 func Conversions(amount Amount, coin Coin, isFee bool, ratesUpdater *rates.RateUpdater) map[string]string {
 	var conversions map[string]string
 	rates := ratesUpdater.Last()

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -176,7 +176,7 @@ func (account *Account) Coin() coin.Coin {
 	return account.coin
 }
 
-// RateUpdater implement accounts.Interface, currently just returning a dummy value
+// RateUpdater implement accounts.Interface, currently just returning a dummy value.
 func (account *Account) RateUpdater() *rates.RateUpdater {
 	return account.rateUpdater
 }

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -152,7 +152,7 @@ func (coin *Coin) Decimals(isFee bool) uint {
 	return 18
 }
 
-// unitFactor returns 10^coin.Decimals()
+// unitFactor returns 10^coin.Decimals().
 func (coin *Coin) unitFactor(isFee bool) *big.Int {
 	return new(big.Int).Exp(
 		big.NewInt(10),

--- a/backend/coins/eth/db/db.go
+++ b/backend/coins/eth/db/db.go
@@ -91,9 +91,11 @@ func (tx *Tx) PutOutgoingTransaction(transaction *types.TransactionWithMetadata)
 
 type byNonce []*types.TransactionWithMetadata
 
-func (txs byNonce) Len() int           { return len(txs) }
-func (txs byNonce) Less(i, j int) bool { return txs[i].Transaction.Nonce() < txs[j].Transaction.Nonce() }
-func (txs byNonce) Swap(i, j int)      { txs[i], txs[j] = txs[j], txs[i] }
+func (txs byNonce) Len() int      { return len(txs) }
+func (txs byNonce) Swap(i, j int) { txs[i], txs[j] = txs[j], txs[i] }
+func (txs byNonce) Less(i, j int) bool {
+	return txs[i].Transaction.Nonce() < txs[j].Transaction.Nonce()
+}
 
 // OutgoingTransactions implements DBTxInterface.
 func (tx *Tx) OutgoingTransactions() ([]*types.TransactionWithMetadata, error) {

--- a/backend/coins/eth/etherscan/etherscan.go
+++ b/backend/coins/eth/etherscan/etherscan.go
@@ -392,7 +392,7 @@ func (etherScan *EtherScan) rpcCall(params url.Values, result interface{}) error
 	return json.Unmarshal(*wrapped.Result, result)
 }
 
-// TransactionReceiptWithBlockNumber implements rpc.Interface
+// TransactionReceiptWithBlockNumber implements rpc.Interface.
 func (etherScan *EtherScan) TransactionReceiptWithBlockNumber(
 	ctx context.Context, hash common.Hash) (*rpcclient.RPCTransactionReceipt, error) {
 	params := url.Values{}
@@ -405,7 +405,7 @@ func (etherScan *EtherScan) TransactionReceiptWithBlockNumber(
 	return result, nil
 }
 
-// HeaderByNumber implements rpc.Interface
+// HeaderByNumber implements rpc.Interface.
 func (etherScan *EtherScan) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	params := url.Values{}
 	params.Set("action", "eth_getBlockByNumber")
@@ -422,7 +422,7 @@ func (etherScan *EtherScan) HeaderByNumber(ctx context.Context, number *big.Int)
 	return result, nil
 }
 
-// BalanceAt implements rpc.Interface
+// BalanceAt implements rpc.Interface.
 func (etherScan *EtherScan) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 	var result struct {
 		Status  string
@@ -452,7 +452,7 @@ func (etherScan *EtherScan) BalanceAt(ctx context.Context, account common.Addres
 	return balance, nil
 }
 
-// CallContract implements rpc.Interface
+// CallContract implements rpc.Interface.
 func (etherScan *EtherScan) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	params := url.Values{}
 	params.Set("action", "eth_call")
@@ -469,7 +469,7 @@ func (etherScan *EtherScan) CallContract(ctx context.Context, msg ethereum.CallM
 	return result, nil
 }
 
-// CodeAt implements rpc.Interface
+// CodeAt implements rpc.Interface.
 func (etherScan *EtherScan) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
 	panic("not implemented")
 }
@@ -491,7 +491,7 @@ func callMsgParams(params *url.Values, msg ethereum.CallMsg) {
 	}
 }
 
-// EstimateGas implements rpc.Interface
+// EstimateGas implements rpc.Interface.
 func (etherScan *EtherScan) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
 	params := url.Values{}
 	params.Set("action", "eth_estimateGas")
@@ -504,17 +504,17 @@ func (etherScan *EtherScan) EstimateGas(ctx context.Context, msg ethereum.CallMs
 	return uint64(result), nil
 }
 
-// FilterLogs implements rpc.Interface
+// FilterLogs implements rpc.Interface.
 func (etherScan *EtherScan) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
 	panic("not implemented")
 }
 
-// PendingCodeAt implements rpc.Interface
+// PendingCodeAt implements rpc.Interface.
 func (etherScan *EtherScan) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
 	panic("not implemented")
 }
 
-// PendingNonceAt implements rpc.Interface
+// PendingNonceAt implements rpc.Interface.
 func (etherScan *EtherScan) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
 	params := url.Values{}
 	params.Set("action", "eth_getTransactionCount")
@@ -527,7 +527,7 @@ func (etherScan *EtherScan) PendingNonceAt(ctx context.Context, account common.A
 	return uint64(result), nil
 }
 
-// SendTransaction implements rpc.Interface
+// SendTransaction implements rpc.Interface.
 func (etherScan *EtherScan) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	encodedTx, err := rlp.EncodeToBytes(tx)
 	if err != nil {
@@ -540,12 +540,12 @@ func (etherScan *EtherScan) SendTransaction(ctx context.Context, tx *types.Trans
 	return etherScan.rpcCall(params, nil)
 }
 
-// SubscribeFilterLogs implements rpc.Interface
+// SubscribeFilterLogs implements rpc.Interface.
 func (etherScan *EtherScan) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	panic("not implemented")
 }
 
-// SuggestGasPrice implements rpc.Interface
+// SuggestGasPrice implements rpc.Interface.
 func (etherScan *EtherScan) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 	params := url.Values{}
 	params.Set("action", "eth_gasPrice")

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -299,13 +299,13 @@ func NewConfig(appConfigFilename string, accountsConfigFilename string) (*Config
 	return config, nil
 }
 
-// SetBtcOnly sets non-bitcoin accounts in the config to false
+// SetBtcOnly sets non-bitcoin accounts in the config to false.
 func (config *Config) SetBtcOnly() {
 	config.appConfig.Backend.LitecoinActive = false
 	config.appConfig.Backend.EthereumActive = false
 }
 
-// SetBTCElectrumServers sets the BTC configuration to the provided electrumIP and electrumCert
+// SetBTCElectrumServers sets the BTC configuration to the provided electrumIP and electrumCert.
 func (config *Config) SetBTCElectrumServers(electrumAddress, electrumCert string) {
 	config.appConfig.Backend.BTC = btcCoinConfig{
 		ElectrumServers: []*ServerInfo{
@@ -318,7 +318,7 @@ func (config *Config) SetBTCElectrumServers(electrumAddress, electrumCert string
 	}
 }
 
-// SetTBTCElectrumServers sets the TBTC configuration to the provided electrumIP and electrumCert
+// SetTBTCElectrumServers sets the TBTC configuration to the provided electrumIP and electrumCert.
 func (config *Config) SetTBTCElectrumServers(electrumAddress, electrumCert string) {
 	config.appConfig.Backend.TBTC = btcCoinConfig{
 		ElectrumServers: []*ServerInfo{
@@ -379,7 +379,7 @@ func (config *Config) save(filename string, conf interface{}) error {
 	if err != nil {
 		return errp.WithStack(err)
 	}
-	return errp.WithStack(ioutil.WriteFile(filename, jsonBytes, 0644))
+	return errp.WithStack(ioutil.WriteFile(filename, jsonBytes, 0644)) // #nosec G306
 }
 
 func (config *Config) migrateInfura(appConfig AppConfig) AppConfig {

--- a/backend/devices/bitbox/device.go
+++ b/backend/devices/bitbox/device.go
@@ -1264,7 +1264,7 @@ func (dbb *Device) ecdhPK(mobileECDHPK string) (interface{}, error) {
 	return reply["ecdh"], nil
 }
 
-// ecdhChallenge forwards a ecdh challenge command to the Bitbox
+// ecdhChallenge forwards a ecdh challenge command to the Bitbox.
 func (dbb *Device) ecdhChallenge() error {
 	if dbb.bootloaderStatus != nil {
 		return errp.WithStack(errNoBootloader)

--- a/backend/devices/bitbox/events.go
+++ b/backend/devices/bitbox/events.go
@@ -16,8 +16,8 @@ package bitbox
 
 import "github.com/digitalbitbox/bitbox-wallet-app/backend/devices/device/event"
 
-// TODO: improve error handling and change event data into a JSON object, and split BitBox events
-// from generic device events
+// TODO: Improve error handling and change event data into a JSON object, and split BitBox events
+// from generic device events.
 const (
 	// EventPairingStarted is fired when the pairing started.
 	EventPairingStarted event.Event = "pairingStarted"

--- a/backend/devices/usb/hid.go
+++ b/backend/devices/usb/hid.go
@@ -26,47 +26,47 @@ type hidDeviceInfo struct {
 	hid.DeviceInfo
 }
 
-// VendorID implements DeviceInfo
+// VendorID implements DeviceInfo.
 func (info hidDeviceInfo) VendorID() int {
 	return int(info.DeviceInfo.VendorID)
 }
 
-// ProductID implements DeviceInfo
+// ProductID implements DeviceInfo.
 func (info hidDeviceInfo) ProductID() int {
 	return int(info.DeviceInfo.ProductID)
 }
 
-// UsagePage implements DeviceInfo
+// UsagePage implements DeviceInfo.
 func (info hidDeviceInfo) UsagePage() int {
 	return int(info.DeviceInfo.UsagePage)
 }
 
-// Interface implements DeviceInfo
+// Interface implements DeviceInfo.
 func (info hidDeviceInfo) Interface() int {
 	return info.DeviceInfo.Interface
 }
 
-// Serial implements DeviceInfo
+// Serial implements DeviceInfo.
 func (info hidDeviceInfo) Serial() string {
 	return info.DeviceInfo.Serial
 }
 
-// Manufacturer implements DeviceInfo
+// Manufacturer implements DeviceInfo.
 func (info hidDeviceInfo) Manufacturer() string {
 	return info.DeviceInfo.Manufacturer
 }
 
-// Product implements DeviceInfo
+// Product implements DeviceInfo.
 func (info hidDeviceInfo) Product() string {
 	return info.DeviceInfo.Product
 }
 
-// Identifier implements DeviceInfo
+// Identifier implements DeviceInfo.
 func (info hidDeviceInfo) Identifier() string {
 	return hex.EncodeToString([]byte(info.DeviceInfo.Path))
 }
 
-// Open implements DeviceInfo
+// Open implements DeviceInfo.
 func (info hidDeviceInfo) Open() (io.ReadWriteCloser, error) {
 	device, err := info.DeviceInfo.Open()
 	if err != nil {

--- a/backend/keystore/keystores.go
+++ b/backend/keystore/keystores.go
@@ -104,7 +104,7 @@ func (keystores *Keystores) VerifyAddress(
 	return nil
 }
 
-// CanVerifyExtendedPublicKeys returns the indices of the keystores that support secure verification
+// CanVerifyExtendedPublicKeys returns the indices of the keystores that support secure verification.
 func (keystores *Keystores) CanVerifyExtendedPublicKeys() []int {
 	canVerifyExtendedPublicKey := []int{}
 	for index, keystore := range keystores.keystores {

--- a/backend/notifier.go
+++ b/backend/notifier.go
@@ -99,7 +99,7 @@ func (notifier *notifierForAccount) read(
 	return nil
 }
 
-// Put implements accounts.Notifier,
+// Put implements accounts.Notifier.
 func (notifier *notifierForAccount) Put(id []byte) error {
 	return notifier.write(func(bucketUnnotified, bucketSeen *bbolt.Bucket) error {
 		if bucketSeen.Get(id) != nil {

--- a/backend/signing/configuration.go
+++ b/backend/signing/configuration.go
@@ -75,7 +75,7 @@ func NewSinglesigConfiguration(
 		scriptType, absoluteKeypath, []*hdkeychain.ExtendedKey{extendedPublicKey}, "", 1)
 }
 
-// NewAddressConfiguration creates a new account address configuration
+// NewAddressConfiguration creates a new account address configuration.
 func NewAddressConfiguration(
 	scriptType ScriptType,
 	absoluteKeypath AbsoluteKeypath,
@@ -103,12 +103,12 @@ func (configuration *Configuration) ExtendedPublicKeys() []*hdkeychain.ExtendedK
 	return configuration.extendedPublicKeys
 }
 
-// Address returns the configuration's address
+// Address returns the configuration's address.
 func (configuration *Configuration) Address() string {
 	return configuration.address
 }
 
-// IsAddressBased returns whether configuration is address based or not
+// IsAddressBased returns whether configuration is address based or not.
 func (configuration *Configuration) IsAddressBased() bool {
 	return configuration.address != "" && len(configuration.ExtendedPublicKeys()) == 0
 }

--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -37,11 +37,11 @@ const (
 	address = "0.0.0.0"
 )
 
-// webdevEnvironment implements backend.Environment
+// webdevEnvironment implements backend.Environment.
 type webdevEnvironment struct {
 }
 
-// NotifyUser implements backend.Environment
+// NotifyUser implements backend.Environment.
 func (webdevEnvironment) NotifyUser(text string) {
 	log := logging.Get().WithGroup("servewallet")
 	log.Infof("NotifyUser: %s", text)
@@ -63,17 +63,17 @@ func (webdevEnvironment) NotifyUser(text string) {
 	}
 }
 
-// DeviceInfos implements backend.Environment
+// DeviceInfos implements backend.Environment.
 func (webdevEnvironment) DeviceInfos() []usb.DeviceInfo {
 	return usb.DeviceInfos()
 }
 
-// SystemOpen implements backend.Environment
+// SystemOpen implements backend.Environment.
 func (webdevEnvironment) SystemOpen(url string) error {
 	return system.Open(url)
 }
 
-// UsingMobileData implements backend.Environment
+// UsingMobileData implements backend.Environment.
 func (webdevEnvironment) UsingMobileData() bool {
 	return false
 }

--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -53,18 +53,18 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/util/system"
 )
 
-// nativeCommunication implements bridge.NativeCommunication
+// nativeCommunication implements bridge.NativeCommunication.
 type nativeCommunication struct {
 	respond    func(queryID int, response string)
 	pushNotify func(msg string)
 }
 
-// Respond implements bridge.NativeCommunication
+// Respond implements bridge.NativeCommunication.
 func (communication *nativeCommunication) Respond(queryID int, response string) {
 	communication.respond(queryID, response)
 }
 
-// PushNotify implements bridge.NativeCommunication
+// PushNotify implements bridge.NativeCommunication.
 func (communication *nativeCommunication) PushNotify(msg string) {
 	communication.pushNotify(msg)
 }

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -13,7 +13,8 @@ GO_SRC_DIR=src/github.com/digitalbitbox/bitbox-wallet-app
 if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     # Which docker image to use to run the CI. Defaults to Docker Hub.
     # Overwrite with CI_IMAGE=docker/image/path environment variable.
-    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:5}"
+    # Keep this in sync with .github/workflows/ci.yml.
+    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:6}"
     # Time image pull to compare in the future.
     time docker pull "$CI_IMAGE"
 

--- a/util/cert/selfsigned.go
+++ b/util/cert/selfsigned.go
@@ -78,7 +78,7 @@ func createSelfSignedCertificate(privateKey *rsa.PrivateKey, log *logrus.Entry) 
 	return derBytes, nil
 }
 
-// saveAsPEM saves the given PEM block as a file
+// saveAsPEM saves the given PEM block as a file.
 func saveAsPEM(name string, pemBytes *pem.Block) error {
 	certificateDir := filepath.Dir(name)
 	err := os.MkdirAll(certificateDir, os.ModeDir|os.ModePerm)

--- a/util/jsonrpc/jsonrpc.go
+++ b/util/jsonrpc/jsonrpc.go
@@ -450,13 +450,13 @@ func (client *RPCClient) handleResponse(conn *connection, responseBytes []byte) 
 	}
 }
 
-// OnConnect executed the given callback whenever a new connection is established
+// OnConnect executed the given callback whenever a new connection is established.
 func (client *RPCClient) OnConnect(callback func() error) {
 	client.onConnectCallback = callback
 }
 
 // RegisterHeartbeat registers the heartbeat method and parameters that are sent to the backend
-// to keep the connection alive
+// to keep the connection alive.
 func (client *RPCClient) RegisterHeartbeat(
 	method string,
 	params ...interface{},

--- a/util/socksproxy/socksproxy.go
+++ b/util/socksproxy/socksproxy.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/net/proxy"
 )
 
-// SocksProxy holds the proxy address and wether to use it
+// SocksProxy holds the proxy address and wether to use it.
 type SocksProxy struct {
 	useProxy         bool
 	proxyAddress     string
@@ -32,7 +32,7 @@ type SocksProxy struct {
 	log              *logrus.Entry
 }
 
-// NewSocksProxy returns a new socks proxy instance
+// NewSocksProxy returns a new socks proxy instance.
 func NewSocksProxy(useProxy bool, proxyAddress string) SocksProxy {
 	proxy := SocksProxy{
 		useProxy:     useProxy,


### PR DESCRIPTION
Additionally, exclude some annoying and useless linters, especially in test files.

Unfortunately, I went down the godot linter hole deep enough before it was too late. So, here it is. On the bright side, doc comments look more consistent now. Why a doc comment must start with the type name but not end with a dot.

This commit also adds a separate golint-ci job as a GitHub workflow action. This allows for nice annotations right in the Checks tab on a PR:

![image](https://user-images.githubusercontent.com/25405/86609654-81222480-bfac-11ea-9dc4-ca12c76f78e0.png)

@benma if you're ok with this, could you rebuild and push the new image? I'm dockerless for quite some time now. I'd need to pull 10s of Gb otherwise... Instructions on how to update github's image copy are here: https://github.com/digitalbitbox/bitbox-wallet-app/blob/0e0543f/.github/workflows/ci.yml#L6-L22.