### PR TITLE
frontend: fix browserlist

### DIFF
--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -41,6 +41,6 @@
     "sortablejs": "^1.10.1"
   },
   "browserslist": [
-    "last 2 Chrome versions"
+    "chrome >= 65"
   ]
 }


### PR DESCRIPTION
Our desktop app is currently based on 5.11.2:

https://doc.qt.io/archives/qt-5.11/qtwebengine-overview.html

> This version of Qt WebEngine is based on Chromium version
65.0.3325.151, with additional security fixes from newer versions.

The previous value made our JS compilation toolchain output code that
led to a syntax error in the desktop app.