### PR TITLE
frontend/bitbox02: fix sd card inserted state

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -249,7 +249,7 @@ class App extends Component<Props, State> {
                         {/* Use with TypeScript: {Route<{ deviceID: string }>({ path: '/manage-backups/:deviceID', component: ManageBackups })} */}
                         {/* ManageBackups and DeviceSwitch need a key to trigger (re-)mounting when devices change, to handle routing */}
                         <ManageBackups
-                            path="/manage-backups/:deviceID/:sdCardInserted?"
+                            path="/manage-backups/:deviceID"
                             key={this.devicesKey('manage-backups')}
                             devices={devices}
                         />

--- a/frontends/web/src/components/devices/bitbox02/sdcardcheck.tsx
+++ b/frontends/web/src/components/devices/bitbox02/sdcardcheck.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { translate, TranslateProps } from '../../../decorators/translate';
+import * as dialogStyle from '../../dialog/dialog.css';
+import { Dialog } from '../../dialog/dialog';
+import { apiGet } from '../../../utils/request';
+import { Button, ButtonLink } from '../../forms';
+
+interface SDCardCheckProps {
+    deviceID: string;
+}
+
+interface State {
+    sdCardInserted?: boolean;
+}
+
+
+type Props = SDCardCheckProps & TranslateProps;
+
+class SDCardCheck extends Component<Props, State> {
+    public componentDidMount() {
+        this.check();
+    }
+
+    private check = () => {
+        apiGet('devices/bitbox02/' + this.props.deviceID + '/check-sdcard')
+            .then(inserted => this.setState({ sdCardInserted: inserted }));
+    }
+
+    public render(
+        { t,
+          children,
+          deviceID,
+        }: RenderableProps<Props>,
+        { sdCardInserted }: State) {
+        if (sdCardInserted === undefined) {
+            return null;
+        }
+        if (!sdCardInserted) {
+            return (
+                <Dialog title="Check your device" small>
+                    <div className="columnsContainer half">
+                        <div className="columns">
+                            <div className="column">
+                                <p>{this.props.t('backup.insert')}</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div className={dialogStyle.actions}>
+                        <Button
+                            primary
+                            onClick={this.check}>
+                            {t('button.ok')}
+                        </Button>
+                        <ButtonLink
+                            transparent
+                            href={`/device/${deviceID}`}>
+                            {t('button.back')}
+                        </ButtonLink>
+                    </div>
+                </Dialog>
+            );
+        }
+        return (
+            <div>
+                {children}
+            </div>
+        );
+    }
+
+}
+
+const HOC = translate<SDCardCheckProps>()(SDCardCheck);
+export { HOC as SDCardCheck };

--- a/frontends/web/src/components/devices/bitbox02/settings.tsx
+++ b/frontends/web/src/components/devices/bitbox02/settings.tsx
@@ -15,7 +15,6 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
-import { load } from '../../../decorators/load';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet } from '../../../utils/request';
 import { SwissMadeOpenSource } from '../../icon/logo';
@@ -43,11 +42,7 @@ interface State {
     };
 }
 
-interface LoadedSettingsProps {
-    sdCardInserted: boolean;
-}
-
-type Props = LoadedSettingsProps & SettingsProps & TranslateProps;
+type Props = SettingsProps & TranslateProps;
 
 class Settings extends Component<Props, State> {
     private apiPrefix = () => {
@@ -70,7 +65,6 @@ class Settings extends Component<Props, State> {
     public render(
         {
             deviceID,
-            sdCardInserted,
             t,
         }: RenderableProps<Props>,
         {
@@ -96,7 +90,7 @@ class Settings extends Component<Props, State> {
                                             </div>
                                         </div>
                                         <div className="box slim divide">
-                                            <SettingsButton link href={`/manage-backups/${deviceID}/${sdCardInserted}`}>
+                                            <SettingsButton link href={`/manage-backups/${deviceID}`}>
                                                 {t('deviceSettings.secrets.manageBackups')}
                                             </SettingsButton>
                                             <ShowMnemonic apiPrefix={this.apiPrefix()} />
@@ -164,6 +158,5 @@ class Settings extends Component<Props, State> {
     }
 }
 
-const loadHOC = load<LoadedSettingsProps, SettingsProps & TranslateProps>(({ deviceID }) => ({ sdCardInserted: 'devices/bitbox02/' + deviceID + '/check-sdcard' }))(Settings);
-const HOC = translate<SettingsProps>()(loadHOC);
+const HOC = translate<SettingsProps>()(Settings);
 export { HOC as Settings };

--- a/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
+++ b/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
@@ -17,26 +17,16 @@
 import { Component, h } from 'preact';
 import { route } from 'preact-router';
 import { translate } from 'react-i18next';
-import { ButtonLink, Button } from '../../../components/forms';
+import { ButtonLink } from '../../../components/forms';
 import { Guide } from '../../../components/guide/guide';
 import { Entry } from '../../../components/guide/entry';
 import { Backups } from '../../../components/backups/backups';
 import { Header } from '../../../components/layout';
-import * as dialogStyle from '../../../components/dialog/dialog.css';
 import { BackupsV2 } from '../../../components/devices/bitbox02/backups';
-import { apiGet } from '../../../utils/request';
-import { Dialog } from '../../../components/dialog/dialog';
+import { SDCardCheck } from '../../../components/devices/bitbox02/sdcardcheck';
 
 @translate()
 export default class ManageBackups extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            sdCardInserted: this.props.sdCardInserted === 'true',
-            activeDialog: !this.state.sdCardInserted,
-        };
-    }
-
     hasDevice = () => {
         return !!this.props.devices[this.props.deviceID];
     }
@@ -70,46 +60,19 @@ export default class ManageBackups extends Component {
             );
         case 'bitbox02':
             return (
-                this.state.sdCardInserted ?
+                <SDCardCheck deviceID={this.props.deviceID}>
                     <BackupsV2
                         deviceID={this.props.deviceID}
                         showCreate={true}
                         showRestore={false}
                         showRadio={false}>
                         {this.backButton()}
-                    </BackupsV2> : (
-                        <div>
-                            {
-                                this.state.activeDialog && (
-                                    <Dialog title="Check your device" small>
-                                        <div className="columnsContainer half">
-                                            <div className="columns">
-                                                <div className="column">
-                                                    <p>{this.props.t('backup.insert')}</p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div className={dialogStyle.actions}>
-                                            <Button
-                                                primary
-                                                onClick={this.checkBB02SDCard}>
-                                                {this.props.t('button.ok')}
-                                            </Button>
-                                            {this.backButton()}
-                                        </div>
-                                    </Dialog>
-                                )
-                            }
-                        </div>
-                    )
+                    </BackupsV2>
+                </SDCardCheck>
             );
         default:
             return;
         }
-    }
-
-    checkBB02SDCard = () => {
-        apiGet('devices/bitbox02/' + this.props.deviceID + '/check-sdcard').then(inserted => this.setState({ sdCardInserted: inserted }));
     }
 
     renderGuide = t => {


### PR DESCRIPTION
The BackupsV2 component would be fed the sdCardInserted property via
the URL from the Settings component. This is fragile, e.g. if you
remove the sdcard while in the settings screen and then go to backups,
you will get an error.

The url part is also only used for the BitBox02, but the ManageBackups
component is for both BitBox01 and BitBox02, which makes this also
confusing.

For now we abstract away the microSD card check and use it when
loading the Backups component, so it should always work.

There is more refacoring that can be done later, e.g. cleaning up the
back button mess.