### PR TITLE
frontend: use monospaced font for pre element

### DIFF
--- a/frontends/web/src/style/base.css
+++ b/frontends/web/src/style/base.css
@@ -90,3 +90,7 @@ label,
 svg {
     stroke-width: 1.6 !important;
 }
+
+pre {
+    font-family: monospace;
+}


### PR DESCRIPTION
The pairing code font broke on macOS it used something with
serife like Times. We already use monospaced font in textareas
to display receive address or xpub.

Changed font for pre element to always use a monospace font.

![Screen Shot 2021-01-20 at 10 26 32 PM](https://user-images.githubusercontent.com/546900/105243204-06e37700-5b6f-11eb-8412-3fe05d4ceaf5.png)
