### PR TITLE
backend/accounts: fix timeseries computation for erc20 tokens

### DIFF
--- a/backend/accounts/transaction.go
+++ b/backend/accounts/transaction.go
@@ -66,6 +66,9 @@ type TransactionData struct {
 	// Fee is nil for a receiving tx. The fee is only displayed (and relevant) when sending funds
 	// from the wallet.
 	Fee *coin.Amount
+	// FeeIsDifferentUnit is true if the fee is paid in a different unit than the main transaction
+	// amount. Example: ERC20-tokens fees are paid in ETH.
+	FeeIsDifferentUnit bool
 	// Time of confirmation. nil for unconfirmed tx or when the headers are not synced yet.
 	Timestamp *time.Time
 	// TxID is the tx ID.
@@ -152,12 +155,12 @@ func NewOrderedTransactions(txs []*TransactionData) OrderedTransactions {
 		case TxTypeSend:
 			balance.Sub(balance, tx.Amount.BigInt())
 			// Subtract fee as well.
-			if tx.Fee != nil {
+			if tx.Fee != nil && !tx.FeeIsDifferentUnit {
 				balance.Sub(balance, tx.Fee.BigInt())
 			}
 		case TxTypeSendSelf:
 			// Subtract only fee.
-			if tx.Fee != nil {
+			if tx.Fee != nil && !tx.FeeIsDifferentUnit {
 				balance.Sub(balance, tx.Fee.BigInt())
 			}
 		}

--- a/backend/accounts/transaction_test.go
+++ b/backend/accounts/transaction_test.go
@@ -63,14 +63,23 @@ func TestOrderedTransactions(t *testing.T) {
 			Amount:    coin.NewAmountFromInt64(50),
 			Fee:       &fee,
 		},
+		{
+			Timestamp:          tt(time.Date(2020, 9, 22, 12, 0, 0, 0, time.UTC)),
+			Height:             220,
+			Type:               TxTypeSend,
+			Amount:             coin.NewAmountFromInt64(5),
+			Fee:                &fee,
+			FeeIsDifferentUnit: true,
+		},
 	}
 	ordered := NewOrderedTransactions(txs)
-	require.Equal(t, coin.NewAmountFromInt64(569), ordered[0].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(589), ordered[1].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(590), ordered[2].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(290), ordered[3].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(190), ordered[4].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(200), ordered[5].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(564), ordered[0].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(584), ordered[1].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(589), ordered[2].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(590), ordered[3].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(290), ordered[4].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(190), ordered[5].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(200), ordered[6].Balance)
 
 	timeseries, err := ordered.Timeseries(
 		time.Date(2020, 9, 9, 13, 0, 0, 0, time.UTC),

--- a/backend/coins/eth/types/types.go
+++ b/backend/coins/eth/types/types.go
@@ -108,7 +108,9 @@ func (txh *TransactionWithMetadata) TransactionData(
 
 	numConfirmations := txh.numConfirmations(tipHeight)
 	return &accounts.TransactionData{
-		Fee:                      txh.fee(),
+		Fee: txh.fee(),
+		// ERC20 token transaction pay fees in Ether.
+		FeeIsDifferentUnit:       erc20Token != nil,
 		Timestamp:                nil,
 		TxID:                     txh.TxID(),
 		InternalID:               txh.TxID(),


### PR DESCRIPTION
The fee is paid in Ether and is accounted for in the ETH account
already.