### PR TITLE
docker: upgrade nodejs to 14.x and go to 1.14.13 and switch to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,19 @@ env:
   #
   # To update this image, generate a personal token with write:packages scope
   # on https://github.com/settings/tokens and authenticate yourself locally with
-  # "docker login https://docker.pkg.github.com -u <github-username>" using the
+  # "docker login ghcr.io -u <github-username>" using the
   # newly generated token as password.
   # Once logged in, tag an new image:
   #   docker tag shiftcrypto/bitbox-wallet-app:VERSION \
-  #   docker.pkg.github.com/digitalbitbox/bitbox-wallet-app/ci-builder:VERSION
+  #     ghcr.io/digitalbitbox/bitbox-wallet-app-ci:VERSION
   # and push as usual:
-  #   docker push docker.pkg.github.com/digitalbitbox/bitbox-wallet-app/ci-builder:VERSION
+  #   docker push ghcr.io/digitalbitbox/bitbox-wallet-app-ci:VERSION
   # Lastly, update the next line to use the newly pushed image version.
   # See docs for more details:
-  # https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages
+  # https://docs.github.com/en/packages/guides/pushing-and-pulling-docker-images
   #
   # Keep this in sync with default in scripts/travis-ci.sh.
-  CI_IMAGE: docker.pkg.github.com/digitalbitbox/bitbox-wallet-app/ci-builder:6
+  CI_IMAGE: ghcr.io/digitalbitbox/bitbox-wallet-app-ci:7
   TRAVIS_BUILD_DIR: ${{github.workspace}}
 
 jobs:
@@ -30,8 +30,6 @@ jobs:
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2
-      - name: Docker login
-        run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
       - name: Enable caching
         uses: actions/cache@v2
         with:
@@ -48,8 +46,6 @@ jobs:
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2
-      - name: Docker login
-        run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
       - name: Enable caching
         uses: actions/cache@v2
         with:
@@ -72,8 +68,6 @@ jobs:
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2
-      - name: Docker login
-        run: docker login -u ${{github.actor}} -p ${{github.token}} https://docker.pkg.github.com
       - name: Enable caching
         uses: actions/cache@v2
         with:

--- a/scripts/docker_install.sh
+++ b/scripts/docker_install.sh
@@ -18,7 +18,7 @@ apt-get update
 apt-get install -y --no-install-recommends curl ca-certificates
 
 # add repository for node/npm
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
+curl -sL https://deb.nodesource.com/setup_14.x | bash -
 
 apt-get install -y --no-install-recommends \
     clang \
@@ -39,7 +39,7 @@ npm install -g yarn
 npm install -g locize-cli
 
 mkdir -p /opt/go_dist
-curl https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz | tar -xz -C /opt/go_dist
+curl https://dl.google.com/go/go1.14.13.linux-amd64.tar.gz | tar -xz -C /opt/go_dist
 
 # Needed for qt5. fuse is needed to run the linuxdeployqt appimage.
 apt-get install -y --no-install-recommends fuse

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -14,7 +14,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     # Which docker image to use to run the CI. Defaults to Docker Hub.
     # Overwrite with CI_IMAGE=docker/image/path environment variable.
     # Keep this in sync with .github/workflows/ci.yml.
-    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:6}"
+    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:7}"
     # Time image pull to compare in the future.
     time docker pull "$CI_IMAGE"
 
@@ -33,13 +33,10 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     # this script.
     go version
     brew install qt
-    # Install yarn only if it isn't already.
-    # GitHub runners already have node and yarn installed which makes homebrew
-    # fail due to conflicting files.
-    type yarn > /dev/null || brew install yarn
     brew install nvm
     source /usr/local/opt/nvm/nvm.sh
-    nvm install 10.16.3 # install this node version
+    nvm install 14.15.4 # install this node version
+    npm install -g yarn
     export PATH="/usr/local/opt/qt/bin:$PATH"
     export LDFLAGS="-L/usr/local/opt/qt/lib"
     export CPPFLAGS="-I/usr/local/opt/qt/include"


### PR DESCRIPTION
Nodejs is required by newer preact-cli.
While there, also upgrade Go. Been meaning to do it for a while. Seemed
like a good opportunity.

This commit also switching from the now deprecated GitHub docker
registry to its replacement ghcr.io. See more details here:
https://docs.github.com/es/packages/guides/migrating-to-github-container-registry-for-docker-images

On macOS, the yarn tool is now installed using npm instead of
homebrew because homebrew specifies yarn being dependnt on a nodejs
of a version we cannot control. The end result is we may end up with
two nodejs installed and cannot control this.
With "npm install -g yarn", there's only one version of nodejs
installed.

This incorporates and obsoletes https://github.com/digitalbitbox/bitbox-wallet-app/pull/1091.