### PR TITLE
frontend: only show buyable coins in moonpay dropdown

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -526,7 +526,7 @@
       "skip": "Do not show again",
       "title": "Buy {{name}}"
     },
-    "title": "Buy crypto"
+    "title": "Buy {{name}}"
   },
   "changePin": {
     "newTitle": "New device password",

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -17,6 +17,22 @@
 
 import { CoinCode } from './account';
 
+export function isBitcoin(code: string): boolean {
+    switch (code) {
+    case 'btc':
+    case 'btc-p2wpkh':
+    case 'btc-p2wpkh-p2sh':
+    case 'btc-p2pkh':
+    case 'tbtc':
+    case 'tbtc-p2wpkh':
+    case 'tbtc-p2wpkh-p2sh':
+    case 'tbtc-p2pkh':
+        return true;
+    default:
+        return false;
+    }
+}
+
 export function isBitcoinBased(coinCode: CoinCode): boolean {
     switch (coinCode) {
     case 'btc':


### PR DESCRIPTION
The dropdown checks now each coin if buying is supported and
only shows those accounts.