### PR TITLE
backend/eth: initial sync fix

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -66,7 +66,9 @@ type Interface interface {
 	FatalError() bool
 	Close()
 	Notifier() Notifier
+	// Must enforce that initial sync is done before returning.
 	Transactions() (OrderedTransactions, error)
+	// Must enforce that initial sync is done before returning.
 	Balance() (*Balance, error)
 	// SendTx signs and sends the active tx proposal, set by TxProposal. Errors if none
 	// available. The note, if set by ProposeTxNote(), is persisted for the transaction.

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -188,12 +188,13 @@ func (account *Account) Initialize() error {
 	)
 
 	account.coin.Initialize()
-	go account.poll()
+	done := account.Synchronizer.IncRequestsCounter()
+	go account.poll(done)
 
 	return account.BaseAccount.Initialize(accountIdentifier)
 }
 
-func (account *Account) poll() {
+func (account *Account) poll(initDone func()) {
 	timer := time.After(0)
 	for {
 		select {
@@ -212,6 +213,10 @@ func (account *Account) poll() {
 				account.SetOffline(true)
 			} else {
 				account.SetOffline(false)
+			}
+			if initDone != nil {
+				initDone()
+				initDone = nil
 			}
 			timer = time.After(pollInterval)
 		}


### PR DESCRIPTION
An account should enforce Balance() can be safely called after
Initialize() and that the WaitSynchronized() call inside waits for it
to be actually synchronized. in BTC this is enforced as the first
counter increment happens in Initialize() (ensureAddresses()). In ETH
however, it did not. This fixes it, so that account.Balance() returns
the correct data after account.Initialize().