### PR TITLE
backend/handlers: add more info to /supported-coins

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -211,6 +211,13 @@ func (backend *Backend) nextAccountNumber(coinCode coinpkg.Code, keystore keysto
 	return nextAccountNumber, nil
 }
 
+// CanAddAccount returns true if it is possible to add an account for the given coin and keystore.
+func (backend *Backend) CanAddAccount(coinCode coinpkg.Code, keystore keystore.Keystore) bool {
+	conf := backend.config.AccountsConfig()
+	_, err := backend.nextAccountNumber(coinCode, keystore, &conf)
+	return err == nil
+}
+
 // CreateAndPersistAccountConfig checks if an account for the given coin can be added, and if so,
 // adds it to the accounts database. The next account number, which is part of the BIP44 keypath, is
 // determined automatically to be the increment of the highest existing account.

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -17,6 +17,12 @@
 import { CoinCode } from './account';
 import { apiGet } from '../utils/request';
 
-export const getSupportedCoins = (): Promise<CoinCode[]> => {
+export interface ICoin {
+    coinCode: CoinCode;
+    name: string;
+    canAddAccount: boolean;
+}
+
+export const getSupportedCoins = (): Promise<ICoin[]> => {
     return apiGet('supported-coins');
 };


### PR DESCRIPTION
Also show the display name and if an account can be added for this
coin, so the frontend can choose to disable the coin already upfront.