### PR TITLE
Frontend fee styling for largescreen

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1185,12 +1185,20 @@
     },
     "feeTarget": {
       "description": {
-        "economy": "24 blocks (around 4 hours for Bitcoin, 1 hour for Litecoin)",
-        "high": "2 blocks (around 20 minutes for Bitcoin, 5 minutes for Litecoin)",
-        "low": "12 blocks (around 2 hours for Bitcoin, 30 minutes for Litecoin)",
-        "normal": "6 blocks (around 1 hour for Bitcoin, 15 minutes for Litecoin)"
+        "btc": {
+          "economy": "4 hours (24 blocks)",
+          "high": "20 minutes (2 blocks)",
+          "low": "2 hours (12 blocks)",
+          "normal": "1 hour (6 blocks)"
+        },
+        "ltc": {
+          "economy": "1 hour (24 blocks)",
+          "high": "5 minutes (2 blocks)",
+          "low": "30 minutes (12 blocks)",
+          "normal": "15 minutes (6 blocks)"
+        }
       },
-      "estimate": "Estimated wait time:",
+      "estimate": "Estimated confirmation time:",
       "label": {
         "custom": "Custom",
         "economy": "Economy",

--- a/frontends/web/src/routes/account/send/feetargets.css
+++ b/frontends/web/src/routes/account/send/feetargets.css
@@ -15,10 +15,10 @@
     flex-shrink: 0;
 }
 .rowCustomFee .column:first-child {
-    flex-basis: 40%;
+    flex-basis: 50%;
 }
 .rowCustomFee .column:nth-child(2) {
-    flex-basis: 60%;
+    flex-basis: 50%;
 }
 
 @media (min-width: 640px) {
@@ -28,10 +28,10 @@
         flex-wrap: wrap;
     }
     .column:first-child {
-        flex-basis: 40%;
+        flex-basis: 50%;
     }
     .column:nth-child(2) {
-        flex-basis: 60%;
+        flex-basis: 50%;
     }
 }
 
@@ -47,10 +47,6 @@
     border-color: var(--color-mediumgray) !important;
 }
 @media (min-width: 640px) {
-    select.priority {
-        border-right: none;
-        padding-right: 0;
-    }
     .fee input {
         border-bottom-left-radius: 0;
         border-left: none;
@@ -105,8 +101,12 @@ select.priority {
     margin-top: 0;
 }
 
-.feeProposed {
-    text-align: right;
+.feeDescription {
+    margin: 0;
+}
+
+.feeDescription + .feeProposed {
+    margin: var(--space-quarter) 0 0 0;
 }
 
 .customFeeUnit {

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -22,7 +22,7 @@ import { load } from '../../../decorators/load';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet } from '../../../utils/request';
 import { CoinCode } from '../account';
-import { isBitcoinBased } from '../utils';
+import { getCoinCode, isBitcoinBased } from '../utils';
 import * as style from './feetargets.css';
 import { AmountWithConversions } from './send';
 
@@ -124,6 +124,7 @@ class FeeTargets extends Component<Props, State> {
     public render(
     {
         t,
+        coinCode,
         disabled,
         error,
         showCalculatingFeeLabel = false,
@@ -149,60 +150,78 @@ class FeeTargets extends Component<Props, State> {
         const preventFocus = document.activeElement && document.activeElement.nodeName === 'INPUT';
         return (
             hasOptions ? (
-                <div className={isCustom ? style.rowCustomFee : style.row}>
-                    <div className={style.column}>
-                        <Select
-                            className={style.priority}
-                            label={t('send.priority')}
-                            id="feeTarget"
-                            disabled={disabled}
-                            onChange={this.handleFeeTargetChange}
-                            selected={feeTarget}
-                            options={options} />
-                    </div>
-                    <div className={style.column}>
-                        {showCalculatingFeeLabel && !isCustom ? (
+                <div>
+                    {!isCustom ? (
+                        showCalculatingFeeLabel ? (
                             <Input
-                                align="right"
-                                className={style.fee}
                                 disabled
-                                label={t('send.fee.label')}
+                                label={t('send.priority')}
                                 placeholder={t('send.feeTarget.placeholder')}
-                                transparent
-                            />
+                                transparent />
                         ) : (
-                            <Input
-                                type={(disabled || !isCustom) ? 'text' : 'number'}
-                                min="0"
-                                step="any"
-                                autoFocus={isCustom && !preventFocus}
-                                align="right"
-                                className={`${style.fee} ${isCustom ? style.feeCustom : ''}`}
-                                disabled={disabled || !isCustom}
-                                label={t('send.fee.label')}
-                                id="proposedFee"
-                                placeholder={isCustom ? t('send.fee.customPlaceholder') : ''}
-                                error={error}
-                                transparent
-                                onInput={this.handleFeePerByte}
-                                getRef={input => !disabled && input && input.autofocus && input.focus()}
-                                value={isCustom ? feePerByte : proposeFeeText}
-                            >
-                                {isCustom && (<span className={style.customFeeUnit}>sat/vB</span>)}
-                            </Input>
-                        )}
-                    </div>
-                    { feeTarget && (
-                        isCustom ? (
-                            <p class={style.feeProposed}>
-                                {showCalculatingFeeLabel ? t('send.feeTarget.placeholder') : proposeFeeText}
-                            </p>
-                        ) : (
-                            <div>
-                                <label>{t('send.feeTarget.estimate')}</label>
-                                <p class={style.feeDescription}>{t('send.feeTarget.description.' + feeTarget)}</p>
-                            </div>
+                            <Select
+                                className={style.priority}
+                                label={t('send.priority')}
+                                id="feeTarget"
+                                disabled={disabled}
+                                onChange={this.handleFeeTargetChange}
+                                selected={feeTarget}
+                                value={feeTarget}
+                                options={options} />
                         )
+                    ) : (
+                        <div className={style.rowCustomFee}>
+                            <div className={style.column}>
+                                <Select
+                                    className={style.priority}
+                                    label={t('send.priority')}
+                                    id="feeTarget"
+                                    disabled={disabled}
+                                    onChange={this.handleFeeTargetChange}
+                                    selected={feeTarget}
+                                    value={feeTarget}
+                                    options={options} />
+                            </div>
+                            <div className={style.column}>
+                                <Input
+                                    type={disabled ? 'text' : 'number'}
+                                    min="0"
+                                    step="any"
+                                    autoFocus={!preventFocus}
+                                    align="right"
+                                    className={`${style.fee} ${style.feeCustom}`}
+                                    disabled={disabled}
+                                    label={t('send.fee.label')}
+                                    id="proposedFee"
+                                    placeholder={t('send.fee.customPlaceholder')}
+                                    error={error}
+                                    transparent
+                                    onInput={this.handleFeePerByte}
+                                    getRef={input => !disabled && input && input.autofocus && input.focus()}
+                                    value={feePerByte}
+                                >
+                                    <span className={style.customFeeUnit}>sat/vB</span>
+                                </Input>
+                            </div>
+                        </div>
+                    )}
+                    { feeTarget && (
+                        <div>
+                            { !isCustom ? (
+                                <p class={style.feeDescription}>
+                                    {t('send.feeTarget.estimate')}
+                                    {' '}
+                                    {t(`send.feeTarget.description.${getCoinCode(coinCode)}.${feeTarget}`)}
+                                </p>
+                            ) : null }
+                            {(showCalculatingFeeLabel || proposeFeeText ? (
+                                <p class={style.feeProposed}>
+                                    {t('send.fee.label')}:
+                                    {' '}
+                                    {showCalculatingFeeLabel ? t('send.feeTarget.placeholder') : proposeFeeText}
+                                </p>
+                            ) : null)}
+                        </div>
                     )}
                 </div>
             ) : (

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -673,7 +673,20 @@ class Send extends Component<Props, State> {
                                                 placeholder={t('send.amount.placeholder')} />
                                         </div>
                                     </div>
-                                    <div className="columns columns-onlylarge">
+                                    <div className="columns">
+                                        <div className="column column-1-2 m-bottom-half">
+                                            <FeeTargets
+                                                accountCode={account.code}
+                                                coinCode={account.coinCode}
+                                                disabled={!amount && !sendAll}
+                                                fiatUnit={fiatUnit}
+                                                proposedFee={proposedFee}
+                                                feePerByte={feePerByte}
+                                                showCalculatingFeeLabel={isUpdatingProposal}
+                                                onFeeTargetChange={this.feeTargetChange}
+                                                onFeePerByte={fee => this.setState({ feePerByte: fee }, this.validateAndDisplayFee)}
+                                                error={feeError}/>
+                                        </div>
                                         <div className="column column-1-2">
                                             <Input
                                                 label={t('note.title')}
@@ -686,19 +699,6 @@ class Send extends Component<Props, State> {
                                                 onInput={this.handleNoteInput}
                                                 value={note}
                                                 placeholder={t('note.input.placeholder')} />
-                                        </div>
-                                        <div className="column column-1-2">
-                                            <FeeTargets
-                                                accountCode={account.code}
-                                                coinCode={account.coinCode}
-                                                disabled={!amount && !sendAll}
-                                                fiatUnit={fiatUnit}
-                                                proposedFee={proposedFee}
-                                                feePerByte={feePerByte}
-                                                showCalculatingFeeLabel={isUpdatingProposal}
-                                                onFeeTargetChange={this.feeTargetChange}
-                                                onFeePerByte={fee => this.setState({ feePerByte: fee }, this.validateAndDisplayFee)}
-                                                error={feeError}/>
                                         </div>
                                     </div>
                                 </div>
@@ -717,7 +717,7 @@ class Send extends Component<Props, State> {
                                     )
                                     */
                                 }
-                                <div class="buttons ignore reverse">
+                                <div class="buttons ignore reverse m-top-none">
                                     <Button
                                         primary
                                         onClick={this.send}

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2020 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,9 @@
  * limitations under the License.
  */
 
-export function isBitcoinBased(coinCode: string): boolean {
+import { CoinCode } from './account';
+
+export function isBitcoinBased(coinCode: CoinCode): boolean {
     switch (coinCode) {
     case 'btc':
     case 'tbtc':
@@ -26,6 +29,21 @@ export function isBitcoinBased(coinCode: string): boolean {
     }
 }
 
-export function isEthereumBased(coinCode: string): boolean {
+export function isEthereumBased(coinCode: CoinCode): boolean {
     return coinCode === 'eth' || coinCode.startsWith('eth-erc20-');
+}
+
+export function getCoinCode(coinCode: CoinCode): CoinCode | undefined {
+    switch (coinCode) {
+        case 'btc':
+        case 'tbtc':
+            return 'btc';
+        case 'ltc':
+        case 'tltc':
+            return 'ltc';
+        case 'eth':
+        case 'teth':
+        case 'reth':
+            return 'eth';
+    }
 }

--- a/frontends/web/src/style/grid.css
+++ b/frontends/web/src/style/grid.css
@@ -79,14 +79,6 @@
     margin-bottom: 0;
 }
 
-@media (max-width: 1348px) {
-
-    .columns.columns-onlylarge .column {
-        width: calc(100% - (var(--space-half) * 2)) !important;
-    }
-
-}
-
 @media (max-width: 768px) {
     .columnsContainer {
         margin-right: calc(var(--space-half) * -1);
@@ -119,9 +111,5 @@
 
     .columns .column.column-1-3 {
         width: calc((100% - (var(--space-half) * 3)) / 3);
-    }
-
-    .columns.columns-onlylarge .column {
-        width: calc(100% - var(--space-half)) !important;
     }
 }


### PR DESCRIPTION
Addresses https://github.com/digitalbitbox/bitbox-wallet-app/pull/989#issuecomment-687723523

TODO: 
- locize rename and split the info in `send.feeTarget.description`

Screenshots:

![Screen Shot 2020-09-07 at 6 25 59 PM](https://user-images.githubusercontent.com/546900/92406511-7e70b680-f138-11ea-98ec-5e35f8cdc47b.png)
![Screen Shot 2020-09-07 at 6 25 48 PM](https://user-images.githubusercontent.com/546900/92406514-7fa1e380-f138-11ea-9c91-81e42ca7c6e6.png)
![Screen Shot 2020-09-07 at 6 26 27 PM](https://user-images.githubusercontent.com/546900/92406530-87618800-f138-11ea-89ec-2fdf3cbe7ed0.png)
![Screen Shot 2020-09-07 at 6 26 37 PM](https://user-images.githubusercontent.com/546900/92406532-87fa1e80-f138-11ea-8a5e-8942b3d20384.png)
