### PR TITLE
backend/accounts: handle transactions with negative height

### DIFF
--- a/backend/accounts/transaction_test.go
+++ b/backend/accounts/transaction_test.go
@@ -51,6 +51,12 @@ func TestOrderedTransactions(t *testing.T) {
 			Amount:    coin.NewAmountFromInt64(20),
 		},
 		{
+			Timestamp: nil,
+			Height:    -1, // unconfirmed parent
+			Type:      TxTypeSend,
+			Amount:    coin.NewAmountFromInt64(20),
+		},
+		{
 			Timestamp: tt(time.Date(2020, 9, 11, 12, 0, 0, 0, time.UTC)),
 			Height:    11,
 			Type:      TxTypeSend,
@@ -73,13 +79,14 @@ func TestOrderedTransactions(t *testing.T) {
 		},
 	}
 	ordered := NewOrderedTransactions(txs)
-	require.Equal(t, coin.NewAmountFromInt64(564), ordered[0].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(584), ordered[1].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(589), ordered[2].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(590), ordered[3].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(290), ordered[4].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(190), ordered[5].Balance)
-	require.Equal(t, coin.NewAmountFromInt64(200), ordered[6].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(544), ordered[0].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(564), ordered[1].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(584), ordered[2].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(589), ordered[3].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(590), ordered[4].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(290), ordered[5].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(190), ordered[6].Balance)
+	require.Equal(t, coin.NewAmountFromInt64(200), ordered[7].Balance)
 
 	timeseries, err := ordered.Timeseries(
 		time.Date(2020, 9, 9, 13, 0, 0, 0, time.UTC),

--- a/backend/coins/btc/blockchain/blockchain.go
+++ b/backend/coins/btc/blockchain/blockchain.go
@@ -55,6 +55,8 @@ func (txHash *TXHash) UnmarshalJSON(jsonBytes []byte) error {
 
 // TxInfo is returned by ScriptHashGetHistory.
 type TxInfo struct {
+	// >0 for a confirmed transaction. 0 for an unconfirmed transaction. -1 for an unconfirmed
+	// transaction with an unconfirmed parent transaction.
 	Height int    `json:"height"`
 	TXHash TXHash `json:"tx_hash"`
 	Fee    *int64 `json:"fee"`


### PR DESCRIPTION
Electrum servers return -1 for the tx height if the tx is unconfirmed
with an unconfirmed parent. The code in the Timeseries() incorrectly
assumed that unconfirmed means a height of 0, leading to an
false `ErrNotAvailable` error if such a transaction is present.