### PR TITLE
backend/eth: increase update interval to 1min

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -42,7 +42,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var pollInterval = 30 * time.Second
+var pollInterval = 60 * time.Second
 
 // Account is an Ethereum account, with one address.
 type Account struct {


### PR DESCRIPTION
With newly up to 5 accounts per ETH and token, and conservatively 5
requests per update round, updating every 30s is too quick and 1min
should be ok.