### PR TITLE
backend/rates: add jitter to history loops and make them faster

### DIFF
--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -84,6 +84,8 @@ type RateUpdater struct {
 // The dbdir argument is the location of a historical rates database cache.
 // The returned updater can function without a valid database cache but may be
 // impacted by rate limits. The database cache is transparent to the updater users.
+// To stay within acceptable rate limits defined by CoinGeckoRateLimit, callers can
+// use util/ratelimit package.
 //
 // Both Last and PriceAt of the newly created updater always return zero values
 // until data is fetched from the external APIs. To make the updater start fetching data


### PR DESCRIPTION
The forward history update loop was iterating every 10min. This
interval was chosen after an approximate time of a new block on the
chain. However, it may be too slow in the worst case where RateUpdater
provides data stale up to 10min while already available from the API.

This commit reduces the potential staleness to only up to ~1.5min.