### PR TITLE
frontend: enabling tokens now use toggles on manage accounts

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -311,6 +311,12 @@ func (backend *Backend) persistAccount(account config.Account, accountsConfig *c
 
 }
 
+// Erc20AccountCode returns the account code used for an ERC20 token.
+// It is derived from the account code of the parent ETH account and the token code.
+func Erc20AccountCode(ethereumAccountCode, tokenCode string) string {
+	return fmt.Sprintf("%s-%s", ethereumAccountCode, tokenCode)
+}
+
 // The accountsLock must be held when calling this function.
 func (backend *Backend) createAndAddAccount(
 	coin coinpkg.Coin,
@@ -359,7 +365,7 @@ func (backend *Backend) createAndAddAccount(
 				backend.log.WithError(err).Error("could not find ERC20 token")
 				continue
 			}
-			erc20AccountCode := fmt.Sprintf("%s-%s", code, erc20TokenCode)
+			erc20AccountCode := Erc20AccountCode(code, erc20TokenCode)
 			backend.createAndAddAccount(token, erc20AccountCode, token.Name(), signingConfigurations, nil)
 		}
 	default:

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -325,18 +325,26 @@ func writeJSON(w io.Writer, value interface{}) {
 	}
 }
 
-type accountJSON struct {
-	CoinCode              coinpkg.Code `json:"coinCode"`
-	CoinUnit              string       `json:"coinUnit"`
-	CoinName              string       `json:"coinName"`
-	Code                  string       `json:"code"`
-	Name                  string       `json:"name"`
-	IsToken               bool         `json:"isToken"`
-	ActiveTokens          []string     `json:"activeTokens,omitempty"`
-	BlockExplorerTxPrefix string       `json:"blockExplorerTxPrefix"`
+type activeToken struct {
+	// TokenCode is the token code as defined in erc20.go, e.g. "eth-erc20-usdt".
+	TokenCode string `json:"tokenCode"`
+	// AccountCode is the code of the account, which is not the same as the TokenCode, as there can
+	// be many accounts for the same token.
+	AccountCode string `json:"accountCode"`
 }
 
-func newAccountJSON(account accounts.Interface, activeTokens []string) *accountJSON {
+type accountJSON struct {
+	CoinCode              coinpkg.Code  `json:"coinCode"`
+	CoinUnit              string        `json:"coinUnit"`
+	CoinName              string        `json:"coinName"`
+	Code                  string        `json:"code"`
+	Name                  string        `json:"name"`
+	IsToken               bool          `json:"isToken"`
+	ActiveTokens          []activeToken `json:"activeTokens,omitempty"`
+	BlockExplorerTxPrefix string        `json:"blockExplorerTxPrefix"`
+}
+
+func newAccountJSON(account accounts.Interface, activeTokens []activeToken) *accountJSON {
 	eth, ok := account.Coin().(*eth.Coin)
 	isToken := ok && eth.ERC20Token() != nil
 	return &accountJSON{
@@ -477,14 +485,19 @@ func (handlers *Handlers) getAccountsHandler(_ *http.Request) (interface{}, erro
 	accounts := []*accountJSON{}
 	persistedAccounts := handlers.backend.Config().AccountsConfig()
 	for _, account := range handlers.backend.Accounts() {
-		var activeTokens []string
+		var activeTokens []activeToken
 		if account.Coin().Code() == coinpkg.CodeETH {
 			persistedAccount := persistedAccounts.Lookup(account.Config().Code)
 			if persistedAccount == nil {
 				handlers.log.WithField("code", account.Config().Code).Error("account not found in accounts database")
 				continue
 			}
-			activeTokens = persistedAccount.ActiveTokens
+			for _, tokenCode := range persistedAccount.ActiveTokens {
+				activeTokens = append(activeTokens, activeToken{
+					TokenCode:   tokenCode,
+					AccountCode: backend.Erc20AccountCode(account.Config().Code, tokenCode),
+				})
+			}
 		}
 		accounts = append(accounts, newAccountJSON(account, activeTokens))
 	}

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -28,6 +28,10 @@ export type TestnetCoin = 'TBTC' | 'TLTC' | 'TETH' | 'RETH';
 
 export type Coin = MainnetCoin | TestnetCoin;
 
+export interface IActiveToken {
+    tokenCode: string;
+    accountCode: string;
+}
 
 export interface IAccount {
     coinCode: CoinCode;
@@ -36,7 +40,7 @@ export interface IAccount {
     code: string;
     name: string;
     isToken: boolean;
-    activeTokens?: string[];
+    activeTokens?: IActiveToken[];
     blockExplorerTxPrefix: string;
 }
 

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1050,6 +1050,10 @@
       "step": "Select coin",
       "title": "Select cryptocurrency"
     },
+    "settings": {
+      "hideTokens": "Hide tokens",
+      "showTokens": "Show tokens ({{activeTokenCount}})"
+    },
     "success": {
       "message": "<strong>{{accountName}}</strong> has now been added to your accounts.",
       "nextButton": "Done",

--- a/frontends/web/src/routes/settings/manage-accounts.css
+++ b/frontends/web/src/routes/settings/manage-accounts.css
@@ -16,6 +16,23 @@
     color: var(--color-gray-alt);
 }
 
+.coinLogo {
+    outline: 3px solid white;
+    position: relative;
+    z-index: 2;
+}
+
+.acccountLink {
+    align-items: center;
+    display: flex;
+}
+
+.accountName {}
+
+.accountActive {
+    cursor: pointer;
+}
+
 .tokenSection {
     display: flex;
     flex-basis: 100%;
@@ -25,21 +42,24 @@
 
 .token {
     align-items: center;
-    cursor: pointer;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    margin-right: var(--space-default);
     min-height: var(--item-height);
     padding: 10px 0;
+    position: relative;
+    width: 100%;
 }
 
-.token:hover .stacked{
-    background: red;
-}
-
-.token:hover img:last-child {
-    opacity: 1;
+.token::before {
+    background-color: #ddd;
+    content: "";
+    height: 22px;
+    left: 10px;
+    position: absolute;
+    top: -13px;
+    right: 8px;
+    width: 3px;
 }
 
 .token img:first-child {
@@ -51,13 +71,15 @@
     max-width: 24px;
 }
 
+.tokenName {
+    flex: 1;
+    display: inline-block;
+    padding-left: 20px;
+}
+
 .tokenActive {}
 
 .tokenInactive {
     color: var(--color-gray-alt);
     transition: color 0.2s ease;
-}
-
-.tokenInactive:hover {
-    color: var(--color-default);
 }

--- a/frontends/web/src/routes/settings/manage-accounts.css
+++ b/frontends/web/src/routes/settings/manage-accounts.css
@@ -17,7 +17,6 @@
 }
 
 .coinLogo {
-    outline: 3px solid white;
     position: relative;
     z-index: 2;
 }
@@ -34,10 +33,30 @@
 }
 
 .tokenSection {
+    align-items: flex-start;
     display: flex;
     flex-basis: 100%;
+    flex-direction: column;
     flex-wrap: wrap;
-    padding: 10px 4px;
+    padding: 0 4px;
+}
+
+.tokenContainer {
+    max-height: 0vh;
+    overflow: hidden;
+    transition: max-height .27s ease;
+    width: 100%;
+}
+
+.tokenContainerOpen {
+    /*
+        a numeric value that is higher than the height of the token list,
+        so the animation works nicely.
+        could be also be a fixed high value, e.g. 3000rem
+        i.e.
+     */
+    max-height: 200vh;
+    padding: 10px 0 0 0;
 }
 
 .token {
@@ -62,6 +81,11 @@
     width: 3px;
 }
 
+.token:first-child::before {
+    height: 16px;
+    top: -7px;
+}
+
 .token img:first-child {
     margin-right: 0;
 }
@@ -82,4 +106,23 @@
 .tokenInactive {
     color: var(--color-gray-alt);
     transition: color 0.2s ease;
+}
+
+.expandBtn {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.4' aria-labelledby='chevron down' color='%235e94bf'%3E%3Cdefs/%3E%3Cpolyline points='6 10 12 16 18 10'/%3E%3C/svg%3E%0A");
+    background-position: 100% center;
+    background-repeat: no-repeat;
+    height: 40px;
+}
+
+.expandBtnOpen {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.4' aria-labelledby='chevron down' color='%235e94bf'%3E%3Cdefs/%3E%3Cpolyline points='6 16 12 10 18 16'/%3E%3C/svg%3E%0A");
+}
+
+.expandBtn,
+.expandBtn:focus,
+.expandBtn:hover {
+    border-color: white !important;
+    margin-left: 10px;
+    outline: none;
 }

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -19,7 +19,6 @@ import { route } from 'preact-router';
 import * as accountAPI from '../../api/account';
 import * as backendAPI from '../../api/backend';
 import { apiGet } from '../../utils/request';
-import { setConfig } from '../../utils/config';
 import { alertUser } from '../../components/alert/Alert';
 import { Button } from '../../components/forms';
 import Logo from '../../components/icon/logo';
@@ -64,21 +63,22 @@ class ManageAccounts extends Component<Props, State> {
             .catch(console.error);
     }
 
-    private toggleFavorAccount = (e) => {
-        const { checked, id } = e.target as HTMLInputElement;
-        this.setState(({ favorites }) => ({
-            favorites: {
-                ...favorites,
-                [id]: checked,
-            }
-        }), () => {
-            setConfig({
-                frontend: {
-                    favorites: this.state.favorites
-                }
-            }).catch(console.error);
-        });
-    }
+    // TODO: keeping for next release when we enable favorite accounts
+    // private toggleFavorAccount = (e) => {
+    //     const { checked, id } = e.target as HTMLInputElement;
+    //     this.setState(({ favorites }) => ({
+    //         favorites: {
+    //             ...favorites,
+    //             [id]: checked,
+    //         }
+    //     }), () => {
+    //         setConfig({
+    //             frontend: {
+    //                 favorites: this.state.favorites
+    //             }
+    //         }).catch(console.error);
+    //     });
+    // }
 
     private renderAccounts = () => {
         const { favorites, accounts } = this.state;
@@ -89,19 +89,23 @@ class ManageAccounts extends Component<Props, State> {
             const active = (account.code in favorites) ? favorites[account.code] : true;
             return (
                 <div key={account.code} className={style.setting}>
-                    <Logo className="m-right-half" coinCode={account.coinCode} alt={account.coinUnit} />
-                    <span className="flex-1">
-                        {account.name}
-                        {' '}
-                        <span className="unit">({account.coinUnit})</span>
-                    </span>
+                    <div
+                        className={`${style.acccountLink} ${style.accountActive}`}
+                        onClick={() => route(`/account/${account.code}`)}>
+                        <Logo className={`${style.coinLogo} m-right-half`} coinCode={account.coinCode} alt={account.coinUnit} />
+                        <span className={style.accountName}>
+                            {account.name}
+                            {' '}
+                            <span className="unit">({account.coinUnit})</span>
+                        </span>
+                    </div>
                     {/* <ButtonLink>
                         Edit
                     </ButtonLink> */}
-                    <Toggle
+                    {/* <Toggle
                         checked={active}
                         id={account.code}
-                        onChange={this.toggleFavorAccount} />
+                        onChange={this.toggleFavorAccount} /> */}
                         {active && account.coinCode === 'eth' ? (
                             <div className={style.tokenSection}>
                                 {this.renderTokens(account.code, account.activeTokens)}
@@ -132,20 +136,27 @@ class ManageAccounts extends Component<Props, State> {
         }
         return Object.entries(this.erc20TokenCodes)
             .map(([tokenCode, name]) => {
-                const active = activeTokens && activeTokens.includes(tokenCode);
+                const active = activeTokens !== undefined && activeTokens.includes(tokenCode);
                 return (
                     <div key={tokenCode}
-                        onClick={() => this.toggleToken(ethAccountCode, tokenCode, !active)}
                         className={`${style.token} ${active ? style.tokenActive : style.tokenInactive}`}>
-                        <Logo
-                            active={active}
-                            alt={name}
-                            className={style.tokenIcon}
-                            coinCode={tokenCode}
-                            stacked />
-                        <span className="flex-1 p-left-quarter">
-                            {name} ({tokenCode})
-                        </span>
+                        <div
+                            className={`${style.acccountLink} ${active ? style.accountActive : ''}`}
+                            onClick={() => active && route(`/account/${tokenCode}`)}>
+                            <Logo
+                                active={active}
+                                alt={name}
+                                className={style.tokenIcon}
+                                coinCode={tokenCode}
+                                stacked />
+                            <span className={style.tokenName}>
+                                {name}
+                            </span>
+                        </div>
+                        <Toggle
+                            checked={active}
+                            id={tokenCode}
+                            onChange={() => this.toggleToken(ethAccountCode, tokenCode, !active)} />
                     </div>
                 );
             });

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -156,26 +156,21 @@ class ManageAccounts extends Component<Props, State> {
         'eth-erc20-dai0x6b17': 'Dai',
     };
 
-    private renderTokens = (ethAccountCode: string, activeTokens?: string[]) => {
-        const { accounts, favorites } = this.state;
+    private renderTokens = (ethAccountCode: string, activeTokens?: accountAPI.IActiveToken[]) => {
+        const { favorites } = this.state;
         if (!favorites) {
             return null;
         }
         return Object.entries(this.erc20TokenCodes)
             .map(([tokenCode, name]) => {
-                const active = activeTokens !== undefined && activeTokens.includes(tokenCode);
-                const accountCode = accounts
-                    .filter(account => account.coinCode === tokenCode);
-                    // .filter or .find by my ETH account somehow, need ETH parent account
-                if (accountCode.length > 1) {
-                    console.log(accountCode);
-                }
+                const activeToken = (activeTokens || []).find(t => t.tokenCode === tokenCode);
+                const active = activeToken !== undefined;
                 return (
                     <div key={tokenCode}
                         className={`${style.token} ${active ? style.tokenActive : style.tokenInactive}`}>
                         <div
                             className={`${style.acccountLink} ${active ? style.accountActive : ''}`}
-                            onClick={() => active && route(`/account/${tokenCode}`)}>
+                            onClick={() => activeToken !== undefined && route(`/account/${activeToken.accountCode}`)}>
                             <Logo
                                 active={active}
                                 alt={name}

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -157,13 +157,19 @@ class ManageAccounts extends Component<Props, State> {
     };
 
     private renderTokens = (ethAccountCode: string, activeTokens?: string[]) => {
-        const { favorites } = this.state;
+        const { accounts, favorites } = this.state;
         if (!favorites) {
             return null;
         }
         return Object.entries(this.erc20TokenCodes)
             .map(([tokenCode, name]) => {
                 const active = activeTokens !== undefined && activeTokens.includes(tokenCode);
+                const accountCode = accounts
+                    .filter(account => account.coinCode === tokenCode);
+                    // .filter or .find by my ETH account somehow, need ETH parent account
+                if (accountCode.length > 1) {
+                    console.log(accountCode);
+                }
                 return (
                     <div key={tokenCode}
                         className={`${style.token} ${active ? style.tokenActive : style.tokenInactive}`}>

--- a/frontends/web/src/style/layout.css
+++ b/frontends/web/src/style/layout.css
@@ -121,8 +121,9 @@
     overflow: auto;
 }
 
-.scrollableContainer .content {
-    /* overflow: visible; */
+.scrollContainer {
+    overflow-x: auto;
+    overflow-y: scroll;
 }
 
 .subHeaderContainer {


### PR DESCRIPTION
- added small lines to visualize their close relation to the
  parent ethereum account
- commented out but kept the toggle favor account feature
- linked the coin accounts to their account-overview, but
  have not id for tokens to correctly link to