### PR TITLE
frontend,backend: correct and unify/combine whitelists for opening external URLs

### DIFF
--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -158,7 +158,7 @@ public class MainActivity extends AppCompatActivity {
                 // This is only called if the whole page is about to change. Changes inside an iframe proceed normally.
                 try {
                     // Allow opening in external browser instead, for links clicked in an onramp widget.
-                    Pattern pattern = Pattern.compile("^file:///account/[^/]+/buy$");
+                    Pattern pattern = Pattern.compile("^file:///buy/.*$");
                     if (pattern.matcher(view.getUrl()).matches()) {
                         Util.systemOpen(getApplication(), url);
                         return true;

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -58,7 +58,7 @@ public:
         // widgets to load in an iframe as well as let them open external links
         // in a browser.
         auto currentUrl = mainPage->requestedUrl().toString();
-        bool onBuyPage = currentUrl.contains(QRegularExpression("^qrc:/buy/moonpay/[^/]+?$"));
+        bool onBuyPage = currentUrl.contains(QRegularExpression("^qrc:/buy/.*$"));
         if (onBuyPage) {
             if (info.firstPartyUrl().toString() == info.requestUrl().toString()) {
                 // A link with target=_blank was clicked.


### PR DESCRIPTION
At the moment, we have only /buy/moonpay/ but the idea is we will
possibly add more in the future.

This commit also unifies Qt and Android frontend whitelists. They were
disaligned after switching routes back and forth.

There's no reason why keep two separate whitelists in the SystemOpen
function. They serve the same purpose and can be easily combined into
one.

So far, there doesn't seem to be a reason to use a more onerous regexp
compared to just a string prefix. This commit in fact does the latter
and all existing patters line up nicely.

If there's really a need in the future, can always switch to a regexp
based approach.