### PR TITLE
frontend: hide disabled copy button on receive view

### DIFF
--- a/frontends/web/src/assets/icons/copy-disabled.svg
+++ b/frontends/web/src/assets/icons/copy-disabled.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#BBBBBB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-copy"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>

--- a/frontends/web/src/components/copy/Copy.tsx
+++ b/frontends/web/src/components/copy/Copy.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +17,6 @@
 
 import { Component, h, RenderableProps } from 'preact';
 import CheckIcon from '../../assets/icons/check.svg';
-import CopyDisabledIcon from '../../assets/icons/copy-disabled.svg';
 import CopyIcon from '../../assets/icons/copy.svg';
 import { translate, TranslateProps } from '../../decorators/translate';
 import * as style from './Copy.css';
@@ -82,6 +82,14 @@ class CopyableInput extends Component<Props, State> {
         { t, value, className, disabled, flexibleHeight }: RenderableProps<Props>,
         { success }: State,
     ) {
+        const copyButton = disabled ? null : (
+            <button
+                onClick={this.copy}
+                className={[style.button, success && style.success, 'ignore'].join(' ')}
+                title={t('button.copy')}>
+                <img src={success ? CheckIcon : CopyIcon} />
+            </button>
+        );
         return (
             <div class={['flex flex-row flex-start flex-items-start', style.container, className ? className : ''].join(' ')}>
                 <textarea
@@ -92,13 +100,7 @@ class CopyableInput extends Component<Props, State> {
                     ref={this.setRef}
                     rows={1}
                     className={[style.inputField, flexibleHeight && style.flexibleHeight].join(' ')} />
-                <button
-                    disabled={disabled}
-                    onClick={this.copy}
-                    className={[style.button, success && style.success, 'ignore'].join(' ')}
-                    title={t('button.copy')}>
-                        <img src={success ? CheckIcon : disabled ? CopyDisabledIcon : CopyIcon} />
-                </button>
+                {copyButton}
             </div>
         );
     }


### PR DESCRIPTION
There is no point if showing a disabled copy button, also the real
copy button is currently displayed in a different place (dialog).

Closes https://github.com/digitalbitbox/bitbox-wallet-app/issues/1001