### PR TITLE
backend/accounts: separate tx proposal from note proposal

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -59,7 +59,8 @@ type Interface interface {
 	Notifier() Notifier
 	Transactions() ([]Transaction, error)
 	Balance() (*Balance, error)
-	// SendTx signs and sends the active tx proposal, set by TxProposal. Errors if none available.
+	// SendTx signs and sends the active tx proposal, set by TxProposal. Errors if none
+	// available. The note, if set by ProposeTxNote(), is persisted for the transaction.
 	SendTx() error
 	FeeTargets() ([]FeeTarget, FeeTargetCode)
 	TxProposal(*TxProposalArgs) (coin.Amount, coin.Amount, coin.Amount, error)
@@ -77,6 +78,9 @@ type Interface interface {
 	SafelloBuy() *safello.Buy
 
 	Notes() *notes.Notes
+	// ProposeTxnote stores a note. The note is is persisted in the notes database upon calling
+	// SendTx(). This function must be called before `SendTx()`.
+	ProposeTxNote(string)
 	// SetTxNote sets a tx note and refreshes the account.
 	SetTxNote(txID string, note string) error
 }

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -61,11 +61,6 @@ type subaccount struct {
 	changeAddresses      AddressChain
 }
 
-type activeTxProposal struct {
-	proposal *maketx.TxProposal
-	note     string
-}
-
 // Account is a account whose addresses are derived from an xpub.
 type Account struct {
 	*accounts.BaseAccount
@@ -90,7 +85,7 @@ type Account struct {
 	transactions *transactions.Transactions
 
 	// if not nil, SendTx() will sign and send this transaction. Set by TxProposal().
-	activeTxProposal     *activeTxProposal
+	activeTxProposal     *maketx.TxProposal
 	activeTxProposalLock locker.Locker
 
 	feeTargets []*FeeTarget

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -73,6 +73,7 @@ func NewHandlers(
 	handleFunc("/exchange/safello/buy-supported", handlers.ensureAccountInitialized(handlers.getExchangeSafelloBuySupported)).Methods("GET")
 	handleFunc("/exchange/safello/buy", handlers.ensureAccountInitialized(handlers.getExchangeSafelloBuy)).Methods("GET")
 	handleFunc("/exchange/safello/process-message", handlers.ensureAccountInitialized(handlers.postExchangeSafelloProcessMessage)).Methods("POST")
+	handleFunc("/propose-tx-note", handlers.ensureAccountInitialized(handlers.postProposeTxNote)).Methods("POST")
 	handleFunc("/notes/tx", handlers.ensureAccountInitialized(handlers.postSetTxNote)).Methods("POST")
 	return handlers
 }
@@ -546,6 +547,15 @@ func (handlers *Handlers) postExchangeSafelloProcessMessage(r *http.Request) (in
 		path.Join(handlers.account.FilesFolder(), "safello-buy.json"),
 		message,
 	)
+}
+
+func (handlers *Handlers) postProposeTxNote(r *http.Request) (interface{}, error) {
+	var note string
+	if err := json.NewDecoder(r.Body).Decode(&note); err != nil {
+		return nil, errp.WithStack(err)
+	}
+	handlers.account.ProposeTxNote(note)
+	return nil, nil
 }
 
 func (handlers *Handlers) postSetTxNote(r *http.Request) (interface{}, error) {

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -259,7 +259,6 @@ class Send extends Component<Props, State> {
         sendAll: this.state.sendAll ? 'yes' : 'no',
         selectedUTXOs: Object.keys(this.selectedUTXOs),
         data: this.state.data,
-        note: this.state.note,
     })
 
     private sendDisabled = () => {
@@ -298,6 +297,15 @@ class Send extends Component<Props, State> {
             });
             this.pendingProposals.push(propose);
         }, 400);
+    }
+
+    private handleNoteInput = (event: Event) => {
+        const target = (event.target as HTMLInputElement);
+        this.setState(prevState => ({
+            ...prevState,
+            [target.id]: target.value,
+        }));
+        apiPost('account/' + this.getAccount()!.code + '/propose-tx-note', this.state.note);
     }
 
     private txProposal = (updateFiat, result) => {
@@ -657,7 +665,7 @@ class Send extends Component<Props, State> {
                                                     </span>
                                                 }
                                                 id="note"
-                                                onInput={this.handleFormChange}
+                                                onInput={this.handleNoteInput}
                                                 value={note}
                                                 placeholder={t('note.input.placeholder')} />
                                         </div>


### PR DESCRIPTION
When making a tx in the send screen, a tx proposal is created when
form fields are changed, to store the tx proposal to be signed and
sent, and also to compute the tx fees that the frontend should
display. This endpoint can have a long delay, e.g. in Ethereum it does
network requests.

The note was also part of the tx proposal, but that lead to a needless
delay and a display of "calculating fees..." when typing a note.

This commit makes a separate tx note proposal, as it can always be
processed instantly.