### PR TITLE
frontend/send: no autoformatting of custom fee rate

### DIFF
--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -38,10 +38,10 @@ interface FeeTargetsProps {
     disabled: boolean;
     fiatUnit: Fiat;
     proposedFee?: AmountWithConversions;
-    feePerByte: number;
+    feePerByte: string;
     showCalculatingFeeLabel?: boolean;
     onFeeTargetChange: (code: Code) => void;
-    onFeePerByte: (feePerByte: number) => void;
+    onFeePerByte: (feePerByte: string) => void;
     error?: string;
 }
 
@@ -104,7 +104,7 @@ class FeeTargets extends Component<Props, State> {
 
     private handleFeePerByte = (event: Event) => {
         const target = event.target as HTMLInputElement;
-        this.props.onFeePerByte(Number(target.value));
+        this.props.onFeePerByte(target.value);
     }
 
     private setFeeTarget = (feeTarget: Code) => {

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -83,7 +83,7 @@ interface State {
     fiatUnit: Fiat;
     sendAll: boolean;
     feeTarget?: FeeCode;
-    feePerByte: number;
+    feePerByte: string;
     isConfirming: boolean;
     isSent: boolean;
     isAborted: boolean;
@@ -134,7 +134,7 @@ class Send extends Component<Props, State> {
         activeScanQR: false,
         videoLoading: false,
         note: '',
-        feePerByte: 1,
+        feePerByte: '',
     };
 
     private coinSupportsCoinControl = () => {
@@ -234,7 +234,7 @@ class Send extends Component<Props, State> {
                     amount: undefined,
                     data: undefined,
                     note: '',
-                    feePerByte: 1,
+                    feePerByte: '',
                 });
                 if (this.utxos) {
                     (this.utxos as any).getWrappedInstance().clear();
@@ -268,7 +268,7 @@ class Send extends Component<Props, State> {
 
     private sendDisabled = () => {
         const txInput = this.txInput();
-        return !txInput.address || this.state.feeTarget === undefined || (txInput.sendAll === 'no' && !txInput.amount);
+        return !txInput.address || this.state.feeTarget === undefined || (txInput.sendAll === 'no' && !txInput.amount) || (this.state.feeTarget === 'custom' && !this.state.feePerByte);
     }
 
     private validateAndDisplayFee = (updateFiat: boolean = true) => {

--- a/frontends/web/test/routes/account/send/feetargets.test.tsx
+++ b/frontends/web/test/routes/account/send/feetargets.test.tsx
@@ -75,7 +75,7 @@ describe('routes/account/send/feetargets', () => {
                         USD: '0.02',
                     },
                 }}
-                feePerByte={1}
+                feePerByte=""
                 onFeePerByte={jest.fn()}
                 onFeeTargetChange={jest.fn()} />,
         );
@@ -94,7 +94,7 @@ describe('routes/account/send/feetargets', () => {
                 coinCode="eth"
                 disabled={false}
                 fiatUnit="EUR"
-                feePerByte={1}
+                feePerByte=""
                 onFeePerByte={jest.fn()}
                 onFeeTargetChange={jest.fn()} />,
         );
@@ -121,7 +121,7 @@ describe('routes/account/send/feetargets', () => {
                 coinCode="btc"
                 disabled={false}
                 fiatUnit="USD"
-                feePerByte={1}
+                feePerByte=""
                 onFeePerByte={jest.fn()}
                 onFeeTargetChange={onFeeTargetChangeCB} />,
         );


### PR DESCRIPTION
The `Number()` conversion automatically cut off e.g. a zero, so it was
impossible to enter `1.01` without it being truncated back to `1` when
entering `1.0`.

Also, a default rate of `1` might not be good.

Solution: treat the fee rate as a string, like the amount, and let the
backend convert/validate.