### PR TITLE
ci: do not install yarn from homebrew

### DIFF
--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -36,10 +36,10 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     # Install yarn only if it isn't already.
     # GitHub runners already have node and yarn installed which makes homebrew
     # fail due to conflicting files.
-    type yarn > /dev/null || brew install yarn
     brew install nvm
     source /usr/local/opt/nvm/nvm.sh
-    nvm install 10.16.3 # install this node version
+    nvm install 12.19.1 # install this node version
+    npm i -g yarn
     export PATH="/usr/local/opt/qt/bin:$PATH"
     export LDFLAGS="-L/usr/local/opt/qt/lib"
     export CPPFLAGS="-I/usr/local/opt/qt/include"


### PR DESCRIPTION
Because yarn on homebrow has a newer nodejs dependency,
also updated nodejs to 12.x

it still fails but now consistently with github actions