### PR TITLE
backend: persist default set of accounts for a new keystore 

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -303,7 +303,8 @@ func (backend *Backend) emitAccountsStatusChanged() {
 // in `initPersistedAccounts()`.
 func (backend *Backend) persistAccount(account config.Account) error {
 	return backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
-		for _, account2 := range accountsConfig.Accounts {
+		for idx := range accountsConfig.Accounts {
+			account2 := &accountsConfig.Accounts[idx]
 			if account.CoinCode == account2.CoinCode {
 				// We detect a duplicate account (subaccount in a unified account) if any of the
 				// configurations is already present.
@@ -693,8 +694,9 @@ func (backend *Backend) Coin(code coinpkg.Code) (coin.Coin, error) {
 
 // The accountsLock must be held when calling this function.
 func (backend *Backend) initPersistedAccounts() {
-	for _, account := range backend.config.AccountsConfig().Accounts {
-		account := account
+	accounts := backend.config.AccountsConfig().Accounts
+	for idx := range accounts {
+		account := &accounts[idx]
 		if _, isTestnet := coinpkg.TestnetCoins[account.CoinCode]; isTestnet != backend.Testing() {
 			// Don't load testnet accounts when running normally, nor mainnet accounts when running
 			// in testing mode

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -404,9 +404,7 @@ func newScriptTypeWithKeypath(scriptType signing.ScriptType, keypath string) scr
 }
 
 // adds a combined BTC account with the given script types.
-//
-// The accountsLock must be held when calling this function.
-func (backend *Backend) createAndAddBTCAccount(
+func (backend *Backend) persistBTCAccountConfig(
 	keystore keystore.Keystore,
 	coin coin.Coin,
 	code string,
@@ -414,6 +412,8 @@ func (backend *Backend) createAndAddBTCAccount(
 ) {
 	name := coin.Name()
 	log := backend.log.WithField("code", code).WithField("name", name)
+	// This used to be a user-facing setting. Now we simply use it for migration to decide which
+	// coins to add by default.
 	if !backend.config.AppConfig().Backend.CoinActive(coin.Code()) {
 		log.Info("skipping inactive account")
 		return
@@ -428,7 +428,7 @@ func (backend *Backend) createAndAddBTCAccount(
 		log.Info("skipping unsupported account")
 		return
 	}
-	log.Info("init account")
+	log.Info("persist account")
 
 	var signingConfigurations signing.Configurations
 	for _, cfg := range supportedConfigs {
@@ -446,11 +446,29 @@ func (backend *Backend) createAndAddBTCAccount(
 		)
 		signingConfigurations = append(signingConfigurations, signingConfiguration)
 	}
-	backend.createAndAddAccount(coin, code, name, signingConfigurations)
+	rootFingerprint, err := keystore.RootFingerprint()
+	if err != nil {
+		log.WithError(err).Error("Could not retrieve the keystore's root fingerprint")
+		return
+	}
+	err = backend.persistAccount(config.Account{
+		CoinCode:                coin.Code(),
+		Name:                    name,
+		Code:                    code,
+		SupportsUnifiedAccounts: keystore.SupportsUnifiedAccounts(),
+		RootFingerprint:         rootFingerprint,
+		Configurations:          signingConfigurations,
+	})
+
+	if errp.Cause(err) == ErrAccountAlreadyExists {
+		// This is adding initial default accounts. If this already happened, there is nothing else
+		// to do.
+	} else if err != nil {
+		log.WithError(err).Error("Error persisting default BTC account")
+	}
 }
 
-// The accountsLock must be held when calling this function.
-func (backend *Backend) createAndAddETHAccount(
+func (backend *Backend) persistETHAccountConfig(
 	keystore keystore.Keystore,
 	coin coin.Coin,
 	code string,
@@ -458,13 +476,9 @@ func (backend *Backend) createAndAddETHAccount(
 ) {
 	name := coin.Name()
 	log := backend.log.WithField("code", code).WithField("name", name)
-	prefix := "eth-erc20-"
-	if strings.HasPrefix(code, prefix) {
-		if !backend.config.AppConfig().Backend.ETH.ERC20TokenActive(code[len(prefix):]) {
-			log.Info("skipping inactive erc20 token")
-			return
-		}
-	} else if !backend.config.AppConfig().Backend.CoinActive(coin.Code()) {
+	// This used to be a user-facing setting. Now we simply use it for migration to decide which
+	// coins to add by default.
+	if !backend.config.AppConfig().Backend.CoinActive(coin.Code()) {
 		log.Info("skipping inactive account")
 		return
 	}
@@ -474,7 +488,7 @@ func (backend *Backend) createAndAddETHAccount(
 		return
 	}
 
-	log.Info("init account")
+	log.Info("persist account")
 	absoluteKeypath, err := signing.NewAbsoluteKeypath(keypath)
 	if err != nil {
 		panic(err)
@@ -492,7 +506,26 @@ func (backend *Backend) createAndAddETHAccount(
 			extendedPublicKey,
 		),
 	}
-	backend.createAndAddAccount(coin, code, name, signingConfigurations)
+
+	rootFingerprint, err := keystore.RootFingerprint()
+	if err != nil {
+		log.WithError(err).Error("Could not retrieve the keystore's root fingerprint")
+		return
+	}
+	err = backend.persistAccount(config.Account{
+		CoinCode:                coin.Code(),
+		Name:                    name,
+		Code:                    code,
+		SupportsUnifiedAccounts: keystore.SupportsUnifiedAccounts(),
+		RootFingerprint:         rootFingerprint,
+		Configurations:          signingConfigurations,
+	})
+	if errp.Cause(err) == ErrAccountAlreadyExists {
+		// This is adding initial default accounts. If this already happened, there is nothing else
+		// to do.
+	} else if err != nil {
+		log.WithError(err).Error("Error persisting default ETH account")
+	}
 }
 
 // Config returns the app config.
@@ -683,24 +716,15 @@ func (backend *Backend) initPersistedAccounts() {
 	}
 }
 
-// initDefaultAccounts creates a bunch of default accounts for a set of keystores (not manually
-// user-added). Currently the first bip44 account for all supported and active account types.
-//
-// The accountsLock must be held when calling this function.
-func (backend *Backend) initDefaultAccounts() {
-	if backend.keystores.Count() == 0 {
-		return
-	}
-	if backend.keystores.Count() > 1 {
-		// If needed, insert multisig account initialization here based on multiple connected
-		// keystores.
-		return
-	}
-	keystore := backend.keystores.Keystores()[0]
+// persistDefaultAccountConfigs persists a bunch of default accounts for the connected keystore (not
+// manually user-added). Currently the first bip44 account of BTC/LTC/ETH. ERC20 tokens are added if
+// they were configured to be active by the user in the past, when they could still configure them
+// globally in the settings.
+func (backend *Backend) persistDefaultAccountConfigs(keystore keystore.Keystore) {
 	if backend.arguments.Testing() {
 		if backend.arguments.Regtest() {
 			RBTC, _ := backend.Coin(coinpkg.CodeRBTC)
-			backend.createAndAddBTCAccount(keystore, RBTC,
+			backend.persistBTCAccountConfig(keystore, RBTC,
 				"rbtc",
 				[]scriptTypeWithKeypath{
 					newScriptTypeWithKeypath(signing.ScriptTypeP2WPKHP2SH, "m/49'/1'/0'"),
@@ -709,7 +733,7 @@ func (backend *Backend) initDefaultAccounts() {
 			)
 		} else {
 			TBTC, _ := backend.Coin(coinpkg.CodeTBTC)
-			backend.createAndAddBTCAccount(keystore, TBTC,
+			backend.persistBTCAccountConfig(keystore, TBTC,
 				"tbtc",
 				[]scriptTypeWithKeypath{
 					newScriptTypeWithKeypath(signing.ScriptTypeP2WPKH, "m/84'/1'/0'"),
@@ -719,7 +743,7 @@ func (backend *Backend) initDefaultAccounts() {
 			)
 
 			TLTC, _ := backend.Coin(coinpkg.CodeTLTC)
-			backend.createAndAddBTCAccount(keystore, TLTC,
+			backend.persistBTCAccountConfig(keystore, TLTC,
 				"tltc",
 				[]scriptTypeWithKeypath{
 					newScriptTypeWithKeypath(signing.ScriptTypeP2WPKH, "m/84'/1'/0'"),
@@ -727,15 +751,15 @@ func (backend *Backend) initDefaultAccounts() {
 				},
 			)
 			TETH, _ := backend.Coin(coinpkg.CodeTETH)
-			backend.createAndAddETHAccount(keystore, TETH, "teth", "m/44'/1'/0'/0")
+			backend.persistETHAccountConfig(keystore, TETH, "teth", "m/44'/1'/0'/0")
 			RETH, _ := backend.Coin(coinpkg.CodeRETH)
-			backend.createAndAddETHAccount(keystore, RETH, "reth", "m/44'/1'/0'/0")
+			backend.persistETHAccountConfig(keystore, RETH, "reth", "m/44'/1'/0'/0")
 			erc20TEST, _ := backend.Coin(coinpkg.CodeERC20TEST)
-			backend.createAndAddETHAccount(keystore, erc20TEST, "erc20Test", "m/44'/1'/0'/0")
+			backend.persistETHAccountConfig(keystore, erc20TEST, "erc20Test", "m/44'/1'/0'/0")
 		}
 	} else {
 		BTC, _ := backend.Coin(coinpkg.CodeBTC)
-		backend.createAndAddBTCAccount(keystore, BTC,
+		backend.persistBTCAccountConfig(keystore, BTC,
 			"btc",
 			[]scriptTypeWithKeypath{
 				newScriptTypeWithKeypath(signing.ScriptTypeP2WPKH, "m/84'/0'/0'"),
@@ -745,7 +769,7 @@ func (backend *Backend) initDefaultAccounts() {
 		)
 
 		LTC, _ := backend.Coin(coinpkg.CodeLTC)
-		backend.createAndAddBTCAccount(keystore, LTC,
+		backend.persistBTCAccountConfig(keystore, LTC,
 			"ltc",
 			[]scriptTypeWithKeypath{
 				newScriptTypeWithKeypath(signing.ScriptTypeP2WPKH, "m/84'/2'/0'"),
@@ -754,14 +778,7 @@ func (backend *Backend) initDefaultAccounts() {
 		)
 
 		ETH, _ := backend.Coin(coinpkg.CodeETH)
-		backend.createAndAddETHAccount(keystore, ETH, "eth", "m/44'/60'/0'/0")
-
-		if backend.config.AppConfig().Backend.CoinActive(coinpkg.CodeETH) {
-			for _, erc20Token := range erc20Tokens {
-				token, _ := backend.Coin(erc20Token.code)
-				backend.createAndAddETHAccount(keystore, token, string(erc20Token.code), "m/44'/60'/0'/0")
-			}
-		}
+		backend.persistETHAccountConfig(keystore, ETH, "eth", "m/44'/60'/0'/0")
 	}
 }
 
@@ -770,7 +787,6 @@ func (backend *Backend) initAccounts() {
 	// Since initAccounts replaces all previous accounts, we need to properly close them first.
 	backend.uninitAccounts()
 
-	backend.initDefaultAccounts()
 	backend.initPersistedAccounts()
 
 	backend.emitAccountsStatusChanged()
@@ -966,6 +982,8 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 	if backend.arguments.Multisig() && backend.keystores.Count() != 2 {
 		return
 	}
+
+	backend.persistDefaultAccountConfigs(keystore)
 
 	defer backend.accountsLock.Lock()()
 	backend.initAccounts()

--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -30,8 +30,13 @@ type Account struct {
 	//
 	// This is used to unify multiple Bitcoin script types (p2wsh, p2wsh-p2sh) in one account. The
 	// keystore must be able to sign transactions with mixed inputs.
-	SupportsUnifiedAccounts bool                   `json:"supportsUnifiedaccounts"`
-	Configurations          signing.Configurations `json:"configurations"`
+	SupportsUnifiedAccounts bool `json:"supportsUnifiedaccounts"`
+	// If not nil, all configurations must be xpub based and derived from the same BIP39 seed with
+	// this fingerprint. The root fingerprint is the first 32 bits of the hash160 of the pubkey at
+	// the keypath m/.
+	// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#key-identifiers
+	RootFingerprint []byte                 `json:"rootFingerprint"`
+	Configurations  signing.Configurations `json:"configurations"`
 }
 
 // AccountsConfig persists the list of accounts added to the app.

--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -37,6 +37,10 @@ type Account struct {
 	// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#key-identifiers
 	RootFingerprint []byte                 `json:"rootFingerprint"`
 	Configurations  signing.Configurations `json:"configurations"`
+	// ActiveTokens list the tokens that should be loaded along with the account.  Currently, this
+	// only applies to ETH, and the elements are ERC20 token codes (e.g. "eth-erc20-usdt",
+	// "eth-erc20-bat", etc).
+	ActiveTokens []string `json:"activeTokens"`
 }
 
 // AccountsConfig persists the list of accounts added to the app.


### PR DESCRIPTION
Before, we would load them dynamically whenever a keystore is
connected.

Now, we only load accounts from the accounts.json database, and
pre-populate the database with a default set of accounts to kick
things off.

We take into account the global settings for which coins are active,
so that users who already disabled some accounts have a smooth
migration. The global settings to activate/deactivate coins and tokens
will be removed and replaced with functionality to add and remove
accounts per keystore.