### PR TITLE
Frontend: ETH/ERC20 accountinfo

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -304,22 +304,24 @@ class Account extends Component<Props, State> {
                     }
                     <Header
                         title={<h2><span>{account.name}</span></h2>}>
-                        <a href={`/account/${code}/info`} title={t('accountInfo.title')} className="flex flex-row flex-items-center">
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                className={style.accountIcon}>
-                                <circle cx="12" cy="12" r="10"></circle>
-                                <line x1="12" y1="16" x2="12" y2="12"></line>
-                                <line x1="12" y1="8" x2="12" y2="8"></line>
-                            </svg>
-                            <span>{t('accountInfo.label')}</span>
-                        </a>
+                        {isBitcoinBased(account.coinCode) ? (
+                            <a href={`/account/${code}/info`} title={t('accountInfo.title')} className="flex flex-row flex-items-center">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    className={style.accountIcon}>
+                                    <circle cx="12" cy="12" r="10"></circle>
+                                    <line x1="12" y1="16" x2="12" y2="12"></line>
+                                    <line x1="12" y1="8" x2="12" y2="8"></line>
+                                </svg>
+                                <span>{t('accountInfo.label')}</span>
+                            </a>
+                        ) : null}
                     </Header>
                     {initialized && this.dataLoaded() && isBitcoinBased(account.coinCode) && <HeadersSync coinCode={account.coinCode} />}
                     <div className="innerContainer scrollableContainer">

--- a/frontends/web/src/routes/account/info/signingconfiguration.tsx
+++ b/frontends/web/src/routes/account/info/signingconfiguration.tsx
@@ -17,7 +17,6 @@
 import { Component, h, RenderableProps } from 'preact';
 import { CopyableInput } from '../../../components/copy/Copy';
 import { Button } from '../../../components/forms';
-import { ButtonLink } from '../../../components/forms';
 import { QRCode } from '../../../components/qrcode/qrcode';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet, apiPost } from '../../../utils/request';
@@ -80,7 +79,6 @@ class SigningConfiguration extends Component<Props, State> {
     public render(
         { t,
           info,
-          code,
           signingConfigIndex,
         }: RenderableProps<Props>,
         { canVerifyExtendedPublicKey }: State) {
@@ -93,13 +91,6 @@ class SigningConfiguration extends Component<Props, State> {
                     <QRCode data={info.address} />
                     <div className={style.textareaContainer}>
                         <CopyableInput flexibleHeight value={info.address} />
-                    </div>
-                    <div className="buttons">
-                        <ButtonLink
-                            transparent
-                            href={`/account/${code}`}>
-                            {t('button.back')}
-                        </ButtonLink>
                     </div>
                 </div>
                     :


### PR DESCRIPTION
- hide account info for non bitcoin style accounts
- fix double back button in account info (eth) 