### PR TITLE
frontend/accountsummary: remove export

### DIFF
--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -24,6 +24,7 @@ import { Header } from '../../../components/layout';
 import { AmountInterface, Fiat, FiatConversion } from '../../../components/rates/rates';
 import { TranslateProps } from '../../../decorators/translate';
 import Logo from '../../../components/icon/logo';
+import { debug } from '../../../utils/env';
 import { apiGet, apiPost } from '../../../utils/request';
 import { AccountInterface, CoinCode } from '../account';
 import { Chart, ChartData } from './chart';
@@ -153,23 +154,24 @@ class AccountsSummary extends Component<Props, State> {
             <div className="contentWithGuide">
                 <div className="container">
                     <Header title={<h2>{t('accountSummary.title')}</h2>}>
-                        {
-                            exported ? (
-                                <A href={exported} title={exported} className="flex flex-row flex-start flex-items-center">
-                                    <span>
-                                        <img src={checkIcon} style="margin-right: 5px !important;" />
-                                        <span>{t('account.openFile')}</span>
-                                    </span>
-                                </A>
-                            ) : (
-                                <a onClick={this.export} title={t('accountSummary.exportSummary')}>
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#699ec6" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                                        <polyline points="7 10 12 15 17 10"></polyline>
-                                        <line x1="12" y1="15" x2="12" y2="3"></line>
-                                    </svg>
-                                </a>
-                            )
+                        { debug && (
+                              exported ? (
+                                  <A href={exported} title={exported} className="flex flex-row flex-start flex-items-center">
+                                      <span>
+                                          <img src={checkIcon} style="margin-right: 5px !important;" />
+                                          <span>{t('account.openFile')}</span>
+                                      </span>
+                                  </A>
+                              ) : (
+                                  <a onClick={this.export} title={t('accountSummary.exportSummary')}>
+                                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#699ec6" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                                          <polyline points="7 10 12 15 17 10"></polyline>
+                                          <line x1="12" y1="15" x2="12" y2="3"></line>
+                                      </svg>
+                                  </a>
+                              )
+                        )
                         }
                     </Header>
                     <div className="innerContainer scrollableContainer">


### PR DESCRIPTION
We keep the code so we can bring it back easily if needed, but disable
in production.

It was accidentally enabled when we enabled the whole page in
production.