### PR TITLE
Frontend: disable eslint rule lines-around-comment

### DIFF
--- a/frontends/web/.eslintrc.js
+++ b/frontends/web/.eslintrc.js
@@ -74,7 +74,6 @@ module.exports = {
     // "key-spacing": 2,
     "key-spacing": "off",
     "keyword-spacing": 2,
-    // "lines-around-comment": 2,
     "lines-around-comment": "off",
     "new-cap": 1,
     "new-parens": 2,


### PR DESCRIPTION
Tried with beforeBlockComment, allowBlockStart, allowObjectStart but
a comment between arugument destruction and another comment in a
commented out jsx block always errored, therefore completelly
disabled this rule.