### PR TITLE
rates: add brl and hkd currencies

### DIFF
--- a/backend/rates/gecko.go
+++ b/backend/rates/gecko.go
@@ -96,6 +96,8 @@ var (
 		"ILS": "ils",
 		"BTC": "btc",
 		"SGD": "sgd",
+		"HKD": "hkd",
+		"BRL": "brl",
 	}
 
 	// Copied from https://api.coingecko.com/api/v3/simple/supported_vs_currencies.
@@ -114,5 +116,7 @@ var (
 		"ils": "ILS",
 		"btc": "BTC",
 		"sgd": "SGD",
+		"hkd": "HKD",
+		"brl": "BRL",
 	}
 )

--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -40,7 +40,7 @@ import (
 const (
 	// Latest rates are fetched for all these (coin, fiat) pairs.
 	simplePriceAllIDs        = "bitcoin,litecoin,ethereum,basic-attention-token,dai,chainlink,maker,sai,usd-coin,tether,0x,wrapped-bitcoin,pax-gold"
-	simplePriceAllCurrencies = "usd,eur,chf,gbp,jpy,krw,cny,rub,cad,aud,ils,btc,sgd"
+	simplePriceAllCurrencies = "usd,eur,chf,gbp,jpy,krw,cny,rub,cad,aud,ils,btc,sgd,hkd,brl"
 )
 
 const interval = time.Minute

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -20,7 +20,7 @@ import { ChartData } from '../routes/account/summary/chart';
 
 export type CoinCode = 'btc' | 'tbtc' | 'ltc' | 'tltc' | 'eth' | 'teth' | 'reth';
 
-export type Fiat = 'AUD' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'ILS' | 'JPY' | 'KRW' | 'RUB' | 'SGD' | 'USD';
+export type Fiat = 'AUD' | 'BRL' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'HKD' | 'ILS' | 'JPY' | 'KRW' | 'RUB' | 'SGD' | 'USD';
 
 export type MainnetCoin = 'BTC' | 'LTC' | 'ETH';
 

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -38,7 +38,7 @@ export interface SharedProps {
     selected: Fiat[];
 }
 
-export const currencies: Fiat[] = ['AUD', 'CAD', 'CHF', 'CNY', 'EUR', 'GBP', 'ILS', 'JPY', 'KRW', 'RUB', 'SGD', 'USD', 'BTC'];
+export const currencies: Fiat[] = ['AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'EUR', 'GBP', 'HKD', 'ILS', 'JPY', 'KRW', 'RUB', 'SGD', 'USD', 'BTC'];
 
 export const store = new Store<SharedProps>({
     rates: undefined,

--- a/frontends/web/test/routes/account/send/feetargets.test.tsx
+++ b/frontends/web/test/routes/account/send/feetargets.test.tsx
@@ -64,11 +64,13 @@ describe('routes/account/send/feetargets', () => {
                     unit: 'ETH',
                     conversions: {
                         AUD: '0.02',
+                        BRL: '12900',
                         CAD: '0.02',
                         CHF: '0.01',
                         CNY: '0.08',
                         EUR: '0.02',
                         GBP: '0.02',
+                        HKD: '19880',
                         ILS: '0.02',
                         JPY: '1.30',
                         KRW: '14.43',


### PR DESCRIPTION
Added Brazilian Real and Hong Kong Dollar requested by users.

CoinGecko api supports both, see
https://api.coingecko.com/api/v3/simple/supported_vs_currencies

Closes https://github.com/digitalbitbox/bitbox-wallet-app/issues/1266