### PR TITLE
config: add option to enable expert fee settings

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -97,6 +97,10 @@ type Backend struct {
 	LitecoinActive bool `json:"litecoinActive"`
 	EthereumActive bool `json:"ethereumActive"`
 
+	// If enabled, the user will see sat/B fees in the fee target priorities, and be able to set a
+	// custom fee in sat/B.
+	ExpertFee bool `json:"expertFee"`
+
 	// Whether Bitcoin, Litecoin should be shown in multiple accounts - one per script type -
 	// instead of a combined account.
 	SplitAccounts bool `json:"splitAccounts"`
@@ -183,6 +187,8 @@ func NewDefaultAppConfig() AppConfig {
 			BitcoinActive:  true,
 			LitecoinActive: true,
 			EthereumActive: true,
+
+			ExpertFee: false,
 
 			SplitAccounts: false,
 

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1247,6 +1247,7 @@
       "electrum": {
         "title": "Connect your own full node"
       },
+      "fee": "Enable custom fees",
       "setProxyAddress": "Set proxy address",
       "splitAccounts": "Separate accounts by address type (legacy behavior)",
       "title": "Expert settings",

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -105,6 +105,15 @@ class Settings extends Component<Props, State> {
             });
     }
 
+    private handleToggleExpertFee = (event: Event) => {
+        const target = (event.target as HTMLInputElement);
+        setConfig({
+            backend: {
+                [target.id]: target.checked,
+            },
+        }).then(config => this.setState({ config }));
+    }
+
     private handleToggleCoinControl = (event: Event) => {
         const target = (event.target as HTMLInputElement);
         setConfig({
@@ -361,6 +370,19 @@ class Settings extends Component<Props, State> {
                                                                 id="splitAccounts"
                                                                 checked={config.backend.splitAccounts}
                                                                 onChange={this.handleToggleAccount} />
+                                                        </div>
+                                                        <div className={style.currency}>
+                                                            <div>
+                                                                <p className="m-none">{t('settings.expert.fee')}</p>
+                                                                <p className="m-none">
+                                                                    <Badge type="generic">BTC</Badge>
+                                                                    <Badge type="generic" className="m-left-quarter">LTC</Badge>
+                                                                </p>
+                                                            </div>
+                                                            <Toggle
+                                                                checked={config.backend.expertFee}
+                                                                id="expertFee"
+                                                                onChange={this.handleToggleExpertFee} />
                                                         </div>
                                                         <div className={style.currency}>
                                                             <div>


### PR DESCRIPTION
This will enable setting custom fees as well as seeing the sat/vB fee
rate estimations for the four fee targets.