### PR TITLE
frontend: update chart depending on the current source

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -87,7 +87,8 @@ class Chart extends Component<Props, State> {
                 || prev.dataHourly.length !== dataHourly.length
             )
         ) {
-            this.lineSeries.setData(dataDaily);
+            const data = this.state.source === 'hourly' ? dataHourly : dataDaily;
+            this.lineSeries.setData(data);
         }
     }
 


### PR DESCRIPTION
When leaving the chart on the weekly view after a while
it would be overwritten by the daily chart data.

It now checks the current source and updates the chart
accordingly.