### PR TITLE
backend: make sure account code is unique

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -275,7 +275,7 @@ func (account *Account) Initialize() error {
 	}
 	account.notifier = account.Config().GetNotifier(signingConfigurations)
 
-	accountIdentifier := fmt.Sprintf("account-%s-%s", signingConfigurations.Hash(), account.Config().Code)
+	accountIdentifier := fmt.Sprintf("account-%s", account.Config().Code)
 	account.dbSubfolder = path.Join(account.Config().DBFolder, accountIdentifier)
 	if err := os.MkdirAll(account.dbSubfolder, 0700); err != nil {
 		return errp.WithStack(err)

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -138,7 +138,7 @@ func (account *Account) Initialize() error {
 	account.signingConfiguration = signingConfiguration
 	account.notifier = account.Config().GetNotifier(signingConfigurations)
 
-	accountIdentifier := fmt.Sprintf("account-%s-%s", account.signingConfiguration.Hash(), account.Config().Code)
+	accountIdentifier := fmt.Sprintf("account-%s", account.Config().Code)
 	account.dbSubfolder = path.Join(account.Config().DBFolder, accountIdentifier)
 	if err := os.MkdirAll(account.dbSubfolder, 0700); err != nil {
 		return errp.WithStack(err)

--- a/backend/signing/configuration_test.go
+++ b/backend/signing/configuration_test.go
@@ -82,21 +82,3 @@ func TestContainsRootFingerprint(t *testing.T) {
 	require.True(t, configs.ContainsRootFingerprint([]byte{1, 2, 3, 4}))
 	require.True(t, configs.ContainsRootFingerprint([]byte{5, 6, 7, 8}))
 }
-
-func TestConfigurationsHash(t *testing.T) {
-	xpub, err := hdkeychain.NewMaster(make([]byte, 32), &chaincfg.TestNet3Params)
-	require.NoError(t, err)
-	xpub, err = xpub.Neuter()
-	require.NoError(t, err)
-	keypath, err := NewAbsoluteKeypath("m/")
-	require.NoError(t, err)
-	rootFingerprint := []byte{1, 2, 3, 4}
-	cfg1 := NewBitcoinConfiguration(ScriptTypeP2PKH, rootFingerprint, keypath, xpub)
-	cfg2 := NewBitcoinConfiguration(ScriptTypeP2WPKH, rootFingerprint, keypath, xpub)
-	// Different order does not change the hash.
-	require.NotEqual(t, cfg1.Hash(), cfg2.Hash())
-	require.Equal(t,
-		(Configurations{cfg1, cfg2}).Hash(),
-		(Configurations{cfg2, cfg1}).Hash(),
-	)
-}


### PR DESCRIPTION
Also no need to use the config hash anymore, as the account code is
now unique, as it includes the keystore fingerprint.