### PR TITLE
frontend: remove error when continuing

### DIFF
--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -79,7 +79,7 @@ class AddAccount extends Component<Props, State> {
     private back = () => {
         switch (this.state.step) {
             case 'choose-name':
-                this.setState({ step: 'select-coin' });
+                this.setState({ step: 'select-coin', errorMessage: undefined });
                 break;
             case 'success':
                 this.setState({ step: 'choose-name' });
@@ -112,6 +112,7 @@ class AddAccount extends Component<Props, State> {
                         if (data.success) {
                             this.setState({
                                 accountCode: data.accountCode,
+                                errorMessage: undefined,
                                 step: 'success'
                             });
                         } else if (data.errorCode) {


### PR DESCRIPTION
There can be error, i.e. account name already in use, the error
currently stays if the user progresses to the next step or is
going back.

Changed to hide the error when progressing with continue or back.