### PR TITLE
backend/rates: stop all RateUpdater's goroutines when Close'ing backend

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1151,6 +1151,7 @@ func (backend *Backend) Environment() Environment {
 func (backend *Backend) Close() error {
 	errors := []string{}
 
+	backend.ratesUpdater.Stop()
 	backend.uninitAccounts()
 
 	for _, coin := range backend.coins {

--- a/backend/rates/history.go
+++ b/backend/rates/history.go
@@ -101,6 +101,12 @@ func (updater *RateUpdater) ReconfigureHistory(coins, fiats []string) {
 	}
 }
 
+// stopAllHistory shuts down all historical exchange rates goroutines.
+// It may return before the goroutines have exited.
+func (updater *RateUpdater) stopAllHistory() {
+	updater.ReconfigureHistory(nil, nil)
+}
+
 // historyUpdateLoop periodically updates historical market exchange rates
 // forward in time starting with the last fetched timestamp in a loop.
 // It returns when the context is done.


### PR DESCRIPTION
This is useful for an upcoming commit where RateUpdater starts using a
persistent database for historical exchange rates which typically needs
to terminal all transactions.

It is also useful in testing where multiple instances of backends may
introduce lots of loose updater goroutines, if not shut down at the
end of the test.

Builds on top of https://github.com/digitalbitbox/bitbox-wallet-app/pull/1044.