### PR TITLE
frontend/buy: change exchanges guide key

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -821,7 +821,7 @@
       }
     },
     "buy": {
-      "support": {
+      "exchanges": {
         "link": {
           "text": "List of exchanges",
           "url": "/exchanges"

--- a/frontends/web/src/routes/buy/guide.tsx
+++ b/frontends/web/src/routes/buy/guide.tsx
@@ -46,7 +46,7 @@ export default function BuyGuide({
         text: t('buy.info.disclaimer.protection.description', { name }),
         title: t('buy.info.disclaimer.protection.title'),
       }} />
-      <Entry key="guide.buy.support" entry={t('guide.buy.support')} />
+      <Entry key="guide.buy.exchanges" entry={t('guide.buy.exchanges')} />
     </Guide>
   );
 }


### PR DESCRIPTION
The old key has Safello text in translated languages, and the key
'support' also does not fit.