### PR TITLE
backend/electrum: set ServerName to help SNI-capable loadbalancers

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1109,7 +1109,7 @@ func (backend *Backend) RatesUpdater() *rates.RateUpdater {
 
 // DownloadCert downloads the first element of the remote certificate chain.
 func (backend *Backend) DownloadCert(server string) (string, error) {
-	return electrum.DownloadCert(server, backend.socksProxy)
+	return electrum.DownloadCert(server, backend.socksProxy.GetTCPProxyDialer())
 }
 
 // CheckElectrumServer checks if a connection can be established with the electrum server, and

--- a/backend/bitboxbase/bitboxbase.go
+++ b/backend/bitboxbase/bitboxbase.go
@@ -141,7 +141,7 @@ func (base *BitBoxBase) ConnectElectrum() error {
 	}
 	electrumAddress := base.address + ":" + base.electrsRPCPort
 
-	electrumCert, err := electrum.DownloadCert(electrumAddress, base.socksProxy)
+	electrumCert, err := electrum.DownloadCert(electrumAddress, base.socksProxy.GetTCPProxyDialer())
 	if err != nil {
 		base.log.WithField("ElectrumIP: ", electrumAddress).Error(err.Error())
 		return err

--- a/backend/coins/btc/electrum/electrum_test.go
+++ b/backend/coins/btc/electrum/electrum_test.go
@@ -1,0 +1,137 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package electrum
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadCert(t *testing.T) {
+	tt := []struct{ targetServer, wantServerName string }{
+		{"node.example.org:123", "node.example.org"},
+		{"1.2.3.4:123", ""},
+	}
+	for _, testcase := range tt {
+		testcase := testcase
+		t.Run(testcase.targetServer, func(t *testing.T) {
+			// Set up a fake ElectrumX node.
+			var didHandshake bool
+			fakeNode := &test.TCPServer{
+				GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+					didHandshake = true
+					assert.Equal(t, testcase.wantServerName, hello.ServerName, "hello.ServerName")
+					return test.TCPServerCert, nil
+				},
+			}
+			fakeNode.StartTLS(func(conn net.Conn) {
+				conn.Write([]byte("ok")) // unused; just to finish TLS handshake
+				conn.Close()
+			})
+			defer fakeNode.Close()
+
+			// Make sure the client always connects directly to the fake node.
+			dialer := &test.Dialer{DialFn: func(network, addr string) (net.Conn, error) {
+				assert.Equal(t, testcase.targetServer, addr, "dialer addr")
+				return fakeNode.Dialer().Dial(network, addr)
+			}}
+
+			// Run the test.
+			done := make(chan struct{})
+			go func() {
+				cert, err := DownloadCert(testcase.targetServer, dialer)
+				require.NoError(t, err, "DownloadCert")
+				expected, actual := strings.TrimSpace(test.TCPServerCertPub), strings.TrimSpace(cert)
+				assert.Equal(t, expected, actual, "DownloadCert")
+				assert.True(t, didHandshake, "didHandshake")
+				close(done)
+			}()
+
+			select {
+			case <-time.After(3 * time.Second):
+				t.Fatal("DownloadCert took too long to return")
+			case <-done:
+				// ok
+			}
+		})
+	}
+}
+
+func TestEstablishConnectionTLS(t *testing.T) {
+	tt := []struct{ targetServer, wantServerName string }{
+		{"node.example.org:123", "node.example.org"},
+		{"1.2.3.4:123", ""},
+	}
+	for _, testcase := range tt {
+		testcase := testcase
+		t.Run(testcase.targetServer, func(t *testing.T) {
+			// Set up a fake ElectrumX node.
+			var didHandshake bool
+			fakeNode := &test.TCPServer{
+				GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+					didHandshake = true
+					assert.Equal(t, testcase.wantServerName, hello.ServerName, "hello.ServerName")
+					return test.TCPServerCert, nil
+				},
+			}
+			fakeNode.StartTLS(func(conn net.Conn) {
+				io.Copy(conn, conn) // echo back all incoming data
+				conn.Close()
+			})
+			defer fakeNode.Close()
+
+			// Make sure the client always connects directly to the fake node.
+			dialer := &test.Dialer{DialFn: func(network, addr string) (net.Conn, error) {
+				assert.Equal(t, testcase.targetServer, addr, "dialer addr")
+				return fakeNode.Dialer().Dial(network, addr)
+			}}
+
+			// Run the test.
+			info := &config.ServerInfo{
+				Server:  testcase.targetServer,
+				TLS:     true,
+				PEMCert: test.TCPServerCertPub,
+			}
+			done := make(chan struct{})
+			go func() {
+				conn, err := establishConnection(info, dialer)
+				require.NoError(t, err, "establishConnection")
+				conn.Write([]byte("hello"))
+				var buf = make([]byte, 5)
+				conn.Read(buf)
+				assert.Equal(t, "hello", string(buf), "conn.Read")
+				conn.Close()
+				assert.True(t, didHandshake, "didHandshake")
+				close(done)
+			}()
+
+			select {
+			case <-time.After(3 * time.Second):
+				t.Fatal("establishConnection took too long to return")
+			case <-done:
+				// ok
+			}
+		})
+	}
+}

--- a/util/test/tcp.go
+++ b/util/test/tcp.go
@@ -1,0 +1,147 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net"
+
+	"golang.org/x/net/proxy"
+)
+
+// TCPServerCertKey is the private key of TCPServerCert in PEM encoding.
+// It was generated with:
+//     openssl ecparam -out key.pem -name secp256r1 -genkey; cat key.pem
+const TCPServerCertKey = `
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIFlVUmHt+140ZsJz0i2QlFd9m3zLNKQ0FmadLADGWKJvoAoGCCqGSM49
+AwEHoUQDQgAERPPEMbqPxez20a2UIj9YpMkOOTBgdSetREcTYE7VSiL7lFgQWlfF
+jXbEaVL0nhsoi2DbNJbGzMaIBhyYrtaFAw==
+-----END EC PRIVATE KEY-----
+`
+
+// TCPServerCertPub is the TCPServerCert in PEM encoding.
+// It was generated with:
+//     openssl req -new -key key.pem -x509 -nodes -days 10000 \
+//       -subj '/CN=node.example.org' \
+//       -addext 'subjectAltName=DNS:node.example.org'
+const TCPServerCertPub = `
+-----BEGIN CERTIFICATE-----
+MIIBTDCB8qADAgECAgkAqux29iMFU0UwCgYIKoZIzj0EAwIwGzEZMBcGA1UEAwwQ
+bm9kZS5leGFtcGxlLm9yZzAeFw0yMTAzMTIwOTI0MzRaFw00ODA3MjgwOTI0MzRa
+MBsxGTAXBgNVBAMMEG5vZGUuZXhhbXBsZS5vcmcwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAARE88Qxuo/F7PbRrZQiP1ikyQ45MGB1J61ERxNgTtVKIvuUWBBaV8WN
+dsRpUvSeGyiLYNs0lsbMxogGHJiu1oUDox8wHTAbBgNVHREEFDASghBub2RlLmV4
+YW1wbGUub3JnMAoGCCqGSM49BAMCA0kAMEYCIQDfskJocH4jPevTZx0f5etZ3akR
+gpYpt6sWjQN6ZmEHzAIhAPUJx39HV+wXUfiYe4fwlAPihLZyFl1Hy3pfRwit1SZ9
+-----END CERTIFICATE-----
+`
+
+// TCPServerCert is the default certificate presented to the clients
+// by TCPServer if its GetCertificate field was nil at the time StartTLS is called.
+var TCPServerCert *tls.Certificate
+
+func init() {
+	cert, err := tls.X509KeyPair([]byte(TCPServerCertPub), []byte(TCPServerCertKey))
+	if err != nil {
+		panic(fmt.Sprintf("test/TCPServerCert: %v", err))
+	}
+	TCPServerCert = &cert
+}
+
+// TCPServer listens on a randomly chosen TCP port on localhost.
+// To start listening, call StartTLS. To stop, use Close.
+type TCPServer struct {
+	// GetCertificate allows callers to present different certificates based on
+	// the client hello. This requires clients to support SNI.
+	// The field is set directly to tls.Config's GetCertificate.
+	// If nil, TCPServerCert is used.
+	GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+
+	listener net.Listener
+	quit     chan struct{}
+}
+
+// StartTLS makes the server start listening for incoming connections
+// and pass them on to the accept function, each in a separate goroutine.
+// It chooses a random port on localhost. To connect to the server, use s.Dialer.
+// To stop listening, call s.Close.
+//
+// StartTLS panics if it's unable to start listening.
+func (s *TCPServer) StartTLS(accept func(net.Conn)) {
+	// Set up TLS config.
+	conf := &tls.Config{GetCertificate: s.GetCertificate}
+	if conf.GetCertificate == nil {
+		conf.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return TCPServerCert, nil
+		}
+	}
+	// Start listening on a random port. Some systems may support only IPv6.
+	l, err := tls.Listen("tcp", "127.0.0.1:0", conf)
+	if err != nil {
+		l, err = tls.Listen("tcp6", "[::1]:0", conf)
+	}
+	if err != nil {
+		panic(fmt.Sprintf("test/TCPServer.StartTLS: %v", err))
+	}
+	s.listener = l
+
+	// Accept new connections until we're told to quit.
+	s.quit = make(chan struct{})
+	go func() {
+		for {
+			conn, err := s.listener.Accept()
+			select {
+			case <-s.quit:
+				return
+			default:
+				// continue
+			}
+			if err != nil {
+				log.Printf("test/TCPServer accept: %v", err)
+				continue
+			}
+			go accept(conn)
+		}
+	}()
+}
+
+// Dialer allows clients to connect to the started server.
+// It always ignores Dial's network and addr arguments.
+func (s *TCPServer) Dialer() proxy.Dialer {
+	return &Dialer{DialFn: func(network, addr string) (net.Conn, error) {
+		return net.Dial(s.listener.Addr().Network(), s.listener.Addr().String())
+	}}
+}
+
+// Close stops listening. Callers are responsible for closing any idle connections
+// passed on to accept function in StartTLS.
+func (s *TCPServer) Close() {
+	close(s.quit)
+	s.listener.Close() //nolint:errcheck
+}
+
+// Dialer satisfies x/net/proxy.Dialer.
+// It always passes the calls onto its DialFn.
+type Dialer struct {
+	DialFn func(network, addr string) (net.Conn, error)
+}
+
+// Dial simply calls d.DialFn.
+func (d *Dialer) Dial(network, addr string) (net.Conn, error) {
+	return d.DialFn(network, addr)
+}


### PR DESCRIPTION
The commit makes the electrum client provide SNI server name when
connecting to a node over TLS. It is very useful for a setup with
multiple nodes running on the same machine where a loadbalancer
dispatches connections to a specific node based on the SNI during a TLS
handshake. For example:

    btc1.shiftcrypto.io:443  -> local port 50001
    ltc1.shiftcrypto.io:443  -> same machine, local port 50002
    tbtc1.shiftcrypto.io:443 -> same machine, local port 51001

I don't expect any breaking changes. The ServerName field merely
provides an indication to the server, typically for a certificate
selection in a multi cert setup. Our certificate validation remains
the same.
