### PR TITLE
backend/eth: rebroadcast transactions that seem to be lost

### DIFF
--- a/backend/coins/eth/etherscan/etherscan.go
+++ b/backend/coins/eth/etherscan/etherscan.go
@@ -384,6 +384,19 @@ func (etherScan *EtherScan) TransactionReceiptWithBlockNumber(
 	return result, nil
 }
 
+// TransactionByHash implements rpc.Interface.
+func (etherScan *EtherScan) TransactionByHash(
+	ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
+	params := url.Values{}
+	params.Set("action", "eth_getTransactionByHash")
+	params.Set("txhash", hash.Hex())
+	var result rpcclient.RPCTransaction
+	if err := etherScan.rpcCall(params, &result); err != nil {
+		return nil, false, err
+	}
+	return &result.Transaction, result.BlockNumber == nil, nil
+}
+
 // HeaderByNumber implements rpc.Interface.
 func (etherScan *EtherScan) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	params := url.Values{}

--- a/backend/coins/eth/types/types.go
+++ b/backend/coins/eth/types/types.go
@@ -41,6 +41,8 @@ type TransactionWithMetadata struct {
 	// Only applies if Height > 0.
 	// false if contract execution failed, otherwise true.
 	Success bool
+	// Number of broadcast attempts.
+	BroadcastAttempts uint16
 }
 
 // MarshalJSON implements json.Marshaler. Used for DB serialization.
@@ -50,20 +52,22 @@ func (txh *TransactionWithMetadata) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(map[string]interface{}{
-		"tx":      txSerialized,
-		"height":  txh.Height,
-		"gasUsed": hexutil.Uint64(txh.GasUsed),
-		"success": txh.Success,
+		"tx":                txSerialized,
+		"height":            txh.Height,
+		"gasUsed":           hexutil.Uint64(txh.GasUsed),
+		"success":           txh.Success,
+		"broadcastAttempts": txh.BroadcastAttempts,
 	})
 }
 
 // UnmarshalJSON implements json.Unmarshaler. Used for DB serialization.
 func (txh *TransactionWithMetadata) UnmarshalJSON(input []byte) error {
 	m := struct {
-		TransactionRLP []byte         `json:"tx"`
-		Height         uint64         `json:"height"`
-		GasUsed        hexutil.Uint64 `json:"gasUsed"`
-		Success        bool           `json:"success"`
+		TransactionRLP    []byte         `json:"tx"`
+		Height            uint64         `json:"height"`
+		GasUsed           hexutil.Uint64 `json:"gasUsed"`
+		Success           bool           `json:"success"`
+		BroadcastAttempts uint16         `json:"broadcastAttempts"`
 	}{}
 	if err := json.Unmarshal(input, &m); err != nil {
 		return err
@@ -75,6 +79,7 @@ func (txh *TransactionWithMetadata) UnmarshalJSON(input []byte) error {
 	txh.Height = m.Height
 	txh.GasUsed = uint64(m.GasUsed)
 	txh.Success = m.Success
+	txh.BroadcastAttempts = m.BroadcastAttempts
 	return nil
 }
 

--- a/backend/coins/eth/types/types_test.go
+++ b/backend/coins/eth/types/types_test.go
@@ -22,9 +22,10 @@ func TestTransactionWithHeightJSON(t *testing.T) {
 			big.NewInt(123456543),
 			[]byte("contract data"),
 		),
-		Height:  352,
-		GasUsed: 21000,
-		Success: true,
+		Height:            352,
+		GasUsed:           21000,
+		Success:           true,
+		BroadcastAttempts: 10,
 	}
 	tx2 := new(ethtypes.TransactionWithMetadata)
 	require.NoError(t, json.Unmarshal(jsonp.MustMarshal(tx), tx2))
@@ -32,4 +33,5 @@ func TestTransactionWithHeightJSON(t *testing.T) {
 	require.Equal(t, tx.GasUsed, tx2.GasUsed)
 	require.Equal(t, tx.Success, tx2.Success)
 	require.Equal(t, tx.Transaction.Hash(), tx2.Transaction.Hash())
+	require.Equal(t, tx.BroadcastAttempts, tx2.BroadcastAttempts)
 }


### PR DESCRIPTION
By experience, it seems that at least with the Etherscan backend, a
transaction that is broadcast successfully (api endpoint returns 200
OK, no error message) still might be lost and never be mined. This
lead to the ETH account being unusable, especially because follow up
transactions get a new nonce, and it also can never be mined until the
previous nonce was mined.

This is an attempt to fix this: we simply rebroadcast when we see that
the backend does not know about the transaction. It happens the first
time immediately after broadcast, and then regularly with each account
update.

For now we simply log the broadcast attempts, so we can analyse the
problem further. In the future, we might use this to mark a tx as
failed (e.g. more than 10 failed attempts), or to give the user
certain options.