### PR TITLE
frontend/add-account: automatically suggest name

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -288,6 +288,9 @@ func (backend *Backend) emitAccountsStatusChanged() {
 // persistAccount adds the account information to the accounts database. These accounts are loaded
 // in `initPersistedAccounts()`.
 func (backend *Backend) persistAccount(account config.Account, accountsConfig *config.AccountsConfig) error {
+	if account.Name == "" {
+		return errp.New("Account name cannot be empty")
+	}
 	for idx := range accountsConfig.Accounts {
 		account2 := &accountsConfig.Accounts[idx]
 		if account.Code == account2.Code {

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -21,6 +21,7 @@ export interface ICoin {
     coinCode: CoinCode;
     name: string;
     canAddAccount: boolean;
+    suggestedAccountName: string;
 }
 
 export interface ISuccess {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -38,7 +38,6 @@
     "transactionHistory": "Transaction history"
   },
   "addAccount": {
-    "accountName": "Account name",
     "chooseName": {
       "nextButton": "Add account",
       "step": "Name account",

--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -45,6 +45,7 @@ interface State {
     step: TStep;
     supportedCoins: backendAPI.ICoin[];
     adding: boolean; // true while the backend is working to add the account.
+    accountNamePlaceholder: string;
 }
 
 class AddAccount extends Component<Props, State> {
@@ -56,6 +57,7 @@ class AddAccount extends Component<Props, State> {
         step: 'select-coin',
         supportedCoins: [],
         adding: false,
+        accountNamePlaceholder: '',
     };
 
     private onlyOneSupportedCoin = (): boolean => {
@@ -87,7 +89,7 @@ class AddAccount extends Component<Props, State> {
 
     private next = (e: Event) => {
         e.preventDefault();
-        const { accountCode, accountName, coinCode, step } = this.state;
+        const { accountCode, accountName, accountNamePlaceholder, coinCode, step } = this.state;
         const { t } = this.props;
         switch (step) {
             case 'select-coin':
@@ -103,7 +105,7 @@ class AddAccount extends Component<Props, State> {
                 this.setState({ adding: true });
                 apiPost('account-add', {
                     coinCode,
-                    name: accountName,
+                    name: accountName === '' ? accountNamePlaceholder : accountName,
                 })
                     .then((data: ResponseData) => {
                         this.setState({ adding: false });
@@ -154,12 +156,12 @@ class AddAccount extends Component<Props, State> {
 
     private renderContent = () => {
         const { t } = this.props;
-        const { accountName, coinCode, step, supportedCoins } = this.state;
+        const { accountName, accountNamePlaceholder, coinCode, step, supportedCoins} = this.state;
         switch (step) {
             case 'select-coin':
                 return (
                     <CoinDropDown
-                        onChange={(coinCode) => this.setState({ coinCode })}
+                        onChange={coin => this.setState({ coinCode: coin.coinCode, accountNamePlaceholder: coin.suggestedAccountName })}
                         supportedCoins={supportedCoins}
                         value={coinCode} />
                 );
@@ -170,7 +172,7 @@ class AddAccount extends Component<Props, State> {
                         getRef={this.focusRef}
                         id="accountName"
                         onInput={e => this.setState({ accountName: e.target.value })}
-                        placeholder={t('addAccount.accountName')}
+                        placeholder={accountNamePlaceholder}
                         value={accountName} />
                 );
             case 'success':
@@ -210,7 +212,6 @@ class AddAccount extends Component<Props, State> {
     public render(
         { t }: RenderableProps<Props>,
         {
-            accountName,
             coinCode,
             errorMessage,
             step,
@@ -263,7 +264,7 @@ class AddAccount extends Component<Props, State> {
                                 <Button
                                     disabled={
                                         (step === 'select-coin' && coinCode === 'choose')
-                                        || (step === 'choose-name' && (accountName === '' || adding))
+                                        || (step === 'choose-name' && adding)
                                     }
                                     primary
                                     type="submit">

--- a/frontends/web/src/routes/account/add/components/coin-dropdown.tsx
+++ b/frontends/web/src/routes/account/add/components/coin-dropdown.tsx
@@ -15,13 +15,12 @@
  */
 
 import { h, RenderableProps } from 'preact';
-import * as accountApi from '../../../../api/account';
 import * as backendAPI from '../../../../api/backend';
 import { Select } from '../../../../components/forms';
 import { translate, TranslateProps } from '../../../../decorators/translate';
 
 interface CoinDropDownProps {
-    onChange: (coin: accountApi.CoinCode) => void;
+    onChange: (coin: backendAPI.ICoin) => void;
     supportedCoins: backendAPI.ICoin[];
     value: string;
 }
@@ -43,13 +42,15 @@ function CoinDropDown({
                     disabled: true,
                     value: 'choose',
                 },
-                ...(supportedCoins).map(({ coinCode, name, canAddAccount}) => ({
+                ...(supportedCoins).map(({ coinCode, name, canAddAccount }) => ({
                     value: coinCode,
                     text: name,
                     disabled: !canAddAccount,
                 }))
             ]}
-            onInput={e => onChange(e.target.value)}
+            onInput={e => onChange(supportedCoins.find(c => {
+                return c.coinCode === e.target.value;
+            }) as backendAPI.ICoin)}
             defaultValue={'choose'}
             placeholder={t('buy.info.selectPlaceholder')}
             value={value}


### PR DESCRIPTION
Add it as a placeholder, use it as a default name if none was entered.

The suggested name is the coin name followed by the next account number.