### PR TITLE
frontend: remove apple and samsung pay from moonpay

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -499,8 +499,6 @@
             "1_method": "Bank transfers (ACH / SEPA)",
             "2_description": "Quick and nearly instant, but higher fees",
             "2_method": "Credit & debit cards",
-            "3_description": "Quick and nearly instant, but higher fees",
-            "3_method": "Apple / Google / Samsung Pay",
             "description": "Description",
             "fee": "Fee",
             "method": "Method"

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -148,11 +148,6 @@ class BuyInfo extends Component<Props, State> {
                                                     <td class={style.nowrap}>4.9 %</td>
                                                     <td>{t('buy.info.disclaimer.payment.table.2_description')}</td>
                                                 </tr>
-                                                <tr>
-                                                    <td>{t('buy.info.disclaimer.payment.table.3_method')}</td>
-                                                    <td class={style.nowrap}>4.9 %</td>
-                                                    <td>{t('buy.info.disclaimer.payment.table.3_description')}</td>
-                                                </tr>
                                             </tbody>
                                         </table>
                                     </div>


### PR DESCRIPTION
Removing it for now, can be enabled later.