### PR TITLE
backend/btc/transactions: store tx first seen time and sort by it

### DIFF
--- a/backend/coins/btc/db/transactionsdb/transactionsdb_test.go
+++ b/backend/coins/btc/db/transactionsdb/transactionsdb_test.go
@@ -117,23 +117,23 @@ func TestTxQuick(t *testing.T) {
 			if err := tx.PutTx(expectedTxHash, expectedTx, expectedHeight); err != nil {
 				return false
 			}
-			msgTx, addresses, height, headerTimestamp, createdTimestamp, err := tx.TxInfo(expectedTxHash)
+			txInfo, err := tx.TxInfo(expectedTxHash)
 			if err != nil {
 				return false
 			}
-			if !reflect.DeepEqual(expectedTx, msgTx) {
+			if !reflect.DeepEqual(expectedTx, txInfo.Tx) {
 				return false
 			}
-			if !reflect.DeepEqual([]string{}, addresses) {
+			if len(txInfo.Addresses) != 0 {
 				return false
 			}
-			if height != expectedHeight {
+			if txInfo.Height != expectedHeight {
 				return false
 			}
-			if headerTimestamp != nil {
+			if txInfo.HeaderTimestamp != nil {
 				return false
 			}
-			if createdTimestamp == nil {
+			if txInfo.CreatedTimestamp == nil {
 				return false
 			}
 			allTxHashes[expectedTxHash] = struct{}{}
@@ -149,12 +149,13 @@ func TestTxQuick(t *testing.T) {
 				require.NoError(t, tx.MarkTxVerified(txHash, expectedHeaderTimestamp))
 				delete(allUnverifiedTxHashes, txHash)
 				require.True(t, checkTxHashes())
-				_, _, _, headerTimestamp, createdTimestamp, err := tx.TxInfo(txHash)
+				txInfo, err := tx.TxInfo(txHash)
 				require.NoError(t, err)
-				require.Equal(t, expectedHeaderTimestamp.String(), headerTimestamp.String())
+				require.Equal(t, expectedHeaderTimestamp.String(), txInfo.HeaderTimestamp.String())
 				now := time.Now()
-				require.NotNil(t, createdTimestamp)
-				require.True(t, !createdTimestamp.After(now) || *createdTimestamp == now)
+				require.NotNil(t, txInfo.CreatedTimestamp)
+				require.True(t,
+					!txInfo.CreatedTimestamp.After(now) || *txInfo.CreatedTimestamp == now)
 
 				tx.DeleteTx(txHash)
 				delete(allTxHashes, txHash)

--- a/backend/coins/btc/db/transactionsdb/transactionsdb_test.go
+++ b/backend/coins/btc/db/transactionsdb/transactionsdb_test.go
@@ -117,7 +117,7 @@ func TestTxQuick(t *testing.T) {
 			if err := tx.PutTx(expectedTxHash, expectedTx, expectedHeight); err != nil {
 				return false
 			}
-			msgTx, addresses, height, headerTimestamp, err := tx.TxInfo(expectedTxHash)
+			msgTx, addresses, height, headerTimestamp, createdTimestamp, err := tx.TxInfo(expectedTxHash)
 			if err != nil {
 				return false
 			}
@@ -133,6 +133,9 @@ func TestTxQuick(t *testing.T) {
 			if headerTimestamp != nil {
 				return false
 			}
+			if createdTimestamp == nil {
+				return false
+			}
 			allTxHashes[expectedTxHash] = struct{}{}
 			allUnverifiedTxHashes[expectedTxHash] = struct{}{}
 			return checkTxHashes()
@@ -146,9 +149,12 @@ func TestTxQuick(t *testing.T) {
 				require.NoError(t, tx.MarkTxVerified(txHash, expectedHeaderTimestamp))
 				delete(allUnverifiedTxHashes, txHash)
 				require.True(t, checkTxHashes())
-				_, _, _, headerTimestamp, err := tx.TxInfo(txHash)
+				_, _, _, headerTimestamp, createdTimestamp, err := tx.TxInfo(txHash)
 				require.NoError(t, err)
 				require.Equal(t, expectedHeaderTimestamp.String(), headerTimestamp.String())
+				now := time.Now()
+				require.NotNil(t, createdTimestamp)
+				require.True(t, !createdTimestamp.After(now) || *createdTimestamp == now)
 
 				tx.DeleteTx(txHash)
 				delete(allTxHashes, txHash)

--- a/backend/coins/btc/transactions/db.go
+++ b/backend/coins/btc/transactions/db.go
@@ -23,6 +23,16 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/types"
 )
 
+// DBTxInfo contains data stored for a wallet transaction.
+type DBTxInfo struct {
+	Tx               *wire.MsgTx     `json:"Tx"`
+	Height           int             `json:"Height"`
+	Addresses        map[string]bool `json:"addresses"`
+	Verified         *bool           `json:"Verified"`
+	HeaderTimestamp  *time.Time      `json:"ts"`
+	CreatedTimestamp *time.Time      `json:"created"`
+}
+
 // DBTxInterface needs to be implemented to persist all wallet/transaction related data.
 type DBTxInterface interface {
 	// Commit closes the transaction, writing the changes.
@@ -43,15 +53,8 @@ type DBTxInterface interface {
 	AddAddressToTx(chainhash.Hash, blockchain.ScriptHashHex) error
 	RemoveAddressFromTx(chainhash.Hash, blockchain.ScriptHashHex) (bool, error)
 
-	// TxInfo retrieves all data stored with for a transaction. Default values (nil, nil, 0, nil,
-	// nil) are returned for the values not found.
-	TxInfo(chainhash.Hash) (
-		tx *wire.MsgTx,
-		addresses []string,
-		height int,
-		headerTimestamp *time.Time,
-		createdTimestamp *time.Time,
-		err error)
+	// TxInfo retrieves all data stored with for a transaction. nil is returned if not found.
+	TxInfo(chainhash.Hash) (*DBTxInfo, error)
 
 	// Transactions retrieves all stored transaction hashes.
 	Transactions() ([]chainhash.Hash, error)

--- a/backend/coins/btc/transactions/db.go
+++ b/backend/coins/btc/transactions/db.go
@@ -43,10 +43,15 @@ type DBTxInterface interface {
 	AddAddressToTx(chainhash.Hash, blockchain.ScriptHashHex) error
 	RemoveAddressFromTx(chainhash.Hash, blockchain.ScriptHashHex) (bool, error)
 
-	// TxInfo retrieves all data stored with for a transaction. Default values (nil, nil, 0, nil)
-	// are returned for the values not found.
+	// TxInfo retrieves all data stored with for a transaction. Default values (nil, nil, 0, nil,
+	// nil) are returned for the values not found.
 	TxInfo(chainhash.Hash) (
-		tx *wire.MsgTx, addresses []string, height int, headerTimestamp *time.Time, err error)
+		tx *wire.MsgTx,
+		addresses []string,
+		height int,
+		headerTimestamp *time.Time,
+		createdTimestamp *time.Time,
+		err error)
 
 	// Transactions retrieves all stored transaction hashes.
 	Transactions() ([]chainhash.Hash, error)

--- a/backend/coins/btc/transactions/transactions.go
+++ b/backend/coins/btc/transactions/transactions.go
@@ -117,7 +117,7 @@ func (transactions *Transactions) isClosed() bool {
 
 func (transactions *Transactions) processTxForAddress(
 	dbTx DBTxInterface, scriptHashHex blockchain.ScriptHashHex, txHash chainhash.Hash, tx *wire.MsgTx, height int) {
-	_, _, previousHeight, _, _, err := dbTx.TxInfo(txHash)
+	txInfo, err := dbTx.TxInfo(txHash)
 	if err != nil {
 		transactions.log.WithError(err).Panic("Failed to retrieve tx info")
 	}
@@ -131,7 +131,7 @@ func (transactions *Transactions) processTxForAddress(
 	}
 
 	// Newly confirmed tx. Try to verify it.
-	if previousHeight <= 0 && height > 0 {
+	if txInfo.Height <= 0 && height > 0 {
 		transactions.log.Debug("Try to verify newly confirmed tx")
 		go transactions.verifyTransaction(txHash, height)
 	}
@@ -214,14 +214,14 @@ func (transactions *Transactions) SpendableOutputs() map[wire.OutPoint]*Spendabl
 	}
 	result := map[wire.OutPoint]*SpendableOutput{}
 	for outPoint, txOut := range outputs {
-		tx, _, height, _, _, err := dbTx.TxInfo(outPoint.Hash)
+		txInfo, err := dbTx.TxInfo(outPoint.Hash)
 		if err != nil {
 			transactions.log.WithError(err).Panic("Failed to retrieve tx info")
 		}
-		confirmed := height > 0
+		confirmed := txInfo.Height > 0
 
 		spent := transactions.isInputSpent(dbTx, outPoint)
-		if !spent && (confirmed || transactions.allInputsOurs(dbTx, tx)) {
+		if !spent && (confirmed || transactions.allInputsOurs(dbTx, txInfo.Tx)) {
 			result[outPoint] = &SpendableOutput{
 				TxOut:   txOut,
 				Address: transactions.outputToAddress(txOut.PkScript),
@@ -242,11 +242,11 @@ func (transactions *Transactions) isInputSpent(dbTx DBTxInterface, outPoint wire
 func (transactions *Transactions) removeTxForAddress(
 	dbTx DBTxInterface, scriptHashHex blockchain.ScriptHashHex, txHash chainhash.Hash) {
 	transactions.log.Debug("Remove transaction for address")
-	tx, _, _, _, _, err := dbTx.TxInfo(txHash)
+	txInfo, err := dbTx.TxInfo(txHash)
 	if err != nil {
 		transactions.log.WithError(err).Panic("Failed to retrieve tx info")
 	}
-	if tx == nil {
+	if txInfo == nil {
 		// Not yet indexed.
 		transactions.log.Debug("Transaction hash not listed")
 		return
@@ -260,13 +260,13 @@ func (transactions *Transactions) removeTxForAddress(
 	if empty {
 		// Tx is not touching any of our outputs anymore. Remove.
 
-		for _, txIn := range tx.TxIn {
+		for _, txIn := range txInfo.Tx.TxIn {
 			transactions.log.Debug("Deleting transaction iput")
 			dbTx.DeleteInput(txIn.PreviousOutPoint)
 		}
 
 		// Remove the outputs added by this tx.
-		for index := range tx.TxOut {
+		for index := range txInfo.Tx.TxOut {
 			dbTx.DeleteOutput(wire.OutPoint{
 				Hash:  txHash,
 				Index: uint32(index),
@@ -334,12 +334,12 @@ func (transactions *Transactions) getTransactionCached(
 	dbTx DBTxInterface,
 	txHash chainhash.Hash,
 ) *wire.MsgTx {
-	tx, _, _, _, _, err := dbTx.TxInfo(txHash)
+	txInfo, err := dbTx.TxInfo(txHash)
 	if err != nil {
 		transactions.log.WithError(err).Panic("Failed to retrieve transaction info")
 	}
-	if tx != nil {
-		return tx
+	if txInfo.Tx != nil {
+		return txInfo.Tx
 	}
 	txChan := make(chan *wire.MsgTx)
 	transactions.blockchain.TransactionGet(
@@ -379,12 +379,12 @@ func (transactions *Transactions) Balance() *accounts.Balance {
 		if spent := transactions.isInputSpent(dbTx, outPoint); spent {
 			continue
 		}
-		tx, _, height, _, _, err := dbTx.TxInfo(outPoint.Hash)
+		txInfo, err := dbTx.TxInfo(outPoint.Hash)
 		if err != nil {
 			transactions.log.WithError(err).Panic("Failed to retrieve tx info")
 		}
-		confirmed := height > 0
-		if confirmed || transactions.allInputsOurs(dbTx, tx) {
+		confirmed := txInfo.Height > 0
+		if confirmed || transactions.allInputsOurs(dbTx, txInfo.Tx) {
 			available += txOut.Value
 		} else {
 			incoming += txOut.Value
@@ -516,15 +516,13 @@ func (transactions *Transactions) outputToAddress(pkScript []byte) string {
 // txInfo computes additional information to display to the user (type of tx, fee paid, etc.).
 func (transactions *Transactions) txInfo(
 	dbTx DBTxInterface,
-	tx *wire.MsgTx,
-	height int,
-	headerTimestamp, createdTimestamp *time.Time,
+	txInfo *DBTxInfo,
 	isChange func(blockchain.ScriptHashHex) bool) *TxInfo {
 	defer transactions.RLock()()
 	var sumOurInputs btcutil.Amount
 	var result btcutil.Amount
 	allInputsOurs := true
-	for _, txIn := range tx.TxIn {
+	for _, txIn := range txInfo.Tx.TxIn {
 		spentOut, err := dbTx.Output(txIn.PreviousOutPoint)
 		if err != nil {
 			// TODO
@@ -540,10 +538,10 @@ func (transactions *Transactions) txInfo(
 	receiveAddresses := []accounts.AddressAndAmount{}
 	sendAddresses := []accounts.AddressAndAmount{}
 	allOutputsOurs := true
-	for index, txOut := range tx.TxOut {
+	for index, txOut := range txInfo.Tx.TxOut {
 		sumAllOutputs += btcutil.Amount(txOut.Value)
 		output, err := dbTx.Output(wire.OutPoint{
-			Hash:  tx.TxHash(),
+			Hash:  txInfo.Tx.TxHash(),
 			Index: uint32(index),
 		})
 		if err != nil {
@@ -600,22 +598,22 @@ func (transactions *Transactions) txInfo(
 
 	}
 	numConfirmations := 0
-	if height > 0 && transactions.headersTipHeight > 0 {
-		numConfirmations = transactions.headersTipHeight - height + 1
+	if txInfo.Height > 0 && transactions.headersTipHeight > 0 {
+		numConfirmations = transactions.headersTipHeight - txInfo.Height + 1
 	}
-	btcutilTx := btcutil.NewTx(tx)
+	btcutilTx := btcutil.NewTx(txInfo.Tx)
 	return &TxInfo{
-		Tx:               tx,
+		Tx:               txInfo.Tx,
 		VSize:            mempool.GetTxVirtualSize(btcutilTx),
-		Size:             int64(tx.SerializeSize()),
+		Size:             int64(txInfo.Tx.SerializeSize()),
 		Weight:           btcdBlockchain.GetTransactionWeight(btcutilTx),
 		numConfirmations: numConfirmations,
-		Height:           height,
+		Height:           txInfo.Height,
 		txType:           txType,
 		amount:           result,
 		fee:              feeP,
-		headerTimestamp:  headerTimestamp,
-		createdTimestamp: createdTimestamp,
+		headerTimestamp:  txInfo.HeaderTimestamp,
+		createdTimestamp: txInfo.CreatedTimestamp,
 		addresses:        addresses,
 	}
 }
@@ -638,13 +636,12 @@ func (transactions *Transactions) Transactions(
 		panic(err)
 	}
 	for _, txHash := range txHashes {
-		tx, _, height, headerTimestamp, createdTimestamp, err := dbTx.TxInfo(txHash)
+		txInfo, err := dbTx.TxInfo(txHash)
 		if err != nil {
 			// TODO
 			panic(err)
 		}
-		txs = append(txs,
-			transactions.txInfo(dbTx, tx, height, headerTimestamp, createdTimestamp, isChange))
+		txs = append(txs, transactions.txInfo(dbTx, txInfo, isChange))
 	}
 	sort.Sort(sort.Reverse(byHeight(txs)))
 	return txs

--- a/backend/coins/btc/transactions/verification.go
+++ b/backend/coins/btc/transactions/verification.go
@@ -48,12 +48,12 @@ func (transactions *Transactions) unverifiedTransactions() map[chainhash.Hash]in
 	}
 	result := map[chainhash.Hash]int{}
 	for _, txHash := range unverifiedTransactions {
-		_, _, height, _, _, err := dbTx.TxInfo(txHash)
+		txInfo, err := dbTx.TxInfo(txHash)
 		if err != nil {
 			// TODO
 			panic(err)
 		}
-		result[txHash] = height
+		result[txHash] = txInfo.Height
 	}
 	return result
 }

--- a/backend/coins/btc/transactions/verification.go
+++ b/backend/coins/btc/transactions/verification.go
@@ -48,7 +48,7 @@ func (transactions *Transactions) unverifiedTransactions() map[chainhash.Hash]in
 	}
 	result := map[chainhash.Hash]int{}
 	for _, txHash := range unverifiedTransactions {
-		_, _, height, _, err := dbTx.TxInfo(txHash)
+		_, _, height, _, _, err := dbTx.TxInfo(txHash)
 		if err != nil {
 			// TODO
 			panic(err)


### PR DESCRIPTION
Unconfirmed transactions would appear in an arbitrary order in the
app. This commit adds a time of first seen to each tx, and sorts by
that instead, so even unconfirmed transactions are ordered by age.

Same for transactions that confirmed in the same block, which are also
sorted in no particular order currently.