### PR TITLE
backend: sort accounts by coin, account number

### DIFF
--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -1,0 +1,78 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil/hdkeychain"
+	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortAccounts(t *testing.T) {
+	xpub, err := hdkeychain.NewMaster(make([]byte, 32), &chaincfg.TestNet3Params)
+	require.NoError(t, err)
+	xpub, err = xpub.Neuter()
+	require.NoError(t, err)
+	rootFingerprint := []byte{1, 2, 3, 4}
+	btcConfig := func(keypath string) signing.Configurations {
+		kp, err := signing.NewAbsoluteKeypath(keypath)
+		require.NoError(t, err)
+		return signing.Configurations{
+			signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, rootFingerprint, kp, xpub),
+		}
+	}
+	ethConfig := func(keypath string) signing.Configurations {
+		kp, err := signing.NewAbsoluteKeypath(keypath)
+		require.NoError(t, err)
+		return signing.Configurations{
+			signing.NewEthereumConfiguration(rootFingerprint, kp, xpub),
+		}
+	}
+
+	accounts := []*config.Account{
+		{Code: "acct-eth-2", CoinCode: coinpkg.CodeETH, Configurations: ethConfig("m/44'/60'/0'/0/1")},
+		{Code: "acct-eth-1", CoinCode: coinpkg.CodeETH, Configurations: ethConfig("m/44'/60'/0'/0/0")},
+		{Code: "acct-btc-1", CoinCode: coinpkg.CodeBTC, Configurations: btcConfig("m/84'/0'/0'")},
+		{Code: "acct-btc-3", CoinCode: coinpkg.CodeBTC, Configurations: btcConfig("m/84'/0'/2'")},
+		{Code: "acct-btc-2", CoinCode: coinpkg.CodeBTC, Configurations: btcConfig("m/84'/0'/1'")},
+		{Code: "acct-teth", CoinCode: coinpkg.CodeTETH},
+		{Code: "acct-ltc", CoinCode: coinpkg.CodeLTC},
+		{Code: "acct-reth", CoinCode: coinpkg.CodeRETH},
+		{Code: "acct-tltc", CoinCode: coinpkg.CodeTLTC},
+		{Code: "acct-tbtc", CoinCode: coinpkg.CodeTBTC},
+	}
+	sortAccounts(accounts)
+	expectedOrder := []string{
+		"acct-btc-1",
+		"acct-btc-2",
+		"acct-btc-3",
+		"acct-tbtc",
+		"acct-ltc",
+		"acct-tltc",
+		"acct-eth-1",
+		"acct-eth-2",
+		"acct-teth",
+		"acct-reth",
+	}
+	for i := range accounts {
+		assert.Equal(t, expectedOrder[i], accounts[i].Code)
+	}
+}


### PR DESCRIPTION
In lieu of a user-chosen order, we fix the order and group accounts by
coin, ordered by account number.

Tokens are unchanged, are listed after the parent ETH account, in an
arbitrary order.