### PR TITLE
backend/config: make persisted accounts compatible with unified accounts

### DIFF
--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -22,10 +22,10 @@ import (
 
 // Account holds information related to an account.
 type Account struct {
-	CoinCode      coin.Code              `json:"coinCode"`
-	Name          string                 `json:"name"`
-	Code          string                 `json:"code"`
-	Configuration *signing.Configuration `json:"configuration"`
+	CoinCode       coin.Code              `json:"coinCode"`
+	Name           string                 `json:"name"`
+	Code           string                 `json:"code"`
+	Configurations signing.Configurations `json:"configurations"`
 }
 
 // AccountsConfig persists the list of accounts added to the app.


### PR DESCRIPTION
With the unified accoutns feature added some time ago, one
account (e.g. "Bitcoin") can combine multiple configurations,
e.g. p2wsh and p2wsh-psh, each at a separate keypath.

We will use persisted accounts to manage multiple accounts and
watchonly accounts, so they must also be able to store multiple
configs per account.