### PR TITLE
backend/rates: support historical exchange rates for all coins

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -196,6 +196,38 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	backend.ratesUpdater = rates.NewRateUpdater(hclient)
 	backend.ratesUpdater.Observe(backend.Notify)
 	backend.ratesUpdater.Start()
+	for _, fiat := range config.AppConfig().Backend.FiatList {
+		if config.AppConfig().Backend.CoinActive(coin.CodeBTC) {
+			backend.ratesUpdater.EnableHistoryPair("BTC", fiat)
+		}
+		if config.AppConfig().Backend.CoinActive(coin.CodeTBTC) {
+			backend.ratesUpdater.EnableHistoryPair("TBTC", fiat)
+		}
+		if config.AppConfig().Backend.CoinActive(coin.CodeRBTC) {
+			backend.ratesUpdater.EnableHistoryPair("RBTC", fiat)
+		}
+		if config.AppConfig().Backend.CoinActive(coin.CodeLTC) {
+			backend.ratesUpdater.EnableHistoryPair("LTC", fiat)
+		}
+		if config.AppConfig().Backend.CoinActive(coin.CodeTLTC) {
+			backend.ratesUpdater.EnableHistoryPair("TLTC", fiat)
+		}
+		if config.AppConfig().Backend.CoinActive(coin.CodeETH) {
+			backend.ratesUpdater.EnableHistoryPair("ETH", fiat)
+		}
+		if config.AppConfig().Backend.CoinActive(coin.CodeTETH) {
+			backend.ratesUpdater.EnableHistoryPair("TETH", fiat)
+		}
+		if config.AppConfig().Backend.CoinActive(coin.CodeRETH) {
+			backend.ratesUpdater.EnableHistoryPair("RETH", fiat)
+		}
+		for _, token := range config.AppConfig().Backend.ETH.ActiveERC20Tokens {
+			// The prefix is stripped on the frontend and in app config.
+			// TODO: Unify the prefix with frontend and erc20.go, and possibly
+			// move all this with coins/coin/code or eth/erc20.
+			backend.ratesUpdater.EnableHistoryPair("eth-erc20-"+token, fiat)
+		}
+	}
 
 	backend.banners = banners.NewBanners()
 	backend.banners.Observe(backend.Notify)

--- a/backend/erc20.go
+++ b/backend/erc20.go
@@ -30,6 +30,8 @@ type erc20Token struct {
 var erc20Tokens = []erc20Token{
 	// Note: if you change the coinCode from eth-erc20- to something else, make sure to check for
 	// instances of it in the frontend.
+	// The frontend sends them to the backend to store in the config without the prefix
+	// in frontend/web/src/routes/settings/settings.tsx.
 	{
 		code:  "eth-erc20-usdt",
 		name:  "Tether USD",

--- a/backend/rates/history.go
+++ b/backend/rates/history.go
@@ -17,19 +17,27 @@ import (
 const coingeckoAPIV3 = "https://api.coingecko.com/api/v3"
 
 var (
-	// Copied from https://api.coingecko.com/api/v3/coins/list.
-	// The keyes must match entries in coins slice.
+	// Values are copied from https://api.coingecko.com/api/v3/coins/list.
+	// TODO: Replace keys with coin.Code.
 	geckoCoin = map[string]string{
-		"BTC":  "bitcoin",
-		"LTC":  "litecoin",
-		"ETH":  "ethereum",
-		"USDT": "tether",
-		"LINK": "chainlink",
-		"MKR":  "maker",
-		"ZRX":  "0x",
-		"DAI":  "dai",
-		"BAT":  "basic-attention-token",
-		"USDC": "usd-coin",
+		"BTC": "bitcoin",
+		"LTC": "litecoin",
+		"ETH": "ethereum",
+		// Useful for testing with testnets.
+		"TBTC": "bitcoin",
+		"RBTC": "bitcoin",
+		"TLTC": "litecoin",
+		"TETH": "ethereum",
+		"RETH": "ethereum",
+		// ERC20 tokens as used in the backend.
+		// Frontend and app config use unprefixed name, without "eth-erc20-".
+		"eth-erc20-bat":  "basic-attention-token",
+		"eth-erc20-dai":  "dai",
+		"eth-erc20-link": "chainlink",
+		"eth-erc20-mkr":  "maker",
+		"eth-erc20-usdc": "usd-coin",
+		"eth-erc20-usdt": "tether",
+		"eth-erc20-zrx":  "0x",
 	}
 
 	// Copied from https://api.coingecko.com/api/v3/simple/supported_vs_currencies.
@@ -49,16 +57,38 @@ var (
 	}
 )
 
+// EnableHistoryPair spins up a new goroutine to periodically update
+// and backfill historical exchange rates.
+// If a pair is unsupported or already enabled, EnableHistoryPair does nothing.
+// The fiat arg is expected to be uppercase. Supported fiats are currently hardcoded
+// in the unexported geckFiat map in this package.
+func (updater *RateUpdater) EnableHistoryPair(coin, fiat string) {
+	if geckoCoin[coin] == "" || geckoFiat[fiat] == "" {
+		updater.log.Errorf("EnableHistoryPair(%q, %q): unsupported coin or fiat", coin, fiat)
+		return
+	}
+	key := coin + fiat
+	updater.historyMu.Lock()
+	defer updater.historyMu.Unlock()
+	if _, exist := updater.historyGo[key]; exist {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	updater.historyGo[key] = cancel
+	go updater.historyUpdateLoop(ctx, coin, fiat)
+	go updater.backfillHistory(ctx, coin, fiat)
+}
+
 // historyUpdateLoop periodically updates historical market exchange rates
-// forward in time starting with the last fetched timestamp.
-// It never returns.
-func (updater *RateUpdater) historyUpdateLoop() {
+// forward in time starting with the last fetched timestamp in a loop.
+// It returns when the context is done.
+func (updater *RateUpdater) historyUpdateLoop(ctx context.Context, coin, fiat string) {
+	updater.log.Printf("started historyUpdateLoop for %s/%s", coin, fiat)
 	for {
 		// When to update next, after this loop iteration is done.
 		untilNext := 10 * time.Minute // TODO: add jitter
 
-		// TODO: Do this for all supported coins.
-		start := updater.historyLatestTimestamp("BTC")
+		start := updater.historyLatestTimestamp(coin, fiat)
 		// When zero, there's no point in fetching data here because the backfillHistory
 		// will kick in and fill it up for the past 90 days anyway.
 		if !start.IsZero() {
@@ -69,30 +99,37 @@ func (updater *RateUpdater) historyUpdateLoop() {
 			// It's ok if start == now or now < start. CoinGecko simply returns no results.
 			// It's also ok if our "now" doesn't match CoinGecko: it always returns
 			// the latest available data without errors.
-			// TODO: Do this for all supported fiats.
-			_, err := updater.updateHistory("BTC", "USD", start, now)
+			_, err := updater.updateHistory(ctx, coin, fiat, start, now)
+			// If ctx is done, this is ctx.Err() but we don't care because the <-ctx.Done()
+			// select below will take care of it and exit.
 			if err != nil {
-				updater.log.Errorf("updateHistory(%v, %v): %v", start, now, err)
+				updater.log.Errorf("updateHistory(%s, %s, %s, %s): %v", coin, fiat, start, now, err)
 				untilNext = time.Minute // TODO: exponential backoff
 			}
 		}
 
-		time.Sleep(untilNext)
+		select {
+		case <-ctx.Done():
+			updater.log.Printf("stopped historyUpdateLoop for %s/%s: %v", coin, fiat, ctx.Err())
+			return
+		case <-time.After(untilNext):
+			// continue next iteration
+		}
 	}
 }
 
 // backfillHistory fetches historical market exchange rates starting with
 // the earliest fetched timestamp backwards until data is available at the API endpoint.
 //
-// It does so in a loop and returns only after all data is backfilled.
+// It does so in a loop and returns only after all data is backfilled or the context is done.
 // Callers are expected to run this in a separate goroutine.
-func (updater *RateUpdater) backfillHistory() {
+func (updater *RateUpdater) backfillHistory(ctx context.Context, coin, fiat string) {
+	updater.log.Printf("started backfillHistory for %s/%s", coin, fiat)
 	for {
 		// When to update next, after this loop iteration is done.
 		untilNext := time.Second // TODO: add jitter
 
-		// TODO: Do this for all supported coins.
-		end := updater.historyEarliestTimestamp("BTC")
+		end := updater.historyEarliestTimestamp(coin, fiat)
 		var start time.Time
 		if end.IsZero() {
 			// First time; don't have historical data yet.
@@ -107,10 +144,11 @@ func (updater *RateUpdater) backfillHistory() {
 			start = end.Add(-365 * 24 * time.Hour)
 		}
 
-		// TODO: Do this for all supported fiats.
-		n, err := updater.updateHistory("BTC", "USD", start, end)
+		n, err := updater.updateHistory(ctx, coin, fiat, start, end)
+		// If ctx is done, this is ctx.Err() but we don't care because the <-ctx.Done()
+		// select below will take care of it and exit.
 		if err != nil {
-			updater.log.Printf("updateHistory(%s, %s): %v", start, end, err)
+			updater.log.Printf("updateHistory(%s, %s, %s, %s): %v", coin, fiat, start, end, err)
 			untilNext = time.Minute // TODO: exponential backoff
 		}
 		// CoinGecko returns an empty list if we're too far back in history.
@@ -124,47 +162,56 @@ func (updater *RateUpdater) backfillHistory() {
 			untilNext = time.Minute // TODO: exponential backoff
 		}
 
-		time.Sleep(untilNext)
+		select {
+		case <-ctx.Done():
+			updater.log.Printf("stopped backfillHistory for %s/%s: %v", coin, fiat, ctx.Err())
+			return
+		case <-time.After(untilNext):
+			// continue next iteration
+		}
 	}
 }
 
 // updateHistory fetches and stores historical data for later use.
 // It returns a number of the newly fetched and stored entries.
 // The data is stored in updater.history.
-func (updater *RateUpdater) updateHistory(coin, fiat string, start, end time.Time) (n int, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+func (updater *RateUpdater) updateHistory(ctx context.Context, coin, fiat string, start, end time.Time) (n int, err error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	rates, err := updater.fetchGeckoMarketRange(ctx, coin, fiat, start, end)
 	if err != nil {
 		return 0, err
 	}
 
+	key := coin + fiat
 	updater.historyMu.Lock()
 	defer updater.historyMu.Unlock()
-	a := append(updater.history[coin], rates...)
+	a := append(updater.history[key], rates...)
 	sort.Slice(a, func(i, j int) bool {
 		return a[i].timestamp.Before(a[j].timestamp)
 	})
-	updater.history[coin] = a
+	updater.history[key] = a
 	return len(rates), nil
 }
 
-func (updater *RateUpdater) historyLatestTimestamp(coin string) time.Time {
+func (updater *RateUpdater) historyLatestTimestamp(coin, fiat string) time.Time {
+	key := coin + fiat
 	updater.historyMu.RLock()
 	defer updater.historyMu.RUnlock()
 	var t time.Time
-	if n := len(updater.history[coin]); n > 0 {
-		t = updater.history[coin][n-1].timestamp
+	if n := len(updater.history[key]); n > 0 {
+		t = updater.history[key][n-1].timestamp
 	}
 	return t
 }
 
-func (updater *RateUpdater) historyEarliestTimestamp(coin string) time.Time {
+func (updater *RateUpdater) historyEarliestTimestamp(coin, fiat string) time.Time {
+	key := coin + fiat
 	updater.historyMu.RLock()
 	defer updater.historyMu.RUnlock()
 	var t time.Time
-	if len(updater.history[coin]) > 0 {
-		t = updater.history[coin][0].timestamp
+	if len(updater.history[key]) > 0 {
+		t = updater.history[key][0].timestamp
 	}
 	return t
 }

--- a/backend/rates/history_test.go
+++ b/backend/rates/history_test.go
@@ -16,7 +16,7 @@ import (
 func TestPriceAt(t *testing.T) {
 	updater := NewRateUpdater(nil) // don't need to make HTTP requests
 	updater.history = map[string][]exchangeRate{
-		"BTC": {
+		"BTCUSD": {
 			{value: 2, timestamp: time.Date(2020, 9, 1, 0, 0, 0, 0, time.UTC)},
 			{value: 3, timestamp: time.Date(2020, 9, 2, 0, 0, 0, 0, time.UTC)},
 			{value: 5, timestamp: time.Date(2020, 9, 3, 0, 0, 0, 0, time.UTC)},
@@ -75,17 +75,18 @@ func TestUpdateHistory(t *testing.T) {
 	updater := NewRateUpdater(http.DefaultClient)
 	updater.coingeckoURL = ts.URL
 	updater.history = map[string][]exchangeRate{
-		"BTC": {
+		"BTCUSD": {
 			{value: 1.0, timestamp: time.Unix(1598832062, 0)}, // 2020-08-31 00:01:02
 			{value: 2.0, timestamp: time.Unix(1599091262, 0)}, // 2020-09-03 00:01:02
 		},
 	}
 
-	n, err := updater.updateHistory("BTC", "USD", time.Unix(wantStartUnix, 0), time.Unix(wantEndUnix, 0))
+	start, end := time.Unix(wantStartUnix, 0), time.Unix(wantEndUnix, 0)
+	n, err := updater.updateHistory(context.Background(), "BTC", "USD", start, end)
 	require.NoError(t, err, "updater.updateHistory err")
 	assert.Equal(t, 2, n, "updater.updateHistory n")
 	wantHistory := map[string][]exchangeRate{
-		"BTC": {
+		"BTCUSD": {
 			{value: 1.0, timestamp: time.Unix(1598832062, 0)}, // preexisting point
 			{value: 10000.0, timestamp: time.Unix(1598918700, 0)},
 			{value: 10001.0, timestamp: time.Unix(1598922501, 0)},

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -52,12 +52,12 @@ export const store = new Store<SharedProps>({
     selected: ['USD', 'EUR', 'CHF'],
 });
 
-apiGet('config').then(({ frontend }) => {
-    if (frontend && frontend.fiatCode) {
-        store.setState({ active: frontend.fiatCode });
+apiGet('config').then((appconf) => {
+    if (appconf.frontend && appconf.backend.mainFiat) {
+        store.setState({ active: appconf.backend.mainFiat });
     }
-    if (frontend && frontend.fiatList) {
-        store.setState({ selected: frontend.fiatList });
+    if (appconf.backend && appconf.backend.fiatList) {
+        store.setState({ selected: appconf.backend.fiatList });
     }
 });
 
@@ -70,7 +70,7 @@ export function setActiveFiat(fiat: Fiat): void {
         selectFiat(fiat);
     }
     store.setState({ active: fiat });
-    setConfig({ frontend: { fiatCode: fiat } });
+    setConfig({ backend: { mainFiat: fiat } });
 }
 
 export function rotateFiat(): void {
@@ -81,13 +81,13 @@ export function rotateFiat(): void {
 
 export function selectFiat(fiat: Fiat): void {
     const selected = [...store.state.selected, fiat];
-    setConfig({ frontend: { fiatList: selected } });
+    setConfig({ backend: { fiatList: selected } });
     store.setState({ selected });
 }
 
 export function unselectFiat(fiat: Fiat): void {
     const selected = store.state.selected.filter(item => !equal(item, fiat));
-    setConfig({ frontend: { fiatList: selected } });
+    setConfig({ backend: { fiatList: selected } });
     store.setState({ selected });
 }
 

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -59,6 +59,8 @@ class Settings extends Component<Props, State> {
         },
     ];
 
+    // Note: these are stored in the app config as is, without the "eth-erc20-" prefix,
+    // while backend uses the prefix in backend/erc20.go.
     private erc20TokenCodes = {
         usdt: 'Tether USD',
         usdc: 'USD Coin',


### PR DESCRIPTION
All active coin/fiat pairs are taken from the config on startup.
A follow up commit will make the updater enable/disable pairs
when the config is changed at runtime from the UI.

This migrates one bit of frontend's opaque config fiatList to the
backend side since both now need to be aware which fiat currencies
are active.