### PR TITLE
backend: error on duplicate account name

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -46,9 +46,11 @@ func (e ErrorCode) Error() string {
 
 const (
 	// ErrAccountAlreadyExists is returned if an account is being added which already exists.
-	ErrAccountAlreadyExists ErrorCode = "alreadyExists"
+	ErrAccountAlreadyExists ErrorCode = "accountAlreadyExists"
 	// ErrAccountLimitReached is returned when adding an account if no more accounts can be added.
-	ErrAccountLimitReached ErrorCode = "limitReached"
+	ErrAccountLimitReached ErrorCode = "accountLimitReached"
+	// ErrAccountNameAlreadyExists is returned if an account is being added which already exists.
+	ErrAccountNameAlreadyExists ErrorCode = "accountNameAlreadyExists"
 )
 
 // sortAccounts sorts the accounts in-place by 1) coin 2) account number.
@@ -321,6 +323,11 @@ func (backend *Backend) RenameAccount(accountCode string, name string) error {
 		return errp.New("Name cannot be empty")
 	}
 	return backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
+		for _, account := range accountsConfig.Accounts {
+			if strings.EqualFold(account.Name, name) {
+				return errp.WithStack(ErrAccountNameAlreadyExists)
+			}
+		}
 		for i := range accountsConfig.Accounts {
 			account := &accountsConfig.Accounts[i]
 			if account.Code == accountCode {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -290,7 +290,12 @@ func (backend *Backend) emitAccountsStatusChanged() {
 func (backend *Backend) persistAccount(account config.Account, accountsConfig *config.AccountsConfig) error {
 	for idx := range accountsConfig.Accounts {
 		account2 := &accountsConfig.Accounts[idx]
+		if strings.EqualFold(account.Name, account2.Name) {
+			backend.log.Errorf("An account with same name already exists: %s", account.Name)
+			return errp.WithStack(ErrAccountNameAlreadyExists)
+		}
 		if account.Code == account2.Code {
+			backend.log.Errorf("An account with same code exists: %s", account.Code)
 			return errp.WithStack(ErrAccountAlreadyExists)
 		}
 		if account.CoinCode == account2.CoinCode {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -463,7 +463,7 @@ func (handlers *Handlers) postAddAccountHandler(r *http.Request) (interface{}, e
 	if err != nil {
 		handlers.log.WithError(err).Error("Could not add account")
 		if errCode, ok := errp.Cause(err).(backend.ErrorCode); ok {
-			return response{Success: false, ErrorCode: errCode.Error()}, nil
+			return response{Success: false, ErrorCode: string(errCode)}, nil
 		}
 		return response{Success: false, ErrorMessage: err.Error()}, nil
 	}
@@ -537,12 +537,16 @@ func (handlers *Handlers) postRenameAccountHandler(r *http.Request) (interface{}
 	type response struct {
 		Success      bool   `json:"success"`
 		ErrorMessage string `json:"errorMessage,omitempty"`
+		ErrorCode    string `json:"errorCode,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&jsonBody); err != nil {
 		return response{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	if err := handlers.backend.RenameAccount(jsonBody.AccountCode, jsonBody.Name); err != nil {
+		if errCode, ok := errp.Cause(err).(backend.ErrorCode); ok {
+			return response{Success: false, ErrorCode: string(errCode)}, nil
+		}
 		return response{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	return response{Success: true}, nil

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -26,6 +26,7 @@ export interface ICoin {
 export interface ISuccess {
     success: boolean;
     errorMessage?: string;
+    errorCode?: string;
 }
 
 export const getSupportedCoins = (): Promise<ICoin[]> => {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -44,10 +44,6 @@
       "step": "Name account",
       "title": "Name your account"
     },
-    "error": {
-      "alreadyExists": "The account already exists.",
-      "limitReached": "Cannot add account. The maximum number of accounts for this coin has been reached."
-    },
     "selectCoin": {
       "nextButton": "Next",
       "step": "Select coin",
@@ -617,6 +613,11 @@
     "cancel": "Cancel",
     "confirm": "Confirm",
     "confirmTitle": "Confirmation"
+  },
+  "error": {
+    "accountAlreadyExists": "The account already exists.",
+    "accountLimitReached": "Cannot add account. The maximum number of accounts for this coin has been reached.",
+    "accountNameAlreadyExists": "An account with the same name already exists."
   },
   "exchanges": {
     "method": "Select your payment method",

--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -111,7 +111,7 @@ class AddAccount extends Component<Props, State> {
                             });
                         } else if (data.errorCode) {
                             this.setState({
-                                errorMessage: t(`addAccount.error.${data.errorCode}`)
+                                errorMessage: t(`error.${data.errorCode}`)
                             });
                         } else if (data.errorMessage) {
                             this.setState({

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -219,7 +219,11 @@ class ManageAccounts extends Component<Props, State> {
         backendAPI.renameAccount(editAccountCode!, editAccountNewName!)
             .then(result => {
                 if (!result.success) {
-                    this.setState({ editErrorMessage: result.errorMessage });
+                    if (result.errorCode) {
+                        this.setState({ editErrorMessage: this.props.t(`error.${result.errorCode}`) });
+                    } else if (result.errorMessage) {
+                        this.setState({ editErrorMessage: result.errorMessage });
+                    }
                     return;
                 }
                 return backendAPI.reinitializeAccounts()


### PR DESCRIPTION
To avoid confusion, we disallow adding an account with a name that
another account already has.

We check all accounts, even ones that are not currently visible - we
might show them in the future in watch-only mode.