### PR TITLE
backend/coins: unify some common stuff in a BaseAccount

### DIFF
--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -1,0 +1,122 @@
+// Copyright 2020 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accounts
+
+import (
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/synchronizer"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/rates"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
+	"github.com/sirupsen/logrus"
+)
+
+// BaseAccount is an account struct with common functionality to all coin accounts.
+type BaseAccount struct {
+	observable.Implementation
+	Synchronizer *synchronizer.Synchronizer
+	OnEvent      func(Event)
+
+	code string
+	name string
+
+	// synced indicates whether the account has loaded and finished the initial sync of the
+	// addresses.
+	synced      bool
+	keystores   *keystore.Keystores
+	rateUpdater *rates.RateUpdater
+
+	offline bool
+}
+
+// NewBaseAccount creates a new Account instance.
+func NewBaseAccount(
+	code string,
+	name string,
+	keystores *keystore.Keystores,
+	onEvent func(Event),
+	rateUpdater *rates.RateUpdater,
+	log *logrus.Entry,
+) *BaseAccount {
+	account := &BaseAccount{
+		code:        code,
+		name:        name,
+		keystores:   keystores,
+		OnEvent:     onEvent,
+		synced:      false,
+		rateUpdater: rateUpdater,
+	}
+	account.Synchronizer = synchronizer.NewSynchronizer(
+		func() { onEvent(EventSyncStarted) },
+		func() {
+			if !account.synced {
+				account.synced = true
+				onEvent(EventStatusChanged)
+			}
+			onEvent(EventSyncDone)
+		},
+		log,
+	)
+	return account
+}
+
+// Code implements Interface.
+func (account *BaseAccount) Code() string {
+	return account.code
+}
+
+// Name implements Interface.
+func (account *BaseAccount) Name() string {
+	return account.name
+}
+
+// Synced implements Interface.
+func (account *BaseAccount) Synced() bool {
+	return account.synced
+}
+
+// Close stops the account.
+func (account *BaseAccount) Close() {
+	account.synced = false
+}
+
+// Keystores implements Interface.
+func (account *BaseAccount) Keystores() *keystore.Keystores {
+	return account.keystores
+}
+
+// ResetSynced sets synced to false.
+func (account *BaseAccount) ResetSynced() {
+	account.synced = false
+}
+
+// RateUpdater implement Interface, currently just returning a dummy value.
+func (account *BaseAccount) RateUpdater() *rates.RateUpdater {
+	return account.rateUpdater
+}
+
+// Offline implements Interface.
+func (account *BaseAccount) Offline() bool {
+	return account.offline
+}
+
+// SetOffline sets the account offline status and emits the EventStatusChanged() if the status
+// changed.
+func (account *BaseAccount) SetOffline(offline bool) {
+	wasOffline := account.offline
+	account.offline = offline
+	if wasOffline != offline {
+		account.OnEvent(EventStatusChanged)
+	}
+}

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -423,21 +423,39 @@ func (handlers *Handlers) postInit(_ *http.Request) (interface{}, error) {
 	return nil, handlers.account.Initialize()
 }
 
+// status indicates the connection and initialization status.
+type status string
+
+const (
+	// accountSynced indicates that the account is synced.
+	accountSynced status = "accountSynced"
+
+	// accountDisabled indicates that the account has not yet been initialized.
+	accountDisabled status = "accountDisabled"
+
+	// offlineMode indicates that the connection to the blockchain network could not be established.
+	offlineMode status = "offlineMode"
+
+	// fatalError indicates that there was a fatal error in handling the account. When this happens,
+	// an error is shown to the user and the account is made unusable.
+	fatalError status = "fatalError"
+)
+
 func (handlers *Handlers) getAccountStatus(_ *http.Request) (interface{}, error) {
-	status := []btc.Status{}
+	status := []status{}
 	if handlers.account == nil {
-		status = append(status, btc.AccountDisabled)
+		status = append(status, accountDisabled)
 	} else {
 		if handlers.account.Synced() {
-			status = append(status, btc.AccountSynced)
+			status = append(status, accountSynced)
 		}
 
 		if handlers.account.Offline() {
-			status = append(status, btc.OfflineMode)
+			status = append(status, offlineMode)
 		}
 
 		if handlers.account.FatalError() {
-			status = append(status, btc.FatalError)
+			status = append(status, fatalError)
 		}
 	}
 	return status, nil

--- a/backend/coins/btc/sign.go
+++ b/backend/coins/btc/sign.go
@@ -64,10 +64,10 @@ func (account *Account) signTransaction(
 
 	for i := range proposedTransaction.Signatures {
 		// TODO: Replace count with configuration.NumberOfSigners()
-		proposedTransaction.Signatures[i] = make([]*btcec.Signature, account.keystores.Count())
+		proposedTransaction.Signatures[i] = make([]*btcec.Signature, account.Keystores().Count())
 	}
 
-	if err := account.keystores.SignTransaction(proposedTransaction); err != nil {
+	if err := account.Keystores().SignTransaction(proposedTransaction); err != nil {
 		return err
 	}
 

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -148,7 +148,7 @@ func (account *Account) SendTx() error {
 	utxos := account.transactions.SpendableOutputs()
 	getPrevTx := func(txHash chainhash.Hash) *wire.MsgTx {
 		txChan := make(chan *wire.MsgTx)
-		account.blockchain.TransactionGet(txHash,
+		account.coin.Blockchain().TransactionGet(txHash,
 			func(tx *wire.MsgTx) {
 				txChan <- tx
 			},
@@ -164,7 +164,7 @@ func (account *Account) SendTx() error {
 		return errp.WithMessage(err, "Failed to sign transaction")
 	}
 	account.log.Info("Signed transaction is broadcasted")
-	if err := account.blockchain.TransactionBroadcast(txProposal.Transaction); err != nil {
+	if err := account.coin.Blockchain().TransactionBroadcast(txProposal.Transaction); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
btc and eth have a *lot* of copy/pasted fields and functions. This is
a start at putting them into a common helper struct.