### PR TITLE
frontend: hide add-account button in sidebar

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -175,19 +175,6 @@ class Sidebar extends Component<Props> {
                         <span className="sidebarHeader" hidden={!keystores.length}>
                             {t('sidebar.accounts')}
                         </span>
-                        <span className="sidebarHeaderAction" hidden={!keystores.length}>
-                            <Link
-                                href={`/add-account`}
-                                title={t('sidebar.addAccount')}
-                                activeClassName="sidebar-active"
-                                onClick={this.handleSidebarItemClick}>
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                    <circle cx="12" cy="12" r="10"></circle>
-                                    <line x1="12" y1="8" x2="12" y2="16"></line>
-                                    <line x1="8" y1="12" x2="16" y2="12"></line>
-                                </svg>
-                            </Link>
-                        </span>
                     </div>
                     {/* <div className="activeGroup">
                         <div className="sidebarItem">


### PR DESCRIPTION
Reasons are default accounts should be enough for average
users, also once the accounts are created the button does
not always have to be visible.
Add account in manage accounts should be sufficient.