### PR TITLE
frontend: do not use guide entry link url

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -854,8 +854,7 @@
     "buy": {
       "exchanges": {
         "link": {
-          "text": "List of exchanges",
-          "url": "/exchanges"
+          "text": "List of exchanges"
         },
         "text": "Here is a list of ones we recommend depending on your region and purchasing preferences.",
         "title": "Looking for an exchange?"

--- a/frontends/web/src/routes/buy/guide.tsx
+++ b/frontends/web/src/routes/buy/guide.tsx
@@ -46,7 +46,14 @@ export default function BuyGuide({
         text: t('buy.info.disclaimer.protection.description', { name }),
         title: t('buy.info.disclaimer.protection.title'),
       }} />
-      <Entry key="guide.buy.exchanges" entry={t('guide.buy.exchanges')} />
+      <Entry key="guide.buy.exchanges" entry={{
+        link: {
+          text: t('guide.buy.exchanges.link.text'),
+          url: '/exchanges',
+        },
+        text: t('guide.buy.exchanges.text'),
+        title: t('guide.buy.exchanges.title'),
+      }} />
     </Guide>
   );
 }


### PR DESCRIPTION
There is multiple issues:
- in some translations the url is missing or translated
- Entry component does not fallback to english if the
  translated url is missing
- url should probably not be in translations (mostly)

Changed guide buy entry about exchanges to pass link-text,
title and text and hardcode the exchanges url.
Removed in app.json so we don't forget to update it.