### PR TITLE
frontend: route back when unpluggin bb02 in buy view

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -162,6 +162,10 @@ class App extends Component<Props, State> {
             route(`/device/${deviceIDs[0]}`, true);
             return;
         }
+        if (accounts.length === 0 && currentURL.startsWith('/buy/')) {
+            route('/', true);
+            return;
+        }
     }
 
     public componentDidUpdate(prevProps) {


### PR DESCRIPTION
MoonPay needs an address to send to, therefore the device has
to be plugged in when using the service. Unplugging the device
should now route back to /.