### PR TITLE
frontend/qt: move Makefile out of linux resources folder

### DIFF
--- a/frontends/qt/resources/Makefile
+++ b/frontends/qt/resources/Makefile
@@ -1,0 +1,9 @@
+SIZES=16x16 32x32 48x48 64x64 128x128
+
+TARGETS=$(addsuffix /apps/bitbox.png, $(addprefix linux/usr/share/icons/hicolor/, ${SIZES}))
+
+all: $(TARGETS)
+
+linux/usr/share/icons/hicolor/%/apps/bitbox.png: app_icon_source.png
+	mkdir -p $(@D)
+	convert $< -resize '$*' $@

--- a/frontends/qt/resources/Makefile
+++ b/frontends/qt/resources/Makefile
@@ -1,6 +1,6 @@
 SIZES=16x16 32x32 48x48 64x64 128x128
 
-TARGETS=$(addsuffix /apps/bitbox.png, $(addprefix linux/usr/share/icons/hicolor/, ${SIZES}))
+TARGETS=$(addprefix linux/usr/share/icons/hicolor/, $(addsuffix /apps/bitbox.png, ${SIZES}))
 
 all: $(TARGETS)
 

--- a/frontends/qt/resources/linux/Makefile
+++ b/frontends/qt/resources/linux/Makefile
@@ -1,9 +1,0 @@
-SIZES=16x16 32x32 48x48 64x64 128x128
-
-TARGETS=$(addsuffix /apps/bitbox.png, $(addprefix usr/share/icons/hicolor/, ${SIZES}))
-
-all: $(TARGETS)
-
-usr/share/icons/hicolor/%/apps/bitbox.png: ../app_icon_source.png
-	mkdir -p $(@D)
-	convert $< -resize '$*' $@


### PR DESCRIPTION
The whole resources folder is packaged and installed, so the Makefile
was installed at `/Makefile` before.

Installing the new (fixed) package will remove the /Makefile.

Fixes #1081