### PR TITLE
frontend: support editing notes inline in tx overview

### DIFF
--- a/frontends/web/src/components/transactions/components/icons.tsx
+++ b/frontends/web/src/components/transactions/components/icons.tsx
@@ -49,7 +49,7 @@ export const ArrowSelf = (): JSX.Element => (
     </svg>
 );
 
-export const Edit = (): JSX.Element => (
+export const Edit = ({ className }: { className?: string }): JSX.Element => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="20"
@@ -59,7 +59,8 @@ export const Edit = (): JSX.Element => (
         stroke="currentColor"
         strokeWidth="1"
         strokeLinecap="round"
-        strokeLinejoin="round">
+        strokeLinejoin="round"
+        className={className}>
             <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
             <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
     </svg>

--- a/frontends/web/src/components/transactions/transaction.css
+++ b/frontends/web/src/components/transactions/transaction.css
@@ -163,6 +163,12 @@
 
 .textOnlyInput input {
     border: none;
+    height: auto;
+    padding: var(--space-quarter) 0;
+}
+
+.detailInput .textOnlyInput input {
+    padding: 0 var(--space-half);
 }
 
 .editButton {

--- a/frontends/web/src/components/transactions/transactions.css
+++ b/frontends/web/src/components/transactions/transactions.css
@@ -60,6 +60,31 @@
   text-align: left;
 }
 
+.inlineEditButton {
+  background: transparent;
+  border: none;
+  line-height: 1;
+  outline: none;
+  padding: 2px;
+  -webkit-appearance: none;
+}
+
+.activity svg {
+  height: 14px;
+}
+
+.activity input {
+  margin-top: -1px;
+}
+
+.iconActive {
+  stroke: var(--color-blue);
+}
+
+.iconNormal {
+  stroke: var(--color-gray);
+}
+
 .status {
   min-width: 106px;
   width: 106px;

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -20,7 +20,12 @@ import A from '../../components/anchor/anchor';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { runningInAndroid } from '../../utils/env';
 import { Transaction, TransactionInterface } from './transaction';
+import { Edit } from './components/icons';
 import * as style from './transactions.css';
+
+interface State {
+    notesEditMode: boolean;
+}
 
 interface TransactionsProps {
     accountCode: string;
@@ -32,7 +37,17 @@ interface TransactionsProps {
 
 type Props = TransactionsProps & TranslateProps;
 
-class Transactions extends Component<Props> {
+class Transactions extends Component<Props, State> {
+    public readonly state: State = {
+        notesEditMode: false,
+    };
+
+    private handleEditNotes = () => {
+        this.setState(({ notesEditMode }) => ({
+            notesEditMode: !notesEditMode
+        }));
+    }
+
     public render({
         t,
         accountCode,
@@ -40,7 +55,8 @@ class Transactions extends Component<Props> {
         transactions,
         exported,
         handleExport,
-    }: RenderableProps<Props>) {
+    }: RenderableProps<Props>,
+    { notesEditMode }: State) {
         // We don't support CSV export on Android yet, as it's a tricky to deal with the Downloads
         // folder and permissions.
         const csvExportDisabled = runningInAndroid();
@@ -60,7 +76,14 @@ class Transactions extends Component<Props> {
                 <div className={[style.columns, style.headers, style.showOnMedium].join(' ')}>
                     <div className={style.type}>{t('transaction.details.type')}</div>
                     <div className={style.date}>{t('transaction.details.date')}</div>
-                    <div className={style.activity}>{t('transaction.details.activity')}</div>
+                    <div className={style.activity}>
+                        {t('transaction.details.activity')}
+                        {transactions && transactions.length > 0 ? (
+                            <button onClick={this.handleEditNotes} className={style.inlineEditButton}>
+                                <Edit className={notesEditMode ? style.iconActive : style.iconNormal} />
+                            </button>
+                        ) : null}
+                    </div>
                     <div className={style.status}>{t('transaction.details.status')}</div>
                     <div className={style.fiat}>{t('transaction.details.fiatAmount')}</div>
                     <div className={style.currency}>{t('transaction.details.amount')}</div>
@@ -70,9 +93,10 @@ class Transactions extends Component<Props> {
                     (transactions && transactions.length > 0) ? transactions
                     .map((props, index) => (
                         <Transaction
-                            accountCode={accountCode}
                             key={props.internalID}
+                            accountCode={accountCode}
                             explorerURL={explorerURL}
+                            inlineEditMode={notesEditMode}
                             index={index}
                             {...props} />
                     )) : (


### PR DESCRIPTION
Added a small edit button in the tx overview when in table layout.
The edit mode turns all notes/tx into a text field, and chnages
are automatically saved.