### PR TITLE
Frontend: set focus on note input depending on editMode

### DIFF
--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -250,9 +250,9 @@ class Transaction extends Component<Props, State> {
                                 <label for="note">{t('note.title')}</label>
                                 <Input
                                     align="right"
-                                    autoFocus={note ? 'false' : 'true'}
+                                    autoFocus={!editMode ? 'false' : 'true'}
                                     className={style.textOnlyInput}
-                                    readOnly={!editMode && !!note}
+                                    readOnly={!editMode}
                                     type="text"
                                     id="note"
                                     transparent


### PR DESCRIPTION
When the user opens the tx detail and the note is empty
it renders in edit mode. When the user clicks save with
an empty note the input was still editable.
This change sets autofocus and readonly only based on
the editMode, so that the save behavior is consistent.