### PR TITLE
backend/rates: do not let request context expire when rate-limited

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -197,8 +197,7 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	if err := os.MkdirAll(ratesCache, 0700); err != nil {
 		log.Errorf("RateUpdater DB cache dir: %v", err)
 	}
-	client := ratelimit.FromTransport(hclient.Transport, rates.CoinGeckoRateLimit)
-	backend.ratesUpdater = rates.NewRateUpdater(client, ratesCache)
+	backend.ratesUpdater = rates.NewRateUpdater(hclient, ratesCache)
 	backend.ratesUpdater.Observe(backend.Notify)
 
 	backend.banners = banners.NewBanners()

--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -33,6 +33,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable/action"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/ratelimit"
 	"github.com/sirupsen/logrus"
 )
 
@@ -101,6 +102,8 @@ type RateUpdater struct {
 	// CoinGecko is where updater gets the historical conversion rates.
 	// See https://www.coingecko.com/en/api for details.
 	coingeckoURL string
+	// All requests to coingeckoURL are rate-limited using geckoLimiter.
+	geckoLimiter *ratelimit.LimitedCall
 }
 
 // NewRateUpdater returns a new rates updater.
@@ -135,6 +138,7 @@ func NewRateUpdater(client *http.Client, dbdir string) *RateUpdater {
 		log:          log,
 		httpClient:   client,
 		coingeckoURL: coingeckoAPIV3,
+		geckoLimiter: ratelimit.NewLimitedCall(coingeckoRateLimit),
 	}
 }
 


### PR DESCRIPTION
When blocked by a rate limit during a network round trip, the request context keeps running. This causes such requests to abort before they even get a chance to fire due to the expired context.

What we want is to start a request context right before making an API call. This commit does exactly that by moving the rate limiting function at a "layer" above the HTTP round trip.

The commit also changes API requests timeout from 1min to 10sec - more than enough for CoinGecko to respond. If it doesn't, we better retry than wait another 50sec.

Alternatives which didn't work:

1. Make a new context in RateLimitedHTTPTransport once unblocked. This loses the cancel function, needed in ReconfigureHistory. It is still possible to make this work by select'ing on both old and new contexts but the code turns out too complex and ugly.

2. Give RateUpdater a separate CoinGecko client type instead of an HTTP client. We make only one API call, maybe two at the most in the future. This doesn't warrant a separate type at the moment. RateUpdater is effectively that client.