### PR TITLE
backend/coin: add Coin.Name()

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -366,9 +366,9 @@ func (backend *Backend) createAndAddBTCAccount(
 	keystore keystore.Keystore,
 	coin coin.Coin,
 	code string,
-	name string,
 	configs []scriptTypeWithKeypath,
 ) {
+	name := coin.Name()
 	log := backend.log.WithField("code", code).WithField("name", name)
 	if !backend.config.AppConfig().Backend.CoinActive(coin.Code()) {
 		log.Info("skipping inactive account")
@@ -452,9 +452,9 @@ func (backend *Backend) createAndAddETHAccount(
 	keystore keystore.Keystore,
 	coin coin.Coin,
 	code string,
-	name string,
 	keypath string,
 ) {
+	name := coin.Name()
 	log := backend.log.WithField("code", code).WithField("name", name)
 	prefix := "eth-erc20-"
 	if strings.HasPrefix(code, prefix) {
@@ -601,51 +601,51 @@ func (backend *Backend) Coin(code coinpkg.Code) (coin.Coin, error) {
 	switch {
 	case code == coinpkg.CodeRBTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeRBTC, "RBTC", &chaincfg.RegressionNetParams, dbFolder, servers, "", backend.socksProxy)
+		coin = btc.NewCoin(coinpkg.CodeRBTC, "Bitcoin Regtest", "RBTC", &chaincfg.RegressionNetParams, dbFolder, servers, "", backend.socksProxy)
 	case code == coinpkg.CodeTBTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeTBTC, "TBTC", &chaincfg.TestNet3Params, dbFolder, servers,
+		coin = btc.NewCoin(coinpkg.CodeTBTC, "Bitcoin Testnet", "TBTC", &chaincfg.TestNet3Params, dbFolder, servers,
 			"https://blockstream.info/testnet/tx/", backend.socksProxy)
 	case code == coinpkg.CodeBTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeBTC, "BTC", &chaincfg.MainNetParams, dbFolder, servers,
+		coin = btc.NewCoin(coinpkg.CodeBTC, "Bitcoin", "BTC", &chaincfg.MainNetParams, dbFolder, servers,
 			"https://blockstream.info/tx/", backend.socksProxy)
 	case code == coinpkg.CodeTLTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeTLTC, "TLTC", &ltc.TestNet4Params, dbFolder, servers,
+		coin = btc.NewCoin(coinpkg.CodeTLTC, "Litecoin Testnet", "TLTC", &ltc.TestNet4Params, dbFolder, servers,
 			"http://explorer.litecointools.com/tx/", backend.socksProxy)
 	case code == coinpkg.CodeLTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeLTC, "LTC", &ltc.MainNetParams, dbFolder, servers,
+		coin = btc.NewCoin(coinpkg.CodeLTC, "Litecoin", "LTC", &ltc.MainNetParams, dbFolder, servers,
 			"https://insight.litecore.io/tx/", backend.socksProxy)
 	case code == coinpkg.CodeETH:
 		etherScan := etherscan.NewEtherScan("https://api.etherscan.io/api", backend.etherScanHTTPClient)
-		coin = eth.NewCoin(etherScan, code, "ETH", "ETH", params.MainnetChainConfig,
+		coin = eth.NewCoin(etherScan, code, "Ethereum", "ETH", "ETH", params.MainnetChainConfig,
 			"https://etherscan.io/tx/",
 			etherScan,
 			nil)
 	case code == coinpkg.CodeRETH:
 		etherScan := etherscan.NewEtherScan("https://api-rinkeby.etherscan.io/api", backend.etherScanHTTPClient)
-		coin = eth.NewCoin(etherScan, code, "RETH", "RETH", params.RinkebyChainConfig,
+		coin = eth.NewCoin(etherScan, code, "Ethereum Rinkeby", "RETH", "RETH", params.RinkebyChainConfig,
 			"https://rinkeby.etherscan.io/tx/",
 			etherScan,
 			nil)
 	case code == coinpkg.CodeTETH:
 		etherScan := etherscan.NewEtherScan("https://api-ropsten.etherscan.io/api", backend.etherScanHTTPClient)
-		coin = eth.NewCoin(etherScan, code, "TETH", "TETH", params.TestnetChainConfig,
+		coin = eth.NewCoin(etherScan, code, "Ethereum Ropsten", "TETH", "TETH", params.TestnetChainConfig,
 			"https://ropsten.etherscan.io/tx/",
 			etherScan,
 			nil)
 	case code == coinpkg.CodeERC20TEST:
 		etherScan := etherscan.NewEtherScan("https://api-ropsten.etherscan.io/api", backend.etherScanHTTPClient)
-		coin = eth.NewCoin(etherScan, code, "TEST", "TETH", params.TestnetChainConfig,
+		coin = eth.NewCoin(etherScan, code, "ERC20 TEST", "TEST", "TETH", params.TestnetChainConfig,
 			"https://ropsten.etherscan.io/tx/",
 			etherScan,
 			erc20.NewToken("0x2f45b6fb2f28a73f110400386da31044b2e953d4", 18),
 		)
 	case erc20Token != nil:
 		etherScan := etherscan.NewEtherScan("https://api.etherscan.io/api", backend.etherScanHTTPClient)
-		coin = eth.NewCoin(etherScan, erc20Token.code, erc20Token.unit, "ETH", params.MainnetChainConfig,
+		coin = eth.NewCoin(etherScan, erc20Token.code, erc20Token.name, erc20Token.unit, "ETH", params.MainnetChainConfig,
 			"https://etherscan.io/tx/",
 			etherScan,
 			erc20Token.token,
@@ -698,7 +698,7 @@ func (backend *Backend) initDefaultAccounts() {
 		if backend.arguments.Regtest() {
 			RBTC, _ := backend.Coin(coinpkg.CodeRBTC)
 			backend.createAndAddBTCAccount(keystore, RBTC,
-				"rbtc", "Bitcoin Regtest",
+				"rbtc",
 				[]scriptTypeWithKeypath{
 					newScriptTypeWithKeypath(signing.ScriptTypeP2WPKHP2SH, "m/49'/1'/0'"),
 					newScriptTypeWithKeypath(signing.ScriptTypeP2PKH, "m/44'/1'/0'"),
@@ -707,7 +707,7 @@ func (backend *Backend) initDefaultAccounts() {
 		} else {
 			TBTC, _ := backend.Coin(coinpkg.CodeTBTC)
 			backend.createAndAddBTCAccount(keystore, TBTC,
-				"tbtc", "Bitcoin Testnet",
+				"tbtc",
 				[]scriptTypeWithKeypath{
 					newScriptTypeWithKeypath(signing.ScriptTypeP2WPKH, "m/84'/1'/0'"),
 					newScriptTypeWithKeypath(signing.ScriptTypeP2WPKHP2SH, "m/49'/1'/0'"),
@@ -717,7 +717,7 @@ func (backend *Backend) initDefaultAccounts() {
 
 			TLTC, _ := backend.Coin(coinpkg.CodeTLTC)
 			backend.createAndAddBTCAccount(keystore, TLTC,
-				"tltc", "Litecoin Testnet",
+				"tltc",
 				[]scriptTypeWithKeypath{
 					newScriptTypeWithKeypath(signing.ScriptTypeP2WPKH, "m/84'/1'/0'"),
 					newScriptTypeWithKeypath(signing.ScriptTypeP2WPKHP2SH, "m/49'/1'/0'"),
@@ -725,16 +725,16 @@ func (backend *Backend) initDefaultAccounts() {
 			)
 
 			TETH, _ := backend.Coin(coinpkg.CodeTETH)
-			backend.createAndAddETHAccount(keystore, TETH, "teth", "Ethereum Ropsten", "m/44'/1'/0'/0")
+			backend.createAndAddETHAccount(keystore, TETH, "teth", "m/44'/1'/0'/0")
 			RETH, _ := backend.Coin(coinpkg.CodeRETH)
-			backend.createAndAddETHAccount(keystore, RETH, "reth", "Ethereum Rinkeby", "m/44'/1'/0'/0")
+			backend.createAndAddETHAccount(keystore, RETH, "reth", "m/44'/1'/0'/0")
 			erc20TEST, _ := backend.Coin(coinpkg.CodeERC20TEST)
-			backend.createAndAddETHAccount(keystore, erc20TEST, "erc20Test", "ERC20 TEST", "m/44'/1'/0'/0")
+			backend.createAndAddETHAccount(keystore, erc20TEST, "erc20Test", "m/44'/1'/0'/0")
 		}
 	} else {
 		BTC, _ := backend.Coin(coinpkg.CodeBTC)
 		backend.createAndAddBTCAccount(keystore, BTC,
-			"btc", "Bitcoin",
+			"btc",
 			[]scriptTypeWithKeypath{
 				newScriptTypeWithKeypath(signing.ScriptTypeP2WPKH, "m/84'/0'/0'"),
 				newScriptTypeWithKeypath(signing.ScriptTypeP2WPKHP2SH, "m/49'/0'/0'"),
@@ -744,7 +744,7 @@ func (backend *Backend) initDefaultAccounts() {
 
 		LTC, _ := backend.Coin(coinpkg.CodeLTC)
 		backend.createAndAddBTCAccount(keystore, LTC,
-			"ltc", "Litecoin",
+			"ltc",
 			[]scriptTypeWithKeypath{
 				newScriptTypeWithKeypath(signing.ScriptTypeP2WPKH, "m/84'/2'/0'"),
 				newScriptTypeWithKeypath(signing.ScriptTypeP2WPKHP2SH, "m/49'/2'/0'"),
@@ -752,12 +752,12 @@ func (backend *Backend) initDefaultAccounts() {
 		)
 
 		ETH, _ := backend.Coin(coinpkg.CodeETH)
-		backend.createAndAddETHAccount(keystore, ETH, "eth", "Ethereum", "m/44'/60'/0'/0")
+		backend.createAndAddETHAccount(keystore, ETH, "eth", "m/44'/60'/0'/0")
 
 		if backend.config.AppConfig().Backend.CoinActive(coinpkg.CodeETH) {
 			for _, erc20Token := range erc20Tokens {
 				token, _ := backend.Coin(erc20Token.code)
-				backend.createAndAddETHAccount(keystore, token, string(erc20Token.code), erc20Token.name, "m/44'/60'/0'/0")
+				backend.createAndAddETHAccount(keystore, token, string(erc20Token.code), "m/44'/60'/0'/0")
 			}
 		}
 	}

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -43,7 +43,7 @@ func TestAccount(t *testing.T) {
 	defer func() { _ = os.RemoveAll(dbFolder) }()
 
 	coin := btc.NewCoin(
-		code, unit, net, dbFolder, nil, explorer, socksproxy.NewSocksProxy(false, ""))
+		code, "Bitcoin Testnet", unit, net, dbFolder, nil, explorer, socksproxy.NewSocksProxy(false, ""))
 
 	blockchainMock := &blockchainMock.BlockchainMock{}
 	blockchainMock.MockRegisterOnConnectionStatusChangedEvent = func(onConnectionStatusChanged func(blockchain.Status)) {

--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -44,6 +44,7 @@ import (
 type Coin struct {
 	initOnce              sync.Once
 	code                  coin.Code
+	name                  string
 	unit                  string
 	net                   *chaincfg.Params
 	dbFolder              string
@@ -61,6 +62,7 @@ type Coin struct {
 // NewCoin creates a new coin with the given parameters.
 func NewCoin(
 	code coin.Code,
+	name string,
 	unit string,
 	net *chaincfg.Params,
 	dbFolder string,
@@ -71,6 +73,7 @@ func NewCoin(
 	log := logging.Get().WithGroup("coin").WithField("code", code)
 	coin := &Coin{
 		code:                  code,
+		name:                  name,
 		unit:                  unit,
 		net:                   net,
 		dbFolder:              dbFolder,
@@ -126,6 +129,11 @@ func (coin *Coin) Initialize() {
 			}
 		})
 	})
+}
+
+// Name implements coin.Coin.
+func (coin *Coin) Name() string {
+	return coin.name
 }
 
 // Code implements coin.Coin.

--- a/backend/coins/btc/coin_test.go
+++ b/backend/coins/btc/coin_test.go
@@ -56,7 +56,7 @@ type testSuite struct {
 func (s *testSuite) SetupTest() {
 	s.dbFolder = test.TstTempDir("btc-dbfolder")
 
-	s.coin = btc.NewCoin(s.code, s.unit, s.net, s.dbFolder, nil,
+	s.coin = btc.NewCoin(s.code, "Some coin", s.unit, s.net, s.dbFolder, nil,
 		explorer, socksproxy.NewSocksProxy(false, ""))
 	blockchainMock := &blockchainMock.BlockchainMock{}
 	blockchainMock.MockHeadersSubscribe = func(
@@ -82,6 +82,7 @@ func TestSuite(t *testing.T) {
 func (s *testSuite) TestCoin() {
 	require.Equal(s.T(), s.net, s.coin.Net())
 	require.Equal(s.T(), s.code, s.coin.Code())
+	require.Equal(s.T(), "Some coin", s.coin.Name())
 	require.Equal(s.T(), s.unit, s.coin.Unit(false))
 	require.Equal(s.T(), s.unit, s.coin.Unit(true))
 	require.Equal(s.T(), uint(8), s.coin.Decimals(false))

--- a/backend/coins/btc/maketx/maketx_test.go
+++ b/backend/coins/btc/maketx/maketx_test.go
@@ -41,8 +41,8 @@ import (
 
 var noDust = btcutil.Amount(0)
 
-var tltc = btc.NewCoin(coin.CodeTLTC, "TLTC", &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "", socksproxy.NewSocksProxy(false, ""))
-var tbtc = btc.NewCoin(coin.CodeTBTC, "TBTC", &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "https://blockstream.info/testnet/tx/", socksproxy.NewSocksProxy(false, ""))
+var tltc = btc.NewCoin(coin.CodeTLTC, "TLTC", "Litecoin Testnet", &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "", socksproxy.NewSocksProxy(false, ""))
+var tbtc = btc.NewCoin(coin.CodeTBTC, "TBTC", "Bitcoin Testnet", &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "https://blockstream.info/testnet/tx/", socksproxy.NewSocksProxy(false, ""))
 
 // For reference, tx vsizes assuming two outputs (normal + change), for N inputs:
 // 1 inputs: 226

--- a/backend/coins/coin/coin.go
+++ b/backend/coins/coin/coin.go
@@ -24,6 +24,9 @@ import (
 type Coin interface {
 	observable.Interface
 
+	// Name is the name of the coin, show to the user.
+	Name() string
+
 	// Code returns the code used to identify the coin (should be the acronym of the coin in
 	// lowercase).
 	Code() Code

--- a/backend/coins/coin/mocks/coin.go
+++ b/backend/coins/coin/mocks/coin.go
@@ -16,6 +16,7 @@ var (
 	lockCoinMockDecimals                          sync.RWMutex
 	lockCoinMockFormatAmount                      sync.RWMutex
 	lockCoinMockInitialize                        sync.RWMutex
+	lockCoinMockName                              sync.RWMutex
 	lockCoinMockObserve                           sync.RWMutex
 	lockCoinMockSmallestUnit                      sync.RWMutex
 	lockCoinMockToUnit                            sync.RWMutex
@@ -49,6 +50,9 @@ var _ coin.Coin = &CoinMock{}
 //             },
 //             InitializeFunc: func()  {
 // 	               panic("mock out the Initialize method")
+//             },
+//             NameFunc: func() string {
+// 	               panic("mock out the Name method")
 //             },
 //             ObserveFunc: func(in1 func(observable.Event)) func() {
 // 	               panic("mock out the Observe method")
@@ -87,6 +91,9 @@ type CoinMock struct {
 	// InitializeFunc mocks the Initialize method.
 	InitializeFunc func()
 
+	// NameFunc mocks the Name method.
+	NameFunc func() string
+
 	// ObserveFunc mocks the Observe method.
 	ObserveFunc func(in1 func(observable.Event)) func()
 
@@ -124,6 +131,9 @@ type CoinMock struct {
 		}
 		// Initialize holds details about calls to the Initialize method.
 		Initialize []struct {
+		}
+		// Name holds details about calls to the Name method.
+		Name []struct {
 		}
 		// Observe holds details about calls to the Observe method.
 		Observe []struct {
@@ -315,6 +325,32 @@ func (mock *CoinMock) InitializeCalls() []struct {
 	lockCoinMockInitialize.RLock()
 	calls = mock.calls.Initialize
 	lockCoinMockInitialize.RUnlock()
+	return calls
+}
+
+// Name calls NameFunc.
+func (mock *CoinMock) Name() string {
+	if mock.NameFunc == nil {
+		panic("CoinMock.NameFunc: method is nil but Coin.Name was just called")
+	}
+	callInfo := struct {
+	}{}
+	lockCoinMockName.Lock()
+	mock.calls.Name = append(mock.calls.Name, callInfo)
+	lockCoinMockName.Unlock()
+	return mock.NameFunc()
+}
+
+// NameCalls gets all the calls that were made to Name.
+// Check the length with:
+//     len(mockedCoin.NameCalls())
+func (mock *CoinMock) NameCalls() []struct {
+} {
+	var calls []struct {
+	}
+	lockCoinMockName.RLock()
+	calls = mock.calls.Name
+	lockCoinMockName.RUnlock()
 	return calls
 }
 

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -44,6 +44,7 @@ type Coin struct {
 	observable.Implementation
 	client                rpcclient.Interface
 	code                  coin.Code
+	name                  string
 	unit                  string
 	feeUnit               string
 	net                   *params.ChainConfig
@@ -63,6 +64,7 @@ type Coin struct {
 func NewCoin(
 	client rpcclient.Interface,
 	code coin.Code,
+	name string,
 	unit string,
 	feeUnit string,
 	net *params.ChainConfig,
@@ -73,6 +75,7 @@ func NewCoin(
 	return &Coin{
 		client:                client,
 		code:                  code,
+		name:                  name,
 		unit:                  unit,
 		feeUnit:               feeUnit,
 		net:                   net,
@@ -91,6 +94,11 @@ func (coin *Coin) Net() *params.ChainConfig { return coin.net }
 
 // Initialize implements coin.Coin.
 func (coin *Coin) Initialize() {}
+
+// Name implements coin.Coin.
+func (coin *Coin) Name() string {
+	return coin.name
+}
 
 // Code implements coin.Coin.
 func (coin *Coin) Code() coin.Code {


### PR DESCRIPTION
The "Bitcoin"/"Litecoin" etc. strings we define for accounts are in
fact coin names.

We mov this to the coin so it can be used to show the name of the coin
to the user, e.g. in the account summary page (table headers, which
currently just shows the coin code).

The accounts automatically added from a keystore just adopt the coin
name, so it behaves the same as before.