### PR TITLE
windows: always run the installer as admin

### DIFF
--- a/frontends/qt/setup.nsi
+++ b/frontends/qt/setup.nsi
@@ -1,6 +1,9 @@
 Name "BitBoxApp"
 
-RequestExecutionLevel highest
+# Need admin privileges for writing to $PROGRAMFILES64 and HKLM.
+# Unfortunately, the installer mixes per-user and system-wide things.
+# TODO: Switch to per-user install and drop admin execution level.
+RequestExecutionLevel admin
 SetCompressor /SOLID lzma
 
 # General Symbol Definitions


### PR DESCRIPTION
The installer needs admin privileges for writing to `$PROGRAMFILES64`
and HKLM. The previously used value of "highest" escalates only to the
available permissions under that user. If the user can't escalate to
admin, the installer won't be able to write to `$PROGRAMFILES64`.
Setting `RequestExecutionLevel` to admin always escalates to admin or
fails the process.

Docs:
https://nsis.sourceforge.io/Reference/RequestExecutionLevel

---

Unfortunately, the setup.nsi script mixes system-wide and per-user
installation. For example, it writes files to the system-wide
$PROGRAMFILES64 and Start menu but then registers the uninstaller under
HKCU (Current User) for some unknown reason.

Neither the installer nor BitBox.exe need any special privileges.
Ideally, everything is run under current user and the install is
strictly on a per-user basis with RequestExecutionLevel set to "user".
This is the easy part.

The hard part is what to do with the existing installations.
An installer with RequestExecutionLevel set to "user" cannot delete a
previous system-wide installation. It can't delete files from
$PROGRAMFILES64 or HKLM entries. Neither can it scalate to admin in the
middle of the process: it has only one chance at the beginning.
A possible way to solve this is to start up an uninstall.exe
as a child process with escalated privileges. Wait for the
uninstall-as-admin to finish and proceed under regular user level.

However, the uninstaller currently deletes things with /REBOOTOK which
assumes a clean state only after a reboot. It would be a very
annoying user experience if we required users to reboot during a
software install.

I hope the above can serve as notes for future improvements.
