### PR TITLE
backend: drop usage of DeprecatedCoinActive in exchange rates updater

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -244,16 +244,6 @@ func (backend *Backend) configureHistoryExchangeRates() {
 	for _, acct := range backend.accounts {
 		coins = append(coins, string(acct.Coin().Code()))
 	}
-	// No reason continue with ERC20 tokens if Ethereum is inactive.
-	// TODO: don't use deprecated setting to configure exchange rates.
-	if backend.config.AppConfig().Backend.DeprecatedCoinActive(coinpkg.CodeETH) {
-		for _, token := range backend.config.AppConfig().Backend.ETH.DeprecatedActiveERC20Tokens {
-			// The prefix is stripped on the frontend and in app config.
-			// TODO: Unify the prefix with frontend and erc20.go, and possibly
-			// move all that to coins/coin/code or eth/erc20.
-			coins = append(coins, "eth-erc20-"+token)
-		}
-	}
 	fiats := backend.config.AppConfig().Backend.FiatList
 	backend.ratesUpdater.ReconfigureHistory(coins, fiats)
 }


### PR DESCRIPTION
When exchange rates updater is reconfigured, the backend needs to
collect all coins + ERC20 tokens.

It just so happens that an account.Coin().Code() already returns ERC20
tokens, meaning the second loop for collecting the tokens was
absolutely redundant.
