### PR TITLE
appveyor: use newer version of nodejs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 image: Visual Studio 2017
 
 environment:
+  nodejs_version: "12"
   matrix:
     - QT: C:\Qt\5.11.3\msvc2017_64
       GO: C:\go
@@ -10,6 +11,9 @@ environment:
 
 # https://www.appveyor.com/docs/windows-images-software/#golang
 stack: go 1.14
+
+install:
+  - ps: Install-Product node $env:nodejs_version
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Attempt to fix this CI error:

warning sha.js@2.4.11: Invalid bin entry for "sha.js" (in "sha.js").
info fsevents@1.2.9: The platform "win32" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
error compression-webpack-plugin@4.0.1: The engine "node" is incompatible with this module. Expected version ">= 10.13.0". Got "8.17.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
make[1]: *** [Makefile:54: buildweb] Error 1
make[1]: Leaving directory 'C:/gopath/src/github.com/digitalbitbox/bitbox-wallet-app'
make: *** [Makefile:72: qt-windows] Error 2