### PR TITLE
frontend: fix moonpay background on large screen

### DIFF
--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -89,7 +89,7 @@ class Moonpay extends Component<Props, State> {
                 <div class="container">
                     <Header />
                     <div ref={this.ref} class="innerContainer">
-                        <div class="content noSpace" style={{ height }}>
+                        <div class="noSpace" style={{ height }}>
                             <Spinner text={t('loading')} />
                             <iframe
                                 width="100%"


### PR DESCRIPTION
Did not cover the whole available area on larger screens.
Changed by just removing the content class that limits the
width of the content area.