### PR TITLE
WIP frontend/buy: remove 'Select a coin' label

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -518,7 +518,6 @@
       },
       "next": "Next",
       "selectLabel": "Choose your account",
-      "selectPlaceholder": "Select a coin",
       "skip": "Do not show again",
       "title": "Buy {{name}}"
     },

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -194,10 +194,8 @@ class BuyInfo extends Component<Props, State> {
                                 <div class="content narrow isVerticallyCentered">
                                     <h1 class={style.title}>{t('buy.title', { name })}</h1>
                                     <Select
-                                        label={t('buy.info.selectLabel')}
-                                        placeholder={t('buy.info.selectPlaceholder')}
                                         options={[{
-                                                text: t('buy.info.selectPlaceholder'),
+                                                text: t('buy.info.selectLabel'),
                                                 disabled: true,
                                                 value: 'choose',
                                             },


### PR DESCRIPTION
The dropdown lists accounts, not coins.

The placeholder attribute is removed as it does not seem to do
anything.

The label is also removed as it is the same text again.