### PR TITLE
frontend: allow Moonpay to request camera access

### DIFF
--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -134,6 +134,8 @@ public class MainActivity extends AppCompatActivity {
         vw.clearHistory();
         vw.getSettings().setJavaScriptEnabled(true);
         vw.getSettings().setAllowUniversalAccessFromFileURLs(true);
+        // For MoonPay WebRTC camera access.
+        vw.getSettings().setMediaPlaybackRequiresUserGesture(false);
 
         vw.setWebViewClient(new WebViewClient() {
             @Override

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -205,9 +205,6 @@ int main(int argc, char *argv[])
         view->page(),
         &QWebEnginePage::featurePermissionRequested,
         [&](const QUrl& securityOrigin, QWebEnginePage::Feature feature) {
-            if (securityOrigin.scheme() != "qrc") {
-                return;
-            }
             if (feature == QWebEnginePage::MediaVideoCapture) {
                 // Allow video capture for QR code scanning.
                 view->page()->setFeaturePermission(

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -99,7 +99,7 @@ class Moonpay extends Component<Props, State> {
                                 height={height}
                                 frameBorder="0"
                                 className={style.iframe}
-                                allow="payment"
+                                allow="camera; payment"
                                 src={`${moonpay.url}&colorCode=%235E94BF`}>
                             </iframe>
                         </div>

--- a/frontends/web/src/utils/custom.d.ts
+++ b/frontends/web/src/utils/custom.d.ts
@@ -30,7 +30,7 @@ declare module '*.svg';
 declare namespace JSX { // tslint:disable-line:no-namespace
     interface HTMLAttributes {
         align?: 'left' | 'right' | 'center';
-        allow?: 'payment';
+        allow?: string;
         autocorrect?: 'on' | 'off';
         spellcheck?: boolean;
     }


### PR DESCRIPTION
They state that from March 31st, 2021, their in-app KYC process will
require camera access.

They said that
https://webrtc.github.io/samples/src/content/getusermedia/gum/ can be
used to test if it is working. This commit makes the camera at that
site work in the moonpay.tsx iframe.

In the Qt app, the security origin scheme check is dropped, as that is
easier than checking for the moonpay url. Note that all external
requests are blocked anyway, so only already whitelisted pages can
even be loaded, so the check was redundant.