### PR TITLE
frontend: render time in chart tooltip

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.css
+++ b/frontends/web/src/routes/account/summary/chart.css
@@ -115,3 +115,7 @@
   font-size: var(--size-small);
   padding: 0 .125rem;
 }
+
+.toolTipTime {
+  white-space: nowrap;
+}

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -339,11 +339,18 @@ class Chart extends Component<Props, State> {
     }
 
     private renderDate = (date) => {
-        return new Date(date).toLocaleString(this.props.i18n.language, {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-        });
+        return new Date(date).toLocaleString(
+            this.props.i18n.language,
+            {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                ...(this.state.source === 'hourly' ? {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                } : null)
+            }
+        );
     }
 
     public render(
@@ -423,7 +430,9 @@ class Chart extends Component<Props, State> {
                                     {formatNumber(toolTipValue, 2)}
                                     <span className={styles.toolTipUnit}>{fiatUnit}</span>
                                 </h2>
-                                {this.renderDate(toolTipTime * 1000)}
+                                <span className={styles.toolTipTime}>
+                                    {this.renderDate(toolTipTime * 1000)}
+                                </span>
                             </span>
                         ): null}
                     </span>


### PR DESCRIPTION
On the weekly chart with many datapoints it should
now display date and time in the chart tooltip.
Did only display date before.