### PR TITLE
frontend: add guide entry to receive about address formats

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -793,6 +793,10 @@
         "text": "As soon as you transact, a new address is automatically added to the list so there are always 20 addresses available which have never received any coins.",
         "title": "When do the addresses change?"
       },
+      "addressFormats": {
+        "text": "A compatible address is standard segwit whereas the modern address is native segwit (bech32). By default the BitBox02 uses the modern address. If you are having issues sending to this address, click \"change to compatible address\".",
+        "title": "What is the difference between compatible address and modern address?"
+      },
       "howVerify": {
         "text": "For the BitBox01, click on the BitBox icon in the sidebar on the left and see the Pairing section. The guide will update and you can continue following the instructions from there.\nFor the BitBox02, you can verify addresses directly on the device during the send/receive process.",
         "title": "How can I verify an address securely?"

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -343,6 +343,7 @@ class Receive extends Component<Props, State> {
                     {currentAddresses.length > 1 && <Entry key="guide.receive.whyMany" entry={t('guide.receive.whyMany')} />}
                     {currentAddresses.length > 1 && <Entry key="guide.receive.why20" entry={t('guide.receive.why20')} />}
                     {currentAddresses.length > 1 && <Entry key="guide.receive.addressChange" entry={t('guide.receive.addressChange')} />}
+                    {receiveAddresses.length > 1 && currentAddresses.length > 1 && <Entry key="guide.receive.addressFormats" entry={t('guide.receive.addressFormats')} />}
                 </Guide>
             </div>
         );


### PR DESCRIPTION
Only for unified accounts, where the user can actually choose the format.