### PR TITLE
frontend/account: remove invisible offline status

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -288,11 +288,6 @@ class Account extends Component<Props, State> {
                     <Status type="warning">
                         {hasCard && t('warning.sdcard')}
                     </Status>
-                    { status.offlineError !== null ? (
-                        <Status>
-                            <p>{t('account.reconnecting')}</p>
-                        </Status>
-                    ) : null }
                     <Header
                         title={<h2><span>{account.name}</span></h2>}>
                         {isBitcoinBased(account.coinCode) ? (


### PR DESCRIPTION
The spinner takes up the whole screen. Afaik the status removed in
this commit is never visible.