### PR TITLE
Frontend: use custom chart tooltip

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.css
+++ b/frontends/web/src/routes/account/summary/chart.css
@@ -1,27 +1,20 @@
 .chart {
   box-sizing: border-box;
   margin-bottom: var(--spacing-large);
-}
-
-.chartCanvas {
   position: relative;
-}
-
-.chartUpdatignMessage {
-  text-align: center;
 }
 
 .invisible {
   visibility: hidden;
 }
 
-.summary {}
-
 .chart header {
   display: flex;
   flex-wrap: wrap;
   margin-bottom: var(--spacing-half);
 }
+
+.summary {}
 
 .filters {
   align-items: baseline;
@@ -86,4 +79,39 @@
 .diffUnit {
   font-size: 1rem;
   padding: 0 .25rem;
+}
+
+.chartCanvas {
+  position: relative;
+}
+
+.chartUpdatignMessage {
+  text-align: center;
+}
+
+.tooltip {
+  background: white;
+  border: 1px solid #dedede;
+  border-radius: 3px;
+  font-size: var(--size-small);
+  margin-top: -25px;
+  min-width: 140px;
+  padding: .75rem .6rem;
+  pointer-events: none;
+  position: absolute;
+  text-align: center;
+  transition: left .03s ease-out, top .03s ease-out;
+  z-index: 12;
+}
+
+.toolTipValue {
+  font-weight: normal;
+  font-size: 1rem;
+  margin: 0 0 .25rem 0;
+}
+
+.toolTipUnit {
+  color: var(--color-secondary);
+  font-size: var(--size-small);
+  padding: 0 .125rem;
 }


### PR DESCRIPTION
Disabled the standard crosshair price and time labels and added
a custom tooltip, displaying price and date (and time on weekly).

Also enabled entireTextOnly for the priceScale so text should
not be cut off anymore.