### PR TITLE
frontend/app: show account summary in production, fix routing

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -141,13 +141,17 @@ class App extends Component<Props, State> {
         const isIndex = currentURL === '/' || currentURL === '/index.html' || currentURL === '/android_asset/web/index.html';
         const inAccounts = currentURL.startsWith('/account/');
         const accounts = this.props.accounts;
+        if (currentURL.startsWith('/account-summary') && accounts.length === 0) {
+            route('/', true);
+            return;
+        }
         if (inAccounts && !accounts.some(account => currentURL.startsWith('/account/' + account.code))) {
             route('/', true);
             return;
         }
         if (isIndex || currentURL === '/account') {
             if (accounts && accounts.length) {
-                route(`/account/${accounts[0].code}`, true);
+                route(`/account-summary`, true);
                 return;
             }
         }

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -217,7 +217,7 @@ class Sidebar extends Component<Props> {
                             </div>
                         </div>
                     </div> */}
-                    {debug &&
+                    { accounts.length &&
                         <div className="sidebarItem">
                             <Link
                                 activeClassName="sidebar-active"


### PR DESCRIPTION
Default route to account summary after unlock.

When there are no accounts, route to /, to not stay in the account summary.