### PR TITLE
aopp: register URI scheme on linux

### DIFF
--- a/frontends/qt/resources/linux/usr/share/applications/bitbox.desktop
+++ b/frontends/qt/resources/linux/usr/share/applications/bitbox.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Type=Application
 Name=BitBoxApp
-Exec=BitBox
+Exec=BitBox %u
 Icon=bitbox
 Comment=Manage your crypto assets
 Categories=Network;Utility;Finance;
 Terminal=false
+MimeType=x-scheme-handler/aopp;


### PR DESCRIPTION
See
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#mime-types

Installing the .deb package automatically registers the scheme based
on this entry in the .desktop file. Manual changes to the desktop file
require calling `sudo update-desktop-database`.