### PR TITLE
frontend: fix manage backup buttons

### DIFF
--- a/frontends/web/src/components/backups/backups.css
+++ b/frontends/web/src/components/backups/backups.css
@@ -59,8 +59,13 @@
     display: flex;
     flex-wrap: wrap;
     flex-direction: row-reverse;
-    gap: var(--space-half);
     margin-top: var(--space-default);
+}
+
+@media (min-width: 769px) {
+    .backupButtons > *:not(:first-child) {
+        margin-right: var(--space-half);
+    }
 }
 
 @media (max-width: 768px) {
@@ -68,5 +73,9 @@
         align-items: center;
         flex-direction: column;
         margin-top: var(--space-default);
+    }
+
+    .backupButtons > *:not(:first-child) {
+        margin-top: var(--space-half);
     }
 }

--- a/frontends/web/src/components/steps/steps.css
+++ b/frontends/web/src/components/steps/steps.css
@@ -336,7 +336,6 @@
 }
 
 .step button {
-    height: var(--wizard-item-height);
     font-size: var(--size-wizard-text);
 }
 


### PR DESCRIPTION
On the manage backups view the buttons have no space and on restore
from backup the buttons are too big. The gap CSS attribute only works
in newer webkit versions.

- changed from gap to margin to fix spacing issue
- removed button height on the restore backup from sd card, so that
  the button uses the default button height