### PR TITLE
frontend: refactor subscriptions and acountsync

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -17,6 +17,30 @@
 import { apiGet, apiPost } from '../utils/request';
 import { ChartData } from '../routes/account/summary/chart';
 
+
+export type CoinCode = 'btc' | 'tbtc' | 'ltc' | 'tltc' | 'eth' | 'teth' | 'reth';
+
+export type Fiat = 'AUD' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'ILS' | 'JPY' | 'KRW' | 'RUB' | 'SGD' | 'USD';
+
+export type MainnetCoin = 'BTC' | 'LTC' | 'ETH';
+
+export type TestnetCoin = 'TBTC' | 'TLTC' | 'TETH' | 'RETH';
+
+export type Coin = MainnetCoin | TestnetCoin;
+
+
+export interface IAccount {
+    coinCode: CoinCode;
+    coinUnit: string;
+    code: string;
+    name: string;
+    blockExplorerTxPrefix: string;
+}
+
+export const getAccounts = (): Promise<IAccount[]> => {
+    return apiGet(`accounts`);
+};
+
 export type AccountState = 'accountSynced' | 'accountDisabled' | 'fatalError' | 'offlineMode';
 
 export const getStatus = (code: string): Promise<AccountState[]> => {
@@ -66,14 +90,6 @@ export const exportSummary = (): Promise<string> => {
     return apiPost('export-account-summary');
 };
 
-export type MainnetCoin = 'BTC' | 'LTC' | 'ETH';
-
-export type TestnetCoin = 'TBTC' | 'TLTC' | 'TETH' | 'RETH';
-
-export type Coin = MainnetCoin | TestnetCoin;
-
-export type Fiat = 'AUD' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'ILS' | 'JPY' | 'KRW' | 'RUB' | 'SGD' | 'USD';
-
 export type Conversions = null | {
     [key in Fiat]: string;
 }
@@ -83,8 +99,6 @@ export interface IAmount {
     conversions: Conversions;
     unit: Coin;
 }
-
-export type CoinCode = 'btc' | 'tbtc' | 'ltc' | 'tltc' | 'eth' | 'teth' | 'reth';
 
 export interface IBalance {
     available: IAmount;

--- a/frontends/web/src/api/accountsync.ts
+++ b/frontends/web/src/api/accountsync.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { subscribeEndpoint } from './subscribe';
+import { Unsubscribe } from '../utils/event';
+import { IAccount} from './account';
+
+/**
+ * Subscribes the given function on the "account" event and receives the
+ * list of all available accounts from the backend.
+ * Returns a method to unsubscribe.
+ */
+
+export const syncAccountsList = (
+    cb: (accounts: IAccount[],) => void
+): Unsubscribe => {
+    return subscribeEndpoint('accounts', cb);
+};
+
+/**
+ * Subscribes the given function on an "account/<CODE>/synced-addresses-count" event
+ * to receive the progress of the address sync.
+ * Returns a method to unsubscribe.
+ */
+
+export const syncAddressesCount = (
+    code: string,
+    cb: (code: string, syncedAddressesCount: number) => void,
+): Unsubscribe => {
+    return subscribeEndpoint(`account/${code}/synced-addresses-count`, (
+        data: number,
+    ) => {
+        cb(code, data);
+    });
+};

--- a/frontends/web/src/api/subscribe-legacy.ts
+++ b/frontends/web/src/api/subscribe-legacy.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { subscribe, IUnsubscribe } from '../utils/event-legacy';
+
+export const statusChanged = (
+    code: string,
+    cb: (code: string) => void,
+): IUnsubscribe => {
+    const unsubscribe = subscribe('statusChanged', data => {
+        if (data.type === 'account' && data.code === code) {
+            cb(code);
+        }
+    });
+    return unsubscribe;
+};
+
+export const syncdone = (
+    code: string,
+    cb: (code: string) => void,
+): IUnsubscribe => {
+    return subscribe('syncdone', data => {
+        if (data.type === 'account' && data.code === code) {
+            cb(code);
+        }
+    });
+};

--- a/frontends/web/src/api/subscribe.ts
+++ b/frontends/web/src/api/subscribe.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apiSubscribe, Event, Unsubscribe } from '../utils/event';
+import { apiGet } from '../utils/request';
+
+/**
+ * Subscribes the given function on an endpoint on which the backend
+ * can push data through. This should be mostly used within api.
+ * Note there is a subscibe-legacy.ts module that supports older events.
+ */
+
+export function subscribeEndpoint(endpoint: string, cb): Unsubscribe {
+    return apiSubscribe(endpoint, (event: Event) => {
+        switch (event.action) {
+        case 'replace':
+            cb(event.object);
+            break;
+        case 'reload':
+            // TODO: backend should push data with "replace" and not use "reload"
+            apiGet(event.subject)
+                .then(object => cb(object))
+                .catch(console.error);
+            break;
+        default:
+            throw new Error(`Event: ${event} not supported`);
+        }
+    });
+}
+
+/**
+ * Subscribes the given function to the backend/connected event.
+ * This is not an event sent by the backend, but is called when
+ * the connection to the backend is lost.
+ * See utils/websocket.js
+ */
+
+export const backendConnected = (
+    cb: (connected: boolean) => void
+): Unsubscribe => {
+    return subscribeEndpoint('backend/connected', cb);
+};

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -17,6 +17,7 @@
 
 import { Component, h, JSX, RenderableProps } from 'preact';
 import { Link, Match } from 'preact-router/match';
+import { IAccount } from '../../api/account';
 import coins from '../../assets/icons/coins.svg';
 import ejectIcon from '../../assets/icons/eject.svg';
 import info from '../../assets/icons/info.svg';
@@ -27,7 +28,6 @@ import { SharedProps as SharedPanelProps, store as panelStore } from '../../comp
 import { share } from '../../decorators/share';
 import { subscribe } from '../../decorators/subscribe';
 import { translate, TranslateProps } from '../../decorators/translate';
-import { IAccount } from '../../routes/account/account';
 import { debug } from '../../utils/env';
 import { apiPost } from '../../utils/request';
 import Logo, { AppLogoInverted } from '../icon/logo';

--- a/frontends/web/src/index.js
+++ b/frontends/web/src/index.js
@@ -20,12 +20,12 @@
 
 import { h } from 'preact';
 import { I18nextProvider } from 'react-i18next';
-import { ConnectedApp } from './connected';
+import { App } from './app';
 import i18n from './i18n/i18n';
 import './style';
 
 export default function Index() {
     return (
-        <I18nextProvider i18n={i18n}><ConnectedApp /></I18nextProvider>
+        <I18nextProvider i18n={i18n}><App /></I18nextProvider>
     );
 }

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -31,14 +31,13 @@ import { load } from '../../../decorators/load';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet, apiPost } from '../../../utils/request';
 import { Devices } from '../../device/deviceswitch';
-import { IAccount } from '../account';
 import { isEthereumBased } from '../utils';
 import * as style from './receive.css';
 
 interface ReceiveProps {
     code?: string;
     devices: Devices;
-    accounts: IAccount[];
+    accounts: accountApi.IAccount[];
     deviceIDs: string[];
 }
 

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -19,7 +19,6 @@ import { BrowserQRCodeReader } from '@zxing/library';
 import { Component, h, RenderableProps } from 'preact';
 import { route } from 'preact-router';
 import * as accountApi from '../../../api/account';
-import { IAccount } from '../account';
 import reject from '../../../assets/icons/cancel.svg';
 import approve from '../../../assets/icons/checked.svg';
 import qrcodeIcon from '../../../assets/icons/qrcode.png';
@@ -46,7 +45,7 @@ import * as style from './send.css';
 import { Props as UTXOsProps, SelectedUTXO, UTXOs } from './utxos';
 
 interface SendProps {
-    accounts: IAccount[];
+    accounts: accountApi.IAccount[];
     code?: string;
     devices: Devices;
     deviceIDs: string[];

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -29,12 +29,11 @@ import Logo from '../../../components/icon/logo';
 import Spinner from '../../../components/spinner/ascii';
 import { debug } from '../../../utils/env';
 import { apiWebsocket } from '../../../utils/websocket';
-import { IAccount } from '../account';
 import { Chart } from './chart';
 import * as style from './accountssummary.css';
 
 interface AccountSummaryProps {
-    accounts: IAccount[];
+    accounts: accountApi.IAccount[];
 }
 
 interface Balances {
@@ -98,10 +97,7 @@ class AccountsSummary extends Component<Props, State> {
             if (data.subject ===  'account/' + account.code + '/synced-addresses-count') {
                 this.setState(state => {
                     const syncStatus = {...state.syncStatus};
-                    syncStatus[account.code] = this.props.t('account.syncedAddressesCount', {
-                        count: data.object.toString(),
-                        defaultValue: 0,
-                    });
+                    syncStatus[account.code] = data.object;
                     return { syncStatus };
                 });
             }
@@ -179,7 +175,10 @@ class AccountsSummary extends Component<Props, State> {
             <tr key={code}>
                 { nameCol }
                 <td colSpan={2}>
-                    { syncStatus }
+                    { t('account.syncedAddressesCount', {
+                        count: syncStatus?.toString(),
+                        defaultValue: 0,
+                    }) }
                     <Spinner />
                 </td>
             </tr>

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -16,7 +16,7 @@
 
 import { Component, h, RenderableProps } from 'preact';
 import { route } from 'preact-router';
-import { CoinCode } from '../../api/account';
+import { CoinCode, IAccount } from '../../api/account';
 import Guide from './guide';
 import A from '../../components/anchor/anchor';
 import { Header } from '../../components/layout';
@@ -24,7 +24,6 @@ import { load } from '../../decorators/load';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { Button, Checkbox, Select } from '../../components/forms';
 import { Devices } from '../device/deviceswitch';
-import { IAccount } from '../account/account';
 import { setConfig } from '../../utils/config';
 import { apiGet } from '../../utils/request';
 import { isBitcoin } from '../account/utils';

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -16,12 +16,12 @@
  */
 
 import { Component, createRef, h, RenderableProps } from 'preact';
+import { IAccount } from '../../api/account';
 import Guide from './guide';
 import { Header } from '../../components/layout';
 import { load } from '../../decorators/load';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { Devices } from '../device/deviceswitch';
-import { IAccount } from '../account/account';
 import { Spinner } from '../../components/spinner/Spinner';
 import { isBitcoin } from '../account/utils';
 import * as style from './moonpay.css';

--- a/frontends/web/src/utils/event-legacy.ts
+++ b/frontends/web/src/utils/event-legacy.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apiWebsocket } from '../utils/websocket';
+
+/**
+ * This type describes the subject of an event.
+ */
+
+type Subject = string;
+
+/**
+ * This interface models the legacy events that are received from the backend.
+ */
+
+export interface IEvent {
+    readonly data?: Subject;
+    readonly deviceID?: string;
+    readonly meta?: null;
+    readonly type?: string;
+    readonly code?: string;
+}
+
+/**
+ * This type describes the function used to observe the events.
+ */
+
+ type Observer = (event: IEvent) => void;
+
+/**
+ * This type describes the method returned to unsubscribe again.
+ */
+
+export type IUnsubscribe = () => void;
+
+/**
+ * This interface describes how the subscriptions are stored.
+ */
+
+interface ISubscriptions {
+    [subject: string]: Observer[];
+}
+
+/**
+ * Stores the subscriptions as an object-based hash map.
+ */
+
+const subscriptions: ISubscriptions = {};
+
+/**
+ * This function dispatches the events from the websocket to the observers.
+ */
+
+function handleMessages(payload: IEvent): void {
+    if (
+        payload.data
+        && typeof payload.data === 'string'
+        && payload.data in subscriptions
+        && subscriptions[payload.data].length
+    ) {
+        for (const observer of subscriptions[payload.data]) {
+            observer(payload);
+        }
+    }
+}
+
+/**
+ * Subscribes the given observer on events of the given subject and returns a method to unsubscribe.
+ */
+
+export function subscribe(subject: Subject, observer: Observer): IUnsubscribe {
+    if (!subscriptions[subject]) {
+        subscriptions[subject] = [];
+    }
+    const observers = subscriptions[subject];
+    if (observers.includes(observer)) {
+        console.error(`observer already registered for ${subject}`);
+    }
+    observers.push(observer);
+    return () => {
+        if (!observers.includes(observer)) {
+            console.error('!observers.includes(observer)');
+        }
+        const index = observers.indexOf(observer);
+        observers.splice(index, 1);
+    };
+}
+
+apiWebsocket(handleMessages);

--- a/frontends/web/src/utils/subscriptions.ts
+++ b/frontends/web/src/utils/subscriptions.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Unsubscribe } from './event';
+import { IUnsubscribe as UnsubscribeLegacy } from './event-legacy';
+
+export type UnsubscribeList = Array<(Unsubscribe | UnsubscribeLegacy)>;
+
+/**
+ * Helper function that takes an array of unsubscribe callbacks.
+ * It calls and removes all unsubscribers from the array.
+ * This is only useful if you component has more than 1 subscribtion.
+ */
+
+export function unsubscribe(unsubscribeList: UnsubscribeList) {
+    for (const unsubscribeCallback of unsubscribeList) {
+        unsubscribeCallback();
+    }
+    unsubscribeList.splice(0, unsubscribeList.length);
+}

--- a/util/observable/action/action.go
+++ b/util/observable/action/action.go
@@ -21,15 +21,6 @@ const (
 	// Replace replaces the current value of the subject with the object.
 	Replace Action = "replace"
 
-	// Prepend prepends the object to the list of values of the subject.
-	Prepend Action = "prepend"
-
-	// Append appends the object to the list of values of the subject.
-	Append Action = "append"
-
-	// Remove removes the object from the list of values of the subject.
-	Remove Action = "remove"
-
 	// Reload tells the listener to reload the state of the subject.
 	Reload Action = "reload"
 )


### PR DESCRIPTION
The subscribe decorator is currently used to push data from the go
backend to the frontend, using websocket in devmode and qt bridge
in the app. But it currently only works for the "newer" events,
containing "subject", "action" and "object", but not the "older"
events that have "data", "deviceID", "meta", "type" or "code"
keys. To support "older" events the pushed data needs to be handled
differently, this is done in utils/events-legacy.ts which is similar
to the existing utils/events.ts.

While the decorators are convinient to use and nicely abstract away
the data fetching they also have drawbacks:
- pushed data have no typed interfaces, so the interfaces have to
  be defined on the component level as component props, which works
  but is harder to share between different components and spread
  all over various components
- difficult to mock
- add unnecessary stateful wrapper components that add pushed data
  via props, i.e. progess of account synced in %, which still has
  to be manually compared to oldprops on willreceiveprops or
  didreceiveprops
- renderOnlyOnceLoaded option adds another stateful wrapper and
  renders nothing until all endpoints are loaded, causing
  a flicker when for example changing accounts
- components are harder to read, there are interfaces describing
  the props it is still unclear where the data is coming from,
  as descriptors are hidden at the bottom of the component code
- having multiple subscribers with different renderOnlyOnceLoaded
  options is not possible in the same decorator, this can be
  solved by using multiple subscribe decorators in sequence, but
  the order is important otherwise data isn't loaded in parallel
  and adds even more wrappers

This change is the first step of refactoring subscribable push
data into frontends/web/src/api by using simple functions
functions and interfaces instead of react components. Grouped
and centralized api modules under src/api. Typed return data.
Support legacy Events. Deprecation of "New-style" event actions
that have never been used, specifically "remove", "prepend" and
"append".
@thisconnect
thisconnect committed 17 hours ago
