### PR TITLE
frontend: show fee on transaction overview

### DIFF
--- a/frontends/web/src/components/transactions/transaction.css
+++ b/frontends/web/src/components/transactions/transaction.css
@@ -223,7 +223,7 @@
 
 @media (max-width: 1080px), (min-width: 1200px) and (max-width: 1322px) {
     .container {
-        margin: 0 0 var(--space-half) 0;
+        margin: 0 0 2px 0;
     }
 
     .container.first {
@@ -271,5 +271,8 @@
 
     .fee {
         min-width: 0;
+    }
+    .status {
+        display: none;
     }
 }

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -205,16 +205,25 @@ class Transaction extends Component<Props, State> {
                             />
                             <span className={style.status}>{statusText}</span>
                         </div>
-                        <div className={parentStyle.fiat}>
-                            <span className={`${style.fiat} ${typeClassName}`}>
-                                <FiatConversion amount={amount} noAction>{sign}</FiatConversion>
-                            </span>
-                        </div>
                         <div className={parentStyle.currency}>
                             <span className={`${style.currency} ${typeClassName}`}>
                                 {sign}{amount.amount}
                                 {' '}
                                 <span className={style.currencyUnit}>{amount.unit}</span>
+                            </span>
+                        </div>
+                        <div className={parentStyle.fee}>
+                            { type !== 'receive' ? (
+                                <span className={`${style.currency} ${style.send}`}>
+                                    −{fee.amount}
+                                    {' '}
+                                    <span className={style.currencyUnit}>{fee.unit}</span>
+                                </span>
+                            ) : null }
+                        </div>
+                        <div className={parentStyle.fiat}>
+                            <span className={`${style.fiat} ${typeClassName}`}>
+                                <FiatConversion amount={amount} noAction>{sign}</FiatConversion>
                             </span>
                         </div>
                         <div className={[parentStyle.action, parentStyle.showOnMedium].join(' ')}>

--- a/frontends/web/src/components/transactions/transactions.css
+++ b/frontends/web/src/components/transactions/transactions.css
@@ -26,7 +26,6 @@
 .headers {
   height: 48px;
   color: var(--color-softblack);
-  text-transform: uppercase;
 }
 
 .columns >  *,
@@ -55,8 +54,8 @@
 }
 
 .activity {
-  min-width: 362px;
-  width: 362px;
+  min-width: 162px;
+  width: 162px;
   text-align: left;
 }
 
@@ -72,6 +71,12 @@
 }
 
 .currency {
+  min-width: 202px;
+  width: 202px;
+  justify-content: flex-end;
+}
+
+.fee {
   min-width: 202px;
   width: 202px;
   justify-content: flex-end;
@@ -139,7 +144,9 @@
   }
 
   .fiat,
-  .currency {
+  .currency,
+  .fee,
+  .status {
     justify-content: flex-start;
     min-width: 0;
     width: auto;
@@ -188,7 +195,7 @@
   }
 
   .status {
-    min-width: 100px;
+    min-width: 30px;
     margin-left: 2px;
   }
 }

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -63,8 +63,9 @@ class Transactions extends Component<Props> {
                     <div className={style.date}>{t('transaction.details.date')}</div>
                     <div className={style.activity}>{t('transaction.details.activity')}</div>
                     <div className={style.status}>{t('transaction.details.status')}</div>
-                    <div className={style.fiat}>{t('transaction.details.fiatAmount')}</div>
                     <div className={style.currency}>{t('transaction.details.amount')}</div>
+                    <div className={style.fee}>{t('transaction.details.fee')}</div>
+                    <div className={style.fiat}>{t('transaction.details.fiatAmount')}</div>
                     <div className={style.action}>&nbsp;</div>
                 </div>
                 {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1361,6 +1361,7 @@
       "address": "Address",
       "amount": "Amount",
       "date": "Date",
+      "fee": "Fee",
       "fiat": "Fiat",
       "fiatAmount": "Fiat amount",
       "status": "Status",


### PR DESCRIPTION
The total balance should be incoming - outgoing tx, but
we currently do not show outgoing fees and especially
with small amounts it visible that fees are missing.
Fees of incoming tx do not matter as they go to the
miner.

- added fee info for send and sendtoself tx
- moved Fiat to the last numeric column
- vertically reduced space between cells in responsive view
- hide pending/complete label text on small screen
- removed UPPERCASE table header styling for more consistent look