### PR TITLE
backend/rates: make historical rates settings configurable at runtime

### DIFF
--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -122,10 +122,11 @@ func (updater *RateUpdater) PriceAt(coin, fiat string, at time.Time) float64 {
 	return a.value + x*(b.value-a.value)
 }
 
-// Start spins up the updater's goroutines to periodically update current exchange rates.
+// StartCurrentRates spins up the updater's goroutines to periodically update current exchange rates.
 // It returns immediately.
-// To initiate historical exchange rates update, the callers can use EnableHistoryPair.
-func (updater *RateUpdater) Start() {
+// To initiate historical exchange rates update, the callers can use ConfigureHistory.
+// The current and historical exchange rates are independent from each other.
+func (updater *RateUpdater) StartCurrentRates() {
 	go updater.lastUpdateLoop()
 }
 

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -21,7 +21,7 @@ import { Store } from '../../decorators/store';
 import { setConfig } from '../../utils/config';
 import { equal } from '../../utils/equal';
 import { apiSubscribe } from '../../utils/event';
-import { apiGet } from '../../utils/request';
+import { apiGet, apiPost } from '../../utils/request';
 import * as style from './rates.css';
 
 export type MainnetCoin = 'BTC' | 'LTC' | 'ETH';
@@ -81,14 +81,24 @@ export function rotateFiat(): void {
 
 export function selectFiat(fiat: Fiat): void {
     const selected = [...store.state.selected, fiat];
-    setConfig({ backend: { fiatList: selected } });
-    store.setState({ selected });
+    setConfig({ backend: { fiatList: selected } })
+    .then(() => {
+        store.setState({ selected });
+        // Need to reconfigure currency exchange rates updater
+        // which is done during accounts reset.
+        apiPost('accounts/reinitialize');
+    });
 }
 
 export function unselectFiat(fiat: Fiat): void {
     const selected = store.state.selected.filter(item => !equal(item, fiat));
-    setConfig({ backend: { fiatList: selected } });
-    store.setState({ selected });
+    setConfig({ backend: { fiatList: selected } })
+    .then(() => {
+        store.setState({ selected });
+        // Need to reconfigure currency exchange rates updater
+        // which is done during accounts reset.
+        apiPost('accounts/reinitialize');
+    });
 }
 
 function formatAsCurrency(amount: number): string {


### PR DESCRIPTION
This is done in two places: at the backend startup and whenever active
coin accounts or selected fiats list changes. In both cases, all
historical rates goroutines are shut down and then started again
but only for the selected coin/fiat pairs.

Maybe a better way would've been to shut down only those goroutines
for which no coin or fiat is active anymore, but this complicates a
simple function and with an added jitter in a follow up commit will be
unnecessary.