### PR TITLE
ci: prevent homebrew from running cleanup on github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
         # in their database.
         run: >
           export HOMEBREW_NO_AUTO_UPDATE=1;
+          export HOMEBREW_NO_INSTALL_CLEANUP=1;
           brew install go@1.14;
           export PATH=/usr/local/opt/go@1.14/bin:$PATH;
           ./scripts/travis-ci.sh qt-osx;


### PR DESCRIPTION
Turns out homebrew kicks off its clean up process each 30 days.
However, this fails with strange errors like
"Error: Not a directory @ dir_s_rmdir - /usr/local/Cellar/openssl"
in https://github.com/digitalbitbox/bitbox-wallet-app/pull/1054/checks?check_run_id=1276415647

Wouldn't want to waste time on homebrew quirks and bugs.
So, I propose we disable its cleanup. It's a CI cache anyway.

https://github.com/Homebrew/brew/blob/master/docs/FAQ.md#how-can-i-keep-old-versions-of-a-formula-when-upgrading