### PR TITLE
frontend: styling for fee targets and custom fee on small screen

### DIFF
--- a/frontends/web/src/routes/account/send/feetargets.css
+++ b/frontends/web/src/routes/account/send/feetargets.css
@@ -1,38 +1,95 @@
 .row {
     display: flex;
+    flex-direction: column;
+}
+
+.rowCustomFee {
+    display: flex;
+    flex-direction: row;
     flex-wrap: wrap;
 }
 
 .column {
     flex-basis: 50%;
     flex-grow: 1;
-    flex-shrink: 1;
+    flex-shrink: 0;
 }
-.column:first-child {
+.rowCustomFee .column:first-child {
     flex-basis: 40%;
 }
-
-select.priority {
-    border-right: none;
-    padding-right: 0;
-    text-transform: capitalize;
+.rowCustomFee .column:nth-child(2) {
+    flex-basis: 60%;
 }
 
-.fee input {
+@media (min-width: 640px) {
+    .row {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+    .column:first-child {
+        flex-basis: 40%;
+    }
+    .column:nth-child(2) {
+        flex-basis: 60%;
+    }
+}
+
+.rowCustomFee select.priority {
+    border-right: none;
+    padding-right: 0;
+}
+.rowCustomFee .fee input {
     border-bottom-left-radius: 0;
     border-left: none;
     border-top-left-radius: 0;
     padding-left: 0;
+    border-color: var(--color-mediumgray) !important;
+}
+@media (min-width: 640px) {
+    select.priority {
+        border-right: none;
+        padding-right: 0;
+    }
+    .fee input {
+        border-bottom-left-radius: 0;
+        border-left: none;
+        border-top-left-radius: 0;
+        padding-left: 0;
+    }
 }
 
-select:disabled.priority,
-.fee input:disabled {
+select:disabled.priority {
     border-color: var(--color-lightgray) !important;
 }
 
-select.priority,
-.fee input {
+select.priority {
     border-color: var(--color-mediumgray) !important;
+}
+
+@media (min-width: 640px) {
+    .fee input:disabled {
+        border-color: var(--color-lightgray) !important;
+    }
+    .fee input {
+        border-color: var(--color-mediumgray) !important;
+    }
+}
+
+@media (max-width: 639px) {
+    .row .fee * {
+        display: block !important;
+        text-align: left !important;
+    }
+    .row .fee input {
+        border: none;
+        color: var(--color-secondary) !important;
+        font-size: var(--size-small);
+        font-weight: 400;
+        height: auto;
+        margin-top: 0;
+        padding: 0;
+    }
 }
 
 .feeCustom input {

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -145,10 +145,11 @@ class FeeTargets extends Component<Props, State> {
         }
         const isCustom = feeTarget === 'custom';
         const hasOptions = options.length > 0;
+        const proposeFeeText = this.getProposeFeeText();
         const preventFocus = document.activeElement && document.activeElement.nodeName === 'INPUT';
         return (
             hasOptions ? (
-                <div className={style.row}>
+                <div className={isCustom ? style.rowCustomFee : style.row}>
                     <div className={style.column}>
                         <Select
                             className={style.priority}
@@ -180,12 +181,12 @@ class FeeTargets extends Component<Props, State> {
                                 disabled={disabled || !isCustom}
                                 label={t('send.fee.label')}
                                 id="proposedFee"
-                                placeholder={t(isCustom ? 'send.fee.customPlaceholder' : 'send.fee.placeholder')}
+                                placeholder={isCustom ? t('send.fee.customPlaceholder') : ''}
                                 error={error}
                                 transparent
                                 onInput={this.handleFeePerByte}
                                 getRef={input => !disabled && input && input.autofocus && input.focus()}
-                                value={isCustom ? feePerByte : this.getProposeFeeText()}
+                                value={isCustom ? feePerByte : proposeFeeText}
                             >
                                 {isCustom && (<span className={style.customFeeUnit}>sat/vB</span>)}
                             </Input>
@@ -193,7 +194,9 @@ class FeeTargets extends Component<Props, State> {
                     </div>
                     { feeTarget && (
                         isCustom ? (
-                            <p class={style.feeProposed}>{this.getProposeFeeText()}</p>
+                            <p class={style.feeProposed}>
+                                {showCalculatingFeeLabel ? t('send.feeTarget.placeholder') : proposeFeeText}
+                            </p>
                         ) : (
                             <div>
                                 <label>{t('send.feeTarget.estimate')}</label>
@@ -210,7 +213,7 @@ class FeeTargets extends Component<Props, State> {
                     placeholder={t('send.fee.placeholder')}
                     error={error}
                     transparent
-                    value={this.getProposeFeeText()}
+                    value={proposeFeeText}
                 />
             )
         );

--- a/frontends/web/src/style/grid.css
+++ b/frontends/web/src/style/grid.css
@@ -79,6 +79,14 @@
     margin-bottom: 0;
 }
 
+@media (max-width: 1348px) {
+
+    .columns.columns-onlylarge .column {
+        width: calc(100% - (var(--space-half) * 2)) !important;
+    }
+
+}
+
 @media (max-width: 768px) {
     .columnsContainer {
         margin-right: calc(var(--space-half) * -1);
@@ -112,12 +120,8 @@
     .columns .column.column-1-3 {
         width: calc((100% - (var(--space-half) * 3)) / 3);
     }
-}
-
-@media (max-width: 1348px) {
 
     .columns.columns-onlylarge .column {
-        width: calc(100% - (var(--space-half) * 2)) !important;
+        width: calc(100% - var(--space-half)) !important;
     }
-
 }


### PR DESCRIPTION
With expert custom fee enabled the feetargets use now more space
as it displays sats per byte information. This change breaks the
proposed fee text onto a new line, but keeps the custom fee on
the same line on small screen.

![Screen Shot 2020-09-03 at 3 42 36 PM](https://user-images.githubusercontent.com/546900/92123690-36325b00-edfd-11ea-8527-c07cd30178b8.png) 
![Screen Shot 2020-09-03 at 3 42 46 PM](https://user-images.githubusercontent.com/546900/92123718-3d596900-edfd-11ea-8ab6-8af6705abd9e.png)

