### PR TITLE
frontend/feeTargets: save the estimation translations

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1185,18 +1185,14 @@
     },
     "feeTarget": {
       "description": {
-        "btc": {
-          "economy": "4 hours (24 blocks)",
-          "high": "20 minutes (2 blocks)",
-          "low": "2 hours (12 blocks)",
-          "normal": "1 hour (6 blocks)"
-        },
-        "ltc": {
-          "economy": "1 hour (24 blocks)",
-          "high": "5 minutes (2 blocks)",
-          "low": "30 minutes (12 blocks)",
-          "normal": "15 minutes (6 blocks)"
-        }
+        "economy": "4 hours (24 blocks)",
+        "economy_ltc": "1 hour (24 blocks)",
+        "high": "20 minutes (2 blocks)",
+        "high_ltc": "5 minutes (2 blocks)",
+        "low": "2 hours (12 blocks)",
+        "low_ltc": "30 minutes (12 blocks)",
+        "normal": "1 hour (6 blocks)",
+        "normal_ltc": "15 minutes (6 blocks)"
       },
       "estimate": "Estimated confirmation time:",
       "label": {

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -211,7 +211,9 @@ class FeeTargets extends Component<Props, State> {
                                 <p class={style.feeDescription}>
                                     {t('send.feeTarget.estimate')}
                                     {' '}
-                                    {t(`send.feeTarget.description.${getCoinCode(coinCode)}.${feeTarget}`)}
+                                    {t(`send.feeTarget.description.${feeTarget}`, {
+                                        context: getCoinCode(coinCode) || '',
+                                    })}
                                 </p>
                             ) : null }
                             {(showCalculatingFeeLabel || proposeFeeText ? (


### PR DESCRIPTION
c38dd0fc63704d290f1b552c67a1022f108ff8bd changed the translation keys,
which means all translations are lost.

Since it is only a text modification, it is best to keep the keys, so
the previous translations are marked for review instead of being
deleted.

The context field can be be translated with `_context` keys,
e.g. `_ltc`. If the translation is missing, it falls back to the key
without context.