### PR TITLE
backend,frontend: implement AOPP workflow

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -41,21 +41,6 @@ const hardenedKeystart uint32 = hdkeychain.HardenedKeyStart
 // limit, but simply use a hard limit for simplicity.
 const accountsHardLimit = 5
 
-// ErrorCode are errors that are represented by an error code. This helps the frontend to translate
-// error messages.
-type ErrorCode string
-
-func (e ErrorCode) Error() string {
-	return string(e)
-}
-
-const (
-	// ErrAccountAlreadyExists is returned if an account is being added which already exists.
-	ErrAccountAlreadyExists ErrorCode = "accountAlreadyExists"
-	// ErrAccountLimitReached is returned when adding an account if no more accounts can be added.
-	ErrAccountLimitReached ErrorCode = "accountLimitReached"
-)
-
 // sortAccounts sorts the accounts in-place by 1) coin 2) account number.
 func sortAccounts(accounts []*config.Account) {
 	compareCoin := func(coin1, coin2 coinpkg.Code) int {

--- a/backend/accounts/address.go
+++ b/backend/accounts/address.go
@@ -14,9 +14,12 @@
 
 package accounts
 
+import "github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
+
 // Address models a blockchain address to which coins can be sent.
 type Address interface {
 	// ID is an identifier for the address.
 	ID() string
 	EncodeForHumans() string
+	AbsoluteKeypath() signing.AbsoluteKeypath
 }

--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -1,0 +1,306 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/observable/action"
+	"github.com/digitalbitbox/bitbox02-api-go/api/firmware"
+)
+
+// aoppCoinMap maps from the asset codes specified by AOPP to our own coin codes.
+var aoppCoinMap = map[string]coinpkg.Code{
+	"btc": coinpkg.CodeBTC,
+	// TODO: add support for ETH
+	// "eth": coinpkg.CodeETH,
+}
+
+type account struct {
+	Name string        `json:"name"`
+	Code accounts.Code `json:"code"`
+}
+
+// aoppState is the current state of an AOPP request. See The values below.
+type aoppState string
+
+const (
+	// The states progress linearly from top to bottom starting at aoppStateInactive. In case of
+	// error, the state goes to aoppStateError.
+
+	// Something went wrong. The frontend is to display an error message based on the `ErrorCode`.
+	aoppStateError aoppState = "error"
+
+	// Nothing is happening, we are waiting for an AOPP request.
+	aoppStateInactive aoppState = "inactive"
+	// No keystore is connected, so we are waiting for the user to insert and unlock their device.
+	aoppStateAwaitingKeystore aoppState = "awaiting-keystore"
+	// Keystore is registered - the user chooses an account from which to get a receive address
+	// from.
+	aoppStateChoosingAccount aoppState = "choosing-account"
+	// The account is still syncing - need to wait for that to finish before we can get a fresh
+	// address.
+	aoppStateSyncing aoppState = "syncing"
+	// The user is prompted to confirm and sign the address on the device.
+	aoppStateSigning aoppState = "signing"
+	// Everything went well, the address and signature was delievered to the AOPP callback.
+	aoppStateSuccess aoppState = "success"
+)
+
+// AOPP holds all the state needed to process an AOPP (Address Ownership Proof Protocol) request.
+type AOPP struct {
+	// State is the current state the request is in. See `aoppState*` for the possible values.
+	State aoppState `json:"state"`
+	// ErrorCode is an "aopp*" error code, see errors.go. Only applies if State == aoppStateError.
+	ErrorCode ErrorCode `json:"errorCode"`
+	// Accounts is the list of accounts the user can choose from. Only applies if State == aoppStateChoosingAccount.
+	Accounts []account `json:"accounts"`
+	// Address that will be delivered to the requesting party via the callback. Only applies if State == aoppStateSigning.
+	Address string `json:"address"`
+	// CallbackHost contains the host of the AOPP callback URL. Available for all states except
+	// aoppStateInactive.
+	CallbackHost string `json:"callbackHost"`
+	// coinCode is the requested asset. Available for all states except aoppStateInactive.
+	coinCode coinpkg.Code
+	// message is the requested message to be signed. Available for all states except
+	// aoppStateInactive.
+	message string
+	// callback is the AOPP callback param. Available for all states except aoppStateInactive.
+	callback string
+}
+
+// AOPP returns the current AOPP state.
+func (backend *Backend) AOPP() AOPP {
+	defer backend.accountsAndKeystoreLock.RLock()()
+	return backend.aopp
+}
+
+// notifyAOPP sends the aopp state to the frontend. `accountsAndKeystoreLock` must be held when
+// calling this function.
+func (backend *Backend) notifyAOPP() {
+	backend.Notify(observable.Event{
+		Subject: "aopp",
+		Action:  action.Replace,
+		Object:  backend.aopp,
+	})
+}
+
+// AOPPCancel resets the aopp state.
+func (backend *Backend) AOPPCancel() {
+	defer backend.accountsAndKeystoreLock.Lock()()
+	backend.aopp = AOPP{State: aoppStateInactive}
+	backend.notifyAOPP()
+}
+
+// aoppSetError pushes an error to the frontend to display. `accountsAndKeystoreLock` must be held
+// when calling this function.
+func (backend *Backend) aoppSetError(err ErrorCode) {
+	backend.aopp.State = aoppStateError
+	backend.aopp.ErrorCode = err
+	backend.notifyAOPP()
+}
+
+// aoppKeystoreRegistered must be called after a keystore is available, to display a list of
+// accounts to choose from. It is called when a keystore is registered, or right away in
+// `handleAOPP()` if a keystore is already registered. `accountsAndKeystoreLock` must be held when
+// calling this function.
+func (backend *Backend) aoppKeystoreRegistered() {
+	if backend.aopp.State != aoppStateAwaitingKeystore {
+		return
+	}
+	if !backend.keystore.CanSignMessage(backend.aopp.coinCode) {
+		backend.aoppSetError(errAOPPUnsupportedKeystore)
+		return
+	}
+	var accounts []account
+	for _, acct := range backend.accounts {
+		if !acct.Config().Active {
+			continue
+		}
+		if acct.Coin().Code() != backend.aopp.coinCode {
+			continue
+		}
+		accounts = append(accounts, account{
+			Name: acct.Config().Name,
+			Code: acct.Config().Code,
+		})
+	}
+
+	if len(accounts) == 0 {
+		backend.aoppSetError(errAOPPNoAccounts)
+		return
+	}
+
+	backend.aopp.Accounts = accounts
+	backend.aopp.State = aoppStateChoosingAccount
+	backend.notifyAOPP()
+}
+
+// handleAOPP handles an AOPP (Address Ownership Proof Protocol) request. See https://aopp.group/.
+func (backend *Backend) handleAOPP(uri url.URL) {
+	defer backend.accountsAndKeystoreLock.Lock()()
+	log := backend.log.WithField("aopp-uri", uri.String())
+	q := uri.Query()
+	backend.aopp.CallbackHost = "<unknown>"
+
+	if q.Get("v") != "0" {
+		log.Error("Can only handle version 0 aopp URIs")
+		backend.aoppSetError(errAOPPVersion)
+		return
+	}
+
+	callback := q.Get("callback")
+	if callback == "" {
+		log.Error("callback param missing")
+		backend.aoppSetError(errAOPPInvalidRequest)
+		return
+	}
+	callbackURL, err := url.Parse(callback)
+	if err != nil {
+		log.WithError(err).Error("Invalid callback")
+		backend.aoppSetError(errAOPPInvalidRequest)
+		return
+	}
+	backend.aopp.CallbackHost = callbackURL.Host
+	backend.aopp.callback = callback
+
+	coinCode, ok := aoppCoinMap[strings.ToLower(q.Get("asset"))]
+	if !ok {
+		log.Error("Unrecognized coin")
+		backend.aoppSetError(errAOPPUnsupportedAsset)
+		return
+	}
+	backend.aopp.coinCode = coinCode
+
+	msg := q.Get("msg")
+	if msg == "" {
+		log.Error("msg param missing")
+		backend.aoppSetError(errAOPPInvalidRequest)
+		return
+	}
+	backend.aopp.message = msg
+
+	backend.aopp.State = aoppStateAwaitingKeystore
+	if backend.keystore == nil {
+		backend.notifyAOPP()
+		return
+	}
+	backend.aoppKeystoreRegistered()
+}
+
+// AOPPChooseAccount is called when an AOPP request is being processed and the user has chosen an
+// account.
+func (backend *Backend) AOPPChooseAccount(code accounts.Code) {
+	defer backend.accountsAndKeystoreLock.Lock()()
+	if backend.aopp.State != aoppStateChoosingAccount {
+		return
+	}
+
+	backend.aopp.State = aoppStateSyncing
+	backend.notifyAOPP()
+
+	log := backend.log.WithField("accountCode", code)
+	var account accounts.Interface
+	for _, acct := range backend.accounts {
+		if acct.Config().Code == code {
+			account = acct
+			break
+		}
+	}
+	if account == nil {
+		backend.log.Error("aopp: could not find account")
+		backend.aoppSetError(errAOPPUnknown)
+		return
+	}
+	if err := account.Initialize(); err != nil {
+		backend.log.
+			WithError(err).
+			WithField("code", account.Config().Code).
+			Error("could not initialize account")
+		backend.aoppSetError(errAOPPUnknown)
+		return
+	}
+
+	unused := account.GetUnusedReceiveAddresses()
+
+	signingConfigIdx := 0 // TODO: use the aopp format hint to choose the signing config.
+	addr := unused[signingConfigIdx][0]
+
+	backend.aopp.Address = addr.EncodeForHumans()
+	backend.aopp.State = aoppStateSigning
+	backend.notifyAOPP()
+
+	var signature []byte
+	switch account.Coin().Code() {
+	case coinpkg.CodeBTC:
+		sig, err := backend.keystore.SignBTCMessage(
+			[]byte(backend.aopp.message),
+			addr.AbsoluteKeypath(),
+			account.Config().SigningConfigurations[signingConfigIdx].ScriptType(),
+		)
+		if err != nil {
+			if firmware.IsErrorAbort(err) {
+				backend.log.WithError(err).Error("user aborted msg signing")
+				backend.aoppSetError(errAOPPSigningAborted)
+				return
+			}
+			backend.log.WithError(err).Error("signing error")
+			backend.aoppSetError(errAOPPUnknown)
+			return
+		}
+		signature = sig
+	default:
+		backend.log.Errorf("unsupported coin: %s", account.Coin().Code())
+		backend.aoppSetError(errAOPPUnknown)
+		return
+	}
+
+	jsonBody, err := json.Marshal(struct {
+		Version   int    `json:"version"`
+		Address   string `json:"address"`
+		Signature []byte `json:"signature"` // is base64 encoded
+	}{
+		Version:   0,
+		Address:   addr.EncodeForHumans(),
+		Signature: signature,
+	})
+	if err != nil {
+		log.WithError(err).Error("JSON error")
+		backend.aoppSetError(errAOPPUnknown)
+		return
+	}
+	resp, err := backend.httpClient.Post(backend.aopp.callback, "application/json", bytes.NewBuffer(jsonBody))
+	if err != nil {
+		log.WithError(err).Error("Error calling callback")
+		backend.aoppSetError(errAOPPCallback)
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusNoContent {
+		log.Errorf("AOPP callback response code is %d, expected %d", resp.StatusCode, 204)
+		backend.aoppSetError(errAOPPCallback)
+		return
+	}
+
+	backend.aopp.State = aoppStateSuccess
+	backend.notifyAOPP()
+}

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -1,0 +1,130 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+	keystoremock "github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/mocks"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/software"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAOPPSuccess(t *testing.T) {
+	// From mnemonic: wisdom minute home employ west tail liquid mad deal catalog narrow mistake
+	rootKey := mustXKey("xprv9s21ZrQH143K3gie3VFLgx8JcmqZNsBcBc6vAdJrsf4bPRhx69U8qZe3EYAyvRWyQdEfz7ZpyYtL8jW2d2Lfkfh6g2zivq8JdZPQqxoxLwB")
+	keystoreHelper := software.NewKeystore(rootKey)
+	dummySignature := []byte(`signature`)
+	const dummyMsg = "message to be signed"
+	const expectedAddress = "bc1qxp6xr63t098rl9udlynrktq00un6vqduzjgua3"
+
+	ks := &keystoremock.KeystoreMock{
+		RootFingerprintFunc: func() ([]byte, error) {
+			return []byte{0x55, 0x055, 0x55, 0x55}, nil
+		},
+		SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
+			return true
+		},
+		SupportsUnifiedAccountsFunc: func() bool {
+			return true
+		},
+		SupportsMultipleAccountsFunc: func() bool {
+			return true
+		},
+		CanSignMessageFunc: func(coinpkg.Code) bool {
+			return true
+		},
+		SignBTCMessageFunc: func(message []byte, keypath signing.AbsoluteKeypath, scriptType signing.ScriptType) ([]byte, error) {
+			require.Equal(t, dummyMsg, string(message))
+			return dummySignature, nil
+		},
+		ExtendedPublicKeyFunc: keystoreHelper.ExtendedPublicKey,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		require.Equal(t,
+			[]string{"application/json"},
+			r.Header["Content-Type"],
+		)
+		body, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		require.JSONEq(t,
+			fmt.Sprintf(`{"version": 0, "address": "%s", "signature": "c2lnbmF0dXJl"}`, expectedAddress),
+			string(body),
+		)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	callback := server.URL
+	aoppURI := fmt.Sprintf("aopp:?v=0&msg=%s&asset=btc&format=any&callback=%s", dummyMsg, callback)
+
+	callbackURL, err := url.Parse(callback)
+	require.NoError(t, err)
+	callbackHost := callbackURL.Host
+
+	require.Equal(t, AOPP{State: aoppStateInactive}, b.AOPP())
+	b.HandleURI(aoppURI)
+	require.Equal(t,
+		AOPP{
+			State:        aoppStateAwaitingKeystore,
+			CallbackHost: callbackHost,
+			coinCode:     coinpkg.CodeBTC,
+			message:      dummyMsg,
+			callback:     callback,
+		},
+		b.AOPP(),
+	)
+
+	b.registerKeystore(ks)
+
+	require.Equal(t,
+		AOPP{
+			State:        aoppStateChoosingAccount,
+			Accounts:     []account{{Name: "Bitcoin", Code: "v0-55555555-btc-0"}},
+			CallbackHost: callbackHost,
+			coinCode:     coinpkg.CodeBTC,
+			message:      dummyMsg,
+			callback:     callback,
+		},
+		b.AOPP(),
+	)
+
+	b.AOPPChooseAccount("v0-55555555-btc-0")
+	require.Equal(t,
+		AOPP{
+			State:        aoppStateSuccess,
+			Accounts:     []account{{Name: "Bitcoin", Code: "v0-55555555-btc-0"}},
+			Address:      expectedAddress,
+			CallbackHost: callbackHost,
+			coinCode:     coinpkg.CodeBTC,
+			message:      dummyMsg,
+			callback:     callback,
+		},
+		b.AOPP(),
+	)
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -17,6 +17,7 @@ package backend
 
 import (
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -154,6 +155,7 @@ type Backend struct {
 	// keystore is nil if no keystore is connected.
 	accounts []accounts.Interface
 	keystore keystore.Keystore
+	aopp     AOPP
 
 	onAccountInit   func(accounts.Interface)
 	onAccountUninit func(accounts.Interface)
@@ -191,6 +193,7 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 		devices:  map[string]device.Interface{},
 		coins:    map[coinpkg.Code]coinpkg.Coin{},
 		accounts: []accounts.Interface{},
+		aopp:     AOPP{State: aoppStateInactive},
 		log:      log,
 	}
 	notifier, err := NewNotifier(filepath.Join(arguments.MainDirectoryPath(), "notifier.db"))
@@ -452,7 +455,6 @@ func (backend *Backend) Start() <-chan interface{} {
 
 	backend.ratesUpdater.StartCurrentRates()
 	backend.configureHistoryExchangeRates()
-
 	return backend.events
 }
 
@@ -500,6 +502,8 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 	}
 
 	backend.initAccounts()
+
+	backend.aoppKeystoreRegistered()
 }
 
 // DeregisterKeystore removes the registered keystore.
@@ -689,6 +693,15 @@ func (backend *Backend) Banners() *banners.Banners {
 // param can be any string, as it is potentially passed without any validation from the calling
 // platform.
 func (backend *Backend) HandleURI(uri string) {
-	// TODO: handle
-	backend.log.Debugf("Handle URI: %s", uri)
+	u, err := url.Parse(uri)
+	if err != nil {
+		backend.log.WithError(err).Warningf("Handling URI failed: %s", uri)
+		return
+	}
+	switch u.Scheme {
+	case "aopp":
+		backend.handleAOPP(*u)
+	default:
+		backend.log.Warningf("Unknown URI scheme: %s", uri)
+	}
 }

--- a/backend/coins/btc/addresses/address.go
+++ b/backend/coins/btc/addresses/address.go
@@ -115,6 +115,11 @@ func (address *AccountAddress) EncodeForHumans() string {
 	return address.EncodeAddress()
 }
 
+// AbsoluteKeypath implements coin.AbsoluteKeypath.
+func (address *AccountAddress) AbsoluteKeypath() signing.AbsoluteKeypath {
+	return address.Configuration.AbsoluteKeypath()
+}
+
 func (address *AccountAddress) isUsed() bool {
 	return address.HistoryStatus != ""
 }

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -154,7 +154,8 @@ func (account *Account) Initialize() error {
 	account.log.Debugf("Opened the database '%s' to persist the transactions.", dbName)
 
 	account.address = Address{
-		Address: crypto.PubkeyToAddress(*account.signingConfiguration.PublicKey().ToECDSA()),
+		Address:         crypto.PubkeyToAddress(*account.signingConfiguration.PublicKey().ToECDSA()),
+		absoluteKeypath: account.signingConfiguration.AbsoluteKeypath(),
 	}
 
 	account.signingConfiguration = signing.NewEthereumConfiguration(

--- a/backend/coins/eth/address.go
+++ b/backend/coins/eth/address.go
@@ -14,11 +14,15 @@
 
 package eth
 
-import "github.com/ethereum/go-ethereum/common"
+import (
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
+	"github.com/ethereum/go-ethereum/common"
+)
 
 // Address holds an Ethereum address and implements coin.Address.
 type Address struct {
 	common.Address
+	absoluteKeypath signing.AbsoluteKeypath
 }
 
 // ID implements coin.Address.
@@ -29,4 +33,9 @@ func (address Address) ID() string {
 // EncodeForHumans implements coin.Address.
 func (address Address) EncodeForHumans() string {
 	return address.Address.Hex()
+}
+
+// AbsoluteKeypath implements coin.Address.
+func (address Address) AbsoluteKeypath() signing.AbsoluteKeypath {
+	return address.absoluteKeypath
 }

--- a/backend/errors.go
+++ b/backend/errors.go
@@ -28,14 +28,21 @@ const (
 	// ErrAccountLimitReached is returned when adding an account if no more accounts can be added.
 	ErrAccountLimitReached ErrorCode = "accountLimitReached"
 
-	// errAoppUnsupportedAsset is returned when an AOPP request is for an asset we don't support AOPP
-	// for.
-	errAoppUnsupportedAsset ErrorCode = "aoppUnsupportedAsset"
-	// errAoppVersion is returned when we cannot handle an AOPP request because we don't support the
+	// errAOPPUnsupportedAsset is returned when an AOPP request is for an asset we don't support
+	// AOPP for.
+	errAOPPUnsupportedAsset ErrorCode = "aoppUnsupportedAsset"
+	// errAOPPVersion is returned when we cannot handle an AOPP request because we don't support the
 	// request version.
-	errAoppVersion ErrorCode = "aoppVersion"
-	// errAoppNoAccounts is returned when there are no available accounts to choose from.
-	errAoppNoAccounts ErrorCode = "aoppNoAccounts"
-	// errAoppCannotSign is returned when the connected keystore does not support signing messages.
-	errAoppCannotSign ErrorCode = "aoppCannotSign"
+	errAOPPVersion        ErrorCode = "aoppVersion"
+	errAOPPInvalidRequest ErrorCode = "aoppInvalidRequest"
+	// errAOPPNoAccounts is returned when there are no available accounts to choose from.
+	errAOPPNoAccounts ErrorCode = "aoppNoAccounts"
+	// errAOPPUnsupportedKeystore is returned when the connected keystore does not support signing messages.
+	errAOPPUnsupportedKeystore ErrorCode = "aoppUnsupportedKeystore"
+	// errAOPPUnknown is returned on unexpected errors that in theory should never happen.
+	errAOPPUnknown ErrorCode = "aoppUnknown"
+	// errAOPPSigningAborted is returned when the user cancels the message signing on the device.
+	errAOPPSigningAborted ErrorCode = "aoppSigningAborted"
+	// errAOPPCallback is returned when there was an error calling the callback in the AOPP request.
+	errAOPPCallback ErrorCode = "aoppCallback"
 )

--- a/backend/errors.go
+++ b/backend/errors.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+// ErrorCode are errors that are represented by an error code. This helps the frontend to translate
+// error messages.
+type ErrorCode string
+
+func (e ErrorCode) Error() string {
+	return string(e)
+}
+
+const (
+	// ErrAccountAlreadyExists is returned if an account is being added which already exists.
+	ErrAccountAlreadyExists ErrorCode = "accountAlreadyExists"
+	// ErrAccountLimitReached is returned when adding an account if no more accounts can be added.
+	ErrAccountLimitReached ErrorCode = "accountLimitReached"
+
+	// errAoppUnsupportedAsset is returned when an AOPP request is for an asset we don't support AOPP
+	// for.
+	errAoppUnsupportedAsset ErrorCode = "aoppUnsupportedAsset"
+	// errAoppVersion is returned when we cannot handle an AOPP request because we don't support the
+	// request version.
+	errAoppVersion ErrorCode = "aoppVersion"
+	// errAoppNoAccounts is returned when there are no available accounts to choose from.
+	errAoppNoAccounts ErrorCode = "aoppNoAccounts"
+	// errAoppCannotSign is returned when the connected keystore does not support signing messages.
+	errAoppCannotSign ErrorCode = "aoppCannotSign"
+)

--- a/frontends/web/src/api/aopp.ts
+++ b/frontends/web/src/api/aopp.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AccountCode } from './account';
+import { apiPost } from '../utils/request';
+
+export interface Account {
+    name: string;
+    code: AccountCode;
+}
+
+export interface Aopp {
+    // See backend/aopp.go for a description of the states.
+    state: 'error' | 'inactive' | 'awaiting-keystore' | 'choosing-account' | 'syncing' | 'signing' | 'success';
+    accounts: Account[];
+    // See backend/errors.go for a description of the errors.
+    errorCode: '' | 'aoppUnsupportedAsset' | 'aoppVersion' | 'aoppInvalidRequest' | 'aoppNoAccounts' | 'aoppUnsupportedKeystore' | 'aoppUnknown' | 'aoppSigningAborted' | 'aoppCallback';
+    address: string;
+    callbackHost: string;
+}
+
+export const cancel = (): Promise<null> => {
+    return apiPost('aopp/cancel');
+};
+
+export const chooseAccount = (accountCode: AccountCode): Promise<null> => {
+    return apiPost('aopp/choose-account', { accountCode });
+};

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CoinCode } from './account';
+import { AccountCode, CoinCode } from './account';
 import { apiGet, apiPost } from '../utils/request';
 
 export interface ICoin {
@@ -34,15 +34,15 @@ export const getSupportedCoins = (): Promise<ICoin[]> => {
     return apiGet('supported-coins');
 };
 
-export const setAccountActive = (accountCode: string, active: boolean): Promise<ISuccess> => {
+export const setAccountActive = (accountCode: AccountCode, active: boolean): Promise<ISuccess> => {
     return apiPost('set-account-active', { accountCode, active });
 };
 
-export const setTokenActive = (accountCode: string, tokenCode: string, active: boolean): Promise<ISuccess> => {
+export const setTokenActive = (accountCode: AccountCode, tokenCode: string, active: boolean): Promise<ISuccess> => {
     return apiPost('set-token-active', { accountCode, tokenCode, active });
 };
 
-export const renameAccount = (accountCode: string, name: string): Promise<ISuccess> => {
+export const renameAccount = (accountCode: AccountCode, name: string): Promise<ISuccess> => {
     return apiPost('rename-account', { accountCode, name });
 };
 

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -24,6 +24,7 @@ import { syncDeviceList } from './api/devicessync';
 import { unsubscribe, UnsubscribeList } from './utils/subscriptions';
 import { ConnectedApp } from './connected';
 import { Alert } from './components/alert/Alert';
+import { Aopp } from './components/aopp/aopp';
 import { Banner } from './components/banner/banner';
 import { Confirm } from './components/confirm/Confirm';
 import { Container } from './components/container/container';
@@ -192,6 +193,7 @@ class App extends Component<Props, State> {
                         <Update />
                         <Banner msgKey="bitbox01" />
                         <MobileDataWarning />
+                        <Aopp />
                         <Container toggleSidebar={this.toggleSidebar} onChange={this.handleRoute}>
                             <Send
                                 path="/account/:code/send"

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { AccountCode } from '../../api/account';
+import * as aoppAPI from '../../api/aopp';
+import { subscribe } from '../../decorators/subscribe';
+import { translate, TranslateProps } from '../../decorators/translate';
+import { Button, Select } from '../forms';
+
+interface State {
+}
+
+interface AoppProps {
+}
+
+interface SubscribedProps {
+    aopp?: aoppAPI.Aopp;
+}
+
+type Props = SubscribedProps & AoppProps & TranslateProps;
+
+class Aopp extends Component<Props, State> {
+    public readonly state: State = {
+        aopp: {
+            state: 'inactive',
+            accounts: [],
+            errorCode: '',
+            address: '',
+            callbackHost: '',
+        },
+    };
+
+    private chooseAccount = (code: AccountCode) => {
+        aoppAPI.chooseAccount(code);
+    }
+
+    public render(
+        { t, aopp }: RenderableProps<Props>,
+    ) {
+        if (!aopp) {
+            return null;
+        }
+        switch (aopp.state) {
+            case 'error':
+                return (
+                    <div>
+                        <p>{ t('aopp.addressRequested', { host: aopp.callbackHost }) }</p>
+                        <p>{ t(`error.${aopp.errorCode}`, { host: aopp.callbackHost }) }</p>
+                        <Button primary onclick={aoppAPI.cancel}>Dismiss</Button>
+                    </div>
+                );
+            case 'inactive':
+                // Inactive, waiting for action.
+                return null;
+            case 'awaiting-keystore':
+                return (
+                    <div>
+                        <p>{ t('aopp.addressRequested', { host: aopp.callbackHost }) }</p>
+                        <p>{ t('aopp.awaitingKeystore') }</p>
+                        <Button primary onclick={aoppAPI.cancel}>Cancel</Button>
+                    </div>
+                );
+            case 'choosing-account': {
+                const options = aopp.accounts.map(account => {
+                    return {
+                        text: account.name,
+                        value: account.code,
+                    };
+                });
+                return (
+                    <div>
+                        <Select
+                            options={[{
+                                text: t('buy.info.selectLabel'),
+                                disabled: true,
+                                value: 'choose',
+                            }, ...options]
+                            }
+                            defaultValue={'choose'}
+                            onChange={e => this.chooseAccount(e.target.value)}
+                            id="account"
+                        />
+                        <Button primary onclick={aoppAPI.cancel}>Cancel</Button>
+                    </div>
+                );
+            }
+            case 'syncing':
+                return <div>Syncing the account, please stand by.</div>;
+            case 'signing':
+                return (
+                    <div>
+                        <p>Address: {aopp.address}</p>
+                        <p>Please confirm on your BitBox.</p>
+                    </div>
+                );
+            case 'success':
+                return (
+                    <div>
+                        <p>Successfully delivered a fresh address to the third party.</p>
+                        <Button primary onclick={aoppAPI.cancel}>Dismiss</Button>
+                    </div>
+                );
+        }
+    }
+}
+
+const subscribeHOC = subscribe<SubscribedProps, AoppProps & TranslateProps>(
+    { aopp: 'aopp' },
+    false,
+    false,
+)(Aopp);
+
+const translateHOC = translate<AoppProps>()(subscribeHOC);
+export { translateHOC as Aopp };

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -62,6 +62,10 @@
     },
     "title": "Add account"
   },
+  "aopp": {
+    "addressRequested": "A receive address was requested by {{host}}.",
+    "awaitingKeystore": "Please insert and unlock your BitBox."
+  },
   "app": {
     "upgrade": "A new version of this app is available! Please upgrade from {{current}} to {{version}}."
   },
@@ -415,7 +419,15 @@
   },
   "error": {
     "accountAlreadyExists": "The account already exists.",
-    "accountLimitReached": "Cannot add account. The maximum number of accounts for this coin has been reached."
+    "accountLimitReached": "Cannot add account. The maximum number of accounts for this coin has been reached.",
+    "aoppCallback": "There was an error delivering the address to {{host}}.",
+    "aoppInvalidRequest": "Invalid request.",
+    "aoppNoAccounts": "There are no available accounts.",
+    "aoppSigningAborted": "Address ownership request cancelled.",
+    "aoppUnknown": "An unknown error occurred.",
+    "aoppUnsupportedAsset": "The asset is not supported.",
+    "aoppUnsupportedKeystore": "The connected device cannot sign messages for this asset.",
+    "aoppVersion": "Unknown version."
   },
   "exchanges": {
     "method": "Select your payment method",


### PR DESCRIPTION
More unit tests to follow. This is a start, but I tried to be as complete as possible. If the concept makes sense, ideally we merge this and iterate with improving the workflow, UI and edge cases.

One can test by going to https://testing.aopp.group/ and clicking the link after installing the app (on macOS: dragging the app to the Applications folder).

You can also copy the link and launch the app on the command line with the aopp URI as the argument, e.g.:

./BitBox 'aopp:?v=0&msg=I+confirm+that+this+Bitcoin+%28BTC%29+address+is+controlled+by+David+Lopez%2C+Poststrasse+22%2C+Zug%2C+Switzerland.+Unique+Identifier%3A+b83762dfbd8696a&asset=btc&format=any&callback=https%3A%2F%2Ftesting.21analytics.ch%2Fproofs%2F3730c437-4c4a-4364-8e7c-1b5a84b039f2'

@thisconnect to iteratively develop with `make webdev`, I used this patch in the backend to invoke the AOPP workflow a few seconds after the backend starts: https://github.com/benma/bitbox-wallet-app/commit/0529615c76c1cb6f2845ef6b9fe4a6aeee171269
