### PR TITLE
ci: delete troublesome golangci github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,6 @@ env:
   TRAVIS_BUILD_DIR: ${{github.workspace}}
 
 jobs:
-  golangci:
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Clone the repo
-        uses: actions/checkout@v2
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v1
-        with:
-          # Keep this in sync with the version in envinit make target.
-          version: v1.27
   test-lint:
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
TL;DIR: we're stuck with go1.14 + linter v1.27 for now. The longer explanation below is for potential gotchas when and if we'll ever upgrade to go1.15 or a more recent golangci-lint.

golangci-lint always uses the latest version of Go, which has recently released go1.15. Any linter version starting with the currently in use 1.27 and up to the latest 1.30 fails on go1.15 with panics. Any linter version past 1.27 with go1.14 panics, too.

Unfortunately, golangci-lint always overwrites the Go version when run in a github action in https://github.com/golangci/golangci-lint-action/blob/v1.2.2/src/install.ts#L26. I made a working PoC which allows to specify a Go version in https://github.com/x1ddos/golangci-lint-action/commit/6f8897f but wouldn't be able to send them a pull request because they always work in the master branch. Their master branch is way ahead and [doesn't support 1.27 linter version anymore](https://github.com/golangci/golangci-lint-action/blob/1d3f25bff95b27bd81c4a177e585f69a0296368d/src/version.ts#L69-L75). So, my PoC is useless: we wouldn't want to maintain a fork of golangci-lint-action.

Note that golangci-lint is alwasy run in the docker container, too, in test-lint action anyway. What's removed here was a very quick separate CI step to identify potential pull request issues within seconds.

Alternatives are more time consuming and not worth it at the moment.