### PR TITLE
backend: remove dynamic split accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Validate socks proxy url
+- Remove the setting 'Separate accounts by address type (legacy behavior)'. BitBox02 accounts are now always unified.
 
 ## 4.27.0 [released 2021-03-17]
 - Buy ERC20 tokens using Moonpay

--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -22,16 +22,10 @@ import (
 
 // Account holds information related to an account.
 type Account struct {
-	CoinCode coin.Code `json:"coinCode"`
-	Name     string    `json:"name"`
-	Code     string    `json:"code"`
-	// SupportsUnifiedAccounts, if true, allows multiple configurations in one account. If false,
-	// one account will be added per configuration.
-	//
-	// This is used to unify multiple Bitcoin script types (p2wsh, p2wsh-p2sh) in one account. The
-	// keystore must be able to sign transactions with mixed inputs.
-	SupportsUnifiedAccounts bool                   `json:"supportsUnifiedAccounts"`
-	Configurations          signing.Configurations `json:"configurations"`
+	CoinCode       coin.Code              `json:"coinCode"`
+	Name           string                 `json:"name"`
+	Code           string                 `json:"code"`
+	Configurations signing.Configurations `json:"configurations"`
 	// ActiveTokens list the tokens that should be loaded along with the account.  Currently, this
 	// only applies to ETH, and the elements are ERC20 token codes (e.g. "eth-erc20-usdt",
 	// "eth-erc20-bat", etc).

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -66,10 +66,6 @@ type Backend struct {
 	DeprecatedLitecoinActive bool `json:"litecoinActive"`
 	DeprecatedEthereumActive bool `json:"ethereumActive"`
 
-	// Whether Bitcoin, Litecoin should be shown in multiple accounts - one per script type -
-	// instead of a combined account.
-	SplitAccounts bool `json:"splitAccounts"`
-
 	BTC  btcCoinConfig `json:"btc"`
 	TBTC btcCoinConfig `json:"tbtc"`
 	RBTC btcCoinConfig `json:"rbtc"`
@@ -142,8 +138,6 @@ func NewDefaultAppConfig() AppConfig {
 			DeprecatedBitcoinActive:  true,
 			DeprecatedLitecoinActive: true,
 			DeprecatedEthereumActive: true,
-
-			SplitAccounts: false,
 
 			BTC: btcCoinConfig{
 				ElectrumServers: []*ServerInfo{

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -942,10 +942,6 @@
       "servers": {
         "text": "This app communicates with the Shift Crypto servers to check for updates, load transactions, and send information to paired mobile apps.\nThe app also retrieves the latest exchange rates from CryptoCompare. All conversions are calculated locally which means no data about the amount of your transaction is ever transmitted.\nNote: For Ethereum and ERC20 Tokens, we use Etherscan.io APIs.",
         "title": "Which servers does this app talk to?"
-      },
-      "whyMultipleAccounts": {
-        "text": "Some cryptocurrencies have multiple address and transaction formats. These addresses are separated into extra accounts.",
-        "title": "$t(settings.expert.splitAccounts)"
       }
     },
     "title": "Guide",
@@ -1331,7 +1327,6 @@
       },
       "fee": "Enable custom fees",
       "setProxyAddress": "Set proxy address",
-      "splitAccounts": "Separate accounts by address type (legacy behavior)",
       "title": "Expert settings",
       "useProxy": "Enable tor proxy"
     },

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -21,8 +21,6 @@ import { apiGet } from '../../utils/request';
 import { setConfig } from '../../utils/config';
 import { Button } from '../../components/forms';
 import Logo from '../../components/icon/logo';
-import { Entry } from '../../components/guide/entry';
-import { Guide } from '../../components/guide/guide';
 import { Header } from '../../components/layout';
 import { Toggle } from '../../components/toggle/toggle';
 import { translate, TranslateProps } from '../../decorators/translate';
@@ -128,9 +126,6 @@ class ManageAccounts extends Component<Props, State> {
                         </div>
                     </div>
                 </div>
-                <Guide>
-                    <Entry key="guide.settings.whyMultipleAccounts" entry={t('guide.settings.whyMultipleAccounts')} />
-                </Guide>
             </div>
         );
     }

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -74,19 +74,6 @@ class Settings extends Component<Props, State> {
         }
     }
 
-    private handleToggleSplitAccounts = (event: Event) => {
-        const target = (event.target as HTMLInputElement);
-        setConfig({
-            backend: {
-                [target.id]: target.checked,
-            },
-        })
-            .then(config => {
-                this.setState({ config });
-                this.reinitializeAccounts();
-            });
-    }
-
     private handleToggleFrontendSetting = (event: Event) => {
         const target = (event.target as HTMLInputElement);
         setConfig({
@@ -95,10 +82,6 @@ class Settings extends Component<Props, State> {
             },
         })
             .then(config => this.setState({ config }));
-    }
-
-    private reinitializeAccounts = () => {
-        apiPost('accounts/reinitialize');
     }
 
     private handleFormChange = (event: Event) => {
@@ -266,25 +249,6 @@ class Settings extends Component<Props, State> {
                                                                 id="coinControl"
                                                                 onChange={this.handleToggleFrontendSetting} />
                                                         </div>
-                                                        <div className={style.setting}>
-                                                            <div className="m-top-quarter m-bottom-quarter">
-                                                                <p className="m-none">{t('settings.expert.splitAccounts')}</p>
-                                                                <p className="m-none">
-                                                                    <Badge type="generic">BitBox02</Badge>
-                                                                    <span className="text-gray"> (</span>
-                                                                    <Badge type="primary">Multi</Badge>
-                                                                    <span className="text-gray">,</span>
-                                                                    <Badge type="secondary" className="m-left-quarter">Bitcoin-only</Badge>
-                                                                    <span className="text-gray">)</span>
-                                                                    <Badge type="generic" className="m-left-quarter">BTC</Badge>
-                                                                    <Badge type="generic" className="m-left-quarter">LTC</Badge>
-                                                                </p>
-                                                            </div>
-                                                            <Toggle
-                                                                id="splitAccounts"
-                                                                checked={config.backend.splitAccounts}
-                                                                onChange={this.handleToggleSplitAccounts} />
-                                                        </div>
                                                         <SettingsButton
                                                             onClick={this.showProxyDialog}
                                                             optionalText={t('generic.enabled', { context: config.backend.proxy.useProxy.toString() })}>
@@ -350,7 +314,6 @@ class Settings extends Component<Props, State> {
                     </div>
                 </div>
                 <Guide>
-                    <Entry key="guide.settings.whyMultipleAccounts" entry={t('guide.settings.whyMultipleAccounts')} />
                     <Entry key="guide.settings.servers" entry={t('guide.settings.servers')} />
                     <Entry key="guide.settings-electrum.why" entry={t('guide.settings-electrum.why')} />
                     <Entry key="guide.accountRates" entry={t('guide.accountRates')} />


### PR DESCRIPTION
Before, we would dynamically explode a unified account into multiple
individual accounts (one per signing config) if the keystore didn't
support unified accounts. This does not work well with account
management, where one wants to list all accounts, edit their names,
etc.

We kept a toggle in the settings to force-explode accounts, so that
users who (ab)used multiple signing configurations as multiple
accounts could get the behavior back. It was meant to be temporary,
but the above forces us to speed up its removal.

After this commit, users will find their split accounts to be unified,
and they can split the funds manually again by sendint the funds to a
new account (by using coin control).