### PR TITLE
docker: unify docker image names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ clean:
 	cd frontends/qt && $(MAKE) clean
 	cd frontends/android && $(MAKE) clean
 dockerinit:
-	docker build --pull --force-rm -t bitbox-wallet .
+	docker build --pull --force-rm -t shiftcrypto/bitbox-wallet-app .
 dockerdev:
 	./scripts/dockerdev.sh
 locize-push:

--- a/scripts/dockerdev.sh
+++ b/scripts/dockerdev.sh
@@ -18,7 +18,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 dockerdev () {
     local container_name=bitbox-wallet-dev
 
-    if ! docker images | grep -q bitbox-wallet; then
+    if ! docker images | grep -q bitbox-wallet-app; then
         echo "No bitbox-wallet docker image found! Maybe you need to run 'make dockerinit'?" >&2
         exit 1
     fi
@@ -43,7 +43,7 @@ dockerdev () {
            --add-host="dev1.shiftcrypto.ch:176.9.28.155" \
            --add-host="dev2.shiftcrypto.ch:176.9.28.156" \
            -v $repo_path:/opt/go/src/github.com/digitalbitbox/bitbox-wallet-app \
-           bitbox-wallet bash
+           shiftcrypto/bitbox-wallet-app bash
 
     # Use same user/group id as on the host, so that files are not created as root in the mounted
     # volume.


### PR DESCRIPTION
`make dockerdev` entered an image called `bitbox-wallet` made from
`make dockerinit`.

The official image on dockerhub is shiftcrypto/bitbox-wallet-app. Just
pulling that should be enough for someone to get started.

Fixes #1060.