### PR TITLE
frontends/web: more user-friendly messages for first firmware install

### DIFF
--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -29,6 +29,9 @@ interface BitBox02BootloaderProps {
 }
 
 interface LoadedProps {
+    // Indicates whether the device has any firmware already installed on it.
+    // It is considered "erased" if there's no firmware, and it also happens
+    // to be the state in which BitBox02 is shipped to customers.
     erased: boolean;
 }
 
@@ -113,7 +116,12 @@ class BitBox02Bootloader extends Component<Props, State> {
             if (status.upgradeSuccessful) {
                 contents = (
                     <div className="box large">
-                        <p style="margin-bottom: 0;">{t('bb02Bootloader.success', { rebootSeconds: status.rebootSeconds.toString() })}</p>
+                        <p style="margin-bottom: 0;">
+                            {t('bb02Bootloader.success', {
+                                rebootSeconds: status.rebootSeconds.toString(),
+                                context: (erased ? 'install' : ''),
+                            })}
+                        </p>
                     </div>
                 );
             } else {
@@ -121,20 +129,31 @@ class BitBox02Bootloader extends Component<Props, State> {
                 contents = (
                     <div className="box large">
                         <progress value={value} max="100">{value}%</progress>
-                        <p style="margin-bottom: 0;">{t('bootloader.progress', {
-                            progress: value.toString(),
-                        })}</p>
+                        <p style="margin-bottom: 0;">
+                            {t('bootloader.progress', {
+                                progress: value.toString(),
+                                context: (erased ? 'install' : ''),
+                            })}
+                        </p>
                     </div>
                 );
             }
         } else {
             contents = (
                 <div className="box large" style="min-height: 390px">
+                    {erased && (
+                        <div class="subHeaderContainer first">
+                            <div class="subHeader">
+                              <h2>{t('welcome.title')}</h2>
+                              <h3>{t('welcome.getStarted')}</h3>
+                            </div>
+                        </div>
+                    )}
                     <div className="buttons">
                         <Button
                             primary
                             onClick={this.upgradeFirmware}>
-                            {t('bootloader.button')}
+                            {t('bootloader.button', { context: (erased ? 'install' : '') })}
                         </Button>
                         { !erased && (
                             <Button

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -123,7 +123,8 @@
     },
     "flipscreen": "Flip screen",
     "orientation": "Device oriented the wrong way?",
-    "success": "Upgrade successful! Continuing in {{rebootSeconds}} seconds..."
+    "success": "Upgrade successful! Continuing in {{rebootSeconds}} seconds...",
+    "success_install": "Installation successful! Continuing in {{rebootSeconds}} seconds..."
   },
   "bitbox": {
     "error": {
@@ -250,7 +251,9 @@
   },
   "bootloader": {
     "button": "Upgrade firmware now",
+    "button_install": "Install firmware now",
     "progress": "Upgrading: {{progress}}%",
+    "progress_install": "Installing: {{progress}}%",
     "success": "Upgrade successful! Please replug the device. This time, do not touch the button."
   },
   "button": {
@@ -1251,6 +1254,7 @@
     "sendPairing": "Please pair the BitBox to securely verify transaction details. Go to 'Manage device' in the sidebar."
   },
   "welcome": {
+    "getStarted": "Let's get started by installing firmware on your BitBox02.",
     "insertBitBox02": "For the BitBox02, please tap the device to continue.",
     "insertDevice": "Please connect your device to get started",
     "title": "Welcome"


### PR DESCRIPTION
When no firmware is installed, a "upgrade" messages may be confusing.
This commit makes the app display "install" in such cases.

This comes together with a bootloader change in which the same
messaging occurs now: installation vs upgrade.

@thisconnect, not sure if this is the right approach. You tell me.

FYI the bootloader changes are here:
https://github.com/digitalbitbox/bitbox02-firmware/pull/759
