### PR TITLE
frontend: show 0 value in chart tooltip

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -37,7 +37,7 @@ interface State {
     difference?: number;
     diffSince?: string;
     toolTipVisible: boolean;
-    toolTipValue: number;
+    toolTipValue?: number;
     toolTipTop: number;
     toolTipLeft: number;
     toolTipTime: number;
@@ -57,7 +57,7 @@ class Chart extends Component<Props, State> {
         display: 'all',
         source: 'daily',
         toolTipVisible: false,
-        toolTipValue: 0,
+        toolTipValue: undefined,
         toolTipTop: 0,
         toolTipLeft: 0,
         toolTipTime: 0,
@@ -417,7 +417,7 @@ class Chart extends Component<Props, State> {
                         className={styles.tooltip}
                         style={`left: ${toolTipLeft}px; top: ${toolTipTop}px;`}
                         hidden={!toolTipVisible}>
-                        {toolTipValue ? (
+                        {toolTipValue !== undefined ? (
                             <span>
                                 <h2 className={styles.toolTipValue}>
                                     {formatNumber(toolTipValue, 2)}


### PR DESCRIPTION
Before it was just an empty tooltip if the balance is 0.