### PR TITLE
backend: move root fingerprint into the signing config

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -15,7 +15,6 @@
 package backend
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/btcsuite/btcutil/hdkeychain"
@@ -210,7 +209,7 @@ func (backend *Backend) nextAccountNumber(coinCode coinpkg.Code, keystore keysto
 			return false
 		}
 		// Belongs to keystore:
-		return bytes.Equal(rootFingerprint, account.RootFingerprint)
+		return account.Configurations.ContainsRootFingerprint(rootFingerprint)
 	}
 
 	nextAccountNumber := uint16(len(backend.filterAccounts(accountsConfig, filter)))

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -386,6 +386,7 @@ func (account *Account) Info() *accounts.Info {
 		)
 		signingConfigurations[idx] = signing.NewBitcoinConfiguration(
 			subacc.signingConfiguration.ScriptType(),
+			subacc.signingConfiguration.BitcoinSimple.KeyInfo.RootFingerprint,
 			subacc.signingConfiguration.AbsoluteKeypath(),
 			xpubCopy,
 		)

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -59,6 +59,7 @@ func TestAccount(t *testing.T) {
 
 	signingConfigurations := signing.Configurations{signing.NewBitcoinConfiguration(
 		signing.ScriptTypeP2WPKHP2SH,
+		[]byte{1, 2, 3, 4},
 		keypath,
 		xpub)}
 

--- a/backend/coins/btc/addresses/addresschain_test.go
+++ b/backend/coins/btc/addresses/addresschain_test.go
@@ -57,7 +57,8 @@ func (s *addressChainTestSuite) SetupTest() {
 	s.chainIndex = 1
 	s.xpub = xpub
 	s.addresses = addresses.NewAddressChain(
-		signing.NewBitcoinConfiguration(signing.ScriptTypeP2PKH, signing.NewEmptyAbsoluteKeypath(), xpub),
+		signing.NewBitcoinConfiguration(
+			signing.ScriptTypeP2PKH, []byte{1, 2, 3, 4}, signing.NewEmptyAbsoluteKeypath(), xpub),
 		net, s.gapLimit, s.chainIndex, s.log)
 }
 

--- a/backend/coins/btc/addresses/test/test.go
+++ b/backend/coins/btc/addresses/test/test.go
@@ -46,7 +46,7 @@ func NewAddressChain() (*signing.Configuration, *addresses.AddressChain) {
 		panic(err)
 	}
 	configuration := signing.NewBitcoinConfiguration(
-		signing.ScriptTypeP2PKH, derivationPath, xpub)
+		signing.ScriptTypeP2PKH, []byte{1, 2, 3, 4}, derivationPath, xpub)
 	return configuration, addresses.NewAddressChain(configuration, net, 20, 0, log)
 }
 
@@ -56,7 +56,8 @@ func GetAddress(scriptType signing.ScriptType) *addresses.AccountAddress {
 	if err != nil {
 		panic(err)
 	}
-	configuration := signing.NewBitcoinConfiguration(scriptType, absoluteKeypath, extendedPublicKey)
+	configuration := signing.NewBitcoinConfiguration(
+		scriptType, []byte{1, 2, 3, 4}, absoluteKeypath, extendedPublicKey)
 	return addresses.NewAccountAddress(
 		configuration,
 		signing.NewEmptyRelativeKeypath(),

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -158,6 +158,7 @@ func (account *Account) Initialize() error {
 	}
 
 	account.signingConfiguration = signing.NewEthereumConfiguration(
+		account.signingConfiguration.EthereumSimple.KeyInfo.RootFingerprint,
 		account.signingConfiguration.AbsoluteKeypath(),
 		account.signingConfiguration.ExtendedPublicKey(),
 	)

--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -30,13 +30,8 @@ type Account struct {
 	//
 	// This is used to unify multiple Bitcoin script types (p2wsh, p2wsh-p2sh) in one account. The
 	// keystore must be able to sign transactions with mixed inputs.
-	SupportsUnifiedAccounts bool `json:"supportsUnifiedaccounts"`
-	// If not nil, all configurations must be xpub based and derived from the same BIP39 seed with
-	// this fingerprint. The root fingerprint is the first 32 bits of the hash160 of the pubkey at
-	// the keypath m/.
-	// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#key-identifiers
-	RootFingerprint []byte                 `json:"rootFingerprint"`
-	Configurations  signing.Configurations `json:"configurations"`
+	SupportsUnifiedAccounts bool                   `json:"supportsUnifiedaccounts"`
+	Configurations          signing.Configurations `json:"configurations"`
 	// ActiveTokens list the tokens that should be loaded along with the account.  Currently, this
 	// only applies to ETH, and the elements are ERC20 token codes (e.g. "eth-erc20-usdt",
 	// "eth-erc20-bat", etc).


### PR DESCRIPTION
It belongs with the xpub and keypath, as each one can have a different
rootFingerprint in theory (e.g. multisig accounts).