### PR TITLE
frontend: fix send/receie titles to use the coin name

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -325,6 +325,7 @@ func writeJSON(w io.Writer, value interface{}) {
 type accountJSON struct {
 	CoinCode              coinpkg.Code `json:"coinCode"`
 	CoinUnit              string       `json:"coinUnit"`
+	CoinName              string       `json:"coinName"`
 	Code                  string       `json:"code"`
 	Name                  string       `json:"name"`
 	BlockExplorerTxPrefix string       `json:"blockExplorerTxPrefix"`
@@ -334,6 +335,7 @@ func newAccountJSON(account accounts.Interface) *accountJSON {
 	return &accountJSON{
 		CoinCode:              account.Coin().Code(),
 		CoinUnit:              account.Coin().Unit(false),
+		CoinName:              account.Coin().Name(),
 		Code:                  account.Config().Code,
 		Name:                  account.Config().Name,
 		BlockExplorerTxPrefix: account.Coin().BlockExplorerTransactionURLPrefix(),

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -32,6 +32,7 @@ export type Coin = MainnetCoin | TestnetCoin;
 export interface IAccount {
     coinCode: CoinCode;
     coinUnit: string;
+    coinName: string;
     code: string;
     name: string;
     blockExplorerTxPrefix: string;

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -318,7 +318,7 @@ class Receive extends Component<Props, State> {
                     <Status type="warning">
                         {paired === false && t('warning.receivePairing')}
                     </Status>
-                    <Header title={<h2>{t('receive.title', { accountName: account.name })}</h2>} />
+                    <Header title={<h2>{t('receive.title', { accountName: account.coinName })}</h2>} />
                     <div class="innerContainer scrollableContainer">
                         <div class="content narrow isVerticallyCentered">
                             <div class="box large text-center">

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -589,7 +589,7 @@ class Send extends Component<Props, State> {
                     <Status type="warning">
                         {paired === false && t('warning.sendPairing')}
                     </Status>
-                    <Header title={<h2>{t('send.title', { accountName: account.name })}</h2>} />
+                    <Header title={<h2>{t('send.title', { accountName: account.coinName })}</h2>} />
                     <div class="innerContainer scrollableContainer">
                         <div class="content padded">
                             <div>


### PR DESCRIPTION
Account name is not good, especially with user-named accounts. "Get My
Savings" does not make sense.