### PR TITLE
Frontend: eslint inlucde .eslintrc

### DIFF
--- a/frontends/web/.eslintrc.js
+++ b/frontends/web/.eslintrc.js
@@ -1,3 +1,5 @@
+/* eslint quotes: "off", quote-props: "off" */
+
 module.exports = {
   "env": {
     "browser": true
@@ -17,7 +19,7 @@ module.exports = {
     "ecmaFeatures": {
       "jsx": true
     },
-    "project": require.resolve("./tsconfig.json"),
+    "project": require.resolve("./tsconfig.eslint.json"),
   },
   "settings": {
     "react": {

--- a/frontends/web/tsconfig.eslint.json
+++ b/frontends/web/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "include": [
+      "src/**/*",
+      ".eslintrc.js"
+  ]
+}


### PR DESCRIPTION
Including .eslintrc fixed the following error:
Parsing error: parserOptions.project has been set for @typescript-eslint/parser.
The file does not match your project config: frontends/web/.eslintrc.js.
The file must be included in at least one of the projects provided.eslint