### PR TITLE
frontend: focus custom fee input and rearange fee info

### DIFF
--- a/frontends/web/src/components/dialog/dialog.css
+++ b/frontends/web/src/components/dialog/dialog.css
@@ -21,7 +21,7 @@
 .modal {
     background-color: white;
     width: 100%;
-    max-width: 380px;
+    max-width: 420px;
     border-radius: 2px;
     box-shadow: 0px 3px 5px rgba(0, 0, 0, 0.3);
     text-align: left;

--- a/frontends/web/src/components/forms/select.css
+++ b/frontends/web/src/components/forms/select.css
@@ -1,7 +1,7 @@
 .select {
-    width: 100%;
     margin-bottom: var(--space-half);
     position: relative;
+    width: 100%;
 }
 
 .select label {
@@ -12,6 +12,9 @@
 .select select {
     appearance: none;
     background-color: var(--color-white);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-labelledby='chevron down' color='%23777'%3E%3Cdefs/%3E%3Cpolyline points='6 10 12 16 18 10'/%3E%3C/svg%3E%0A");
+    background-position: calc(100% - 12px);
+    background-repeat: no-repeat;
     border: solid 1px var(--color-mediumgray);
     border-radius: 2px;
     color: var(--color-default);
@@ -21,6 +24,10 @@
     height: 52px;
     padding: 0 var(--space-half);
     width: 100%;
+}
+
+.select select[disabled] {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-labelledby='chevron down' color='%23ccc'%3E%3Cdefs/%3E%3Cpolyline points='6 10 12 16 18 10'/%3E%3C/svg%3E%0A");
 }
 
 .select option {

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -197,7 +197,13 @@ class FeeTargets extends Component<Props, State> {
                                     error={error}
                                     transparent
                                     onInput={this.handleFeePerByte}
-                                    getRef={input => !disabled && input && input.autofocus && input.focus()}
+                                    getRef={input => {
+                                        setTimeout(() => {
+                                            if (!disabled && input && input.autofocus) {
+                                                input.focus();
+                                            }
+                                        });
+                                    }}
                                     value={feePerByte}
                                 >
                                     <span className={style.customFeeUnit}>sat/vB</span>
@@ -207,6 +213,13 @@ class FeeTargets extends Component<Props, State> {
                     )}
                     { feeTarget && (
                         <div>
+                            {(showCalculatingFeeLabel || proposeFeeText ? (
+                                <p class={style.feeProposed}>
+                                    {t('send.fee.label')}:
+                                    {' '}
+                                    {showCalculatingFeeLabel ? t('send.feeTarget.placeholder') : proposeFeeText}
+                                </p>
+                            ) : null)}
                             { !isCustom ? (
                                 <p class={style.feeDescription}>
                                     {t('send.feeTarget.estimate')}
@@ -216,13 +229,6 @@ class FeeTargets extends Component<Props, State> {
                                     })}
                                 </p>
                             ) : null }
-                            {(showCalculatingFeeLabel || proposeFeeText ? (
-                                <p class={style.feeProposed}>
-                                    {t('send.fee.label')}:
-                                    {' '}
-                                    {showCalculatingFeeLabel ? t('send.feeTarget.placeholder') : proposeFeeText}
-                                </p>
-                            ) : null)}
                         </div>
                     )}
                 </div>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -748,10 +748,10 @@ class Send extends Component<Props, State> {
                                 <div className={style.confirmItem}>
                                     <label>{t('send.amount.label')}</label>
                                     <p>
-                                        <span>{proposedAmount && proposedAmount.amount || 'N/A'} {proposedAmount && proposedAmount.unit || 'N/A'}</span>
+                                        <span>{proposedAmount && proposedAmount.amount || 'N/A'} <small>{proposedAmount && proposedAmount.unit || 'N/A'}</small></span>
                                         {
                                             proposedAmount && proposedAmount.conversions && (
-                                                <span> <span className="text-gray">/</span> {proposedAmount.conversions[fiatUnit]} {fiatUnit}</span>
+                                                <span> <span className="text-gray">/</span> {proposedAmount.conversions[fiatUnit]} <small>{fiatUnit}</small></span>
                                             )
                                         }
                                     </p>
@@ -765,12 +765,16 @@ class Send extends Component<Props, State> {
                                 <div className={style.confirmItem}>
                                     <label>{t('send.fee.label')}{feeTarget ? ' (' + t(`send.feeTarget.label.${feeTarget}`) + ')' : ''}</label>
                                     <p>
-                                        <span>{proposedFee && proposedFee.amount || 'N/A'} {proposedFee && proposedFee.unit || 'N/A'}</span>
-                                        {
-                                            proposedFee && proposedFee.conversions && (
-                                                <span> <span className="text-gray">/</span> {proposedFee.conversions[fiatUnit]} {fiatUnit}</span>
-                                            )
-                                        }
+                                        <span key="amount">{proposedFee && proposedFee.amount || 'N/A'} <small>{proposedFee && proposedFee.unit || 'N/A'}</small></span>
+                                        {proposedFee && proposedFee.conversions && (
+                                            <span key="conversation">
+                                                <span className="text-gray"> / </span>
+                                                {proposedFee.conversions[fiatUnit]} <small>{fiatUnit}</small>
+                                            </span>
+                                        )}
+                                        {feePerByte ? (
+                                            <span key="feeperbyte"><br/><small>({feePerByte} sat/vB)</small></span>
+                                        ) : null}
                                     </p>
                                 </div>
                                 {
@@ -788,12 +792,10 @@ class Send extends Component<Props, State> {
                                 <div className={[style.confirmItem, style.total].join(' ')}>
                                     <label>{t('send.confirm.total')}</label>
                                     <p>
-                                        <span>{proposedTotal && proposedTotal.amount || 'N/A'} {proposedTotal && proposedTotal.unit || 'N/A'}</span>
-                                        {
-                                            (proposedTotal && proposedTotal.conversions) && (
-                                                <span> <span className="text-gray">/</span> {proposedTotal.conversions[fiatUnit]} {fiatUnit}</span>
-                                            )
-                                        }
+                                        <span><strong>{proposedTotal && proposedTotal.amount || 'N/A'}</strong> <small>{proposedTotal && proposedTotal.unit || 'N/A'}</small></span>
+                                        {(proposedTotal && proposedTotal.conversions) && (
+                                            <span> <span className="text-gray">/</span> <strong>{proposedTotal.conversions[fiatUnit]}</strong> <small>{fiatUnit}</small></span>
+                                        )}
                                     </p>
                                 </div>
                             </WaitDialog>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -434,8 +434,10 @@ class Send extends Component<Props, State> {
     }
 
     private feeTargetChange = (feeTarget: FeeCode) => {
-        this.setState({ feeTarget });
-        this.validateAndDisplayFee(this.state.sendAll);
+        this.setState(
+            { feeTarget, feePerByte: '' },
+            () => this.validateAndDisplayFee(this.state.sendAll),
+        );
     }
 
     private onSelectedUTXOsChange = (selectedUTXOs: SelectedUTXO) => {


### PR DESCRIPTION
The input focus stopped working after last rearrangement.
This fix delays calling input.focus as somewhat the input
is not ready at render to be focused.

This change also swaps network fee info and conditional
estimated confirmation time, as the fee is always displayed
and it is less flickering.

![Screen Shot 2020-09-16 at 8 03 52 AM](https://user-images.githubusercontent.com/546900/93298285-41b95500-f7f3-11ea-9b29-cc8024ca1562.png)
