### PR TITLE
Frontend portfolio loading

### DIFF
--- a/frontends/web/src/components/spinner/ascii.css
+++ b/frontends/web/src/components/spinner/ascii.css
@@ -1,0 +1,30 @@
+.spinnerContainer {
+  position: relative;
+  display: inline-block;
+}
+
+.spinner {
+  color: var(--color-blue);
+}
+
+.spinner:after {
+  position: relative;
+  top: 2px;
+  animation: changeContent .8s linear infinite;
+  display: block;
+  content: "⠋";
+  font-size: 14px;
+  margin-left: 3px;
+}
+
+@keyframes changeContent {
+  10% { content: "⠙"; }
+  20% { content: "⠹"; }
+  30% { content: "⠸"; }
+  40% { content: "⠼"; }
+  50% { content: "⠴"; }
+  60% { content: "⠦"; }
+  70% { content: "⠧"; }
+  80% { content: "⠇"; }
+  90% { content: "⠏"; }
+}

--- a/frontends/web/src/components/spinner/ascii.tsx
+++ b/frontends/web/src/components/spinner/ascii.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2020 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { h } from 'preact';
+import * as style from './ascii.css';
+
+export default function AsciiSpinner() {
+    return (
+        <div class={style.spinnerContainer}>
+            <div class={style.spinner}></div>
+        </div>
+    );
+}

--- a/frontends/web/src/routes/account/summary/accountssummary.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.css
@@ -17,6 +17,10 @@
     margin-right: calc(var(--space-half) / 2);
 }
 
+.dataMissing {
+    text-align: center;
+}
+
 .table {
     width: 100%;
     border-collapse: collapse;
@@ -51,6 +55,10 @@
 
 .table tbody td {
     background-color: var(--color-white);
+}
+
+.summaryTableBalance {
+    white-space: nowrap;
 }
 
 .table tfoot th {
@@ -106,6 +114,7 @@
 
     .table tbody td::before {
         content: attr(data-label);
+        white-space: nowrap;
     }
 
     .table tbody td:last-child {

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -26,6 +26,7 @@ import { Guide } from '../../../components/guide/guide';
 import { Fiat, FiatConversion } from '../../../components/rates/rates';
 import { TranslateProps } from '../../../decorators/translate';
 import Logo from '../../../components/icon/logo';
+import Spinner from '../../../components/spinner/ascii';
 import { debug } from '../../../utils/env';
 import { apiGet, apiPost } from '../../../utils/request';
 import { apiWebsocket } from '../../../utils/websocket';
@@ -66,10 +67,6 @@ interface Response {
 }
 
 type Props = TranslateProps & AccountSummaryProps;
-
-export type GroupedByCoinCode = {
-    [key in CoinCode]?: AccountAndBalanceInterface[];
-}
 
 interface BalanceRowProps {
     code: string;
@@ -176,7 +173,7 @@ class AccountsSummary extends Component<Props, State> {
                 <tr key={code}>
                     { nameCol }
                     <td data-label={t('accountSummary.balance')}>
-                        <span>
+                        <span className={style.summaryTableBalance}>
                             {balance.available.amount}{' '}
                             <span className={style.coinUnit}>{coinUnit}</span>
                         </span>
@@ -191,7 +188,10 @@ class AccountsSummary extends Component<Props, State> {
         return (
             <tr key={code}>
                 { nameCol }
-                <td colSpan={2}>spinning... { syncStatus }</td>
+                <td colSpan={2}>
+                    { syncStatus }
+                    <Spinner />
+                </td>
             </tr>
         );
     }
@@ -205,35 +205,43 @@ class AccountsSummary extends Component<Props, State> {
                 <div className="container">
                     <Header title={<h2>{t('accountSummary.title')}</h2>}>
                         { debug && (
-                              exported ? (
-                                  <A href={exported} title={exported} className="flex flex-row flex-start flex-items-center">
-                                      <span>
-                                          <img src={checkIcon} style="margin-right: 5px !important;" />
-                                          <span>{t('account.openFile')}</span>
-                                      </span>
-                                  </A>
-                              ) : (
-                                  <a onClick={this.export} title={t('accountSummary.exportSummary')}>
-                                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#699ec6" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                                          <polyline points="7 10 12 15 17 10"></polyline>
-                                          <line x1="12" y1="15" x2="12" y2="3"></line>
-                                      </svg>
-                                  </a>
-                              )
-                        )
-                        }
+                            exported ? (
+                                <A href={exported} title={exported} className="flex flex-row flex-start flex-items-center">
+                                    <span>
+                                        <img src={checkIcon} style="margin-right: 5px !important;" />
+                                        <span>{t('account.openFile')}</span>
+                                    </span>
+                                </A>
+                            ) : (
+                                <a onClick={this.export} title={t('accountSummary.exportSummary')}>
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#699ec6" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                                        <polyline points="7 10 12 15 17 10"></polyline>
+                                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                                    </svg>
+                                </a>
+                            )
+                        )}
                     </Header>
                     <div className="innerContainer scrollableContainer">
                         <div className="content padded">
-                            {data && <Chart
-                                dataDaily={data.chartDataMissing ? undefined : data.chartDataDaily}
-                                dataHourly={data.chartDataMissing ? undefined : data.chartDataHourly}
-                                fiatUnit={data.chartFiat}
-                                total={data.chartTotal}
-                                isUpToDate={data.chartIsUpToDate} />}
+                            {data ? (
+                                <Chart
+                                    dataDaily={data.chartDataMissing ? undefined : data.chartDataDaily}
+                                    dataHourly={data.chartDataMissing ? undefined : data.chartDataHourly}
+                                    fiatUnit={data.chartFiat}
+                                    total={data.chartTotal}
+                                    isUpToDate={data.chartIsUpToDate} />
+                            ) : (
+                                <p>&nbsp;</p>
+                            )}
                             <div className={style.balanceTable}>
                                 <table className={style.table}>
+                                    <colgroup>
+                                        <col width="33%" />
+                                        <col width="33%" />
+                                        <col width="*" />
+                                    </colgroup>
                                     <thead>
                                         <tr>
                                             <th>{t('accountSummary.name')}</th>

--- a/frontends/web/src/routes/account/summary/chart.css
+++ b/frontends/web/src/routes/account/summary/chart.css
@@ -8,6 +8,10 @@
   visibility: hidden;
 }
 
+.chartUpdatingMessage {
+  text-align: center;
+}
+
 .chart header {
   display: flex;
   flex-wrap: wrap;
@@ -83,10 +87,6 @@
 
 .chartCanvas {
   position: relative;
-}
-
-.chartUpdatignMessage {
-  text-align: center;
 }
 
 .tooltip {


### PR DESCRIPTION
- should flicker less during loading, due to fixed widths
- use animated text spinner

tested with:
- just `make servewallet`
- `rm -rf appfolder.dev && cp -r appfolder.dev.brokentxdate appfolder.dev && make servewallet` Note: required new pairing, best unplug BitBox02 first
- `rm -rf appfolder.dev/cache/exchangerates && make servewallet`