### PR TITLE
frontend/accounts/add: suggested name missing for Bitcoin-only

### DIFF
--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -71,6 +71,9 @@ class AddAccount extends Component<Props, State> {
                     step: onlyOneSupportedCoin ? 'choose-name' : 'select-coin',
                     supportedCoins: coins,
                 });
+                if (onlyOneSupportedCoin) {
+                    this.setState({ accountName: coins[0].suggestedAccountName });
+                }
             });
     }
 


### PR DESCRIPTION
The suggested (default) account name was only set when choosing the
coin from the dropdown. In BitBox02 Bitcoin-only, the default name was missing.