### PR TITLE
backend/rates: use lowercase coin symbols

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -198,28 +198,28 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	backend.ratesUpdater.Start()
 	for _, fiat := range config.AppConfig().Backend.FiatList {
 		if config.AppConfig().Backend.CoinActive(coin.CodeBTC) {
-			backend.ratesUpdater.EnableHistoryPair("BTC", fiat)
+			backend.ratesUpdater.EnableHistoryPair("btc", fiat)
 		}
 		if config.AppConfig().Backend.CoinActive(coin.CodeTBTC) {
-			backend.ratesUpdater.EnableHistoryPair("TBTC", fiat)
+			backend.ratesUpdater.EnableHistoryPair("tbtc", fiat)
 		}
 		if config.AppConfig().Backend.CoinActive(coin.CodeRBTC) {
-			backend.ratesUpdater.EnableHistoryPair("RBTC", fiat)
+			backend.ratesUpdater.EnableHistoryPair("rbtc", fiat)
 		}
 		if config.AppConfig().Backend.CoinActive(coin.CodeLTC) {
-			backend.ratesUpdater.EnableHistoryPair("LTC", fiat)
+			backend.ratesUpdater.EnableHistoryPair("ltc", fiat)
 		}
 		if config.AppConfig().Backend.CoinActive(coin.CodeTLTC) {
-			backend.ratesUpdater.EnableHistoryPair("TLTC", fiat)
+			backend.ratesUpdater.EnableHistoryPair("tltc", fiat)
 		}
 		if config.AppConfig().Backend.CoinActive(coin.CodeETH) {
-			backend.ratesUpdater.EnableHistoryPair("ETH", fiat)
+			backend.ratesUpdater.EnableHistoryPair("eth", fiat)
 		}
 		if config.AppConfig().Backend.CoinActive(coin.CodeTETH) {
-			backend.ratesUpdater.EnableHistoryPair("TETH", fiat)
+			backend.ratesUpdater.EnableHistoryPair("teth", fiat)
 		}
 		if config.AppConfig().Backend.CoinActive(coin.CodeRETH) {
-			backend.ratesUpdater.EnableHistoryPair("RETH", fiat)
+			backend.ratesUpdater.EnableHistoryPair("reth", fiat)
 		}
 		for _, token := range config.AppConfig().Backend.ETH.ActiveERC20Tokens {
 			// The prefix is stripped on the frontend and in app config.

--- a/backend/rates/history.go
+++ b/backend/rates/history.go
@@ -20,24 +20,25 @@ var (
 	// Values are copied from https://api.coingecko.com/api/v3/coins/list.
 	// TODO: Replace keys with coin.Code.
 	geckoCoin = map[string]string{
-		"BTC": "bitcoin",
-		"LTC": "litecoin",
-		"ETH": "ethereum",
+		"btc": "bitcoin",
+		"ltc": "litecoin",
+		"eth": "ethereum",
 		// Useful for testing with testnets.
-		"TBTC": "bitcoin",
-		"RBTC": "bitcoin",
-		"TLTC": "litecoin",
-		"TETH": "ethereum",
-		"RETH": "ethereum",
+		"tbtc": "bitcoin",
+		"rbtc": "bitcoin",
+		"tltc": "litecoin",
+		"teth": "ethereum",
+		"reth": "ethereum",
 		// ERC20 tokens as used in the backend.
 		// Frontend and app config use unprefixed name, without "eth-erc20-".
-		"eth-erc20-bat":  "basic-attention-token",
-		"eth-erc20-dai":  "dai",
-		"eth-erc20-link": "chainlink",
-		"eth-erc20-mkr":  "maker",
-		"eth-erc20-usdc": "usd-coin",
-		"eth-erc20-usdt": "tether",
-		"eth-erc20-zrx":  "0x",
+		"eth-erc20-bat":       "basic-attention-token",
+		"eth-erc20-dai0x6b17": "dai",
+		"eth-erc20-link":      "chainlink",
+		"eth-erc20-mkr":       "maker",
+		"eth-erc20-sai0x89d2": "sai",
+		"eth-erc20-usdc":      "usd-coin",
+		"eth-erc20-usdt":      "tether",
+		"eth-erc20-zrx":       "0x",
 	}
 
 	// Copied from https://api.coingecko.com/api/v3/simple/supported_vs_currencies.

--- a/backend/rates/history_test.go
+++ b/backend/rates/history_test.go
@@ -16,7 +16,7 @@ import (
 func TestPriceAt(t *testing.T) {
 	updater := NewRateUpdater(nil) // don't need to make HTTP requests
 	updater.history = map[string][]exchangeRate{
-		"BTCUSD": {
+		"btcUSD": {
 			{value: 2, timestamp: time.Date(2020, 9, 1, 0, 0, 0, 0, time.UTC)},
 			{value: 3, timestamp: time.Date(2020, 9, 2, 0, 0, 0, 0, time.UTC)},
 			{value: 5, timestamp: time.Date(2020, 9, 3, 0, 0, 0, 0, time.UTC)},
@@ -39,7 +39,7 @@ func TestPriceAt(t *testing.T) {
 		{7.25, time.Date(2020, 9, 3, 18, 0, 0, 0, time.UTC)},
 	}
 	for _, test := range tt {
-		assert.Equal(t, test.wantValue, updater.PriceAt("BTC", "USD", test.at), "at = %s", test.at)
+		assert.Equal(t, test.wantValue, updater.PriceAt("btc", "USD", test.at), "at = %s", test.at)
 	}
 }
 
@@ -75,18 +75,18 @@ func TestUpdateHistory(t *testing.T) {
 	updater := NewRateUpdater(http.DefaultClient)
 	updater.coingeckoURL = ts.URL
 	updater.history = map[string][]exchangeRate{
-		"BTCUSD": {
+		"btcUSD": {
 			{value: 1.0, timestamp: time.Unix(1598832062, 0)}, // 2020-08-31 00:01:02
 			{value: 2.0, timestamp: time.Unix(1599091262, 0)}, // 2020-09-03 00:01:02
 		},
 	}
 
 	start, end := time.Unix(wantStartUnix, 0), time.Unix(wantEndUnix, 0)
-	n, err := updater.updateHistory(context.Background(), "BTC", "USD", start, end)
+	n, err := updater.updateHistory(context.Background(), "btc", "USD", start, end)
 	require.NoError(t, err, "updater.updateHistory err")
 	assert.Equal(t, 2, n, "updater.updateHistory n")
 	wantHistory := map[string][]exchangeRate{
-		"BTCUSD": {
+		"btcUSD": {
 			{value: 1.0, timestamp: time.Unix(1598832062, 0)}, // preexisting point
 			{value: 10000.0, timestamp: time.Unix(1598918700, 0)},
 			{value: 10001.0, timestamp: time.Unix(1598922501, 0)},

--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -34,10 +34,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// If modified, also update geckoCoin map.
+// TODO: Unify these with geckoCoin map.
 var coins = []string{"BTC", "LTC", "ETH", "USDT", "LINK", "MKR", "ZRX", "SAI", "DAI", "BAT", "USDC"}
 
-// If modified, also update geckoFiat map.
+// TODO: Unify these with geckoFiat map.
 var fiats = []string{"USD", "EUR", "CHF", "GBP", "JPY", "KRW", "CNY", "RUB", "CAD", "AUD", "ILS"}
 
 const interval = time.Minute
@@ -60,12 +60,12 @@ type RateUpdater struct {
 
 	historyMu sync.RWMutex // guards both history and historyGo
 	// history contains historical conversion rates in asc order, keyed by coin+fiat pair.
-	// For example, BTC/CHF pair's key is "BTCCHF".
+	// For example, BTC/CHF pair's key is "btcCHF".
 	// TODO: store in bolt DB
 	history map[string][]exchangeRate
 	// historyGo contains context canceling funcs to stop periodic updates
 	// of historical data, keyed by coin+fiat pair.
-	// For example, BTC/EUR pair's key is "BTCEUR".
+	// For example, BTC/EUR pair's key is "btcEUR".
 	historyGo map[string]context.CancelFunc
 
 	// CoinGecko is where updater gets the historical conversion rates.


### PR DESCRIPTION
Turns out, they are lowercase everywhere in the backend.

The original CryptoCompare client uses uppercase.
This is left as a TODO for the future.

Note that frontend seem to use all uppercase, both coins and fiats.