### PR TITLE
backend: allow links to shiftcrypto.support and shiftcrypto.shop

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -63,8 +63,9 @@ var fixedURLWhitelist = []string{
 	// Shift Crypto owned domains.
 	"https://shiftcrypto.ch/",
 	"https://ext.shiftcrypto.ch/",
-	"https://shop.shiftcrypto.ch/",
+	"https://shiftcrypto.shop/",
 	"https://guides.shiftcrypto.ch/",
+	"https://shiftcrypto.support/",
 	// Exchange rates.
 	"https://www.coingecko.com/",
 	"https://www.cryptocompare.com/",


### PR DESCRIPTION
shiftcrypto.support should be allowed so we can slowly move to
the new knowledge base, this will replace guides.shiftcrypto.ch.
Keeping guides as there are still some older links pointing to
it.