### PR TITLE
frontend/app: fix bb02 success screen by fixing devices key attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Fix QR-code scanning on Linux
 - Remove BitBox02 random number button
 - Allow camera access in iframe for Moonpay
+- Bring back BitBox02 wallet create/restore success screen

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -168,6 +168,12 @@ class App extends Component<Props, State> {
         }
     }
 
+    // Returns a string representation of the current devices, so it can be used in the `key` property of subcomponents.
+    // The prefix is used so different subcomponents can have unique keys to not confuse the renderer.
+    private devicesKey = (prefix: string): string => {
+        return prefix + ':' + JSON.stringify(this.props.devices, Object.keys(this.props.devices).sort());
+    }
+
     public componentDidUpdate(prevProps) {
         if (prevProps.accounts !== this.props.accounts || prevProps.devices !== this.props.devices) {
             this.maybeRoute();
@@ -244,17 +250,17 @@ class App extends Component<Props, State> {
                         {/* ManageBackups and DeviceSwitch need a key to trigger (re-)mounting when devices change, to handle routing */}
                         <ManageBackups
                             path="/manage-backups/:deviceID/:sdCardInserted?"
-                            key={['manage-backups', devices]}
+                            key={this.devicesKey('manage-backups')}
                             devices={devices}
                         />
                         <DeviceSwitch
                             path="/device/:deviceID"
-                            key={['device-switch', devices]}
+                            key={this.devicesKey('device-switch')}
                             deviceID={null /* dummy to satisfy TS */}
                             devices={devices} />
                         <DeviceSwitch
                             default
-                            key={['device-switch-default', devices]}
+                            key={this.devicesKey('device-switch-default')}
                             deviceID={null}
                             devices={devices} />
                     </Container>


### PR DESCRIPTION
After creating a new wallet or restoring from backup, the app is
supposed to show a success screen. This has not happened due to a
regression.

The screen was skipped because the DeviceSwitch and the BitBox02
components were recreated completely, losing the internal state.

The components were recreated because the key attribute,
e.g. `key={['device-switch', devices]}`, "changed". The devices object
was the same, but in Javascript, one can't compare arrays like
this. `[] == []` or `['device-switch'] == [''device-switch']` is
always false, so the component was re-recreated.

We fix it by turning making the key a string derived from the devices,
so preact will correctly identify when the devices changed and when
they didn't change.