### PR TITLE
android: make sure device list is filtered by vendor/product ID

### DIFF
--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
@@ -119,8 +119,17 @@ public class GoViewModel extends AndroidViewModel {
             Iterator<UsbDevice> deviceIterator = deviceList.values().iterator();
             while (deviceIterator.hasNext()){
                 UsbDevice device = deviceIterator.next();
-                this.device = new GoDeviceInfo(device);
-                break; // only one device supported for now
+                // One other instance where we filter vendor/product IDs is in
+                // @xml/device_filter resource, which is used for USB_DEVICE_ATTACHED
+                // intent to launch the app when a device is plugged and the app is still
+                // closed. This filter, on the other hand, makes sure we feed only valid
+                // devices to the Go backend once the app is launched or opened.
+                //
+                // BitBox02 Vendor ID: 0x03eb, Product ID: 0x2403.
+                if (device.getVendorId() == 1003 && device.getProductId() == 9219) {
+                    this.device = new GoDeviceInfo(device);
+                    break; // only one device supported for now
+                }
             }
         }
 

--- a/frontends/android/BitBoxApp/app/src/main/res/xml/device_filter.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/xml/device_filter.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+<!-- Keep usb-device list in sync with updateDeviceList in GoViewModel.java -->
 <resources>
-    <!-- BitBox02 -->
+    <!-- BitBox02 Vendor ID: 0x03eb, Product ID: 0x2403 -->
     <usb-device vendor-id="1003" product-id="9219" />
 </resources>


### PR DESCRIPTION
Before this change, any device plugged into a USB-C would be accepted
as a BitBox02 device. This results in app crash if the the device isn't
actually a BitBox02 because Go's USB manager expects only valid devices
on the backend.

This commit simply ensures that the Android native code skips unknown
devices when looking for a BitBox02 in the list.

Closes https://github.com/digitalbitbox/bitbox-wallet-app/issues/938