### PR TITLE
frontend: dedup coin and fiat types in rates

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -45,10 +45,6 @@ export const init = (code: string): Promise<null> => {
     return apiPost(`account/${code}/init`);
 };
 
-export const reinitialize = (): Promise<null> => {
-    return apiPost('accounts/reinitialize');
-};
-
 export interface ISummary {
     chartDataMissing: boolean;
     chartDataDaily: ChartData;
@@ -136,18 +132,10 @@ export const exportAccount = (code: string): Promise<string> => {
     return apiPost(`account/${code}/export`);
 };
 
-export const getCanVerifyXPub = (code: string): Promise<number[]> => {
-    return apiGet(`account/${code}/can-verify-extended-public-key`);
-};
-
 export interface IReceiveAddress {
     addressID: string;
     address: string;
 }
-
-export const verifyAddress = (code: string, addressID: string): Promise<boolean> => {
-    return apiPost(`account/${code}/verify-address`, addressID);
-};
 
 export type ReceiveAddressList = IReceiveAddress[][];
 
@@ -182,24 +170,6 @@ export interface IProposeTx {
     success?: boolean;
     errorMessage?: string;
 }
-
-export const proposeTx = (code: string, data: IProposeTxData): Promise<IProposeTx> => {
-    return apiPost(`account/${code}/tx-proposal`, data);
-};
-
-export const proposeTxNote = (code: string, note: string): Promise<null> => {
-    return apiPost(`account/${code}/propose-tx-note`, note);
-};
-
-export interface IUTXO {
-    address: string;
-    amount: IAmount;
-    outPoint: string;
-}
-
-export const getUTXOList = (code: string): Promise<IUTXO[]> => {
-    return apiGet(`account/${code}/utxos`);
-};
 
 export interface IFeeTarget {
     code: FeeTargetCode;

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -16,6 +16,7 @@
  */
 
 import { h, JSX, RenderableProps } from 'preact';
+import { Coin, Fiat, MainnetCoin } from '../../api/account';
 import { share } from '../../decorators/share';
 import { Store } from '../../decorators/store';
 import { setConfig } from '../../utils/config';
@@ -24,13 +25,6 @@ import { apiSubscribe } from '../../utils/event';
 import { apiGet, apiPost } from '../../utils/request';
 import * as style from './rates.css';
 
-export type MainnetCoin = 'BTC' | 'LTC' | 'ETH';
-
-export type TestnetCoin = 'TBTC' | 'TLTC' | 'TETH' | 'RETH';
-
-export type Coin = MainnetCoin | TestnetCoin;
-
-export type Fiat = 'USD' | 'EUR' | 'CHF' | 'GBP' | 'JPY' | 'KRW' | 'CNY' | 'RUB' | 'CAD' | 'AUD' | 'ILS' | 'BTC' | 'SGD';
 
 export type Rates = {
     [coin in MainnetCoin]: {

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -18,7 +18,6 @@
 import { Component, h, RenderableProps } from 'preact';
 import * as accountApi from '../../../api/account';
 import { Input, Select } from '../../../components/forms';
-import { Fiat } from '../../../components/rates/rates';
 import { load } from '../../../decorators/load';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { getCoinCode, isBitcoinBased } from '../utils';
@@ -32,7 +31,7 @@ interface FeeTargetsProps {
     accountCode: string;
     coinCode: accountApi.CoinCode;
     disabled: boolean;
-    fiatUnit: Fiat;
+    fiatUnit: accountApi.Fiat;
     proposedFee?: accountApi.IAmount;
     feePerByte: string;
     showCalculatingFeeLabel?: boolean;

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -31,7 +31,7 @@ import { Button, ButtonLink, Checkbox, Input } from '../../../components/forms';
 import { Entry } from '../../../components/guide/entry';
 import { Guide } from '../../../components/guide/guide';
 import { Header } from '../../../components/layout';
-import { Fiat, store as fiat } from '../../../components/rates/rates';
+import { store as fiat } from '../../../components/rates/rates';
 import { Spinner } from '../../../components/spinner/Spinner';
 import Status from '../../../components/status/status';
 import WaitDialog from '../../../components/wait-dialog/wait-dialog';
@@ -70,7 +70,7 @@ interface State {
     amount?: string;
     data?: string;
     fiatAmount?: string;
-    fiatUnit: Fiat;
+    fiatUnit: accountApi.Fiat;
     sendAll: boolean;
     feeTarget?: accountApi.FeeTargetCode;
     feePerByte: string;

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -15,11 +15,12 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
+import { Coin } from '../../../api/account';
 import A from '../../../components/anchor/anchor';
 import { Dialog } from '../../../components/dialog/dialog';
 import { Button, Checkbox } from '../../../components/forms';
 import { ExpandOpen } from '../../../components/icon/icon';
-import { Coin, FiatConversion } from '../../../components/rates/rates';
+import { FiatConversion } from '../../../components/rates/rates';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet } from '../../../utils/request';
 import * as style from './utxos.css';

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -16,8 +16,9 @@
 
 import { createChart, IChartApi, BarsInfo, LineData, LineStyle, LogicalRange, ISeriesApi, UTCTimestamp, MouseEventHandler } from 'lightweight-charts';
 import { Component, createRef, h, RenderableProps } from 'preact';
+import { Fiat } from '../../../api/account';
 import { translate, TranslateProps } from '../../../decorators/translate';
-import { formatCurrency, formatNumber, Fiat } from '../../../components/rates/rates';
+import { formatCurrency, formatNumber } from '../../../components/rates/rates';
 import * as styles from './chart.css';
 
 export type ChartData = LineData[];

--- a/frontends/web/src/routes/settings/components/fiat/fiat.tsx
+++ b/frontends/web/src/routes/settings/components/fiat/fiat.tsx
@@ -15,9 +15,9 @@
  */
 
 import { h, JSX, RenderableProps } from 'preact';
+import { Fiat } from '../../../../api/account';
 import {
     currencies,
-    Fiat,
     selectFiat,
     setActiveFiat,
     SharedProps,


### PR DESCRIPTION
Only app, accounts-summary, accounts tsx and some of the involved
modules have now migrated to api, but this ended up that we have
duplicate types for coin and fiat.

Moved fiat and coin type to api/account and import it from there,
so it shouldn't have anymore duplicate types.