### PR TITLE
backend/rates: add the missing SAI token to CryptoCompare

### DIFF
--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -35,7 +35,7 @@ import (
 )
 
 // If modified, also update geckoCoin map.
-var coins = []string{"BTC", "LTC", "ETH", "USDT", "LINK", "MKR", "ZRX", "DAI", "BAT", "USDC"}
+var coins = []string{"BTC", "LTC", "ETH", "USDT", "LINK", "MKR", "ZRX", "SAI", "DAI", "BAT", "USDC"}
 
 // If modified, also update geckoFiat map.
 var fiats = []string{"USD", "EUR", "CHF", "GBP", "JPY", "KRW", "CNY", "RUB", "CAD", "AUD", "ILS"}


### PR DESCRIPTION
This is used in most recent exchange rates to show fiat value when
making a transaction.

Historical rates with CoinGecko already has it.