### PR TITLE
frontend/account: if offline and tor proxy enabled, give user a hint

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -14,6 +14,7 @@
       "tbtc-p2wpkh-p2sh": "$t(account.info.btc-p2wpkh-p2sh)"
     },
     "initializing": "Getting information from the blockchain…",
+    "maybeProxyError": "Tor proxy enabled. Ensure that your Tor proxy is running properly, or disable the proxy setting.",
     "openFile": "Open file",
     "reconnecting": "Lost connection, trying to reconnect…",
     "syncedAddressesCount": "Scanned {{count}} addresses"

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -246,6 +246,7 @@ class Account extends Component<Props, State> {
             t,
             code,
             accounts,
+            config,
         }: RenderableProps<Props>,
         {
             status,
@@ -271,6 +272,15 @@ class Account extends Component<Props, State> {
                     defaultValue: 0,
                 })
             ) : '';
+
+        const offlineErrorTextLines: string[] = [];
+        if (status.offlineError !== null) {
+            offlineErrorTextLines.push(t('account.reconnecting'));
+            offlineErrorTextLines.push(status.offlineError);
+            if (config.backend.proxy.useProxy) {
+                offlineErrorTextLines.push(t('account.maybeProxyError'));
+            }
+        }
 
         return (
             <div class="contentWithGuide">
@@ -328,12 +338,10 @@ class Account extends Component<Props, State> {
                                 <Balance balance={balance} />
                             </div>
                             {
-                                !status.synced || status.offlineError !== null || !this.dataLoaded() || status.fatalError ? (
+                                !status.synced || offlineErrorTextLines.length || !this.dataLoaded() || status.fatalError ? (
                                     <Spinner text={
                                         status.fatalError && t('account.fatalError') ||
-                                        status.offlineError !== null && (
-                                            t('account.reconnecting') + '\n' + status.offlineError
-                                        ) ||
+                                        offlineErrorTextLines.join('\n') ||
                                         !status.synced && (
                                             t('account.initializing')
                                             + initializingSpinnerText


### PR DESCRIPTION
Sometimes users activate the setting by mistake, or activate it but
don't have a Tor proxy running.