### PR TITLE
frontend: moonpay check for supported coins on mount

### DIFF
--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -59,12 +59,16 @@ class BuyInfo extends Component<Props, State> {
         options: [],
     }
 
+    componentDidMount = () => {
+        this.checkSupportedCoins();
+    }
+
     private handleProceed = () => {
         const { status, selected } = this.state;
         if (selected && (status === 'choose' || this.props.config.frontend.skipBuyDisclaimer)) {
             route(`/buy/moonpay/${selected}`);
         } else {
-            this.setState({ status: 'choose' }, this.checkSupportedCoins);
+            this.setState({ status: 'choose' });
         }
     }
 


### PR DESCRIPTION
Before the check to find out which coins can be bought was only
executed when the user agreed to the disclaimer. With the 'do not
show the disclaimer again' option checked, the component shows
to the coin selection directly and needs to know which coins can
be bought rightaway.