### PR TITLE
frontend/qt: correct origin check when enabling video capture

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
         view->page(),
         &QWebEnginePage::featurePermissionRequested,
         [&](const QUrl& securityOrigin, QWebEnginePage::Feature feature) {
-            if (securityOrigin.toString() != "qrc://") {
+            if (securityOrigin.scheme() != "qrc") {
                 return;
             }
             if (feature == QWebEnginePage::MediaVideoCapture) {


### PR DESCRIPTION
The expression `securityOrigin.toString() != "qrc://"` was always true
and so the video capture was never enabled when scanning QR code,
resulting in a blank page.

Also, `QUrl::toString()` uses `PrettyDecoded` formatting by default, but:

> The exact behavior of PrettyDecoded varies from component to
> component and may also change from Qt release to Qt release.

See https://doc.qt.io/qt-5.12/qurl.html.
So, comparing the scheme seems more appropriate here.

Unclear when things changed. It is possible the condition has
never worked before but the permission to use video capture was granted
implicitly due to local origin. The fact is Windows and macOS works
without this change. So, this must be a combination of Qt + Linux.
