### PR TITLE
frontend: remove unused property showLogo in Spinner

### DIFF
--- a/frontends/web/src/components/backups/restore.tsx
+++ b/frontends/web/src/components/backups/restore.tsx
@@ -178,7 +178,7 @@ class Restore extends Component<Props, State> {
                 }
                 {
                     isLoading && (
-                        <Spinner text={t('backup.restore.restoring')} showLogo />
+                        <Spinner text={t('backup.restore.restoring')} />
                     )
                 }
             </span>

--- a/frontends/web/src/components/spinner/Spinner.css
+++ b/frontends/web/src/components/spinner/Spinner.css
@@ -76,17 +76,6 @@
 }
 
 
-.logo {
-    visibility: visible;
-    width: 100%;
-}
-
-@media (min-width: 1000px) {
-    .logo {
-        visibility: hidden;
-    }
-}
-
 .overlay {
     position: absolute;
     top: 0;

--- a/frontends/web/src/components/spinner/Spinner.css
+++ b/frontends/web/src/components/spinner/Spinner.css
@@ -14,10 +14,6 @@
     -webkit-backface-visibility: hidden;
 }
 
-.shifted {
-    padding-left: var(--sidebar-width);
-}
-
 .spinner {
     display: inline-block;
     position: relative;

--- a/frontends/web/src/components/spinner/Spinner.tsx
+++ b/frontends/web/src/components/spinner/Spinner.tsx
@@ -24,7 +24,6 @@ import * as style from './Spinner.css';
 
 interface SpinnerProps {
     text?: string;
-    showLogo?: boolean;
 }
 
 type Props = SpinnerProps & TranslateProps & SharedProps;

--- a/frontends/web/src/routes/device/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/setup/initialize.tsx
@@ -191,7 +191,7 @@ class Initialize extends Component<Props, State> {
                     </div>
                     {
                         status === stateEnum.WAITING && (
-                            <Spinner text={t('initialize.creating')} showLogo />
+                            <Spinner text={t('initialize.creating')} />
                         )
                     }
                 </div>

--- a/frontends/web/src/routes/device/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/setup/seed-create-new.jsx
@@ -130,9 +130,9 @@ export default class SeedCreateNew extends Component {
     renderSpinner() {
         switch (this.state.status) {
         case STATUS.CHECKING:
-            return (<Spinner text={this.props.t('checkSDcard')} showLogo />);
+            return (<Spinner text={this.props.t('checkSDcard')} />);
         case STATUS.CREATING:
-            return (<Spinner text={this.props.t('seed.creating')} showLogo />);
+            return (<Spinner text={this.props.t('seed.creating')} />);
         default:
             return null;
         }

--- a/frontends/web/src/routes/device/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/setup/seed-restore.jsx
@@ -73,9 +73,9 @@ export default class SeedRestore extends Component {
     renderSpinner() {
         switch (this.state.status) {
         case STATUS.CHECKING:
-            return (<Spinner text={this.props.t('checkSDcard')} showLogo />);
+            return (<Spinner text={this.props.t('checkSDcard')} />);
         case STATUS.CREATING:
-            return (<Spinner text={this.props.t('seed.creating')} showLogo />);
+            return (<Spinner text={this.props.t('seed.creating')} />);
         default:
             return null;
         }

--- a/frontends/web/src/routes/device/unlock.jsx
+++ b/frontends/web/src/routes/device/unlock.jsx
@@ -115,7 +115,7 @@ export default class Unlock extends Component {
             submissionState = <p>{t('unlock.description')}</p>;
             break;
         case stateEnum.WAITING:
-            submissionState = <Spinner text={t('unlock.unlocking')} showLogo />;
+            submissionState = <Spinner text={t('unlock.unlocking')} />;
             break;
         case stateEnum.ERROR:
             submissionState = (


### PR DESCRIPTION
Last use of showLogo was in 7f3f21b937e982d9c82e1967efbcf157f23a5ccf.