### PR TITLE
backend/erc20: move token code to erc20.Token

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -615,11 +615,11 @@ func (backend *Backend) Coin(code coinpkg.Code) (coinpkg.Coin, error) {
 		coin = eth.NewCoin(etherScan, code, "ERC20 TEST", "TEST", "TETH", params.TestnetChainConfig,
 			"https://ropsten.etherscan.io/tx/",
 			etherScan,
-			erc20.NewToken("0x2f45b6fb2f28a73f110400386da31044b2e953d4", 18),
+			erc20.NewToken("teth-erc20-test", "0x2f45b6fb2f28a73f110400386da31044b2e953d4", 18),
 		)
 	case erc20Token != nil:
 		etherScan := etherscan.NewEtherScan("https://api.etherscan.io/api", backend.etherScanHTTPClient)
-		coin = eth.NewCoin(etherScan, erc20Token.code, erc20Token.name, erc20Token.unit, "ETH", params.MainnetChainConfig,
+		coin = eth.NewCoin(etherScan, erc20Token.token.Code, erc20Token.name, erc20Token.unit, "ETH", params.MainnetChainConfig,
 			"https://etherscan.io/tx/",
 			etherScan,
 			erc20Token.token,

--- a/backend/coins/eth/erc20/erc20.go
+++ b/backend/coins/eth/erc20/erc20.go
@@ -14,21 +14,26 @@
 
 package erc20
 
-import "github.com/ethereum/go-ethereum/common"
+import (
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+	"github.com/ethereum/go-ethereum/common"
+)
 
 // Token holds infos about the erc20 token needed to fetch balances, format amounts, etc.
 type Token struct {
+	Code            coin.Code
 	contractAddress common.Address
 	decimals        uint
 }
 
 // NewToken creates a new Token instance.
-func NewToken(contractAddress string, decimals uint) *Token {
+func NewToken(code coin.Code, contractAddress string, decimals uint) *Token {
 	if !common.IsHexAddress(contractAddress) {
 		panic("invalid erc20 contract address")
 	}
 
 	return &Token{
+		Code:            code,
 		contractAddress: common.HexToAddress(contractAddress),
 		decimals:        decimals,
 	}

--- a/backend/erc20.go
+++ b/backend/erc20.go
@@ -21,7 +21,6 @@ import (
 )
 
 type erc20Token struct {
-	code  coin.Code
 	name  string
 	unit  string
 	token *erc20.Token
@@ -33,70 +32,60 @@ var erc20Tokens = []erc20Token{
 	// The frontend sends them to the backend to store in the config without the prefix
 	// in frontend/web/src/routes/settings/settings.tsx.
 	{
-		code:  "eth-erc20-usdt",
 		name:  "Tether USD",
 		unit:  "USDT",
-		token: erc20.NewToken("0xdac17f958d2ee523a2206206994597c13d831ec7", 6),
+		token: erc20.NewToken("eth-erc20-usdt", "0xdac17f958d2ee523a2206206994597c13d831ec7", 6),
 	},
 	{
-		code:  "eth-erc20-usdc",
 		name:  "USD Coin",
 		unit:  "USDC",
-		token: erc20.NewToken("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", 6),
+		token: erc20.NewToken("eth-erc20-usdc", "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", 6),
 	},
 	{
-		code:  "eth-erc20-bat",
 		name:  "Basic Attention Token",
 		unit:  "BAT",
-		token: erc20.NewToken("0x0d8775f648430679a709e98d2b0cb6250d2887ef", 18),
+		token: erc20.NewToken("eth-erc20-bat", "0x0d8775f648430679a709e98d2b0cb6250d2887ef", 18),
 	},
 	{
-		code:  "eth-erc20-sai0x89d2",
 		name:  "Sai",
 		unit:  "SAI",
-		token: erc20.NewToken("0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359", 18),
+		token: erc20.NewToken("eth-erc20-sai0x89d2", "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359", 18),
 	},
 	{
-		code:  "eth-erc20-dai0x6b17",
 		name:  "Dai",
 		unit:  "DAI",
-		token: erc20.NewToken("0x6b175474e89094c44da98b954eedeac495271d0f", 18),
+		token: erc20.NewToken("eth-erc20-dai0x6b17", "0x6b175474e89094c44da98b954eedeac495271d0f", 18),
 	},
 	{
-		code:  "eth-erc20-link",
 		name:  "Chainlink",
 		unit:  "LINK",
-		token: erc20.NewToken("0x514910771af9ca656af840dff83e8264ecf986ca", 18),
+		token: erc20.NewToken("eth-erc20-link", "0x514910771af9ca656af840dff83e8264ecf986ca", 18),
 	},
 	{
-		code:  "eth-erc20-mkr",
 		name:  "Maker",
 		unit:  "MKR",
-		token: erc20.NewToken("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2", 18),
+		token: erc20.NewToken("eth-erc20-mkr", "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2", 18),
 	},
 	{
-		code:  "eth-erc20-zrx",
 		name:  "0x",
 		unit:  "ZRX",
-		token: erc20.NewToken("0xe41d2489571d322189246dafa5ebde1f4699f498", 18),
+		token: erc20.NewToken("eth-erc20-zrx", "0xe41d2489571d322189246dafa5ebde1f4699f498", 18),
 	},
 	{
-		code:  "eth-erc20-wbtc",
 		name:  "Wrapped Bitcoin",
 		unit:  "WBTC",
-		token: erc20.NewToken("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 8),
+		token: erc20.NewToken("eth-erc20-wbtc", "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 8),
 	},
 	{
-		code:  "eth-erc20-paxg",
 		name:  "Pax Gold",
 		unit:  "PAXG",
-		token: erc20.NewToken("0x45804880De22913dAFE09f4980848ECE6EcbAf78", 18),
+		token: erc20.NewToken("eth-erc20-paxg", "0x45804880De22913dAFE09f4980848ECE6EcbAf78", 18),
 	},
 }
 
 func erc20TokenByCode(code coin.Code) *erc20Token {
 	for _, token := range erc20Tokens {
-		if code == token.code {
+		if code == token.token.Code {
 			token := token
 			return &token
 		}


### PR DESCRIPTION
So that one can access it via coin.erc20Token.Code, which will be
needed to configure the exchange rates fetcher.