### PR TITLE
frontend/account: bundle status data

### DIFF
--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -379,42 +379,27 @@ func (handlers *Handlers) postInit(_ *http.Request) (interface{}, error) {
 	return nil, handlers.account.Initialize()
 }
 
-// status indicates the connection and initialization status.
-type status string
-
-const (
-	// accountSynced indicates that the account is synced.
-	accountSynced status = "accountSynced"
-
-	// accountDisabled indicates that the account has not yet been initialized.
-	accountDisabled status = "accountDisabled"
-
-	// offlineMode indicates that the connection to the blockchain network could not be established.
-	offlineMode status = "offlineMode"
-
-	// fatalError indicates that there was a fatal error in handling the account. When this happens,
+type statusResponse struct {
+	// Disabled indicates that the account has not yet been initialized.
+	Disabled bool `json:"disabled"`
+	// Synced indicates that the account is synced.
+	Synced bool `json:"synced"`
+	// Offline indicates that the connection to the blockchain network could not be established.
+	Offline bool `json:"offline"`
+	// FatalError indicates that there was a fatal error in handling the account. When this happens,
 	// an error is shown to the user and the account is made unusable.
-	fatalError status = "fatalError"
-)
+	FatalError bool `json:"fatalError"`
+}
 
 func (handlers *Handlers) getAccountStatus(_ *http.Request) (interface{}, error) {
-	status := []status{}
 	if handlers.account == nil {
-		status = append(status, accountDisabled)
-	} else {
-		if handlers.account.Synced() {
-			status = append(status, accountSynced)
-		}
-
-		if handlers.account.Offline() {
-			status = append(status, offlineMode)
-		}
-
-		if handlers.account.FatalError() {
-			status = append(status, fatalError)
-		}
+		return statusResponse{Disabled: true}, nil
 	}
-	return status, nil
+	return statusResponse{
+		Synced:     handlers.account.Synced(),
+		Offline:    handlers.account.Offline(),
+		FatalError: handlers.account.FatalError(),
+	}, nil
 }
 
 type jsonAddress struct {

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -41,9 +41,14 @@ export const getAccounts = (): Promise<IAccount[]> => {
     return apiGet(`accounts`);
 };
 
-export type AccountState = 'accountSynced' | 'accountDisabled' | 'fatalError' | 'offlineMode';
+export interface IStatus {
+    disabled: boolean;
+    synced: boolean;
+    fatalError: boolean;
+    offline: boolean;
+}
 
-export const getStatus = (code: string): Promise<AccountState[]> => {
+export const getStatus = (code: string): Promise<IStatus> => {
     return apiGet(`account/${code}/status`);
 };
 

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -117,12 +117,10 @@ class AccountsSummary extends Component<Props, State> {
 
     private onStatusChanged(code: string) {
         accountApi.getStatus(code).then(status => {
-            const accountSynced = status.includes('accountSynced');
-            const accountDisabled = status.includes('accountDisabled');
-            if (accountDisabled) {
+            if (status.disabled) {
                 return;
             }
-            if (!accountSynced) {
+            if (!status.synced) {
                 return accountApi.init(code);
             }
             return accountApi.getBalance(code).then(balance => {


### PR DESCRIPTION
It matches better what the getStatus call handling wants.

This will make it easier to add additional info such as error codes or
error messages to be displayed.