### PR TITLE
cmd/servewallet: correct comment about unsupported charset in LANG

### DIFF
--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -87,8 +87,9 @@ func (webdevEnvironment) NativeLocale() string {
 	if v == "" {
 		v = os.Getenv("LANG")
 	}
-	// Strip charset from the LANG. It is unsupported by the i18next package
-	// used in the frontend.
+	// Strip charset from the LANG. It is unsupported by JS Date formatting
+	// used in the frontend and breaks UI in unexpected ways.
+	// We are always UTF-8 anyway.
 	return strings.Split(v, ".")[0]
 }
 


### PR DESCRIPTION
I was too quick to push ef22a19f and forgot to update the comment.