### PR TITLE
frontend/accountsummary: remove coin title

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -815,8 +815,6 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 
 	jsonAccounts := []*extendedAccountJSON{}
 	totals := map[coinpkg.Coin]*big.Int{}
-	// coin code to coin name.
-	coinNames := map[string]string{}
 
 	// If true, we are missing headers or historical conversion rates necessary to compute the chart
 	// data,
@@ -869,7 +867,6 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 		}
 
 		totals[account.Coin()] = new(big.Int).Add(totals[account.Coin()], balance.Available().BigInt())
-		coinNames[string(account.Coin().Code())] = account.Coin().Name()
 
 		// e.g. 1e8 for Bitcoin/Litecoin, 1e18 for Ethereum, etc. Used to convert from the smallest
 		// unit to the standard unit (BTC, LTC; ETH, etc.).
@@ -1011,7 +1008,6 @@ func (handlers *Handlers) getAccountSummary(_ *http.Request) (interface{}, error
 	return map[string]interface{}{
 		"accounts":         jsonAccounts,
 		"totals":           jsonTotals,
-		"coinNames":        coinNames,
 		"chartDataMissing": chartDataMissing,
 		"chartDataDaily":   toSortedSlice(chartEntriesDaily),
 		"chartDataHourly":  toSortedSlice(chartEntriesHourly),

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -73,7 +73,6 @@ interface BalanceRowProps {
     balance: BalanceInterface;
     coinUnit: string;
     coinCode: CoinCode;
-    title: string;
 }
 
 class AccountsSummary extends Component<Props, State> {
@@ -107,13 +106,13 @@ class AccountsSummary extends Component<Props, State> {
         });
     }
 
-    private balanceRow = ({ name, balance, coinCode, title, coinUnit }: RenderableProps<BalanceRowProps>) => {
+    private balanceRow = ({ name, balance, coinCode, coinUnit }: RenderableProps<BalanceRowProps>) => {
         const { t } = this.props;
         return (
             <tr key={name}>
                 <td data-label={t('accountSummary.name')}>
                     <div class={style.coinName}>
-                        <Logo className={style.coincode} coinCode={coinCode} active={true} alt={title} />
+                        <Logo className={style.coincode} coinCode={coinCode} active={true} alt={coinCode} />
                         {name}
                     </div>
                 </td>
@@ -180,10 +179,7 @@ class AccountsSummary extends Component<Props, State> {
                                     </thead>
                                     <tbody>
                                         { data.accounts.length > 0 ? (
-                                            data.accounts.map(account => this.balanceRow({
-                                                title: data.coinNames[account.coinCode],
-                                                ...account
-                                            }))
+                                            data.accounts.map(account => this.balanceRow(account))
                                         ) : (
                                             <p>{t('accountSummary.noAccount')}</p>
                                         )}


### PR DESCRIPTION
Was previously added to show the coin title when coin grouping was
still around. Not needed anymore.