### PR TITLE
backend/rates: expose history earliest/latest methods for handlers

### DIFF
--- a/backend/rates/history.go
+++ b/backend/rates/history.go
@@ -88,7 +88,7 @@ func (updater *RateUpdater) historyUpdateLoop(ctx context.Context, coin, fiat st
 		// When to update next, after this loop iteration is done.
 		untilNext := 10 * time.Minute // TODO: add jitter
 
-		start := updater.historyLatestTimestamp(coin, fiat)
+		start := updater.HistoryLatestTimestamp(coin, fiat)
 		// When zero, there's no point in fetching data here because the backfillHistory
 		// will kick in and fill it up for the past 90 days anyway.
 		if !start.IsZero() {
@@ -129,7 +129,7 @@ func (updater *RateUpdater) backfillHistory(ctx context.Context, coin, fiat stri
 		// When to update next, after this loop iteration is done.
 		untilNext := time.Second // TODO: add jitter
 
-		end := updater.historyEarliestTimestamp(coin, fiat)
+		end := updater.HistoryEarliestTimestamp(coin, fiat)
 		var start time.Time
 		if end.IsZero() {
 			// First time; don't have historical data yet.
@@ -194,7 +194,9 @@ func (updater *RateUpdater) updateHistory(ctx context.Context, coin, fiat string
 	return len(rates), nil
 }
 
-func (updater *RateUpdater) historyLatestTimestamp(coin, fiat string) time.Time {
+// HistoryLatestTimestamp reports the most recent timestamp at which an exchange rate
+// is available for the given coin/fiat pair.
+func (updater *RateUpdater) HistoryLatestTimestamp(coin, fiat string) time.Time {
 	key := coin + fiat
 	updater.historyMu.RLock()
 	defer updater.historyMu.RUnlock()
@@ -205,7 +207,9 @@ func (updater *RateUpdater) historyLatestTimestamp(coin, fiat string) time.Time 
 	return t
 }
 
-func (updater *RateUpdater) historyEarliestTimestamp(coin, fiat string) time.Time {
+// HistoryEarliestTimestamp reports the oldest timestamp at which an exchange rate
+// is available for the given coin/fiat pair.
+func (updater *RateUpdater) HistoryEarliestTimestamp(coin, fiat string) time.Time {
 	key := coin + fiat
 	updater.historyMu.RLock()
 	defer updater.historyMu.RUnlock()

--- a/backend/rates/history_test.go
+++ b/backend/rates/history_test.go
@@ -111,3 +111,24 @@ func TestFetchGeckoMarketRangeInvalidCoinFiat(t *testing.T) {
 		cancel()
 	}
 }
+
+func TestHistoryEarliestLatest(t *testing.T) {
+	updater := NewRateUpdater(nil)
+	updater.history = map[string][]exchangeRate{
+		"btcUSD": {
+			{value: 1, timestamp: time.Unix(1598832062, 0)}, // 2020-08-31 00:01:02
+			{value: 2, timestamp: time.Unix(1598918700, 0)},
+			{value: 3, timestamp: time.Unix(1598922501, 0)},
+			{value: 4, timestamp: time.Unix(1599091262, 0)}, // 2020-09-03 00:01:02
+		},
+	}
+
+	earliest := updater.HistoryEarliestTimestamp("btc", "USD")
+	assert.Equal(t, updater.history["btcUSD"][0].timestamp, earliest, "earliest")
+
+	latest := updater.HistoryLatestTimestamp("btc", "USD")
+	assert.Equal(t, updater.history["btcUSD"][3].timestamp, latest, "latest")
+
+	assert.Zero(t, updater.HistoryEarliestTimestamp("foo", "bar"), "zero earliest")
+	assert.Zero(t, updater.HistoryLatestTimestamp("foo", "bar"), "zero latest")
+}


### PR DESCRIPTION
So that the handlers can identify whether the data is ready to plot a chart for a given range in the account portolio.