### PR TITLE
Frontend multiaccount UI

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -35,7 +35,7 @@ import { Update } from './components/update/update';
 import { translate, TranslateProps } from './decorators/translate';
 import { i18nEditorActive } from './i18n/i18n';
 import { Account } from './routes/account/account';
-import { AddAccount } from './routes/account/add/addaccount';
+import { ManageAccount } from './routes/account/manage/manage';
 import { Moonpay } from './routes/buy/moonpay';
 import { BuyInfo } from './routes/buy/info';
 import Info from './routes/account/info/info';
@@ -254,8 +254,8 @@ class App extends Component<Props, State> {
                                 code={'' /* dummy to satisfy TS */}
                                 devices={devices}
                                 accounts={accounts} />
-                            <AddAccount
-                                path="/add-account" />
+                            <ManageAccount
+                                path="/add-account/:type?" />
                             <AccountsSummary accounts={accounts}
                                 path="/account-summary" />
                             <BitBoxBaseConnect

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1044,6 +1044,26 @@
     "successEnable": "Successfully enabled the legacy hidden wallet. Replug your BitBox and enter the hidden device password to access the legacy hidden wallet."
   },
   "loading": "loading…",
+  "manageAccounts": {
+    "addAccount": "Add account",
+    "choose-name": {
+      "nextButton": "Next",
+      "step": "Name account",
+      "title": "Name your account"
+    },
+    "select-coin": {
+      "nextButton": "Next",
+      "step": "Select coin",
+      "title": "Select cryptocurrency"
+    },
+    "success": {
+      "message": "<strong>{{accountName}}</strong> has now been added to your accounts.",
+      "nextButton": "Done",
+      "step": "Finished",
+      "title": "Account added"
+    },
+    "title": "Manage accounts"
+  },
   "mobile": {
     "usingMobileDataWarning": "Mobile data usage: this app may download up to a few hundred megabytes of blockchain header data after unlocking an account. Please connect to Wi-Fi to avoid using mobile data. After dismissing it, this message won't be shown again."
   },

--- a/frontends/web/src/routes/account/manage/components/coin-dropdown.tsx
+++ b/frontends/web/src/routes/account/manage/components/coin-dropdown.tsx
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { h, RenderableProps } from 'preact';
+import * as accountApi from '../../../../api/account';
+import { Select } from '../../../../components/forms';
+import { translate, TranslateProps } from '../../../../decorators/translate';
+
+// copied over from old addacconut.tsx
+const COIN_AND_ACCOUNT_CODES = {
+    'btc': {
+        name: 'Bitcoin',
+        coinCode: 'btc',
+    },
+    // TODO: what about those?
+    'btc-p2wpkh-p2sh': {
+        name: 'Bitcoin',
+        coinCode: 'btc',
+        scriptType: 'p2wpkh-p2sh',
+    },
+    'btc-p2wpkh': {
+        name: 'Bitcoin: bech32',
+        coinCode: 'btc',
+        scriptType: 'p2wpkh',
+    },
+    'btc-p2pkh': {
+        name: 'Bitcoin Legacy',
+        coinCode: 'btc',
+        scriptType: 'p2pkh',
+    },
+    'btc-addr': {
+        name: 'Bitcoin Address',
+        coinCode: 'btc',
+        scriptType: 'p2wpkh', // TODO dummy script type to pass DecodeScriptType
+    },
+    'ltc': {
+        name: 'Litecoin',
+        coinCode: 'ltc',
+    },
+    'ltc-p2wpkh-p2sh': {
+        name: 'Litecoin',
+        coinCode: 'ltc',
+        scriptType: 'p2wpkh-p2sh',
+    },
+    'ltc-p2wpkh': {
+        name: 'Litecoin: bech32',
+        coinCode: 'ltc',
+        scriptType: 'p2wpkh',
+    },
+    'ltc-addr': {
+        name: 'Litecoin Address',
+        coinCode: 'ltc',
+        scriptType: 'p2wpkh', // TODO dummy script type to pass DecodeScriptType
+    },
+    'eth': {
+        name: 'Ethereum',
+        coinCode: 'eth',
+        scriptType: 'p2wpkh',
+    },
+    // Testnet
+    'tbtc': {
+        name: 'Bitcoin Testnet',
+        coinCode: 'tbtc',
+    },
+    'tbtc-p2wpkh-p2sh': {
+        name: 'Bitcoin Testnet',
+        coinCode: 'tbtc',
+        scriptType: 'p2wpkh-p2sh',
+    },
+    'tbtc-p2wpkh': {
+        name: 'Bitcoin Testnet: bech32',
+        coinCode: 'tbtc',
+        scriptType: 'p2wpkh',
+    },
+    'tbtc-p2pkh': {
+        name: 'Bitcoin Testnet Legacy',
+        coinCode: 'tbtc',
+        scriptType: 'p2pkh',
+    },
+    'tltc': {
+        name: 'Litecoin Testnet',
+        coinCode: 'tltc',
+    },
+    'tltc-p2wpkh-p2sh': {
+        name: 'Litecoin Testnet',
+        coinCode: 'tltc',
+        scriptType: 'p2wpkh-p2sh',
+    },
+    'tltc-p2wpkh': {
+        name: 'Litecoin Testnet: bech32',
+        coinCode: 'tltc',
+        scriptType: 'p2wpkh',
+    },
+    'teth': {
+        name: 'Ethereum Ropsten Testnet',
+        coinCode: 'teth',
+        scriptType: 'p2wpkh', // TODO dummy script type to pass DecodeScriptType
+    },
+};
+
+interface CoinDropDownProps {
+    onChange: (coin: accountApi.CoinCode) => void;
+    supportedCoins: string[];
+    value: string;
+}
+
+type Props = CoinDropDownProps & TranslateProps;
+
+function CoinDropDown({
+    onChange,
+    supportedCoins,
+    t,
+    value,
+}: RenderableProps<Props>) {
+    return (
+        <Select
+            options={[
+                {
+                    text: t('buy.info.selectPlaceholder'),
+                    disabled: true,
+                    value: 'choose',
+                },
+                ...(supportedCoins).map(item => ({
+                    value: item,
+                    text: COIN_AND_ACCOUNT_CODES[item].name,
+                }))
+            ]}
+            onInput={e => onChange(e.target.value)}
+            defaultValue={'choose'}
+            placeholder={t('buy.info.selectPlaceholder')}
+            value={value}
+            id="coinCodeDropDown" />
+    );
+}
+
+const HOC = translate<CoinDropDownProps>()(CoinDropDown);
+
+export { HOC as CoinDropDown };

--- a/frontends/web/src/routes/account/manage/components/steps.css
+++ b/frontends/web/src/routes/account/manage/components/steps.css
@@ -1,0 +1,119 @@
+:root {
+    --icon-size: 10px;
+    --icon-size-small: 8px;
+}
+
+.steps {
+    align-items: flex-start;
+    display: inline-flex;
+    flex-shrink: 0;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    margin-bottom: var(--space-half);
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+}
+
+/* .steps::before {
+    content: "";
+    background: #1f87e2;
+    display: block;
+    width: 100%;
+    height: 3px;
+    position: absolute;
+    top: 6px;
+} */
+
+.step {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    position: relative;
+    text-align: left;
+}
+
+.dot {
+    display: inline-block;
+    margin-bottom: var(--space-quarter);
+    min-height: var(--icon-size);
+}
+
+.dot::before {
+    background: var(--color-primary);
+    border: 4px solid white;
+    border-radius: 50%;
+    content: "";
+    display: inline-block;
+    flex-shrink: 0;
+    font-size: 14px;
+    height: var(--icon-size);
+    line-height: var(--icon-size);
+    position: relative;
+    text-align: center;
+    transition: background-color .3s, border-color .3s;
+    vertical-align: top;
+    width: var(--icon-size);
+    z-index: 13;
+}
+
+.dot::after {
+    border-top: 5px solid white;
+    content: "";
+    position: absolute;
+    top: 6px;
+    right: 50%;
+    width: 100vw;
+    z-index: 12;
+}
+
+.line .dot::after {
+    z-index: 1;
+}
+
+.finish .dot::before {
+    height: var(--icon-size-small);
+    width: var(--icon-size-small);
+}
+
+.wait {
+    color: var(--color-gray-alt);
+}
+
+.finish .dot::before,
+.wait .dot::before {
+    margin-top: 1px;
+}
+
+.wait .dot::before {
+    background: var(--color-mediumgray);
+    height: var(--icon-size-small);
+    width: var(--icon-size-small);
+}
+
+.finish.line .dot::after,
+.process.line .dot::after {
+    border-color: var(--color-primary);
+    border-top-width: 3px;
+    z-index: 11;
+    top: 7px;
+}
+
+.wait.line .dot::after {
+    border-color: var(--color-mediumgray);
+    border-top-width: 3px;
+    top: 7px;
+}
+
+.content {
+    font-size: var(--size-small);
+    line-height: 1;
+    margin: 0;
+    min-width: 90px;
+    position: relative;
+    text-align: center;
+    width: min-content;
+    white-space: nowrap;
+}

--- a/frontends/web/src/routes/account/manage/components/steps.tsx
+++ b/frontends/web/src/routes/account/manage/components/steps.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2021 Shift Devices AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { h, cloneElement, RenderableProps } from 'preact';
+import * as style from './steps.css';
+
+// type Status = 'process' | 'finish' | 'wait';
+
+export function Steps({
+    current,
+    children
+}) {
+    return (
+        <div className={style.steps}>
+            { children
+            .filter((child) => !child.attributes.hidden)
+            .map((child, step) => {
+                if (!child) return null;
+                const status = step === current ? 'process' : (
+                    step < current ? 'finish' : 'wait'
+                );
+                const line = (step > 0);
+                return cloneElement(child, {
+                    step: step + 1,
+                    line,
+                    status,
+                    ...child.props,
+                });
+            }) }
+        </div>
+    );
+}
+
+interface StepProps {
+    line?: boolean;
+    status?: 'process' | 'finish' | 'wait';
+    step?: number;
+    hidden?: boolean;
+}
+
+export function Step({
+    children,
+    hidden = false,
+    line,
+    status = 'wait',
+}: RenderableProps<StepProps>) {
+    if (hidden) {
+        return null;
+    }
+    return (
+        <div className={`${style.step} ${style[status]} ${line ? style.line : ''}`}>
+            <div className={style.dot}></div>
+            <div className={style.content}>
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/frontends/web/src/routes/account/manage/manage.css
+++ b/frontends/web/src/routes/account/manage/manage.css
@@ -1,0 +1,14 @@
+.manageContainer {
+    min-height: 350px;
+}
+
+.title {
+    font-size: var(--size-large);
+    font-weight: 400;
+}
+
+.successCheck {
+    background-color: var(--color-success);
+    border: .5rem solid var(--color-success);
+    border-radius: 100px;
+}

--- a/frontends/web/src/routes/account/manage/manage.tsx
+++ b/frontends/web/src/routes/account/manage/manage.tsx
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { route } from 'preact-router';
+import * as accountApi from '../../../api/account';
+import { getSupportedCoins } from '../../../api/backend';
+import SimpleMarkup from '../../../utils/simplemarkup';
+import { Button, Input } from '../../../components/forms';
+import { Entry } from '../../../components/guide/entry';
+import { Guide } from '../../../components/guide/guide';
+import { Header } from '../../../components/layout';
+import { translate, TranslateProps } from '../../../decorators/translate';
+import { Step, Steps } from './components/steps';
+import { CoinDropDown } from './components/coin-dropdown';
+import * as styles from '../manage/manage.css';
+import checkicon from '../../../assets/icons/check.svg';
+
+interface AddAccountProps {
+    // type?: 'multi' | 'btconly'
+}
+
+type Props = AddAccountProps & TranslateProps;
+
+interface State {
+    accountName: string;
+    coinCode: 'choose' | accountApi.CoinCode;
+    onlyOneSupportedCoin: boolean;
+    step: 0 | 1 | 2;
+    supportedCoins: string[];
+}
+
+class ManageAccount extends Component<Props, State> {
+    public readonly state: State = {
+        accountName: '',
+        coinCode: 'choose',
+        onlyOneSupportedCoin: false,
+        step: 0,
+        supportedCoins: [],
+    };
+
+    public componentDidMount() {
+        getSupportedCoins()
+            // TEST with only 1 coin
+            // .then(() => (['btc']))
+            .then((coins) => {
+                const onlyOneSupportedCoin = (coins.length === 1);
+                this.setState({
+                    // @ts-ignore
+                    coinCode: onlyOneSupportedCoin ? coins[0] : 'choose',
+                    onlyOneSupportedCoin,
+                    supportedCoins: coins
+                });
+            })
+            .catch(console.error);
+    }
+
+    private getStep = () => {
+        const { onlyOneSupportedCoin, step } = this.state;
+        if (onlyOneSupportedCoin) {
+            return step === 0 ? 'choose-name' : 'success';
+        }
+        switch (step) {
+            case 0: return 'select-coin';
+            case 1: return 'choose-name';
+            case 2: return 'success';
+        }
+    }
+
+    private back = () => {
+        this.setState(({ step }) => {
+            switch (step) {
+                case 0:
+                case 1: return ({ step: 0 });
+                case 2: return ({ step: 1 });
+            }
+        });
+    }
+
+    private next = () => {
+        const { accountName, coinCode } = this.state;
+        switch (this.getStep()) {
+            case 'select-coin':
+                console.info(`${coinCode} selected`);
+                break;
+            case 'choose-name':
+                // TODO: post accountName and coinCode to backend
+                console.info(`add new account for ${coinCode} with the name: ${accountName}`);
+                break;
+            case 'success':
+                route('/account-summary');
+                return;
+                break;
+        }
+        this.setState((state) => {
+            switch (state.step) {
+                case 0: return ({ step: 1 });
+                case 1: return ({ step: 2 });
+                case 2: return ({ step: 2 });
+            }
+        });
+    }
+
+    private renderContent = () => {
+        const { t } = this.props;
+        const { accountName, coinCode, supportedCoins } = this.state;
+        switch (this.getStep()) {
+            case 'select-coin':
+                return (
+                    <CoinDropDown
+                        onChange={(coinCode) => this.setState({ coinCode })}
+                        supportedCoins={supportedCoins}
+                        value={coinCode} />
+                );
+            case 'choose-name':
+                return (
+                    <Input
+                        id="accountName"
+                        onInput={e => this.setState({ accountName: e.target.value })}
+                        placeholder={t('addAccount.accountName')}
+                        value={accountName} />
+                );
+            case 'success':
+                return (
+                    <div className="text-center">
+                        <img src={checkicon} className={styles.successCheck} /><br />
+                        <SimpleMarkup
+                            markup={t('manageAccounts.success.message', { accountName })}
+                            tagName="p" />
+                        
+                    </div>
+                );
+        }
+    }
+
+    public render(
+        { t }: RenderableProps<Props>,
+        {
+            accountName,
+            coinCode,
+            onlyOneSupportedCoin,
+            step,
+            supportedCoins,
+        }: Readonly<State>
+    ) {
+        if (supportedCoins.length === 0) {
+            return null;
+        }
+        const logicalStep = this.getStep();
+        return (
+            <div class="contentWithGuide">
+                <div class="container">
+                    <Header title={<h2>{t('manageAccounts.title')}</h2>} />
+                    <div class="innerContainer scrollableContainer">
+                        <div class="content narrow isVerticallyCentered">
+                        <div className="box large" style="min-height: 370px;">
+                            <div className="text-center">
+                                {t('manageAccounts.addAccount')}
+                                <h1 class={styles.title}>{t(`manageAccounts.${logicalStep}.title`)}</h1>
+                            </div>
+                            <div class="row">
+                                {this.renderContent()}
+                            </div>
+                            <div class="row">
+                                <Steps current={step}>
+                                    <Step key="select-coin" hidden={onlyOneSupportedCoin}>
+                                        {t('manageAccounts.select-coin.step')}
+                                    </Step>
+                                    <Step key="choose-name">
+                                    {t('manageAccounts.choose-name.step')}
+                                    </Step>
+                                    <Step key="success">
+                                        {t('manageAccounts.success.step')}
+                                    </Step>
+                                </Steps>
+                            </div>
+                            <div class="row flex flex-row flex-between flex-start m-bottom">
+                                <Button
+                                    onClick={this.back}
+                                    disabled={step === 0}
+                                    transparent>
+                                    {t('button.back')}
+                                </Button>
+                                <Button
+                                    disabled={
+                                        (logicalStep === 'select-coin' && coinCode === 'choose')
+                                        || (logicalStep === 'choose-name' && accountName === '')
+                                    }
+                                    onClick={this.next}
+                                    primary>
+                                    {t(`manageAccounts.${logicalStep}.nextButton`)}
+                                </Button>
+                            </div>
+                        </div>
+                        </div>
+                    </div>
+                </div>
+                <Guide>
+                    <Entry key="guide.accountInfo.xpub" entry={t('guide.accountInfo.xpub')} />
+                </Guide>
+            </div>
+        );
+    }
+}
+
+const HOC = translate<AddAccountProps>()(ManageAccount);
+
+export { HOC as ManageAccount };


### PR DESCRIPTION
Added the add account workflow with the select-coin, choose-name
and success steps. The select-coin step is hidden if there is only
one coin that can be added.

TODO not part of this PR:
- call add-account backend with coin and name
- cleanup i18n
- add manage account button in settings
- edit account name in account info view