### PR TITLE
moonpay: propagate fiat and language to the widget 

### DIFF
--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -33,7 +33,6 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/util"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth"
-	"github.com/digitalbitbox/bitbox-wallet-app/backend/exchanges"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
@@ -67,8 +66,6 @@ func NewHandlers(
 	handleFunc("/can-verify-extended-public-key", handlers.ensureAccountInitialized(handlers.getCanVerifyExtendedPublicKey)).Methods("GET")
 	handleFunc("/verify-extended-public-key", handlers.ensureAccountInitialized(handlers.postVerifyExtendedPublicKey)).Methods("POST")
 	handleFunc("/has-secure-output", handlers.ensureAccountInitialized(handlers.getHasSecureOutput)).Methods("GET")
-	handleFunc("/exchange/moonpay/buy-supported", handlers.ensureAccountInitialized(handlers.getExchangeMoonpayBuySupported)).Methods("GET")
-	handleFunc("/exchange/moonpay/buy", handlers.ensureAccountInitialized(handlers.getExchangeMoonpayBuy)).Methods("GET")
 	handleFunc("/propose-tx-note", handlers.ensureAccountInitialized(handlers.postProposeTxNote)).Methods("POST")
 	handleFunc("/notes/tx", handlers.ensureAccountInitialized(handlers.postSetTxNote)).Methods("POST")
 	return handlers
@@ -482,29 +479,6 @@ func (handlers *Handlers) getHasSecureOutput(r *http.Request) (interface{}, erro
 		"hasSecureOutput": hasSecureOutput,
 		"optional":        optional,
 	}, nil
-}
-
-func (handlers *Handlers) getExchangeMoonpayBuySupported(r *http.Request) (interface{}, error) {
-	return exchanges.IsMoonpaySupported(handlers.account.Coin().Code()), nil
-}
-
-func (handlers *Handlers) getExchangeMoonpayBuy(r *http.Request) (interface{}, error) {
-	params := exchanges.BuyMoonpayParams{
-		Fiat: "CHF", // TODO: Get this from app config
-		Lang: "en",  // TODO: Get this from the backend
-	}
-	buy, err := exchanges.BuyMoonpay(handlers.account, params)
-	if err != nil {
-		return nil, err
-	}
-	resp := struct {
-		URL     string `json:"url"`
-		Address string `json:"address"`
-	}{
-		URL:     buy.URL,
-		Address: buy.Address,
-	}
-	return resp, nil
 }
 
 func (handlers *Handlers) postProposeTxNote(r *http.Request) (interface{}, error) {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -899,8 +899,8 @@ func (handlers *Handlers) getExchangeMoonpayBuy(r *http.Request) (interface{}, e
 		return nil, fmt.Errorf("unknown account code %q", acctCode)
 	}
 	params := exchanges.BuyMoonpayParams{
-		Fiat: "CHF", // TODO: Get this from app config
-		Lang: "en",  // TODO: Get this from the backend
+		Fiat: handlers.backend.Config().AppConfig().Backend.MainFiat,
+		Lang: handlers.backend.Config().AppConfig().Backend.UserLanguage,
 	}
 	buy, err := exchanges.BuyMoonpay(acct, params)
 	if err != nil {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -48,6 +48,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox02bootloader"
 	bitbox02bootloaderHandlers "github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox02bootloader/handlers"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/device"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/exchanges"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/rates"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
@@ -202,6 +203,8 @@ func NewHandlers(
 	getAPIRouter(apiRouter)("/coins/btc/headers/status", handlers.getHeadersStatus(coinpkg.CodeBTC)).Methods("GET")
 	getAPIRouter(apiRouter)("/certs/download", handlers.postCertsDownloadHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/electrum/check", handlers.postElectrumCheckHandler).Methods("POST")
+	getAPIRouter(apiRouter)("/exchange/moonpay/buy-supported/{code}", handlers.getExchangeMoonpayBuySupported).Methods("GET")
+	getAPIRouter(apiRouter)("/exchange/moonpay/buy/{code}", handlers.getExchangeMoonpayBuy).Methods("GET")
 	getAPIRouter(apiRouter)("/bitboxbases/establish-connection", handlers.postEstablishConnectionHandler).Methods("POST")
 
 	devicesRouter := getAPIRouter(apiRouter.PathPrefix("/devices").Subrouter())
@@ -867,4 +870,48 @@ func (handlers *Handlers) postExportAccountSummary(_ *http.Request) (interface{}
 		}
 	}
 	return path, nil
+}
+
+func (handlers *Handlers) getExchangeMoonpayBuySupported(r *http.Request) (interface{}, error) {
+	acctCode := mux.Vars(r)["code"]
+	// TODO: Refactor to make use of a map.
+	var acct accounts.Interface
+	for _, a := range handlers.backend.Accounts() {
+		if a.Config().Code == acctCode {
+			acct = a
+			break
+		}
+	}
+	return acct != nil && exchanges.IsMoonpaySupported(acct.Coin().Code()), nil
+}
+
+func (handlers *Handlers) getExchangeMoonpayBuy(r *http.Request) (interface{}, error) {
+	acctCode := mux.Vars(r)["code"]
+	// TODO: Refactor to make use of a map.
+	var acct accounts.Interface
+	for _, a := range handlers.backend.Accounts() {
+		if a.Config().Code == acctCode {
+			acct = a
+			break
+		}
+	}
+	if acct == nil {
+		return nil, fmt.Errorf("unknown account code %q", acctCode)
+	}
+	params := exchanges.BuyMoonpayParams{
+		Fiat: "CHF", // TODO: Get this from app config
+		Lang: "en",  // TODO: Get this from the backend
+	}
+	buy, err := exchanges.BuyMoonpay(acct, params)
+	if err != nil {
+		return nil, err
+	}
+	resp := struct {
+		URL     string `json:"url"`
+		Address string `json:"address"`
+	}{
+		URL:     buy.URL,
+		Address: buy.Address,
+	}
+	return resp, nil
 }

--- a/frontends/web/src/i18n/config.js
+++ b/frontends/web/src/i18n/config.js
@@ -28,9 +28,9 @@ export default {
     type: 'languageDetector',
     async: true,
     detect: (cb) => {
-        apiGet('config').then(({ frontend }) => {
-            if (frontend && frontend.userLanguage) {
-                cb(frontend.userLanguage);
+        apiGet('config').then(({ backend }) => {
+            if (backend && backend.userLanguage) {
+                cb(backend.userLanguage);
                 return;
             }
             apiGet('native-locale').then(locale => {

--- a/frontends/web/src/i18n/i18n.js
+++ b/frontends/web/src/i18n/i18n.js
@@ -108,10 +108,14 @@ if (!i18nEditorActive) {
 }
 
 i18n.on('languageChanged', (lng) => {
-    // Set userLanguage in config back to null if system locale matches
+    // Set userLanguage in config back to empty if system locale matches
     // the newly selected language lng to make the app use native-locale again.
     // This also covers partial matches. For example, if native locale is pt_BR
     // and the app has only pt translation, assume they match.
+    //
+    // Since userLanguage is stored in the backend config as a string,
+    // setting it to null here in JS turns it into an empty string "" in Go backend.
+    // This is ok since we're just checking for a truthy value in the language detector.
     return apiGet('native-locale').then((nativeLocale) => {
         let match = lng === nativeLocale;
         if (!match) {
@@ -122,7 +126,7 @@ i18n.on('languageChanged', (lng) => {
             match = lngLang === localeLang;
         }
         const uiLang = match ? null : lng;
-        return setConfig({ frontend: { userLanguage: uiLang } });
+        return setConfig({ backend: { userLanguage: uiLang } });
     });
 });
 

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -410,7 +410,7 @@ class Account extends Component<Props, State> {
 }
 
 const loadHOC = load<LoadedAccountProps, SubscribedAccountProps & AccountProps & TranslateProps>(({ code }) => ({
-    moonpayBuySupported: `account/${code}/exchange/moonpay/buy-supported`,
+    moonpayBuySupported: `exchange/moonpay/buy-supported/${code}`,
     config: 'config',
 }))(Account);
 

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -71,7 +71,7 @@ class BuyInfo extends Component<Props, State> {
     private checkSupportedCoins = () => {
         Promise.all(
             this.props.accounts.map((account) => (
-                apiGet(`account/${account.code}/exchange/moonpay/buy-supported`)
+                apiGet(`exchange/moonpay/buy-supported/${account.code}`)
                     .then(isSupported => (isSupported ? account : false))
             ))
         )

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -109,7 +109,7 @@ class Moonpay extends Component<Props, State> {
 }
 
 const loadHOC = load<LoadedBuyProps, BuyProps & TranslateProps>(({ code }) => ({
-    moonpay: `account/${code}/exchange/moonpay/buy`,
+    moonpay: `exchange/moonpay/buy/${code}`,
 }))(Moonpay);
 const HOC = translate<BuyProps>()(loadHOC);
 export { HOC as Moonpay };

--- a/frontends/web/test/i18n/config.test.tsx
+++ b/frontends/web/test/i18n/config.test.tsx
@@ -34,7 +34,7 @@ describe('language detector', () => {
     it('prefers userLanguage if available', done => {
         (apiGet as jest.Mock).mockImplementation(endpoint => {
             switch (endpoint) {
-                case 'config': { return Promise.resolve({frontend: {userLanguage: 'it'}}); }
+                case 'config': { return Promise.resolve({backend: {userLanguage: 'it'}}); }
                 case 'native-locale': { return Promise.resolve('de'); }
                 default: { return Promise.resolve(); }
             }
@@ -73,10 +73,10 @@ describe('language detector', () => {
         });
     });
 
-    it('uses native-locale if userLanguage is null', done => {
+    it('uses native-locale if userLanguage is empty', done => {
         (apiGet as jest.Mock).mockImplementation(endpoint => {
             switch (endpoint) {
-                case 'config': { return Promise.resolve({frontend: {userLanguage: null}}); }
+                case 'config': { return Promise.resolve({backend: {userLanguage: ""}}); }
                 case 'native-locale': { return Promise.resolve('de'); }
                 default: { return Promise.resolve(); }
             }

--- a/frontends/web/test/i18n/i18n.test.tsx
+++ b/frontends/web/test/i18n/i18n.test.tsx
@@ -68,8 +68,8 @@ describe('i18n', () => {
                 });
                 i18n.listeners.languageChanged(test.newLang).then(() => {
                     expect(apiPost).toBeCalledWith('config', {
-                        frontend: {userLanguage: test.userLang},
-                        backend: {},
+                        frontend: {},
+                        backend: {userLanguage: test.userLang},
                     });
                     done();
                 });


### PR DESCRIPTION
Preferences are taken straight from the app config.

If a value is unsupported by Moonpay, they fall back to some default
values, according to their documentation. Worst case scenario, users
are still able to change both fiat and language directly in the widget.