### PR TITLE
backend: remove multisig

### DIFF
--- a/backend/arguments/arguments.go
+++ b/backend/arguments/arguments.go
@@ -179,11 +179,6 @@ func (arguments *Arguments) Regtest() bool {
 	return arguments.regtest
 }
 
-// Multisig returns whether the backend is in multisig mode.
-func (arguments *Arguments) Multisig() bool {
-	return false
-}
-
 // GapLimits returns the gap limits to be used in btc/ltc (all account types).
 // This is optional, so nil is a valid return value.
 func (arguments *Arguments) GapLimits() *btctypes.GapLimits {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1066,7 +1066,7 @@ func (backend *Backend) Register(theDevice device.Interface) error {
 				// HACK: for device based, only one is supported at the moment.
 				backend.keystores = keystore.NewKeystores()
 
-				backend.registerKeystore(theDevice.KeystoreForConfiguration())
+				backend.registerKeystore(theDevice.Keystore())
 			}
 		}
 		backend.events <- deviceEvent{

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1062,13 +1062,6 @@ func (backend *Backend) Register(theDevice device.Interface) error {
 		case deviceevent.EventKeystoreGone:
 			backend.DeregisterKeystore()
 		case deviceevent.EventKeystoreAvailable:
-			// absoluteKeypath := signing.NewEmptyAbsoluteKeypath().Child(44, signing.Hardened)
-			// extendedPublicKey, err := backend.device.ExtendedPublicKey(absoluteKeypath)
-			// if err != nil {
-			// 	panic(err)
-			// }
-			// configuration := signing.NewConfiguration(absoluteKeypath,
-			// 	[]*hdkeychain.ExtendedKey{extendedPublicKey}, 1)
 			if mainKeystore {
 				// HACK: for device based, only one is supported at the moment.
 				backend.keystores = keystore.NewKeystores()

--- a/backend/devices/bitbox/device.go
+++ b/backend/devices/bitbox/device.go
@@ -1373,16 +1373,13 @@ func (dbb *Device) ExtendedPublicKey(keypath signing.AbsoluteKeypath) (*hdkeycha
 }
 
 // KeystoreForConfiguration implements device.Interface.
-func (dbb *Device) KeystoreForConfiguration(
-	cosignerIndex int,
-) keystoreInterface.Keystore {
+func (dbb *Device) KeystoreForConfiguration() keystoreInterface.Keystore {
 	if dbb.Status() != StatusSeeded {
 		return nil
 	}
 	return &keystore{
-		dbb:           dbb,
-		cosignerIndex: cosignerIndex,
-		log:           dbb.log,
+		dbb: dbb,
+		log: dbb.log,
 	}
 }
 

--- a/backend/devices/bitbox/device.go
+++ b/backend/devices/bitbox/device.go
@@ -1372,8 +1372,8 @@ func (dbb *Device) ExtendedPublicKey(keypath signing.AbsoluteKeypath) (*hdkeycha
 	return dbb.xpub(keypath.Encode())
 }
 
-// KeystoreForConfiguration implements device.Interface.
-func (dbb *Device) KeystoreForConfiguration() keystoreInterface.Keystore {
+// Keystore implements device.Interface.
+func (dbb *Device) Keystore() keystoreInterface.Keystore {
 	if dbb.Status() != StatusSeeded {
 		return nil
 	}

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -32,9 +32,8 @@ import (
 )
 
 type keystore struct {
-	dbb           *Device
-	cosignerIndex int
-	log           *logrus.Entry
+	dbb *Device
+	log *logrus.Entry
 }
 
 // Type implements keystore.Keystore.
@@ -56,17 +55,11 @@ func (keystore *keystore) RootFingerprint() ([]byte, error) {
 	return fingerprint, nil
 }
 
-// CosignerIndex implements keystore.Keystore.
-func (keystore *keystore) CosignerIndex() int {
-	return keystore.cosignerIndex
-}
-
 // SupportsAccount implements keystore.Keystore.
-func (keystore *keystore) SupportsAccount(
-	coin coin.Coin, multisig bool, meta interface{}) bool {
+func (keystore *keystore) SupportsAccount(coin coin.Coin, meta interface{}) bool {
 	switch coin.(type) {
 	case *btc.Coin:
-		return !multisig
+		return true
 	default:
 		return false
 	}
@@ -168,7 +161,7 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 	}
 	for i, signature := range signatures {
 		signature := signature
-		btcProposedTx.Signatures[i][keystore.CosignerIndex()] = &signature.Signature
+		btcProposedTx.Signatures[i][0] = &signature.Signature
 	}
 	return nil
 }

--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -109,8 +109,8 @@ func (device *Device) Identifier() string {
 	return device.deviceID
 }
 
-// KeystoreForConfiguration implements device.Device.
-func (device *Device) KeystoreForConfiguration() keystoreInterface.Keystore {
+// Keystore implements device.Device.
+func (device *Device) Keystore() keystoreInterface.Keystore {
 	if device.Status() != firmware.StatusInitialized {
 		return nil
 	}

--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -110,14 +110,13 @@ func (device *Device) Identifier() string {
 }
 
 // KeystoreForConfiguration implements device.Device.
-func (device *Device) KeystoreForConfiguration(cosignerIndex int) keystoreInterface.Keystore {
+func (device *Device) KeystoreForConfiguration() keystoreInterface.Keystore {
 	if device.Status() != firmware.StatusInitialized {
 		return nil
 	}
 	return &keystore{
-		device:        device,
-		cosignerIndex: cosignerIndex,
-		log:           device.log,
+		device: device,
+		log:    device.log,
 	}
 }
 

--- a/backend/devices/bitbox02bootloader/device.go
+++ b/backend/devices/bitbox02bootloader/device.go
@@ -98,7 +98,7 @@ func (device *Device) Identifier() string {
 }
 
 // KeystoreForConfiguration implements device.Device.
-func (device *Device) KeystoreForConfiguration(cosignerIndex int) keystoreInterface.Keystore {
+func (device *Device) KeystoreForConfiguration() keystoreInterface.Keystore {
 	panic("not supported")
 }
 

--- a/backend/devices/bitbox02bootloader/device.go
+++ b/backend/devices/bitbox02bootloader/device.go
@@ -97,8 +97,8 @@ func (device *Device) Identifier() string {
 	return device.deviceID
 }
 
-// KeystoreForConfiguration implements device.Device.
-func (device *Device) KeystoreForConfiguration() keystoreInterface.Keystore {
+// Keystore implements device.Device.
+func (device *Device) Keystore() keystoreInterface.Keystore {
 	panic("not supported")
 }
 

--- a/backend/devices/device/device.go
+++ b/backend/devices/device/device.go
@@ -35,7 +35,7 @@ type Interface interface {
 	Identifier() string
 
 	// Keystore returns the keystore provided by the device (or an nil if not seeded).
-	KeystoreForConfiguration(cosignerIndex int) keystore.Keystore
+	KeystoreForConfiguration() keystore.Keystore
 
 	// SetOnEvent installs a callback which is called for various events.
 	SetOnEvent(func(event.Event, interface{}))

--- a/backend/devices/device/device.go
+++ b/backend/devices/device/device.go
@@ -35,7 +35,7 @@ type Interface interface {
 	Identifier() string
 
 	// Keystore returns the keystore provided by the device (or an nil if not seeded).
-	KeystoreForConfiguration() keystore.Keystore
+	Keystore() keystore.Keystore
 
 	// SetOnEvent installs a callback which is called for various events.
 	SetOnEvent(func(event.Event, interface{}))

--- a/backend/devices/usb/manager.go
+++ b/backend/devices/usb/manager.go
@@ -86,8 +86,6 @@ type Manager struct {
 	onRegister   func(device.Interface) error
 	onUnregister func(string)
 
-	onlyOne bool
-
 	socksProxy socksproxy.SocksProxy
 
 	log *logrus.Entry
@@ -105,7 +103,6 @@ func NewManager(
 	deviceInfos func() []DeviceInfo,
 	onRegister func(device.Interface) error,
 	onUnregister func(string),
-	onlyOne bool,
 ) *Manager {
 	return &Manager{
 		devices:           map[string]device.Interface{},
@@ -114,7 +111,6 @@ func NewManager(
 		deviceInfos:       deviceInfos,
 		onRegister:        onRegister,
 		onUnregister:      onUnregister,
-		onlyOne:           onlyOne,
 		socksProxy:        socksProxy,
 
 		log: logging.Get().WithGroup("manager"),
@@ -280,7 +276,7 @@ func (manager *Manager) listen() {
 				continue
 			}
 			// Skip if we already have another device registered and we only support one device.
-			if manager.onlyOne && len(manager.devices) != 0 {
+			if len(manager.devices) != 0 {
 				continue
 			}
 			var device device.Interface

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -48,14 +48,10 @@ type Keystore interface {
 	// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#key-identifiers
 	RootFingerprint() ([]byte, error)
 
-	// CosignerIndex returns the index at which the keystore signs in a multisig configuration.
-	// The returned value is always zero for a singlesig configuration.
-	CosignerIndex() int
-
 	// SupportsAccount returns true if they keystore supports the given coin/account.
 	// meta is a coin-specific metadata related to the account type.
 	// If false, the backend will add one account per supported script type.
-	SupportsAccount(coin coin.Coin, multisig bool, meta interface{}) bool
+	SupportsAccount(coin coin.Coin, meta interface{}) bool
 
 	// SupportsUnifiedAccounts returns true if the keystore supports signing transactions with mixed
 	// input script types in BTC/LTC, for single-sig accounts.

--- a/backend/keystore/keystores.go
+++ b/backend/keystore/keystores.go
@@ -15,9 +15,7 @@
 package keystore
 
 import (
-	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
-	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 )
@@ -124,28 +122,6 @@ func (keystores *Keystores) SignTransaction(proposedTransaction interface{}) err
 		}
 	}
 	return nil
-}
-
-// Configuration returns the configuration at the given path with the given signing threshold.
-func (keystores *Keystores) Configuration(
-	coin coinpkg.Coin,
-	scriptType signing.ScriptType,
-	absoluteKeypath signing.AbsoluteKeypath,
-	signingThreshold int,
-) (*signing.Configuration, error) {
-	extendedPublicKeys := make([]*hdkeychain.ExtendedKey, len(keystores.keystores))
-	for index, keystore := range keystores.keystores {
-		if keystore.CosignerIndex() != index {
-			return nil, errp.New("The keystores are in the wrong order.")
-		}
-		extendedPublicKey, err := keystore.ExtendedPublicKey(coin, absoluteKeypath)
-		if err != nil {
-			return nil, err
-		}
-		extendedPublicKeys[index] = extendedPublicKey
-	}
-	return signing.NewConfiguration(
-		scriptType, absoluteKeypath, extendedPublicKeys, "", signingThreshold), nil
 }
 
 // Keystores returns all keystores.

--- a/backend/keystore/software/software_test.go
+++ b/backend/keystore/software/software_test.go
@@ -26,7 +26,7 @@ func TestRootFingerprint(t *testing.T) {
 	// awkward squirrel wait rubber biology escape toe daring still pause fitness vendor
 	rootXprv, err := hdkeychain.NewKeyFromString("xprv9s21ZrQH143K3uDh9hiNXB3a9GVzcCujEmCwmZA9g8m4i5nUDVdLHJjsLMPzV26vj8Q7ceGrUhX119Y3XzGhJqq5K6LWP1h6gjv2cbkMEH1")
 	require.NoError(t, err)
-	keystore := NewKeystore(0, rootXprv)
+	keystore := NewKeystore(rootXprv)
 	rootFingerprint, err := keystore.RootFingerprint()
 	require.NoError(t, err)
 	// Verified by comparing to the root fingerprint produced by the BitBox02 and Electrum.


### PR DESCRIPTION
It was a "hacky" 2-of-2 multisig if two bitboxes are connected, which
was used to play with multisig in the past. The multisig argument to
enable this mode has been long removed. The cosigner index concept was
also wrong, as the cosigner index is not a property of the keystore,
but a property of the signing configuration (and could be infered
there from the xpubs that are present).