### PR TITLE
backend/handlers: show chart until last available date

### DIFF
--- a/backend/rates/history.go
+++ b/backend/rates/history.go
@@ -268,6 +268,22 @@ func (updater *RateUpdater) HistoryEarliestTimestamp(coin, fiat string) time.Tim
 	return t
 }
 
+// HistoryLatestTimestampAll returns the latest timestamp for which there an exchange rates is
+// available for all coins. In other words: the earliest of all latest timestamps.
+func (updater *RateUpdater) HistoryLatestTimestampAll(coins []string, fiat string) time.Time {
+	var result time.Time
+	for _, coin := range coins {
+		latest := updater.HistoryLatestTimestamp(coin, fiat)
+		if latest.IsZero() {
+			return latest
+		}
+		if result.IsZero() || latest.Before(result) {
+			result = latest
+		}
+	}
+	return result
+}
+
 // fetchGeckoMarketRange slurps historical exchange rates using CoinGecko's
 // "market_chart/range" API.
 func (updater *RateUpdater) fetchGeckoMarketRange(ctx context.Context, coin, fiat string, start, end time.Time) ([]exchangeRate, error) {

--- a/backend/rates/history_test.go
+++ b/backend/rates/history_test.go
@@ -135,6 +135,10 @@ func TestHistoryEarliestLatest(t *testing.T) {
 			{value: 3, timestamp: time.Unix(1598922501, 0)},
 			{value: 4, timestamp: time.Unix(1599091262, 0)}, // 2020-09-03 00:01:02
 		},
+		"ltcUSD": {
+			{value: 4, timestamp: time.Date(2020, 8, 02, 23, 0, 0, 0, time.UTC)},
+			{value: 4, timestamp: time.Date(2020, 9, 02, 23, 0, 0, 0, time.UTC)},
+		},
 	}
 
 	earliest := updater.HistoryEarliestTimestamp("btc", "USD")
@@ -145,6 +149,13 @@ func TestHistoryEarliestLatest(t *testing.T) {
 
 	assert.Zero(t, updater.HistoryEarliestTimestamp("foo", "bar"), "zero earliest")
 	assert.Zero(t, updater.HistoryLatestTimestamp("foo", "bar"), "zero latest")
+
+	assert.Equal(t,
+		updater.history["ltcUSD"][1].timestamp,
+		updater.HistoryLatestTimestampAll([]string{"btc", "ltc"}, "USD"))
+
+	assert.Zero(t, updater.HistoryLatestTimestampAll([]string{"btc", "foo"}, "USD"))
+	assert.Zero(t, updater.HistoryLatestTimestampAll([]string{"foo", "btc"}, "USD"))
 }
 
 // TestLoadDumpUnusableDB ensures no panic when the RateUpdater.historyDB is unusable.


### PR DESCRIPTION
If we try to chart until the current hour, often there are no rates
for the last hour, and the error 'gathering info' would be shown.

Now, the chart goes up until the latest datetime for which we can
compute a chart entry.