### PR TITLE
backend/keystore: add RootFingerprint()

### DIFF
--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -47,6 +47,11 @@ func (keystore *keystore) Type() keystorePkg.Type {
 	return keystorePkg.TypeHardware
 }
 
+// RootFingerprint implements keystore.Keystore.
+func (keystore *keystore) RootFingerprint() ([]byte, error) {
+	return keystore.device.RootFingerprint()
+}
+
 // CosignerIndex implements keystore.Keystore.
 func (keystore *keystore) CosignerIndex() int {
 	return keystore.cosignerIndex

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -42,6 +42,12 @@ type Keystore interface {
 	// Type denotes the type of the keystore.
 	Type() Type
 
+	// RootFingerprint returns the keystore's root fingerprint, which is the first 32 bits of the
+	// hash160 of the pubkey at the keypath m/.
+	//
+	// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#key-identifiers
+	RootFingerprint() ([]byte, error)
+
 	// CosignerIndex returns the index at which the keystore signs in a multisig configuration.
 	// The returned value is always zero for a singlesig configuration.
 	CosignerIndex() int

--- a/backend/keystore/software/software_test.go
+++ b/backend/keystore/software/software_test.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package software
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootFingerprint(t *testing.T) {
+	// Xprv derived from BIP39 mnemonic (no passphrase):
+	// awkward squirrel wait rubber biology escape toe daring still pause fitness vendor
+	rootXprv, err := hdkeychain.NewKeyFromString("xprv9s21ZrQH143K3uDh9hiNXB3a9GVzcCujEmCwmZA9g8m4i5nUDVdLHJjsLMPzV26vj8Q7ceGrUhX119Y3XzGhJqq5K6LWP1h6gjv2cbkMEH1")
+	require.NoError(t, err)
+	keystore := NewKeystore(0, rootXprv)
+	rootFingerprint, err := keystore.RootFingerprint()
+	require.NoError(t, err)
+	// Verified by comparing to the root fingerprint produced by the BitBox02 and Electrum.
+	require.Equal(t, []byte{0xfb, 0x70, 0x89, 0xbd}, rootFingerprint)
+}


### PR DESCRIPTION
And implement it for all three keystore backends we have.