### PR TITLE
frontend: catch language c and fallback to en

### DIFF
--- a/frontends/web/src/i18n/config.js
+++ b/frontends/web/src/i18n/config.js
@@ -35,6 +35,12 @@ export default {
             }
             apiGet('native-locale').then(locale => {
                 if (typeof locale === 'string' && locale) {
+                    try {
+                        new Date().toLocaleString(i18nextFormat(locale));
+                    } catch (e) {
+                        cb(defaultUserLanguage);
+                        return;
+                    }
                     cb(i18nextFormat(locale));
                     return;
                 }

--- a/frontends/web/test/i18n/config.test.tsx
+++ b/frontends/web/test/i18n/config.test.tsx
@@ -59,6 +59,20 @@ describe('language detector', () => {
         });
     });
 
+    it('uses defaultUserLanguage fallback if native-locale is C.UTF-8', done => {
+        (apiGet as jest.Mock).mockImplementation(endpoint => {
+            switch (endpoint) {
+                case 'config': { return Promise.resolve({}); }
+                case 'native-locale': { return Promise.resolve('C.UTF-8'); }
+                default: { return Promise.resolve(); }
+            }
+        });
+        i18nconfig.detect((lang) => {
+            expect(lang).toEqual('en');
+            done();
+        });
+    });
+
     it('uses native-locale if userLanguage is null', done => {
         (apiGet as jest.Mock).mockImplementation(endpoint => {
             switch (endpoint) {


### PR DESCRIPTION
BitBoxApp currently does not support LANG=C.UTF-8 and errors with
`js: Uncaught RangeError: Invalid language tag: C`

Adding another fallback in case the proposed locale errors with Date.toLocaleString.

