### PR TITLE
docker: upgrade nodejs to 14.x and go to 1.14.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   # https://docs.github.com/en/packages/guides/pushing-and-pulling-docker-images
   #
   # Keep this in sync with default in scripts/travis-ci.sh.
-  CI_IMAGE: ghcr.io/digitalbitbox/bitbox-wallet-app-ci:8
+  CI_IMAGE: ghcr.io/digitalbitbox/bitbox-wallet-app-ci:9
   TRAVIS_BUILD_DIR: ${{github.workspace}}
 
 jobs:

--- a/scripts/docker_install.sh
+++ b/scripts/docker_install.sh
@@ -18,7 +18,7 @@ apt-get update
 apt-get install -y --no-install-recommends curl ca-certificates
 
 # add repository for node/npm
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
+curl -sL https://deb.nodesource.com/setup_14.x | bash -
 
 apt-get install -y --no-install-recommends \
     clang \
@@ -39,7 +39,7 @@ npm install -g yarn
 npm install -g locize-cli
 
 mkdir -p /opt/go_dist
-curl https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz | tar -xz -C /opt/go_dist
+curl https://dl.google.com/go/go1.14.15.linux-amd64.tar.gz | tar -xz -C /opt/go_dist
 
 # Needed for qt5. fuse is needed to run the linuxdeployqt appimage.
 apt-get install -y --no-install-recommends fuse

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -14,7 +14,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     # Which docker image to use to run the CI. Defaults to Docker Hub.
     # Overwrite with CI_IMAGE=docker/image/path environment variable.
     # Keep this in sync with .github/workflows/ci.yml.
-    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:8}"
+    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:9}"
     # Time image pull to compare in the future.
     time docker pull "$CI_IMAGE"
 


### PR DESCRIPTION
Nodejs LTS 14.x is required by newer preact-cli.

While there, also upgrade Go. Been meaning to do it for a while. Seemed
like a good opportunity.