### PR TITLE
ci: skip macos homebrew auto-update on github runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,12 +106,21 @@ jobs:
       - name: Enable caching
         uses: actions/cache@v2
         with:
-          key: ${{runner.os}}-qt-osx
+          # The key version is just an incremental number.
+          # Bump it every time there are changes in CI scripts.
+          key: ${{runner.os}}-qt-osx-v2
           path: |
             frontends/web/node_modules
             ~/Library/Caches/Homebrew
       - name: Build macOS app
-        run: ./scripts/travis-ci.sh qt-osx
+        # Unlike Travis where Go is pre-installed, GitHub has none so we use homebrew
+        # but prevent the very long update process because go1.14 already present
+        # in their database.
+        run: >
+          export HOMEBREW_NO_AUTO_UPDATE=1;
+          brew install go@1.14;
+          export PATH=/usr/local/opt/go@1.14/bin:$PATH;
+          ./scripts/travis-ci.sh qt-osx;
         env:
           TRAVIS_OS_NAME: osx
       - name: Archive app

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -28,8 +28,9 @@ fi
 
 # The following is executed only on macOS machines.
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew install go@1.14
-    export PATH=/usr/local/opt/go@1.14/bin:$PATH
+    # Go is pre-installed according to the settings in .travis.yml.
+    # GitHub CI installs it directly in the macos action, before executing
+    # this script.
     go version
     brew install qt
     # Install yarn only if it isn't already.


### PR DESCRIPTION
The auto-update seems to be erroring out which prevents the whole job to continue on GitHub CI.
Travis on the other hand already has Go preinstalled, as configured in .travis.yml.