### PR TITLE
Makefile: fix servewallet commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ osx-init:
 servewallet:
 	go run -mod=vendor ./cmd/servewallet
 servewallet-mainnet:
-	go run -mod=vendor ./cmd/servewallet
+	go run -mod=vendor ./cmd/servewallet -mainnet
 servewallet-regtest:
-	go run -mod=vendor ./cmd/servewallet
+	go run -mod=vendor ./cmd/servewallet -regtest
 servewallet-prodservers:
-	go run -mod=vendor ./cmd/servewallet
+	go run -mod=vendor ./cmd/servewallet -devservers=false
 buildweb:
 	node --version
 	rm -rf ${WEBROOT}/build


### PR DESCRIPTION
Regression from 401bf795715738d5f47e95f4b060ac2a91a09ba9 where the
args were dropped.