### PR TITLE
backend/accounts: load signing configurations immediately

### DIFF
--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -43,12 +43,12 @@ type AccountConfig struct {
 	// DBFolder is the folder for all accounts. Full path.
 	DBFolder string
 	// NotesFolder is the folder where the transaction notes are stored. Full path.
-	NotesFolder              string
-	Keystores                *keystore.Keystores
-	OnEvent                  func(Event)
-	RateUpdater              *rates.RateUpdater
-	GetSigningConfigurations func() (signing.Configurations, error)
-	GetNotifier              func(signing.Configurations) Notifier
+	NotesFolder           string
+	Keystores             *keystore.Keystores
+	OnEvent               func(Event)
+	RateUpdater           *rates.RateUpdater
+	SigningConfigurations signing.Configurations
+	GetNotifier           func(signing.Configurations) Notifier
 }
 
 // BaseAccount is an account struct with common functionality to all coin accounts.

--- a/backend/accounts/baseaccount_test.go
+++ b/backend/accounts/baseaccount_test.go
@@ -40,15 +40,15 @@ func TestBaseAccount(t *testing.T) {
 	}
 	const accountIdentifier = "test-account-identifier"
 	cfg := &AccountConfig{
-		Code:                     "test",
-		Name:                     "Test",
-		DBFolder:                 test.TstTempDir("baseaccount_test_dbfolder"),
-		NotesFolder:              test.TstTempDir("baseaccount_test_notesfolder"),
-		Keystores:                nil,
-		OnEvent:                  func(event Event) { events <- event },
-		RateUpdater:              nil,
-		GetSigningConfigurations: nil,
-		GetNotifier:              nil,
+		Code:                  "test",
+		Name:                  "Test",
+		DBFolder:              test.TstTempDir("baseaccount_test_dbfolder"),
+		NotesFolder:           test.TstTempDir("baseaccount_test_notesfolder"),
+		Keystores:             nil,
+		OnEvent:               func(event Event) { events <- event },
+		RateUpdater:           nil,
+		SigningConfigurations: nil,
+		GetNotifier:           nil,
 	}
 
 	mockCoin := &mocks.CoinMock{

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -270,10 +270,7 @@ func (account *Account) Initialize() error {
 	}
 	account.initialized = true
 
-	signingConfigurations, err := account.Config().GetSigningConfigurations()
-	if err != nil {
-		return err
-	}
+	signingConfigurations := account.Config().SigningConfigurations
 	if len(signingConfigurations) == 0 {
 		return errp.New("There must be a least one signing configuration")
 	}

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -50,30 +50,28 @@ func TestAccount(t *testing.T) {
 
 	coin.TstSetMakeBlockchain(func() blockchain.Interface { return blockchainMock })
 
-	getSigningConfigurations := func() (signing.Configurations, error) {
-		keypath, err := signing.NewAbsoluteKeypath("m/49'/1'/0'")
-		require.NoError(t, err)
-		xpub, err := hdkeychain.NewMaster(make([]byte, 32), net)
-		require.NoError(t, err)
-		xpub, err = xpub.Neuter()
-		require.NoError(t, err)
+	keypath, err := signing.NewAbsoluteKeypath("m/49'/1'/0'")
+	require.NoError(t, err)
+	xpub, err := hdkeychain.NewMaster(make([]byte, 32), net)
+	require.NoError(t, err)
+	xpub, err = xpub.Neuter()
+	require.NoError(t, err)
 
-		return signing.Configurations{signing.NewSinglesigConfiguration(
-			signing.ScriptTypeP2WPKHP2SH,
-			keypath,
-			xpub,
-		)}, nil
-	}
+	signingConfigurations := signing.Configurations{signing.NewSinglesigConfiguration(
+		signing.ScriptTypeP2WPKHP2SH,
+		keypath,
+		xpub)}
+
 	account := btc.NewAccount(
 		&accounts.AccountConfig{
-			Code:                     "accountcode",
-			Name:                     "accountname",
-			DBFolder:                 dbFolder,
-			Keystores:                nil,
-			OnEvent:                  func(accounts.Event) {},
-			RateUpdater:              nil,
-			GetSigningConfigurations: getSigningConfigurations,
-			GetNotifier:              func(signing.Configurations) accounts.Notifier { return nil },
+			Code:                  "accountcode",
+			Name:                  "accountname",
+			DBFolder:              dbFolder,
+			Keystores:             nil,
+			OnEvent:               func(accounts.Event) {},
+			RateUpdater:           nil,
+			SigningConfigurations: signingConfigurations,
+			GetNotifier:           func(signing.Configurations) accounts.Notifier { return nil },
 		},
 		coin, nil,
 		logging.Get().WithGroup("account_test"),

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -129,11 +129,7 @@ func (account *Account) Initialize() error {
 	}
 	account.initialized = true
 
-	signingConfigurations, err := account.Config().GetSigningConfigurations()
-	if err != nil {
-		return err
-	}
-
+	signingConfigurations := account.Config().SigningConfigurations
 	if len(signingConfigurations) != 1 {
 		return errp.New("Ethereum only supports one signing config")
 	}


### PR DESCRIPTION
The reason that the signing configurations were loaded lazily was that
it requires querying the xpubs from the device. With the BitBox01,
this is especially slow, but also the BitBox02 shows a small delay
when loading e.g. 3 xpubs.

Since we want to persist the accounts/configs anyway (to support
multiple accounts and watch-only), we need to get them
immediately. Since they will be persisted, this will only happens once
per keystore.