### PR TITLE
backend/rates: reduce max range during initial backfill to 1 year

### DIFF
--- a/backend/rates/gecko.go
+++ b/backend/rates/gecko.go
@@ -7,6 +7,13 @@ const (
 	coingeckoAPIV3 = "https://api.coingecko.com/api/v3"
 	// A mirror of CoinGecko API specifically for use with BitBoxApp.
 	shiftGeckoMirrorAPIV3 = "https://exchangerates.shiftcrypto.io/api/v3"
+	// The maximum duration the updater is allowed to get exchange rates for
+	// in a single request. If increasing the range, make sure the response
+	// fits into LimitReader in fetchGeckoMarketRange.
+	// Larger range reduces the QPS but increases size and IO time, and may lead
+	// to increased request failures especially with an intermittent connection.
+	// For comparison, a range of 2 years is about 1Mb.
+	maxGeckoRange = 364 * 24 * time.Hour
 )
 
 // apiRateLimit specifies the minimal interval between equally spaced API calls


### PR DESCRIPTION
The fetchGeckoMarketRange limits a single response to 1Mb or 1048576
bytes. It turns out a dataset for 2 years is about 1064916 bytes, as
observed in the logs of our coingecko mirror.

I believe the limits were ok at first but our mirror is now serving
rates at 5min interval data points for any range. Compared to
hourly/daily rates, this is a lot more data which doesn't fit into the
1Mb response limit.

Instead of increasing the response limit, I think it's best to reduce
initial backfill range. It doubles the backfill QPS but makes response
size smaller - faster network roundtrip, less room for failed requests
when internet connection is bad.
