### PR TITLE
Frontend: update copy component state init, var and type naming

### DIFF
--- a/frontends/web/src/components/copy/Copy.tsx
+++ b/frontends/web/src/components/copy/Copy.tsx
@@ -35,14 +35,11 @@ interface State {
 }
 
 class CopyableInput extends Component<Props, State> {
-    private inputField!: HTMLInputElement;
-
-    constructor(props: Props) {
-        super(props);
-        this.state = {
-            success: false,
-        };
+    public readonly state: State = {
+        success: false,
     }
+
+    private textArea!: HTMLTextAreaElement;
 
     public componentDidMount() {
         this.setHeight();
@@ -53,24 +50,26 @@ class CopyableInput extends Component<Props, State> {
     }
 
     private setHeight() {
-        const textarea = this.inputField;
+        const textarea = this.textArea;
         const fontSize = window.getComputedStyle(textarea, null).getPropertyValue('font-size');
         const units = Number(fontSize.replace('px', '')) + 2;
         textarea.setAttribute('rows', '1');
         textarea.setAttribute('rows', String(Math.round((textarea.scrollHeight / units) - 2)));
     }
 
-    private setRef = (input: HTMLInputElement) => {
-        this.inputField = input;
+    private setRef = (textarea: HTMLTextAreaElement) => {
+        this.textArea = textarea;
     }
 
-    private onFocus = (e: Event) => {
-        const input = e.target as HTMLInputElement;
-        input.focus();
+    private onFocus = (e: FocusEvent) => {
+        const textarea = e.target as HTMLTextAreaElement;
+        if (textarea) {
+            textarea.focus();
+        }
     }
 
     private copy = () => {
-        this.inputField.select();
+        this.textArea.select();
         if (document.execCommand('copy')) {
             this.setState({ success: true }, () => {
                 setTimeout(() => this.setState({ success: false }), 1500);

--- a/frontends/web/src/components/qrcode/qrcode.tsx
+++ b/frontends/web/src/components/qrcode/qrcode.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,11 +29,8 @@ interface State {
 }
 
 class QRCode extends Component<Props, State> {
-    constructor(props) {
-        super(props);
-        this.state = {
-            src: '',
-        };
+    public readonly state: State = {
+        src: '',
     }
 
     public static defaultProps = {

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -61,14 +61,11 @@ interface LoadedReceiveProps {
 type Props = LoadedReceiveProps & ReceiveProps & TranslateProps;
 
 class Receive extends Component<Props, State> {
-    constructor(props) {
-        super(props);
-        this.state = {
-            verifying: false,
-            activeIndex: 0,
-            paired: null,
-            addressType: 0,
-        };
+    public readonly state: State = {
+        verifying: false,
+        activeIndex: 0,
+        paired: null,
+        addressType: 0,
     }
 
     public componentDidMount() {


### PR DESCRIPTION
Moved state initialization out of constructor and use readonly
state initialization. We already do that in various places, reason
is less boilerplate and it tells TypeScript that the state key
shall not be mutated, example this.state.foo = 'bar'.
The linter should already know that this.state should be readonly
via eslint-plugin-react.

A while ago the copy component's input element has been changed
to textarea to support multiple lines, but the variable names and
types where still using input as name and type.
Changed variable names and types to use textarea, this should not
have a practical difference.

on top of https://github.com/digitalbitbox/bitbox-wallet-app/pull/1211