### PR TITLE
backend: undo duplicate account name check

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -49,8 +49,6 @@ const (
 	ErrAccountAlreadyExists ErrorCode = "accountAlreadyExists"
 	// ErrAccountLimitReached is returned when adding an account if no more accounts can be added.
 	ErrAccountLimitReached ErrorCode = "accountLimitReached"
-	// ErrAccountNameAlreadyExists is returned if an account is being added which already exists.
-	ErrAccountNameAlreadyExists ErrorCode = "accountNameAlreadyExists"
 )
 
 // sortAccounts sorts the accounts in-place by 1) coin 2) account number.
@@ -337,11 +335,6 @@ func (backend *Backend) RenameAccount(accountCode string, name string) error {
 		return errp.New("Name cannot be empty")
 	}
 	return backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
-		for _, account := range accountsConfig.Accounts {
-			if strings.EqualFold(account.Name, name) {
-				return errp.WithStack(ErrAccountNameAlreadyExists)
-			}
-		}
 		for i := range accountsConfig.Accounts {
 			account := &accountsConfig.Accounts[i]
 			if account.Code == accountCode {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -293,10 +293,6 @@ func (backend *Backend) persistAccount(account config.Account, accountsConfig *c
 	}
 	for idx := range accountsConfig.Accounts {
 		account2 := &accountsConfig.Accounts[idx]
-		if strings.EqualFold(account.Name, account2.Name) {
-			backend.log.Errorf("An account with same name already exists: %s", account.Name)
-			return errp.WithStack(ErrAccountNameAlreadyExists)
-		}
 		if account.Code == account2.Code {
 			backend.log.Errorf("An account with same code exists: %s", account.Code)
 			return errp.WithStack(ErrAccountAlreadyExists)

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -616,8 +616,7 @@
   },
   "error": {
     "accountAlreadyExists": "The account already exists.",
-    "accountLimitReached": "Cannot add account. The maximum number of accounts for this coin has been reached.",
-    "accountNameAlreadyExists": "An account with the same name already exists."
+    "accountLimitReached": "Cannot add account. The maximum number of accounts for this coin has been reached."
   },
   "exchanges": {
     "method": "Select your payment method",


### PR DESCRIPTION
Doning a global name check did not work as expected. Adding default
accounts with default names can fail if there are already accounts of
the same name (e.g. from a different seed).