### PR TITLE
frontend: support deactivating account prototype

### DIFF
--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -34,6 +34,11 @@ export const getSupportedCoins = (): Promise<ICoin[]> => {
     return apiGet('supported-coins');
 };
 
+// TODO: implemnt backend
+export const setCoinActive = (accountCode: string, active: boolean): Promise<ISuccess> => {
+    return apiPost('set-coin-active', { accountCode, active });
+};
+
 export const setTokenActive = (accountCode: string, tokenCode: string, active: boolean): Promise<ISuccess> => {
     return apiPost('set-token-active', { accountCode, tokenCode, active });
 };

--- a/frontends/web/src/routes/settings/manage-accounts.css
+++ b/frontends/web/src/routes/settings/manage-accounts.css
@@ -3,7 +3,7 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    justify-content: space-between;
+    justify-content: flex-end;
     min-height: var(--item-height);
     padding: 10px var(--space-half);
 }
@@ -24,6 +24,7 @@
 .acccountLink {
     align-items: center;
     display: flex;
+    flex-grow: 1;
 }
 
 .accountName {}
@@ -33,6 +34,7 @@
     border: none;
     color: var(--color-primary);
     line-height: 2;
+    margin-right: var(--spacing-default);
 }
 
 .accountActive {
@@ -45,7 +47,7 @@
     flex-basis: 100%;
     flex-direction: column;
     flex-wrap: wrap;
-    padding: 0 4px;
+    padding: 0 0 0 4px;
 }
 
 .tokenContainer {

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -121,10 +121,10 @@ class ManageAccounts extends Component<Props, State> {
                         onClick={() => this.setState({ editAccountCode: account.code, editAccountNewName: account.name })}>
                         {t('manageAccounts.editAccount')}
                     </button>
-                    {/* <Toggle
+                    <Toggle
                         checked={active}
                         id={account.code}
-                        onChange={this.toggleFavorAccount} /> */}
+                        onChange={() => this.toggleCoin(account.code, !active)} />
                     {active && account.coinCode === 'eth' ? (
                         <div className={style.tokenSection}>
                             <div className={`${style.tokenContainer} ${tokensVisible ? style.tokenContainerOpen : ''}`}>
@@ -142,6 +142,17 @@ class ManageAccounts extends Component<Props, State> {
                     ) : null}
                 </div>
             );
+        });
+    }
+
+    private toggleCoin = (accountCode: string, active: boolean) => {
+        backendAPI.setCoinActive(accountCode, active).then(({ success, errorMessage }) => {
+            if (success) {
+                this.fetchAccounts();
+                backendAPI.reinitializeAccounts();
+            } else if (errorMessage) {
+                alertUser(errorMessage);
+            }
         });
     }
 


### PR DESCRIPTION
In BBApp 4.27 altcoins could be deactivated by a toggle in
the settings view. With multiaccounts support this got lost,
once an account is created it cannot be removed again.

BIP44 accounts can't technically be deleted, coins would
still be there even if the account is removed. Also remove
could be scary as a user might be affraid that coins could
be lost.

Added toggles to deactivate coins on the manage accounts
view.

TODO:
- backend api set-coin-active
- indicate or warn when deactivating an account that has coins
- add error when the last account is deactivated, at least 1
  account must be active