### PR TITLE
frontends/qt: make the libserver build work on go1.16

### DIFF
--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -76,9 +76,9 @@ func backendCall(queryID C.int, s *C.char) {
 
 //export serve
 func serve(
-	pushNotificationsCallback C.pushNotificationsCallback,
-	responseCallback C.responseCallback,
-	notifyUserCallback C.notifyUserCallback,
+	pushNotificationsFn C.pushNotificationsCallback,
+	responseFn C.responseCallback,
+	notifyUserFn C.notifyUserCallback,
 	preferredLocale *C.char,
 ) {
 	log := logging.Get().WithGroup("server")
@@ -122,16 +122,16 @@ func serve(
 		&nativeCommunication{
 			respond: func(queryID int, response string) {
 				cResponse := C.CString(response)
-				C.respond(responseCallback, C.int(queryID), cResponse)
+				C.respond(responseFn, C.int(queryID), cResponse)
 				C.free(unsafe.Pointer(cResponse))
 			},
 			pushNotify: func(msg string) {
-				C.pushNotify(pushNotificationsCallback, C.CString(msg))
+				C.pushNotify(pushNotificationsFn, C.CString(msg))
 			},
 		},
 		&bridgecommon.BackendEnvironment{
 			NotifyUserFunc: func(text string) {
-				C.notifyUser(notifyUserCallback, C.CString(text))
+				C.notifyUser(notifyUserFn, C.CString(text))
 			},
 			DeviceInfosFunc:     usb.DeviceInfos,
 			SystemOpenFunc:      system.Open,


### PR DESCRIPTION
This resolves a CGO-related compile time errors:

    # github.com/digitalbitbox/bitbox-wallet-app/frontends/qt/server
    _cgo_export.c: In function 'serve':
    _cgo_export.c:48:3: error: expected specifier-qualifier-list before 'pushNotificationsCallback'
       pushNotificationsCallback p0;
       ^~~~~~~~~~~~~~~~~~~~~~~~~

The reason is, when a CGO-exported Go function has args matching
the type, even if it's a C type, like so:

     //export serve
    func serve(pushNotificationsCallback C.pushNotificationsCallback)

the C code generated by CGO becomes invalid due to the arg and its type
taking identical name. Here's a snippet example:

    CGO_NO_SANITIZE_THREAD
    void serve(pushNotificationsCallback pushNotificationsCallback, ...)
    {
      __SIZE_TYPE__ _cgo_ctxt = _cgo_wait_runtime_init_done();
      typedef struct {
          pushNotificationsCallback p0;
          responseCallback p1;
          notifyUserCallback p2;
          char* p3;
      } __attribute__((__packed__, __gcc_struct__)) _cgo_argtype;

Note the resulting pushNotificationsCallback.
Simply renaming the arg names resolves the issue.

Unclear when this has changed. Release notes for go1.15 and go1.16
don't seem to include anything about it.
