### PR TITLE
logging: don't panic, truncate and rotate

### DIFF
--- a/backend/chart.go
+++ b/backend/chart.go
@@ -106,7 +106,6 @@ func (backend *Backend) ChartData() (*Chart, error) {
 		backend.log.Info("ChartDataMissing, until is zero")
 	}
 	isUpToDate := time.Since(until) < 2*time.Hour
-	backend.log.Infof("Chart/isUptodate: %v", isUpToDate)
 
 	currentTotal := new(big.Rat)
 	currentTotalMissing := false

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -266,7 +266,6 @@ func (account *Account) Initialize() error {
 	}
 	defer account.Lock()()
 	if account.initialized {
-		account.log.Debug("Account has already been initialized")
 		return nil
 	}
 	account.initialized = true

--- a/backend/coins/btc/synchronizer/synchronizer.go
+++ b/backend/coins/btc/synchronizer/synchronizer.go
@@ -70,12 +70,10 @@ func (synchronizer *Synchronizer) decRequestsCounter() {
 
 // WaitSynchronized blocks until all pending synchronization tasks are finished.
 func (synchronizer *Synchronizer) WaitSynchronized() {
-	synchronizer.log.WithFields(logrus.Fields{"requestCounter": synchronizer.requestsCounter}).
-		Debug("wait synchronized")
-	if func() int32 {
-		defer synchronizer.waitLock.RLock()()
-		return synchronizer.requestsCounter
-	}() == 0 {
+	unlock := synchronizer.waitLock.RLock()
+	n := synchronizer.requestsCounter
+	unlock()
+	if n == 0 {
 		return
 	}
 	<-synchronizer.wait

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -728,10 +728,8 @@ func isAPITokenValid(w http.ResponseWriter, r *http.Request, apiData *Connection
 	methodLogEntry := log.WithField("path", r.URL.Path)
 	// In dev mode, we allow unauthorized requests
 	if apiData.devMode {
-		// methodLogEntry.Debug("Allowing access without authorization token in dev mode")
 		return true
 	}
-	methodLogEntry.Debug("Checking API token")
 
 	if len(r.Header.Get("Authorization")) == 0 {
 		methodLogEntry.Error("Missing token in API request. WARNING: this could be an attack on the API")

--- a/util/jsonrpc/jsonrpc.go
+++ b/util/jsonrpc/jsonrpc.go
@@ -438,10 +438,6 @@ func (client *RPCClient) handleResponse(conn *connection, responseBytes []byte) 
 			if ok {
 				client.log.Debug("Pong")
 				delete(client.pingRequests, *response.ID)
-			} else {
-				client.log.WithField("request_id", *response.ID).WithField("response", string(response.Result)).Info("Request not found in list of " +
-					"pending requests. It's likely that it finished before a failover and we therefore " +
-					"do not have to do anything.")
 			}
 			unlock()
 		}

--- a/util/logging/logger.go
+++ b/util/logging/logger.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,6 +29,7 @@ type Logger struct {
 
 // NewLogger returns a new logger based on the given configuration.
 func NewLogger(configuration *Configuration) *Logger {
+	fmt.Printf("Logging into '%s' from '%s'.\n", configuration.Output, configuration.Level)
 	var logger = Logger{}
 	logger.Formatter = &logrus.TextFormatter{}
 	logger.Hooks = make(logrus.LevelHooks)
@@ -43,16 +43,19 @@ func NewLogger(configuration *Configuration) *Logger {
 		logger.Out = os.Stderr
 	default:
 		if err := os.MkdirAll(filepath.Dir(configuration.Output), os.ModeDir|os.ModePerm); err != nil {
-			panic(errp.WithStack(err))
+			fmt.Fprintf(os.Stderr, "Can't create log dir: %v; logging to stderr.\n", err)
+			logger.Out = os.Stderr
+			break
 		}
 		file, err := os.OpenFile(configuration.Output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
-			panic(errp.WithStack(err))
+			fmt.Fprintf(os.Stderr, "Can't open log file: %v; logging to stderr.\n", err)
+			logger.Out = os.Stderr
+			break
 		}
 		logger.Out = file
 	}
 	logger.Level = configuration.Level
-	fmt.Printf("Logging into '%s' from '%s'.\n", configuration.Output, configuration.Level)
 	return &logger
 }
 

--- a/util/logging/logger.go
+++ b/util/logging/logger.go
@@ -16,11 +16,22 @@ package logging
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 )
+
+// How many bytes before rotating the log file.
+// Note that rotation preserves the old file. The total size occupied
+// by the log files on disk is thus capped at double this value.
+//
+// It is a pkg var instead of a const for easier testing.
+var maxLogFileSizeBytes int64 = 1 << 24 // ~16Mb
+// A commonly used suffix for rotated log files.
+const rotatedSuffix = ".1"
 
 // Logger adds a method to the logrus logger.
 type Logger struct {
@@ -28,6 +39,8 @@ type Logger struct {
 }
 
 // NewLogger returns a new logger based on the given configuration.
+// It is unsafe for concurrent use because NewLogger may rotate and truncate
+// an existing log file if it's too big.
 func NewLogger(configuration *Configuration) *Logger {
 	fmt.Printf("Logging into '%s' from '%s'.\n", configuration.Output, configuration.Level)
 	var logger = Logger{}
@@ -47,19 +60,125 @@ func NewLogger(configuration *Configuration) *Logger {
 			logger.Out = os.Stderr
 			break
 		}
-		file, err := os.OpenFile(configuration.Output, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		rotWriter, err := openRotatingWriter(configuration.Output)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Can't open log file: %v; logging to stderr.\n", err)
 			logger.Out = os.Stderr
 			break
 		}
-		logger.Out = file
+		logger.Out = rotWriter
 	}
 	logger.Level = configuration.Level
+	logger.SetNoLock() // rotatingWriter already employs a writer mutex
 	return &logger
 }
 
 // WithGroup sets a trace group for the log entry.
 func (logger *Logger) WithGroup(group string) *logrus.Entry {
 	return logger.WithField("group", group)
+}
+
+// openRotatingWriter creates a new rotatingWrite which writes log messages
+// to the named file.
+// It also rotates and truncates head of the log file before returning
+// if the existing file size exceeds maxLogFileSizeBytes.
+func openRotatingWriter(name string) (*rotatingWriter, error) {
+	file, err := os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+	// In earlier app versions, log file didn't have a size limit.
+	// If this is the case and the old log file is too big, keep only the last bytes.
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := stat.Size()
+	if size > maxLogFileSizeBytes {
+		newfile, oldname, err := rotate(file)
+		if err != nil {
+			return nil, err
+		}
+		go func() {
+			if err := truncateHead(oldname); err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to truncate old logfile: %v.\n", err)
+			}
+			testDidTruncateHead()
+		}()
+		file = newfile
+		size = 0
+	}
+	return &rotatingWriter{logfile: file, bytesCount: size}, nil
+}
+
+// A test callback once truncateHead returned.
+var testDidTruncateHead = func() {}
+
+// rotatingWriter is an io.Writer which rotates the logfile once its size
+// exceeds maxLogFileSizeBytes.
+// The rotated file is moved to a new name with rotatedSuffix, replacing
+// an existing file, if any.
+type rotatingWriter struct {
+	mu         sync.Mutex
+	logfile    *os.File
+	bytesCount int64
+}
+
+// Write satisfies io.Writer interface.
+// It rotates rot.logfile if its size plus len(p) exceeds maxLogFileSizeBytes.
+func (rot *rotatingWriter) Write(p []byte) (n int, err error) {
+	rot.mu.Lock()
+	defer rot.mu.Unlock()
+	newbytes := int64(len(p))
+	if rot.bytesCount+newbytes > maxLogFileSizeBytes {
+		f, _, err := rotate(rot.logfile)
+		if err != nil {
+			return 0, err
+		}
+		rot.logfile = f
+		rot.bytesCount = 0
+	}
+	rot.bytesCount += newbytes
+	return rot.logfile.Write(p)
+}
+
+// rotate moves logfile to a new name with rotatedSuffix, returning its name
+// under oldname, and opens a new file at logfile.Name().
+func rotate(logfile *os.File) (newfile *os.File, oldname string, err error) {
+	if err := logfile.Close(); err != nil {
+		return nil, "", err
+	}
+	filename := logfile.Name()
+	rotated := filename + rotatedSuffix
+	if err := os.Rename(filename, rotated); err != nil {
+		return nil, "", err
+	}
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY|os.O_APPEND, 0600)
+	return f, rotated, err
+}
+
+// truncateHead keeps the last maxLogFileSizeBytes in the filename log file.
+// This serves as a migration for older app versions where log file size
+// was unlimited.
+func truncateHead(filename string) error {
+	logfile, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	if _, err := logfile.Seek(-maxLogFileSizeBytes, io.SeekEnd); err != nil {
+		return err
+	}
+	tempfile, err := os.OpenFile(filename+".tmp", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tempfile.Name()) //nolint:errcheck // clean up in case of a failure
+	if _, err := io.Copy(tempfile, logfile); err != nil {
+		return err
+	}
+	if err := tempfile.Close(); err != nil {
+		return err
+	}
+	logfile.Close() //nolint:errcheck // don't care about err; will be overwritten anyway
+	return os.Rename(tempfile.Name(), logfile.Name())
 }

--- a/util/logging/logger_test.go
+++ b/util/logging/logger_test.go
@@ -1,0 +1,122 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The parent/child process tests here are to make sure they are deterministic
+// thanks to:
+// 1. All log file descriptors are closed and buffers are flushed at child
+//    process exit.
+// 2. The maxLogFileSizeBytes and other package variables are set only
+//    within the child branch to not affect any other test in the same testing
+//    binary.
+
+func TestNewLogger(t *testing.T) {
+	// If the env var is set, we're in the child process.
+	if logfile := os.Getenv("BITBOX_TEST_APP_LOGFILE"); logfile != "" {
+		maxLogFileSizeBytes = 20
+		done := make(chan struct{})
+		testDidTruncateHead = func() { close(done) }
+
+		// Since the existing log file created in the parent process below
+		// already exceeds maxLogFileSizeBytes, expect NewLogger to immediately
+		// rotate and truncate the log file.
+		logger := NewLogger(&Configuration{Output: logfile, Level: logrus.InfoLevel})
+		logger.Formatter.(*logrus.TextFormatter).DisableTimestamp = true
+		logger.Println("new")
+
+		select {
+		case <-time.After(2 * time.Second):
+			t.Fatal("took too long to truncate old file")
+		case <-done:
+			// ok
+		}
+		return
+	}
+
+	// A dir where testing log files are stored.
+	tempdir, err := ioutil.TempDir("", "logger_test")
+	require.NoError(t, err, "temp dir")
+	defer os.RemoveAll(tempdir)
+
+	// Prep the data: existing file is still smaller than the maxLogFileSizeBytes
+	// but a new sufficiently large message should trigger log file rotation.
+	logfile := filepath.Join(tempdir, "log.txt")
+	v := []byte("0123456789012345678901234") // 25 bytes > maxLogFileSizeBytes
+	require.NoError(t, ioutil.WriteFile(logfile, v, 0644), "write log.txt")
+
+	// Execute the child process where the actual rotation and truncation happens.
+	cmd := exec.Command(os.Args[0], "-test.run=TestNewLogger", "-test.v=true")
+	cmd.Env = []string{fmt.Sprintf("BITBOX_TEST_APP_LOGFILE=%s", logfile)}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run(), "cmd.Run")
+
+	// Expect the rotate log file to also be truncated to
+	// maxLogFileSizeBytes - 25 = last 20 bytes.
+	b1, _ := ioutil.ReadFile(logfile + rotatedSuffix)
+	assert.Equal(t, "56789012345678901234", string(b1), "old truncated logfile")
+	b2, _ := ioutil.ReadFile(logfile)
+	assert.Equal(t, "level=info msg=new\n", string(b2), "new logfile")
+}
+
+func TestLoggerRotatingWriter(t *testing.T) {
+	// If the env var is set, we're in the child process.
+	if logfile := os.Getenv("BITBOX_TEST_APP_LOGFILE"); logfile != "" {
+		maxLogFileSizeBytes = 20
+		logger := NewLogger(&Configuration{Output: logfile, Level: logrus.InfoLevel})
+		logger.Formatter.(*logrus.TextFormatter).DisableTimestamp = true
+		logger.Println("newfile")
+		return
+	}
+
+	// A dir where testing log files are stored.
+	tempdir, err := ioutil.TempDir("", "logger_test")
+	require.NoError(t, err, "temp dir")
+	defer os.RemoveAll(tempdir)
+
+	// Prep the data: existing file is still smaller than the maxLogFileSizeBytes
+	// but a new sufficiently large message should trigger log file rotation.
+	logfile := filepath.Join(tempdir, "log.txt")
+	v := []byte("0123456789") // 10 bytes < maxLogFileSizeBytes
+	require.NoError(t, ioutil.WriteFile(logfile, v, 0644), "write log.txt")
+
+	// Execute the child process which actually logs a new message.
+	cmd := exec.Command(os.Args[0], "-test.run=TestLoggerRotatingWriter", "-test.v=true")
+	cmd.Env = []string{fmt.Sprintf("BITBOX_TEST_APP_LOGFILE=%s", logfile)}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run(), "cmd.Run")
+
+	// Expect the logger to rotate the file since the total size exceeds
+	// maxLogFileSizeBytes.
+	b1, _ := ioutil.ReadFile(logfile + rotatedSuffix)
+	assert.Equal(t, "0123456789", string(b1), "rotated logfile")
+	b2, _ := ioutil.ReadFile(logfile)
+	assert.Equal(t, "level=info msg=newfile\n", string(b2), "new logfile")
+}


### PR DESCRIPTION
App log file is now rotated once its size exceeds a reasonably large
number. The rotated file is moved to a new name with ".1" suffix,
common for log rotations, replacing any existing file.
Once rotated a new empty file is created under the original name.

Thus, the app keeps at most double the threshold size.

Because previously the log file size was unlimited, we also truncate
the head of an existing log file if its size already exceeds the
threshold.