### PR TITLE
windows: kill any running instance of bitbox.exe during the install

### DIFF
--- a/frontends/qt/setup.nsi
+++ b/frontends/qt/setup.nsi
@@ -10,6 +10,7 @@ SetCompressor /SOLID lzma
 !define URL https://github.com/digitalbitbox/bitbox-wallet-app/releases/
 !define BINDIR "build\windows"
 !define ICONDIR "resources\win"
+!define APP_EXE "BitBox.exe"
 
 # MUI Symbol Definitions
 !define MUI_ICON "${ICONDIR}\icon.ico"
@@ -23,7 +24,7 @@ SetCompressor /SOLID lzma
 !define MUI_STARTMENUPAGE_REGISTRY_VALUENAME StartMenuGroup
 !define MUI_STARTMENUPAGE_DEFAULTFOLDER "BitBox"
 !define MUI_FINISHPAGE_RUN "$WINDIR\explorer.exe"
-!define MUI_FINISHPAGE_RUN_PARAMETERS $INSTDIR\BitBox.exe
+!define MUI_FINISHPAGE_RUN_PARAMETERS "$INSTDIR\${APP_EXE}"
 !define MUI_UNICON "${ICONDIR}\icon.ico"
 !define MUI_UNWELCOMEFINISHPAGE_UNICON "${ICONDIR}\icon.ico"
 !define MUI_UNFINISHPAGE_NOAUTOCLOSE
@@ -68,6 +69,13 @@ ShowUninstDetails show
 
 # Installer sections
 Section -Main SEC0000
+    DetailPrint "Shutting down any running instances of ${APP_EXE}"
+    ExecWait "taskkill /IM ${APP_EXE} /F"
+    # taskkill may exit before the process actually terminates.
+    # Give it a couple seconds to release any open files.
+    Sleep 3000
+    DetailPrint "Proceeding with the installation"
+
     SetOutPath $INSTDIR
     SetOverwrite on
     File /r "build\windows\*"
@@ -84,7 +92,7 @@ Section -post SEC0001
     WriteUninstaller $INSTDIR\uninstall.exe
     !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
     CreateDirectory $SMPROGRAMS\$StartMenuGroup
-    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk" $INSTDIR\BitBox.exe
+    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk" "$INSTDIR\${APP_EXE}"
     CreateShortcut "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk" $INSTDIR\uninstall.exe
     !insertmacro MUI_STARTMENU_WRITE_END
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayName "$(^Name)"


### PR DESCRIPTION
If a user already has BitBoxApp installed and it's currently running,
the new installation won't be able to proceed because the bitbox.exe is
not writable, assuming the same install directory is chosen.

This commit forces any running instance of bitbox.exe to quit before
doing anything else.

The taskkill command should be available on at least Windows 7 and on.
Docs: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill
