### PR TITLE
backend/bitbox01: restore longer timeout when starting the pairing

### DIFF
--- a/backend/devices/bitbox/pairing.go
+++ b/backend/devices/bitbox/pairing.go
@@ -60,7 +60,7 @@ func (device *Device) handlePairingError(err error, message string) {
 
 // processPairing processes the pairing after the channel has been displayed as a QR code.
 func (device *Device) processPairing(channel *relay.Channel) {
-	status, err := channel.WaitForScanningSuccess(10 * time.Second)
+	status, err := channel.WaitForScanningSuccess(2 * time.Minute)
 	if err != nil {
 		device.handlePairingError(err, "scanning success message")
 		return


### PR DESCRIPTION
Regression from 53466beec694c0bfdfdd80c5ba4ae10ddba6ff52.

Was accidentally reduced to 10s (maybe a debug leftover).