### PR TITLE
backend: move split/unified accounts logic

### DIFF
--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -22,10 +22,16 @@ import (
 
 // Account holds information related to an account.
 type Account struct {
-	CoinCode       coin.Code              `json:"coinCode"`
-	Name           string                 `json:"name"`
-	Code           string                 `json:"code"`
-	Configurations signing.Configurations `json:"configurations"`
+	CoinCode coin.Code `json:"coinCode"`
+	Name     string    `json:"name"`
+	Code     string    `json:"code"`
+	// SupportsUnifiedAccounts, if true, allows multiple configurations in one account. If false,
+	// one account will be added per configuration.
+	//
+	// This is used to unify multiple Bitcoin script types (p2wsh, p2wsh-p2sh) in one account. The
+	// keystore must be able to sign transactions with mixed inputs.
+	SupportsUnifiedAccounts bool                   `json:"supportsUnifiedaccounts"`
+	Configurations          signing.Configurations `json:"configurations"`
 }
 
 // AccountsConfig persists the list of accounts added to the app.


### PR DESCRIPTION
The accounts are always stored in the unified format (multiple signign
configurations per account) in the accounts.json database. When
loading them, we split them into individual accounts if needed.

This previously happened when adding the BTC accounts when a keystore
is registered, but this will not work anymore as we will persist all
accounts and not load them dynamically after a keystore is registered
anymore. Instead, we will persist the default accounts when a new
keystore is registered.

createAndAddBTCAccount() and createAndAddETHAccount() will be changed
to persist the default accounts instead of loading them dynamically.