### PR TITLE
ci: pin to go1.14 on macOS

### DIFF
--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -28,8 +28,8 @@ fi
 
 # The following is executed only on macOS machines.
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    export HOMEBREW_NO_AUTO_UPDATE=1
-    brew outdated go || brew upgrade go
+    brew install go@1.14
+    export PATH=/usr/local/opt/go@1.14/bin:$PATH
     go version
     brew install qt
     # Install yarn only if it isn't already.


### PR DESCRIPTION
Otherwise, it installs go1.15 which breaks the builds.

Also, removed HOMEBREW_NO_AUTO_UPDATE=1 line because otherwise homebrew
on Travis cannot find go@1.14.