### PR TITLE
frontend: add buy bitcoin or buy crypto in moonpay view

### DIFF
--- a/frontends/web/src/routes/buy/moonpay.css
+++ b/frontends/web/src/routes/buy/moonpay.css
@@ -7,3 +7,8 @@
     position: relative;
     z-index: 3000;
 }
+
+.header {
+    position: relative;
+    z-index: 2200;
+}

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -23,6 +23,7 @@ import { translate, TranslateProps } from '../../decorators/translate';
 import { Devices } from '../device/deviceswitch';
 import { AccountInterface } from '../account/account';
 import { Spinner } from '../../components/spinner/Spinner';
+import { isBitcoin } from '../account/utils';
 import * as style from './moonpay.css';
 
 interface BuyProps {
@@ -83,11 +84,13 @@ class Moonpay extends Component<Props, State> {
         if (!account) {
             return null;
         }
-        const name = code === 'btc' || code === 'tbtc' ? 'Bitcoin' : 'crypto';
+        const name = (code && isBitcoin(code)) ? 'Bitcoin' : 'crypto';
         return (
             <div class="contentWithGuide">
                 <div class="container">
-                    <Header />
+                    <div class={style.header}>
+                        <Header title={<h2>{t('buy.info.title', { name })}</h2>} />
+                    </div>
                     <div ref={this.ref} class="innerContainer">
                         <div class="content noSpace" style={{ height }}>
                             <Spinner text={t('loading')} />


### PR DESCRIPTION
Added same check isBitcoin as in info.tsx and fixed a CSS
issue in combination with the spinner component. The spinner
is always in the background and covered later by the MoonPay
iframe as we just let it load and don't have the info if it
really loaded to hide the spinner again. The CSS issue was
that the spinner covered the title.