### PR TITLE
frontend: rewrite wait-dialog to typescript

### DIFF
--- a/frontends/web/src/components/backups/restore.tsx
+++ b/frontends/web/src/components/backups/restore.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +25,7 @@ import * as dialogStyle from '../dialog/dialog.css';
 import { Button, Checkbox } from '../forms';
 import { PasswordRepeatInput } from '../password';
 import { Spinner } from '../spinner/Spinner';
-import WaitDialog from '../wait-dialog/wait-dialog';
+import { WaitDialog } from '../wait-dialog/wait-dialog';
 import * as style from './backups.css';
 
 interface RestoreProps {

--- a/frontends/web/src/components/devices/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/components/devices/bitbox02/bitbox02.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +37,7 @@ import LanguageSwitch from '../../language/language';
 import { Header } from '../../layout/header';
 import { setSidebarStatus } from '../../sidebar/sidebar';
 import Status from '../../status/status';
-import WaitDialog from '../../wait-dialog/wait-dialog';
+import { WaitDialog } from '../../wait-dialog/wait-dialog';
 import { BackupsV2 } from './backups';
 import { Settings } from './settings';
 import { UpgradeButton, VersionInfo } from './upgradebutton';

--- a/frontends/web/src/components/devices/bitbox02/createbackup.tsx
+++ b/frontends/web/src/components/devices/bitbox02/createbackup.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +21,7 @@ import { apiPost } from '../../../utils/request';
 import { alertUser } from '../../alert/Alert';
 import { confirmation } from '../../confirm/Confirm';
 import { Button } from '../../forms';
-import WaitDialog from '../../wait-dialog/wait-dialog';
+import { WaitDialog } from '../../wait-dialog/wait-dialog';
 
 interface CreateProps {
     deviceID: string;
@@ -70,8 +71,9 @@ class Create extends Component<Props, State> {
 
     public render(
         { t }: RenderableProps<Props>,
-        { creatingBackup,
-          disabled,
+        {
+            creatingBackup,
+            disabled,
         }: State) {
         return (
             <span>
@@ -82,11 +84,9 @@ class Create extends Component<Props, State> {
                     {t('backup.create.title')}
                 </Button>
                 { creatingBackup && (
-                      <WaitDialog
-                          title={t('backup.create.title')}
-                      >
-                          {t('bitbox02Interact.followInstructions')}
-                      </WaitDialog>
+                    <WaitDialog title={t('backup.create.title')}>
+                        {t('bitbox02Interact.followInstructions')}
+                    </WaitDialog>
                 )}
             </span>
         );

--- a/frontends/web/src/components/devices/bitbox02/mnemonicpassphrase.tsx
+++ b/frontends/web/src/components/devices/bitbox02/mnemonicpassphrase.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +21,7 @@ import { apiPost } from '../../../utils/request';
 import SimpleMarkup from '../../../utils/simplemarkup';
 import { alertUser } from '../../alert/Alert';
 import { SettingsButton } from '../../settingsButton/settingsButton';
-import WaitDialog from '../../wait-dialog/wait-dialog';
+import { WaitDialog } from '../../wait-dialog/wait-dialog';
 
 interface MnemonicPassphraseButtonProps {
     apiPrefix: string;

--- a/frontends/web/src/components/devices/bitbox02/reset.tsx
+++ b/frontends/web/src/components/devices/bitbox02/reset.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +23,7 @@ import { Dialog } from '../../dialog/dialog';
 import * as dialogStyle from '../../dialog/dialog.css';
 import { Button, Checkbox } from '../../forms';
 import { SettingsButton } from '../../settingsButton/settingsButton';
-import WaitDialog from '../../wait-dialog/wait-dialog';
+import { WaitDialog } from '../../wait-dialog/wait-dialog';
 
 interface ResetProps {
     apiPrefix: string;
@@ -113,7 +114,6 @@ class Reset extends Component<Props, State> {
                 {
                     isConfirming && (
                         <WaitDialog
-                            active={isConfirming}
                             title={t('reset.title')} >
                             {t('bitbox02Interact.followInstructions')}
                         </WaitDialog>

--- a/frontends/web/src/components/devices/bitbox02/setdevicename.jsx
+++ b/frontends/web/src/components/devices/bitbox02/setdevicename.jsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +23,7 @@ import { Dialog } from '../../dialog/dialog';
 import { alertUser } from '../../alert/Alert';
 import * as dialogStyles from '../../dialog/dialog.css';
 import { SettingsButton } from '../../settingsButton/settingsButton';
-import WaitDialog from '../../wait-dialog/wait-dialog';
+import { WaitDialog } from '../../wait-dialog/wait-dialog';
 
 @translate()
 export class SetDeviceName extends Component {

--- a/frontends/web/src/components/devices/bitbox02/showmnemonic.tsx
+++ b/frontends/web/src/components/devices/bitbox02/showmnemonic.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +21,7 @@ import { apiPost } from '../../../utils/request';
 import SimpleMarkup from '../../../utils/simplemarkup';
 import { confirmation } from '../../confirm/Confirm';
 import { SettingsButton } from '../../settingsButton/settingsButton';
-import WaitDialog from '../../wait-dialog/wait-dialog';
+import { WaitDialog } from '../../wait-dialog/wait-dialog';
 
 interface ShowMnemonicProps {
     apiPrefix: string;

--- a/frontends/web/src/components/devices/bitbox02/upgradebutton.tsx
+++ b/frontends/web/src/components/devices/bitbox02/upgradebutton.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontends/web/src/routes/bitboxbase/basesettings.tsx
+++ b/frontends/web/src/routes/bitboxbase/basesettings.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2019 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +35,7 @@ import { SettingsButton } from '../../components/settingsButton/settingsButton';
 import { SettingsItem } from '../../components/settingsButton/settingsItem';
 import * as spinnerStyle from '../../components/spinner/Spinner.css';
 import { TruncateMiddle } from '../../components/truncateMiddle/truncateMiddle';
-import WaitDialog from '../../components/wait-dialog/wait-dialog';
+import { WaitDialog } from '../../components/wait-dialog/wait-dialog';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { apiSubscribe } from '../../utils/event';
 import { apiGet, apiPost } from '../../utils/request';

--- a/frontends/web/src/routes/device/settings/components/changepin.jsx
+++ b/frontends/web/src/routes/device/settings/components/changepin.jsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +20,7 @@ import { translate } from 'react-i18next';
 import { Button } from '../../../../components/forms';
 import { alertUser } from '../../../../components/alert/Alert';
 import { Dialog } from '../../../../components/dialog/dialog';
-import WaitDialog from '../../../../components/wait-dialog/wait-dialog';
+import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
 import { PasswordInput, PasswordRepeatInput } from '../../../../components/password';
 import { apiPost } from '../../../../utils/request';
 import { SettingsButton } from '../../../../components/settingsButton/settingsButton';

--- a/frontends/web/src/routes/device/settings/components/device-lock.jsx
+++ b/frontends/web/src/routes/device/settings/components/device-lock.jsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +19,7 @@ import { Component, h } from 'preact';
 import { translate } from 'react-i18next';
 import { Button } from '../../../../components/forms';
 import { Dialog } from '../../../../components/dialog/dialog';
-import WaitDialog from '../../../../components/wait-dialog/wait-dialog';
+import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
 import { apiPost } from '../../../../utils/request';
 import { SettingsButton } from '../../../../components/settingsButton/settingsButton';
 import * as style from '../../../../components/dialog/dialog.css';

--- a/frontends/web/src/routes/device/settings/components/hiddenwallet.jsx
+++ b/frontends/web/src/routes/device/settings/components/hiddenwallet.jsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +20,7 @@ import { translate } from 'react-i18next';
 import { Button } from '../../../../components/forms';
 import { alertUser } from '../../../../components/alert/Alert';
 import { Dialog } from '../../../../components/dialog/dialog';
-import WaitDialog from '../../../../components/wait-dialog/wait-dialog';
+import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
 import { PasswordRepeatInput } from '../../../../components/password';
 import { apiPost } from '../../../../utils/request';
 import SimpleMarkup from '../../../../utils/simplemarkup';

--- a/frontends/web/src/routes/device/settings/components/reset.jsx
+++ b/frontends/web/src/routes/device/settings/components/reset.jsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +20,7 @@ import { route } from 'preact-router';
 import { translate } from 'react-i18next';
 import { Button, Checkbox } from '../../../../components/forms';
 import { Dialog } from '../../../../components/dialog/dialog';
-import WaitDialog from '../../../../components/wait-dialog/wait-dialog';
+import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
 import { PasswordInput } from '../../../../components/password';
 import { apiPost } from '../../../../utils/request';
 import { alertUser } from '../../../../components/alert/Alert';
@@ -116,14 +117,9 @@ export default class Reset extends Component {
                         </Dialog>
                     )
                 }
-                {
-                    isConfirming && (
-                        <WaitDialog
-                            active={isConfirming}
-                            title={t('reset.title')}
-                        />
-                    )
-                }
+                { isConfirming ? (
+                    <WaitDialog title={t('reset.title')} />
+                ) : null }
             </div>
         );
     }

--- a/frontends/web/src/routes/device/settings/components/upgradefirmware.jsx
+++ b/frontends/web/src/routes/device/settings/components/upgradefirmware.jsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +19,7 @@ import { Component, h } from 'preact';
 import { translate } from 'react-i18next';
 import { Button } from '../../../../components/forms';
 import { Dialog } from '../../../../components/dialog/dialog';
-import WaitDialog from '../../../../components/wait-dialog/wait-dialog';
+import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
 import { apiGet, apiPost } from '../../../../utils/request';
 import { SettingsButton } from '../../../../components/settingsButton/settingsButton';
 import * as dialogStyle from '../../../../components/dialog/dialog.css';


### PR DESCRIPTION
This potentially fixes TypeError: Cannot read property 'classList'
of null, in rare cases during wait-dialog's animation. The error
did not seem to have any other impact and app was fully functional.