### PR TITLE
frontend/app: restore routing

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -80,9 +80,11 @@ class App extends Component<Props, State> {
         if (panelStore.state.activeSidebar) {
             toggleSidebar();
         }
+        setTimeout(this.maybeRoute);
     }
 
     public componentDidMount() {
+        this.maybeRoute();
         this.onBitBoxBasesRegisteredChanged();
         this.onBitBoxBasesDetectedChanged();
         this.unsubscribe = apiWebsocket(({ type, data, meta }) => {


### PR DESCRIPTION
Fixes a regresseion from
c9401c7cf18884287d743402b64e6a757e203127. Unlocking a device routes to
/account and is stuck there becaue maybeRoute() was not called anymore.