### PR TITLE
frontend: add rename account dialog to manage accounts

### DIFF
--- a/frontends/web/src/components/message/message.tsx
+++ b/frontends/web/src/components/message/message.tsx
@@ -18,15 +18,20 @@ import { h, RenderableProps } from 'preact';
 import * as styles from './message.css';
 
 export interface Props {
+    hidden?: boolean;
     type?: 'message' | 'success' | 'info' | 'warning' | 'error';
     style?: string;
 }
 
 export function Message({
+    hidden,
     type = 'message',
     style = '',
     children,
 }: RenderableProps<Props>) {
+    if (hidden) {
+        return null;
+    }
     return (
         <div className={styles[type]} style={style}>
             {children}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1048,6 +1048,8 @@
   "loading": "loading…",
   "manageAccounts": {
     "addAccount": "$t(addAccount.title)",
+    "editAccount": "Edit",
+    "editAccountNameTitle": "Edit account name",
     "noAccounts": "no accounts found",
     "settings": {
       "hideTokens": "Hide tokens",

--- a/frontends/web/src/routes/settings/manage-accounts.css
+++ b/frontends/web/src/routes/settings/manage-accounts.css
@@ -28,6 +28,13 @@
 
 .accountName {}
 
+.editBtn {
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    line-height: 2;
+}
+
 .accountActive {
     cursor: pointer;
 }

--- a/frontends/web/test/components/message/message.test.tsx
+++ b/frontends/web/test/components/message/message.test.tsx
@@ -36,6 +36,11 @@ describe('components/message/message', () => {
         expect(msg.children()[0]).toEqual(<span>hello</span>);
     });
 
+    it('should return return null', () => {
+        const msg = deep(<Message hidden><span>hello</span></Message>);
+        expect(msg.output()).toEqual(null);
+    });
+
     it('should preserve text', () => {
         const msg = shallow(<Message><span>hello world</span></Message>);
         expect(msg.text()).toBe('hello world');


### PR DESCRIPTION
Added edit button to all accounts that are real coins and can
be named, edit input and save form displayed with a dialog
as inline is a bit trickier and we dont want the current
solution from edit notes.