### PR TITLE
frontend/accountSummary: show coin names instead of coin codes

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -802,7 +802,9 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 	}
 
 	jsonAccounts := []*extendedAccountJSON{}
-	totals := make(map[coinpkg.Coin]*big.Int)
+	totals := map[coinpkg.Coin]*big.Int{}
+	// coin code to coin name.
+	coinNames := map[string]string{}
 
 	// If true, we are missing headers or historical conversion rates necessary to compute the chart
 	// data,
@@ -840,6 +842,7 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 		}
 
 		totals[account.Coin()] = new(big.Int).Add(totals[account.Coin()], balance.Available().BigInt())
+		coinNames[string(account.Coin().Code())] = account.Coin().Name()
 
 		// Below here, only chart data is being computed.
 		if chartDataMissing {
@@ -960,6 +963,7 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 	return map[string]interface{}{
 		"accounts":         jsonAccounts,
 		"totals":           jsonTotals,
+		"coinNames":        coinNames,
 		"chartDataMissing": chartDataMissing,
 		"chartData":        chartEntries,
 	}, nil

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -44,9 +44,14 @@ interface Totals {
     [code: string]: AmountInterface;
 }
 
+interface CoinNames {
+    [code: string]: string;
+}
+
 interface Response {
     accounts: AccountAndBalanceInterface[];
     totals: Totals;
+    coinNames: CoinNames;
     chartDataMissing: boolean;
     chartData: ChartData;
 }
@@ -115,6 +120,7 @@ class AccountsSummary extends Component<Props, State> {
                                                        coinCode={coin}
                                                        accounts={groupedAccounts[coin]}
                                                        total={data.totals[coin]}
+                                                       title={data.coinNames[coin]}
                                                        index={index} />)) :
                                                <p>{t('accountSummary.noAccount')}</p>
                             }

--- a/frontends/web/src/routes/account/summary/balancestable.tsx
+++ b/frontends/web/src/routes/account/summary/balancestable.tsx
@@ -26,6 +26,7 @@ interface ProvidedProps {
     coinCode: string;
     accounts: AccountAndBalanceInterface[];
     total: AmountInterface;
+    title: string;
     index: number;
 }
 
@@ -33,14 +34,14 @@ type Props = ProvidedProps & TranslateProps;
 
 class BalancesTable extends Component<Props> {
     public render(
-        { t, coinCode, accounts, total, index }: RenderableProps<Props>,
+        { t, coinCode, accounts, total, title, index }: RenderableProps<Props>,
     ) {
         return (
             <div>
                 <div className={['subHeaderContainer', index < 1 && 'first'].join(' ')}>
                     <div className={['subHeader', style.coinheader].join(' ')}>
                         <Logo className={style.coincode} coinCode={coinCode} alt={coinCode} active={true} />
-                        <h3>{coinCode.toUpperCase()}</h3>
+                        <h3>{title}</h3>
                     </div>
                 </div>
                 <table className={style.table}>


### PR DESCRIPTION
Since grouping accounts by coin currently happens in the frontend, we
fetch the coin names in the same way as we fetch the coin totals from
the backend: with a map. Maybe some day the backend can prepare all
the data in one go, which would make that part a bit nicer.