### PR TITLE
backend/bitbox02bootloader: log firmware/signing key hashes

### DIFF
--- a/backend/devices/bitbox02bootloader/device.go
+++ b/backend/devices/bitbox02bootloader/device.go
@@ -73,6 +73,13 @@ func NewDevice(
 			device.fireEvent()
 		},
 	)
+
+	firmwareHash, signingKeysHash, err := device.Device.GetHashes(false, false)
+	if err != nil {
+		log.WithError(err).Error("Could not get hashes from bootloader")
+	} else {
+		log.Infof("firmwareHash=%x, signingKeysHash=%x", firmwareHash, signingKeysHash)
+	}
 	return device
 }
 


### PR DESCRIPTION
Easier debugging when e.g. a firmware update goes wrong.