### PR TITLE
frontend: catch language c and fallback to en

### DIFF
--- a/frontends/web/src/i18n/i18n.js
+++ b/frontends/web/src/i18n/i18n.js
@@ -121,6 +121,9 @@ i18n.on('languageChanged', (lng) => {
             const localeLang = nativeLocale.replace('_', '-').split('-')[0];
             match = lngLang === localeLang;
         }
+        if (lng.toLowerCase() === 'c') {
+            lng = 'en';
+        }
         const uiLang = match ? null : lng;
         return setConfig({ frontend: { userLanguage: uiLang } });
     });

--- a/frontends/web/test/i18n/i18n.test.tsx
+++ b/frontends/web/test/i18n/i18n.test.tsx
@@ -56,6 +56,7 @@ describe('i18n', () => {
             {nativeLocale: 'de-DE', newLang: 'de', userLang: null},
             {nativeLocale: 'pt_BR', newLang: 'pt', userLang: null},
             {nativeLocale: 'fr', newLang: 'en', userLang: 'en'},
+            {nativeLocale: 'C.UTF-8', newLang: 'C', userLang: 'en'}
         ];
         table.forEach((test) => {
             it(`sets userLanguage to ${test.userLang} if native-locale is ${test.nativeLocale}`, (done) => {


### PR DESCRIPTION
BitBoxApp currently does not support LANG=C.UTF-8 and errors with
js: Uncaught RangeError: Invalid language tag: C

This update checks if i18n wants to change to c language and sets
en instead.