### PR TITLE
android: separate appID and app display name for debug builds

### DIFF
--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -15,6 +15,11 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            resValue "string", "app_name", "BitBoxApp"
+        }
+        debug {
+            applicationIdSuffix ".debug"
+            resValue "string", "app_name", "BitBoxApp DEBUG"
         }
     }
 }

--- a/frontends/android/BitBoxApp/app/src/main/res/values/strings.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/values/strings.xml
@@ -1,3 +1,2 @@
 <resources>
-    <string name="app_name">BitBoxApp</string>
 </resources>


### PR DESCRIPTION
I don't want to uninstall my main app to test a new build. This will
install a separate app if build in debug mode.