### PR TITLE
backend/etherscan: improve error message related to rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+- Improve error message when EtherScan responds with a rate limit error.
+
+## 4.28.0 [released 2021-05-27]
 - Bundle BitBox02 v9.6.0 firmware
 - New feature: add additional accounts
 - Remove the setting 'Separate accounts by address type (legacy behavior)'. BitBox02 accounts are now always unified.


### PR DESCRIPTION
There was a bogus unmarshal error before. Now:

unexpected response: {"status":"0","message":"NOTOK","result":"Max rate limit reached"}