### PR TITLE
backend/handlers: use starred fiat for chart

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -823,8 +823,7 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 	var chartEntriesDaily []chartEntry
 	var chartEntriesHourly []chartEntry
 
-	// TODO: use active (starred) fiat currency.
-	fiat := "USD"
+	fiat := handlers.backend.Config().AppConfig().Backend.MainFiat
 	// Chart data until this point in time.
 	until := handlers.backend.RatesUpdater().HistoryLatestTimestampAll(handlers.allCoinCodes(), fiat)
 	if until.IsZero() {
@@ -978,6 +977,7 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 		"chartDataMissing": chartDataMissing,
 		"chartDataDaily":   truncateLeadingZeroes(chartEntriesDaily),
 		"chartDataHourly":  truncateLeadingZeroes(chartEntriesHourly),
+		"chartFiat":        fiat,
 	}, nil
 }
 

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -20,7 +20,7 @@ import checkIcon from '../../../assets/icons/check.svg';
 import A from '../../../components/anchor/anchor';
 import { BalanceInterface } from '../../../components/balance/balance';
 import { Header } from '../../../components/layout';
-import { AmountInterface } from '../../../components/rates/rates';
+import { AmountInterface, Fiat } from '../../../components/rates/rates';
 import { load } from '../../../decorators/load';
 import { TranslateProps } from '../../../decorators/translate';
 import { apiPost } from '../../../utils/request';
@@ -55,6 +55,7 @@ interface Response {
     chartDataMissing: boolean;
     chartDataDaily: ChartData;
     chartDataHourly: ChartData;
+    chartFiat: Fiat;
 }
 
 type Props = TranslateProps & AccountSummaryProps;


### PR DESCRIPTION
We will use the fiat marked as starred in the settings for the
charts. This is a quick solution to a fiat cycle button that will take
more time.