### PR TITLE
frontend: increase readability of the sidebarlabel

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.css
+++ b/frontends/web/src/components/sidebar/sidebar.css
@@ -192,7 +192,7 @@ a.sidebar-active .single img,
 }
 
 .sidebar_label {
-    color: var(--color-secondary);
+    color: var(--color-mediumgray);
     line-height: 1;
     flex: 1;
     padding-top: 0;


### PR DESCRIPTION
This increases contrast of the sidebar label link for better
readability, as suggested by Thomas.

![Screen Shot 2020-07-25 at 11 54 34 AM](https://user-images.githubusercontent.com/546900/88454142-a5677780-ce6d-11ea-85a4-0841728bd82f.png)
