### PR TITLE
backend/account/notes: restore transaction notes lost in migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Restore lost transaction notes when ugprading to v4.28.0.
 - Improve error message when EtherScan responds with a rate limit error.
 
 ## 4.28.0 [released 2021-05-27]

--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/notes"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
@@ -84,7 +83,7 @@ type Interface interface {
 	CanVerifyAddresses() (bool, bool, error)
 	VerifyAddress(addressID string) (bool, error)
 
-	Notes() *notes.Notes
+	TxNote(txID string) string
 	// ProposeTxnote stores a note. The note is is persisted in the notes database upon calling
 	// SendTx(). This function must be called before `SendTx()`.
 	ProposeTxNote(string)

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -175,7 +175,7 @@ func (handlers *Handlers) getAccountTransactions(_ *http.Request) (interface{}, 
 			Fee:       feeString,
 			Time:      formattedTime,
 			Addresses: addresses,
-			Note:      handlers.account.Notes().TxNote(txInfo.InternalID),
+			Note:      handlers.account.TxNote(txInfo.InternalID),
 		}
 		switch handlers.account.Coin().(type) {
 		case *btc.Coin:

--- a/backend/signing/legacyconfiguration.go
+++ b/backend/signing/legacyconfiguration.go
@@ -1,0 +1,114 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signing
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+
+	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/jsonp"
+)
+
+// LegacyConfiguration models a signing configuration as it was done up to v4.27.0. From v4.28.0,
+// the configuration format was changed (see `Configuration`). This code remains so that we can
+// still create the `Hash()` over the configurations for migration purposes: the hash was used in
+// account identifiers (changed in v4.28.0), which was used as a key to store transaction
+// notes. This is used to be able to access transaction notes under the old account identifiers.
+type LegacyConfiguration struct {
+	scriptType         ScriptType // Only used in btc and ltc, dummy for eth
+	absoluteKeypath    AbsoluteKeypath
+	extendedPublicKeys []*hdkeychain.ExtendedKey // Should be empty for address based watch only accounts
+	signingThreshold   int                       // TODO Multisig Only
+	address            string                    // For address based accounts only
+}
+
+type legacyConfigurationEncoding struct {
+	ScriptType string          `json:"scriptType"`
+	Keypath    AbsoluteKeypath `json:"keypath"`
+	Threshold  int             `json:"threshold"`
+	Xpubs      []string        `json:"xpubs"`
+	Address    string          `json:"address"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (configuration LegacyConfiguration) MarshalJSON() ([]byte, error) {
+	length := len(configuration.extendedPublicKeys)
+	xpubs := make([]string, length)
+	for i := 0; i < length; i++ {
+		xpubs[i] = configuration.extendedPublicKeys[i].String()
+	}
+	return json.Marshal(&legacyConfigurationEncoding{
+		ScriptType: string(configuration.scriptType),
+		Keypath:    configuration.absoluteKeypath,
+		Threshold:  configuration.signingThreshold,
+		Xpubs:      xpubs,
+		Address:    configuration.address,
+	})
+}
+
+// Hash returns a hash of the configuration in hex format.
+func (configuration *LegacyConfiguration) Hash() string {
+	hash := sha256.Sum256(jsonp.MustMarshal(configuration))
+	return hex.EncodeToString(hash[:])
+}
+
+// LegacyConfigurations is an unordered collection of legacy configurations.
+type LegacyConfigurations []*LegacyConfiguration
+
+// Hash returns a hash of all configurations in hex format. It is defined as
+// `sha256(<32 bytes hash 1>|<32 bytes hash 2>|...)`, where the hashes are first sorted, so
+// changing the order does *not* change the hash.
+func (configs LegacyConfigurations) Hash() string {
+	hashes := make([][]byte, len(configs))
+	for i, cfg := range configs {
+		hash, err := hex.DecodeString(cfg.Hash())
+		if err != nil {
+			panic(errp.WithStack(err))
+		}
+		hashes[i] = hash
+	}
+	sort.Slice(hashes, func(i, j int) bool { return bytes.Compare(hashes[i], hashes[j]) < 0 })
+	h := sha256.New()
+	for _, hash := range hashes {
+		if _, err := h.Write(hash); err != nil {
+			panic(errp.WithStack(err))
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ConvertToLegacyConfigurations converts the new signing configurations format to the legacy format
+// used up to v4.27.0.
+func ConvertToLegacyConfigurations(configurations Configurations) LegacyConfigurations {
+	var result LegacyConfigurations
+	for _, cfg := range configurations {
+		scriptType := ScriptTypeP2PKH // Was used as default for Ethereum
+		if cfg.BitcoinSimple != nil {
+			scriptType = cfg.BitcoinSimple.ScriptType
+		}
+		result = append(result, &LegacyConfiguration{
+			scriptType:         scriptType,
+			absoluteKeypath:    cfg.AbsoluteKeypath(),
+			extendedPublicKeys: []*hdkeychain.ExtendedKey{cfg.ExtendedPublicKey()},
+			signingThreshold:   1,
+		})
+	}
+	return result
+}


### PR DESCRIPTION
Transaction notes are stored in json files named using the account
identifier. In v4.28.0, account identifiers changed as part of the
multi-accounts feature. It used to contain the hash of the signing
configurations. As a result, transaction notes set before were not
shown anymore, as the wrong file was loaded.

This patch restores the legacy transaction notes by loading the legacy
transaction note files.

In v4.27.0, you could have a unified account and split them into
individual accounts (one per signing configuration). Transaction notes
were not shared between these accounts even them. In v4.28.0, we
removed the split-account setting, so we consider notes from split
accounts as well - otherwise they would be lost for good.