### PR TITLE
frontend/account: show number of synced addresses in the spinner

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -22,6 +22,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/rates"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
 )
 
 // AddressList is a list of addresses.
@@ -29,6 +30,8 @@ type AddressList []Address
 
 // Interface is the API of a Account.
 type Interface interface {
+	observable.Interface
+
 	Info() *Info
 	// Code is an identifier for the account *type* (part of account database filenames, apis, etc.).
 	// Type as in btc-p2wpkh, eth-erc20-usdt, etc.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -188,6 +188,7 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 func (backend *Backend) addAccount(account accounts.Interface) {
 	defer backend.accountsLock.Lock()()
 	backend.accounts = append(backend.accounts, account)
+	account.Observe(backend.Notify)
 	backend.onAccountInit(account)
 }
 

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -86,7 +86,11 @@ type Account struct {
 
 	subaccounts []subaccount
 	// How many addresses were synced already during the initial sync. This value is emitted as an
-	// event when it changes.
+	// event when it changes. This counter can overshoot if an address is updated more than once
+	// during initial sync (e.g. if there is a tx touching it). This should be rare and have no bad
+	// consequence, as the counter is only used to display absolute progress in the frontend. If you
+	// need an accurate count of addresses synced, this should probably be turned into a map (set)
+	// instead.
 	syncedAddressesCount uint32
 
 	transactions *transactions.Transactions

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"sync/atomic"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -42,6 +43,8 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable/action"
 	"github.com/sirupsen/logrus"
 )
 
@@ -64,6 +67,7 @@ type subaccount struct {
 // Account is a account whose addresses are derived from an xpub.
 type Account struct {
 	locker.Locker
+	observable.Implementation
 
 	coin *Coin
 	// folder for all accounts. Full path.
@@ -81,6 +85,9 @@ type Account struct {
 	blockchain               blockchain.Interface
 
 	subaccounts []subaccount
+	// How many addresses were synced already during the initial sync. This value is emitted as an
+	// event when it changes.
+	syncedAddressesCount uint32
 
 	transactions *transactions.Transactions
 
@@ -603,6 +610,17 @@ func (account *Account) Balance() (*accounts.Balance, error) {
 	return account.transactions.Balance(), nil
 }
 
+func (account *Account) incAndEmitSyncCounter() {
+	if !account.synced {
+		synced := atomic.AddUint32(&account.syncedAddressesCount, 1)
+		account.Notify(observable.Event{
+			Subject: fmt.Sprintf("account/%s/synced-addresses-count", account.code),
+			Action:  action.Replace,
+			Object:  synced,
+		})
+	}
+}
+
 // onAddressStatus is called when the status (tx history) of an address might have changed. It is
 // called when the address is initialized, and when the backend notifies us of changes to it. If
 // there was indeed change, the tx history is downloaded and processed.
@@ -612,6 +630,7 @@ func (account *Account) onAddressStatus(address *addresses.AccountAddress, statu
 		return
 	}
 	if status == address.HistoryStatus {
+		account.incAndEmitSyncCounter()
 		// Address didn't change.
 		return
 	}
@@ -633,6 +652,7 @@ func (account *Account) onAddressStatus(address *addresses.AccountAddress, statu
 				account.log.Warning("client status should match after sync")
 			}
 			account.transactions.UpdateAddressHistory(address.PubkeyScriptHashHex(), history)
+			account.incAndEmitSyncCounter()
 			account.ensureAddresses()
 		},
 		func(err error) {

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -38,6 +38,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -52,6 +53,7 @@ var pollInterval = 30 * time.Second
 // Account is an Ethereum account, with one address.
 type Account struct {
 	locker.Locker
+	observable.Implementation
 
 	synchronizer *synchronizer.Synchronizer
 	coin         *Coin

--- a/frontends/web/src/components/spinner/Spinner.tsx
+++ b/frontends/web/src/components/spinner/Spinner.tsx
@@ -86,9 +86,9 @@ class Spinner extends Component<Props> {
                     }
                 </div>
                 {
-                    text && (
-                        <p className={style.spinnerText}>{text}</p>
-                    )
+                    text && text.split('\n').map(line => (
+                        <p className={style.spinnerText}>{line}</p>
+                    ))
                 }
                 <div className={style.spinner}>
                     <div></div>

--- a/frontends/web/src/decorators/subscribe.tsx
+++ b/frontends/web/src/decorators/subscribe.tsx
@@ -27,13 +27,13 @@ import { load } from './load';
  * Loads API endpoints into the props of the component that uses this decorator and updates them on events.
  *
  * @param endpointsObjectOrFunction - The endpoints that should be loaded to their respective property name.
- * @param renderOnlyOnceLoaded - Whether the decorated component shall only be rendered once all endpoints are loaded.
- * @param subscribeWithoutLoading - Whether the endpoints shall only be subscribed without loading them first.
+ * @param renderOnlyOnceLoaded - Whether the decorated component shall only be rendered once all endpoints are loaded. Only applies if `subscribeWithoutloading` is false. Use false only if all loaded props are optional!
+ * @param subscribeWithoutLoading - Whether the endpoints shall only be subscribed without loading them first. Use true only if all loaded props are optional!
  * @return A function that returns the higher-order component that loads and updates the endpoints into the props of the decorated component.
  */
 export function subscribe<LoadedProps extends ObjectButNotFunction, ProvidedProps extends ObjectButNotFunction = {}>(
     endpointsObjectOrFunction: EndpointsObject<LoadedProps> | EndpointsFunction<ProvidedProps, LoadedProps>,
-    renderOnlyOnceLoaded: boolean = true, // Use false only if all loaded props are optional!
+    renderOnlyOnceLoaded: boolean = true,
     subscribeWithoutLoading: boolean = false,
 ) {
     return function decorator(
@@ -56,6 +56,10 @@ export function subscribe<LoadedProps extends ObjectButNotFunction, ProvidedProp
                 if (subscription !== undefined) {
                     subscription();
                     delete this.subscriptions[key];
+                    if (subscribeWithoutLoading || !renderOnlyOnceLoaded) {
+                        // There is no loading on component update, so we reset it to the default value.
+                        this.setState({ [key]: undefined as any } as Pick<LoadedProps, keyof LoadedProps>);
+                    }
                 }
             }
 

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -15,7 +15,8 @@
     },
     "initializing": "Getting information from the blockchain…",
     "openFile": "Open file",
-    "reconnecting": "Lost connection, trying to reconnect…"
+    "reconnecting": "Lost connection, trying to reconnect…",
+    "syncedAddressesCount": "Scanned {{count}} addresses"
   },
   "accountInfo": {
     "address": "Address",


### PR DESCRIPTION
On a slow network or on Tor, the initial sync can take a very long
time (minutes). After 10 or 20 seconds without any progress
indication, the user is left guessing if it will ever finish.

Unforuntately, the number of addresses that will be synced is not
known upfront, it could be 20 or 1000 addresses, and it is a rolling
window until there are 20 (or whatever the gap limit) unused addresses
in a row.

We could show `synced X out of Y` addresses, which both numbers
creeping up, but after some discussion decided that this does not help
more than just showing the number of addresses synced. The user still
does not know when it will finish, but at least sees that there is
progress.

The additional line is only shown for >1 synced
addresses. Single-address accounts like address-watchonly or Ethereum
do not show this progress line.