### PR TITLE
backend/btc: don't block in FatalError()

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -408,10 +408,6 @@ func (account *Account) onNewHeader(header *blockchain.Header) {
 
 // FatalError returns true if the account had a fatal error.
 func (account *Account) FatalError() bool {
-	// Wait until synchronized, to include server errors without manually dealing with sync status.
-	if account.Offline() == nil {
-		account.Synchronizer.WaitSynchronized()
-	}
 	return account.fatalError
 }
 


### PR DESCRIPTION
FatalError is called when getting the account status and blocked until
the accoutn was synced. The account component is not rendered until
the status endpoint returns, which would be after syncing. This
prevents the account component from showing the address scan progress
indication.