### PR TITLE
frontend: better actions buttons layout on mobile

### DIFF
--- a/frontends/web/src/routes/account/account.css
+++ b/frontends/web/src/routes/account/account.css
@@ -21,6 +21,7 @@
 }
 
 .actionsContainer {
+    display: flex;
     transform: translateY(-36%);
 }
 
@@ -66,7 +67,17 @@
 
 @media (max-width: 768px) {
     .actionsContainer {
-        transform: translateY(-34%);
+        flex: 0 0 91%;
+        justify-content: space-between;
+        margin-bottom: var(--space-default);
+        max-width: 91%;
+        transform: none;
+        width: 91%;
+    }
+    .actionsContainer a {
+        flex: 1 0 30%;
+        margin-right: 0;
+        max-width: 30%;
     }
 
     .send,

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -329,8 +329,8 @@ class Account extends Component<Props, State> {
                             <Status dismissable={`info-${code}`} type="info" className="m-bottom-default">
                                 {t(`account.info.${code}`, { defaultValue: '' })}
                             </Status>
-                            <div class="flex flex-row flex-between flex-items-center">
-                                <label className="labelXLarge">{t('accountSummary.availableBalance')}</label>
+                            <div class="flex flex-row flex-between flex-items-center flex-column-mobile flex-reverse-mobile">
+                                <label className="labelXLarge flex-self-start-mobile">{t('accountSummary.availableBalance')}</label>
                                 <div className={style.actionsContainer}>
                                     {canSend ? (
                                         <a href={`/account/${code}/send`} className={style.send}><span>{t('button.send')}</span></a>

--- a/frontends/web/src/style/layout.css
+++ b/frontends/web/src/style/layout.css
@@ -16,6 +16,11 @@
 .flex-1 { flex: 1; }
 .flex-none { flex: none !important; }
 .flex > * { min-width: 0; }
+@media (max-width: 768px) {
+    .flex-column-mobile { flex-direction: column; }
+    .flex-reverse-mobile { flex-direction: column-reverse; }
+    .flex-self-start-mobile { align-self: flex-start; }
+}
 
 .text-center { text-align: center; }
 .text-right { text-align: right; }


### PR DESCRIPTION
The new buy was miss-aligned, the buttons now have their own
line and are all equally spaced out and use the same width.

![Screen Shot 2021-01-25 at 10 52 36 PM](https://user-images.githubusercontent.com/546900/105772022-d8481080-5f61-11eb-88b5-daff8b05cae8.png)

cc @jadzeidan 