### PR TITLE
frontend: update moonpay policy and support links

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -489,8 +489,7 @@
       "disclaimer": {
         "intro": [
           "We partner with MoonPay to offer you a seamless way to buy {{name}} directly within the BitBoxApp. It's just a few clicks.",
-          "MoonPay is a fully regulated financial services platform that makes it easy and quick to buy {{name}} in over 160+ countries",
-          "with a few exceptions"
+          "MoonPay is a fully regulated financial services platform that makes it easy and quick to buy {{name}} in over 160+ countries"
         ],
         "payment": {
           "details": "You can buy {{name}} instantly via MoonPay with the following payment methods. Credit or debit card orders are instant and convenient, but more expensive due to increased chargeback risk. We recommend using the bank transfer option for larger amounts. The minimum fee is 4 USD/EUR or equivalent.",

--- a/frontends/web/src/routes/buy/guide.tsx
+++ b/frontends/web/src/routes/buy/guide.tsx
@@ -41,7 +41,7 @@ export default function BuyGuide({
       <Entry key="guide.buy.protection" entry={{
         link: {
             text: t('buy.info.disclaimer.privacyPolicy'),
-            url: 'https://support.moonpay.com/hc/en-gb/articles/360009279877-What-are-your-supported-countries-states-and-territories-',
+            url: 'https://www.moonpay.com/privacy_policy',
         },
         text: t('buy.info.disclaimer.protection.description', { name }),
         title: t('buy.info.disclaimer.protection.title'),

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -118,13 +118,7 @@ class BuyInfo extends Component<Props, State> {
                                         {t('buy.info.disclaimer.title', { name })}
                                     </h2>
                                     <p>{t('buy.info.disclaimer.intro.0', { name })}</p>
-                                    <p>
-                                        {t('buy.info.disclaimer.intro.1', { name })}
-                                        {' '}
-                                        (<A class={style.link} href="https://support.moonpay.com/hc/en-gb/articles/360009279877-What-are-your-supported-countries-states-and-territories-">
-                                            {t('buy.info.disclaimer.intro.2')}
-                                        </A>).
-                                    </p>
+                                    <p>{t('buy.info.disclaimer.intro.1', { name })}</p>
                                     <h2 class={style.title}>
                                         {t('buy.info.disclaimer.payment.title')}
                                     </h2>
@@ -177,7 +171,7 @@ class BuyInfo extends Component<Props, State> {
                                     </h2>
                                     <p>{t('buy.info.disclaimer.protection.description', { name })}</p>
                                     <p>
-                                        <A class={style.link} href="https://support.moonpay.com/hc/en-gb/articles/360009279877-What-are-your-supported-countries-states-and-territories-">
+                                        <A class={style.link} href="https://www.moonpay.com/privacy_policy">
                                             {t('buy.info.disclaimer.privacyPolicy')}
                                         </A>
                                     </p>


### PR DESCRIPTION
Updated links in disclaimer and guide pointing to 'supported countries' and MoonPay's privacy policy.