### PR TITLE
frontend: refactor account into api/account

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apiGet, apiPost } from '../utils/request';
+import { ChartData } from '../routes/account/summary/chart';
+
+export type AccountState = 'accountSynced' | 'accountDisabled' | 'fatalError' | 'offlineMode';
+
+export const getStatus = (code: string): Promise<AccountState[]> => {
+    return apiGet(`account/${code}/status`);
+};
+
+export type ScriptType = 'p2pkh' | 'p2wpkh-p2sh' | 'p2wpkh';
+
+export interface ISigningConfiguration {
+    address: string;
+    keypath: string;
+    scriptType: ScriptType;
+    threshold: number;
+    xpubs: string[];
+}
+
+export interface ISigningConfigurationList {
+    signingConfigurations: ISigningConfiguration[];
+}
+
+export const getInfo = (code: string): Promise<ISigningConfigurationList> => {
+    return apiGet(`account/${code}/info`);
+};
+
+export const init = (code: string): Promise<null> => {
+    return apiPost(`account/${code}/init`);
+};
+
+export const reinitialize = (): Promise<null> => {
+    return apiPost('accounts/reinitialize');
+};
+
+export interface ISummary {
+    chartDataMissing: boolean;
+    chartDataDaily: ChartData;
+    chartDataHourly: ChartData;
+    chartFiat: Fiat;
+    chartTotal: number | null;
+    chartIsUpToDate: boolean; // only valid if chartDataMissing is false
+}
+
+export const getSummary = (): Promise<ISummary> => {
+    return apiGet('account-summary');
+};
+
+export const exportSummary = (): Promise<string> => {
+    return apiPost('export-account-summary');
+};
+
+export type MainnetCoin = 'BTC' | 'LTC' | 'ETH';
+
+export type TestnetCoin = 'TBTC' | 'TLTC' | 'TETH' | 'RETH';
+
+export type Coin = MainnetCoin | TestnetCoin;
+
+export type Fiat = 'AUD' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'ILS' | 'JPY' | 'KRW' | 'RUB' | 'SGD' | 'USD';
+
+export type Conversions = null | {
+    [key in Fiat]: string;
+}
+
+export interface IAmount {
+    amount: string;
+    conversions: Conversions;
+    unit: Coin;
+}
+
+export type CoinCode = 'btc' | 'tbtc' | 'ltc' | 'tltc' | 'eth' | 'teth' | 'reth';
+
+export interface IBalance {
+    available: IAmount;
+    hasIncoming: boolean;
+    incoming: IAmount;
+}
+
+export const getBalance = (code: string): Promise<IBalance> => {
+    return apiGet(`account/${code}/balance`);
+};
+
+export interface ITransaction {
+    addresses: string[];
+    amount: IAmount;
+    fee: IAmount;
+    feeRatePerKb: IAmount;
+    gas: number;
+    internalID: string;
+    note: string;
+    numConfirmations: number;
+    numConfirmationsComplete: number;
+    size: number;
+    status: 'complete' | 'pending' | 'failed';
+    time: string | null;
+    type: 'send' | 'receive' | 'self';
+    txID: string;
+    vsize: number;
+    weight: number;
+}
+
+export interface INoteTx {
+    internalTxID: string;
+    note: string;
+}
+
+export const postNotesTx = (code: string, {
+    internalTxID,
+    note,
+}: INoteTx): Promise<null> => {
+    return apiPost(`account/${code}/notes/tx`, { internalTxID, note });
+};
+
+export const getTransactionList = (code: string): Promise<ITransaction[]> => {
+    return apiGet(`account/${code}/transactions`);
+};
+
+export const exportAccount = (code: string): Promise<string> => {
+    return apiPost(`account/${code}/export`);
+};
+
+export const getCanVerifyXPub = (code: string): Promise<number[]> => {
+    return apiGet(`account/${code}/can-verify-extended-public-key`);
+};
+
+export interface IReceiveAddress {
+    addressID: string;
+    address: string;
+}
+
+export const verifyAddress = (code: string, addressID: string): Promise<boolean> => {
+    return apiPost(`account/${code}/verify-address`, addressID);
+};
+
+export type ReceiveAddressList = IReceiveAddress[][];
+
+export const getReceiveAddressList = (code: string): Promise<ReceiveAddressList> => {
+    return apiGet(`account/${code}/receive-addresses`);
+};
+
+export interface ISendTx {
+    aborted?: boolean;
+    success?: boolean;
+    errorMessage?: string;
+}
+
+export const sendTx = (code: string): Promise<ISendTx> => {
+    return apiPost(`account/${code}/sendtx`);
+};
+
+export type FeeTargetCode = 'custom' | 'low' | 'economy' | 'normal' | 'high';
+
+export interface IProposeTxData {
+    address?: string;
+    amount?: number;
+    // data?: string;
+    feePerByte: string;
+    feeTarget: FeeTargetCode;
+    selectedUTXOs: string[];
+    sendAll: 'yes' | 'no';
+}
+
+export interface IProposeTx {
+    aborted?: boolean;
+    success?: boolean;
+    errorMessage?: string;
+}
+
+export const proposeTx = (code: string, data: IProposeTxData): Promise<IProposeTx> => {
+    return apiPost(`account/${code}/tx-proposal`, data);
+};
+
+export const proposeTxNote = (code: string, note: string): Promise<null> => {
+    return apiPost(`account/${code}/propose-tx-note`, note);
+};
+
+export interface IUTXO {
+    address: string;
+    amount: IAmount;
+    outPoint: string;
+}
+
+export const getUTXOList = (code: string): Promise<IUTXO[]> => {
+    return apiGet(`account/${code}/utxos`);
+};
+
+export interface IFeeTarget {
+    code: FeeTargetCode;
+    feeRateInfo: string;
+}
+
+export interface IFeeTargetList {
+    feeTargets: IFeeTarget[],
+    defaultFeeTarget: FeeTargetCode
+}
+
+export const getFeeTargetList = (code: string): Promise<IFeeTargetList> => {
+    return apiGet(`account/${code}/fee-targets`);
+};

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2020 Shift Crypto AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import { Update } from './components/update/update';
 import { subscribe } from './decorators/subscribe';
 import { translate, TranslateProps } from './decorators/translate';
 import { i18nEditorActive } from './i18n/i18n';
-import { Account, AccountInterface } from './routes/account/account';
+import { Account, IAccount } from './routes/account/account';
 import { AddAccount } from './routes/account/add/addaccount';
 import { Moonpay } from './routes/buy/moonpay';
 import { BuyInfo } from './routes/buy/info';
@@ -53,7 +53,7 @@ interface State {
 }
 
 interface SubscribedProps {
-    accounts: AccountInterface[];
+    accounts: IAccount[];
     devices: Devices;
 }
 

--- a/frontends/web/src/components/alert/Alert.tsx
+++ b/frontends/web/src/components/alert/Alert.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontends/web/src/components/balance/balance.tsx
+++ b/frontends/web/src/components/balance/balance.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +16,13 @@
  */
 
 import { h, RenderableProps } from 'preact';
-import { AmountInterface, FiatConversion } from '../../components/rates/rates';
+import { IBalance } from '../../api/account';
+import { FiatConversion } from '../../components/rates/rates';
 import { translate, TranslateProps } from '../../decorators/translate';
 import * as style from './balance.css';
 
-export interface BalanceInterface {
-    available: AmountInterface;
-    incoming: AmountInterface;
-    hasIncoming: boolean;
-}
-
 interface BalanceProps {
-    balance?: BalanceInterface;
+    balance?: IBalance;
 }
 
 type Props = BalanceProps & TranslateProps;

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +27,7 @@ import { SharedProps as SharedPanelProps, store as panelStore } from '../../comp
 import { share } from '../../decorators/share';
 import { subscribe } from '../../decorators/subscribe';
 import { translate, TranslateProps } from '../../decorators/translate';
-import { AccountInterface } from '../../routes/account/account';
+import { IAccount } from '../../routes/account/account';
 import { debug } from '../../utils/env';
 import { apiPost } from '../../utils/request';
 import Logo, { AppLogoInverted } from '../icon/logo';
@@ -34,7 +35,7 @@ import Logo, { AppLogoInverted } from '../icon/logo';
 interface SidebarProps {
     deviceIDs: string[];
     bitboxBaseIDs: string[];
-    accounts: AccountInterface[];
+    accounts: IAccount[];
 }
 
 interface SubscribedProps {
@@ -122,7 +123,7 @@ class Sidebar extends Component<Props> {
         }
     }
 
-    private getAccountLink = ({ coinCode, code, name }: AccountInterface): JSX.Element => {
+    private getAccountLink = ({ coinCode, code, name }: IAccount): JSX.Element => {
         return (
             <div key={code} className="sidebarItem">
                 <Match>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2020 Shift Crypto AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,14 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
+import * as accountApi from '../../api/account';
 import { Input } from '../../components/forms';
 import { translate, TranslateProps } from '../../decorators/translate';
-import { AmountWithConversions } from '../../routes/account/send/send';
-import { apiPost } from '../../utils/request';
 import A from '../anchor/anchor';
 import { Dialog } from '../dialog/dialog';
 import { ExpandIcon } from '../icon/icon';
 import { ProgressRing } from '../progressRing/progressRing';
-import { AmountInterface, FiatConversion } from '../rates/rates';
+import { FiatConversion } from '../rates/rates';
 import { ArrowIn, ArrowOut, ArrowSelf, Edit, Save } from './components/icons';
 import * as style from './transaction.css';
 import * as parentStyle from './transactions.css';
@@ -35,26 +34,7 @@ interface State {
     editMode: boolean;
 }
 
-export interface TransactionInterface {
-    type: 'send' | 'receive' | 'self';
-    txID: string;
-    amount: AmountInterface;
-    fee: AmountWithConversions;
-    feeRatePerKb: AmountWithConversions;
-    gas: number;
-    vsize: number;
-    size: number;
-    weight: number;
-    numConfirmations: number;
-    numConfirmationsComplete: number;
-    time: string | null;
-    addresses: string[];
-    status: 'complete' | 'pending' | 'failed';
-    internalID: string;
-    note: string;
-}
-
-interface TransactionProps extends TransactionInterface {
+interface TransactionProps extends accountApi.ITransaction {
     accountCode: string;
     index: number;
     explorerURL: string;
@@ -101,10 +81,11 @@ class Transaction extends Component<Props, State> {
     private handleEdit = (e: Event) => {
         e.preventDefault();
         if (this.state.editMode && this.props.note !== this.state.newNote) {
-            apiPost(`account/${this.props.accountCode}/notes/tx`, {
+            accountApi.postNotesTx(this.props.accountCode, {
                 internalTxID: this.props.internalID,
                 note: this.state.newNote,
-            });
+            })
+            .catch(console.error);
         }
         this.focusEdit();
         this.setState(

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2020 Shift Crypto AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
+import { ITransaction } from '../../api/account';
 import A from '../../components/anchor/anchor';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { runningInAndroid } from '../../utils/env';
-import { Transaction, TransactionInterface } from './transaction';
+import { Transaction } from './transaction';
 import * as style from './transactions.css';
 
 interface TransactionsProps {
     accountCode: string;
     explorerURL: string;
-    transactions?: TransactionInterface[];
+    transactions?: ITransaction[];
     exported: string;
     handleExport: () => void;
 }

--- a/frontends/web/src/routes/account/info/signingconfiguration.tsx
+++ b/frontends/web/src/routes/account/info/signingconfiguration.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +16,7 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
+import { ISigningConfiguration } from '../../../api/account';
 import { CopyableInput } from '../../../components/copy/Copy';
 import { Button } from '../../../components/forms';
 import { QRCode } from '../../../components/qrcode/qrcode';
@@ -23,19 +25,9 @@ import { apiGet, apiPost } from '../../../utils/request';
 import * as style from './info.css';
 
 interface ProvidedProps {
-    info: SigningConfigurationInterface;
+    info: ISigningConfiguration;
     code: string;
     signingConfigIndex: number;
-}
-
-export type ScriptType = 'p2pkh' | 'p2wpkh-p2sh' | 'p2wpkh';
-
-export interface SigningConfigurationInterface {
-    scriptType: ScriptType;
-    keypath: string;
-    threshold: number;
-    xpubs: string[];
-    address: string;
 }
 
 interface State {

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +17,7 @@
 
 import { Component, h, RenderableProps } from 'preact';
 import { route } from 'preact-router';
+import * as accountApi from '../../../api/account';
 import { alertUser } from '../../../components/alert/Alert';
 import { CopyableInput } from '../../../components/copy/Copy';
 import { Dialog } from '../../../components/dialog/dialog';
@@ -29,14 +31,14 @@ import { load } from '../../../decorators/load';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet, apiPost } from '../../../utils/request';
 import { Devices } from '../../device/deviceswitch';
-import { AccountInterface } from '../account';
+import { IAccount } from '../account';
 import { isEthereumBased } from '../utils';
 import * as style from './receive.css';
 
 interface ReceiveProps {
     code?: string;
     devices: Devices;
-    accounts: AccountInterface[];
+    accounts: IAccount[];
     deviceIDs: string[];
 }
 
@@ -47,16 +49,9 @@ interface State {
     addressType: number;
 }
 
-interface ReceiveAddress {
-    addressID: string;
-    address: string;
-}
-
-export type ReceiveAddresses = ReceiveAddress[][];
-
 interface LoadedReceiveProps {
     // first array index: address types. second array index: unused addresses of that address type.
-    receiveAddresses: ReceiveAddresses;
+    receiveAddresses: accountApi.ReceiveAddressList;
     secureOutput: {
         hasSecureOutput: boolean;
         optional: boolean;

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2020 Shift Crypto AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { CoinCode } from './account';
+import { CoinCode } from '../../api/account';
 
 export function isBitcoin(code: string): boolean {
     switch (code) {

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Shift Crypto AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 import { Component, h, RenderableProps } from 'preact';
 import { route } from 'preact-router';
+import { CoinCode } from '../../api/account';
 import Guide from './guide';
 import A from '../../components/anchor/anchor';
 import { Header } from '../../components/layout';
@@ -23,14 +24,14 @@ import { load } from '../../decorators/load';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { Button, Checkbox, Select } from '../../components/forms';
 import { Devices } from '../device/deviceswitch';
-import { AccountInterface, CoinCode } from '../account/account';
+import { IAccount } from '../account/account';
 import { setConfig } from '../../utils/config';
 import { apiGet } from '../../utils/request';
 import { isBitcoin } from '../account/utils';
 import * as style from './info.css';
 
 interface BuyInfoProps {
-    accounts: AccountInterface[];
+    accounts: IAccount[];
     code?: string;
     devices: Devices;
 }

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2020 Shift Crypto AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ import { Header } from '../../components/layout';
 import { load } from '../../decorators/load';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { Devices } from '../device/deviceswitch';
-import { AccountInterface } from '../account/account';
+import { IAccount } from '../account/account';
 import { Spinner } from '../../components/spinner/Spinner';
 import { isBitcoin } from '../account/utils';
 import * as style from './moonpay.css';
 
 interface BuyProps {
-    accounts: AccountInterface[];
+    accounts: IAccount[];
     code: string;
     devices: Devices;
 }


### PR DESCRIPTION
Some components contain api interfaces, that got wildly imported

all over and grew organically. This lead to incomplete and duplicate
interfaces and is hard to maintain.

Centralizing all api interfaces and promises into web/src/api helps
reducing duplicates and separates api from ui components.
Additionally promise return values from api all come typed.

This is the first step and collects all account interfaces and api
calls into api/account.ts. Next step is to refactor all components
to import the interfaces and api calls from api/account.