### PR TITLE
frontend: add micro_sd_card warning to create wallet & restore wallet wizard

### DIFF
--- a/frontends/web/src/components/devices/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/components/devices/bitbox02/bitbox02.tsx
@@ -625,6 +625,9 @@ class BitBox02 extends Component<Props, State> {
                                                 <div className="m-top-quarter">
                                                     <Checkbox onChange={this.handleDisclaimerCheck} className={style.wizardCheckbox} id="agreement4" label={t('bitbox02Wizard.backup.userConfirmation4')}/>
                                                 </div>
+                                                <div className="m-top-quarter">
+                                                    <Checkbox onChange={this.handleDisclaimerCheck} className={style.wizardCheckbox} id="agreement5" label={t('bitbox02Wizard.backup.userConfirmation5')}/>
+                                                </div>
                                             </form>
                                             <div className={['buttons text-center', style.fullWidth].join(' ')}>
                                                 <Button
@@ -723,6 +726,7 @@ class BitBox02 extends Component<Props, State> {
                                                 <li>{t('bitbox02Wizard.backup.userConfirmation2')}</li>
                                                 <li>{t('bitbox02Wizard.backup.userConfirmation3')}</li>
                                                 <li>{t('bitbox02Wizard.backup.userConfirmation4')}</li>
+                                                <li>{t('bitbox02Wizard.backup.userConfirmation5')}</li>
                                             </ul>
                                             <div className={['buttons text-center', style.fullWidth].join(' ')}>
                                                 <Button primary onClick={this.handleGetStarted}>
@@ -749,6 +753,7 @@ class BitBox02 extends Component<Props, State> {
                                                 <li>{t('bitbox02Wizard.backup.userConfirmation1')}</li>
                                                 <li>{t('bitbox02Wizard.backup.userConfirmation3')}</li>
                                                 <li>{t('bitbox02Wizard.backup.userConfirmation4')}</li>
+                                                <li>{t('bitbox02Wizard.backup.userConfirmation5')}</li>
                                             </ul>
                                             <div className={['buttons text-center', style.fullWidth].join(' ')}>
                                                 <Button primary onClick={this.handleGetStarted}>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -169,7 +169,8 @@
       "userConfirmation1": "I should store my backup in a secure location.",
       "userConfirmation2": "My backup is not password protected. Anyone with access to it can access my wallet.",
       "userConfirmation3": "If I lose or damage my BitBox02, the only way to recover my funds is to restore from my backup.",
-      "userConfirmation4": "If I lose or damage both my backup and my BitBox02 then my funds will be lost."
+      "userConfirmation4": "If I lose or damage both my backup and my BitBox02 then my funds will be lost.",
+      "userConfirmation5": "I should not insert my microSD card backup into a computer, phone, printer or any device other than a BitBox02."
     },
     "create": {
       "button": "Name device & continue",


### PR DESCRIPTION
This PR adds a warning/checkbox to the create wallet & restore wallet wizard informing users that they should not plug their microSD card into a non-BitBox02 device. 