### PR TITLE
Multi-accounts manage tokens prototype

### DIFF
--- a/frontends/web/src/components/icon/assets/paxg-color.svg
+++ b/frontends/web/src/components/icon/assets/paxg-color.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 71.98 67.9">
+<svg xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" width="32" height="32" viewBox="0 0 71.98 67.9">
   <defs/>
   <defs>
     <mask id="a" width="23.84" height="54.6" x="0" y="4.82" maskUnits="userSpaceOnUse">

--- a/frontends/web/src/components/icon/logo.tsx
+++ b/frontends/web/src/components/icon/logo.tsx
@@ -95,10 +95,10 @@ const logoMap = {
 };
 
 interface Props {
-    coinCode: string;
-    className?: string;
-    alt?: string;
     active?: boolean;
+    alt?: string;
+    className?: string;
+    coinCode: string;
     stacked?: boolean;
 }
 

--- a/frontends/web/src/routes/settings/manage-accounts.css
+++ b/frontends/web/src/routes/settings/manage-accounts.css
@@ -1,0 +1,63 @@
+.setting {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    min-height: var(--item-height);
+    padding: 10px var(--space-half);
+}
+
+.setting > label {
+    flex-shrink: 0;
+}
+
+.setting.disabled > p {
+    color: var(--color-gray-alt);
+}
+
+.tokenSection {
+    display: flex;
+    flex-basis: 100%;
+    flex-wrap: wrap;
+    padding: 10px 4px;
+}
+
+.token {
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-right: var(--space-default);
+    min-height: var(--item-height);
+    padding: 10px 0;
+}
+
+.token:hover .stacked{
+    background: red;
+}
+
+.token:hover img:last-child {
+    opacity: 1;
+}
+
+.token img:first-child {
+    margin-right: 0;
+}
+
+.tokenIcon {
+    max-height: 24px;
+    max-width: 24px;
+}
+
+.tokenActive {}
+
+.tokenInactive {
+    color: var(--color-gray-alt);
+    transition: color 0.2s ease;
+}
+
+.tokenInactive:hover {
+    color: var(--color-default);
+}

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -26,7 +26,7 @@ import { Guide } from '../../components/guide/guide';
 import { Header } from '../../components/layout';
 import { Toggle } from '../../components/toggle/toggle';
 import { translate, TranslateProps } from '../../decorators/translate';
-import * as style from './settings.css';
+import * as style from './manage-accounts.css';
 
 interface ManageAccountsProps {
     accounts: accountAPI.IAccount[];
@@ -80,6 +80,7 @@ class ManageAccounts extends Component<Props, State> {
             return null;
         }
         return accounts.map(account => {
+            const active = (account.code in favorites) ? favorites[account.code] : true;
             return (
                 <div key={account.code} className={style.setting}>
                     <Logo className="m-right-half" coinCode={account.coinCode} alt={account.coinUnit} />
@@ -92,12 +93,60 @@ class ManageAccounts extends Component<Props, State> {
                         Edit
                     </ButtonLink> */}
                     <Toggle
-                        checked={(account.code in favorites) ? favorites[account.code] : true}
+                        checked={active}
                         id={account.code}
                         onChange={this.toggleFavorAccount} />
+                        {active && account.coinCode.includes('eth') ? (
+                            <div className={style.tokenSection}>
+                                {this.renderTokens(account.code)}
+                            </div>
+                        ) : null}
                 </div>
             );
         });
+    }
+
+    private erc20TokenCodes = {
+        usdt: 'Tether USD',
+        usdc: 'USD Coin',
+        link: 'Chainlink',
+        bat: 'Basic Attention Token',
+        mkr: 'Maker',
+        zrx: '0x',
+        wbtc: 'Wrapped Bitcoin',
+        paxg: 'Pax Gold',
+        sai0x89d2: 'Sai',
+        dai0x6b17: 'Dai',
+    };
+
+    private renderTokens = (ethAccountCoinCode) => {
+        const { favorites } = this.state;
+        if (!favorites) {
+            return null;
+        }
+        return Object.entries(this.erc20TokenCodes)
+            .map(([key, value]) => {
+                const active = !(Math.random() < 0.5);
+                return (
+                    <div key={key}
+                        onClick={() => this.toggleToken(ethAccountCoinCode, key)}
+                        className={`${style.token} ${active ? style.tokenActive : style.tokenInactive}`}>
+                        <Logo
+                            active={active}
+                            alt={value}
+                            className={style.tokenIcon}
+                            coinCode={`eth-erc20-${key}`}
+                            stacked />
+                        <span className="flex-1 p-left-quarter">
+                            {value} ({key})
+                        </span>
+                    </div>
+                );
+            });
+    }
+
+    private toggleToken = (ethAccountCoinCode, token) => {
+        console.info('toggle token', ethAccountCoinCode, token);
     }
 
     public render(


### PR DESCRIPTION
Added tokens below ETH accounts if the account is active.
Currently some tokens have dummy active state just for testing.
This will later come when the api supports enabling tokens.

Also fixed a token image gpax that added width and
height so the svg size is the same as all other tokens.