### PR TITLE
backend/aopp: support ETH requests

### DIFF
--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -237,3 +237,8 @@ func (keystore *keystore) CanSignMessage(coin.Code) bool {
 func (keystore *keystore) SignBTCMessage(message []byte, keypath signing.AbsoluteKeypath, scriptType signing.ScriptType) ([]byte, error) {
 	return nil, errp.New("unsupported")
 }
+
+// SignETHMessage implements keystore.Keystore.
+func (keystore *keystore) SignETHMessage(message []byte, keypath signing.AbsoluteKeypath) ([]byte, error) {
+	return nil, errp.New("unsupported")
+}

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -453,7 +453,7 @@ func (keystore *keystore) SignTransaction(proposedTx interface{}) error {
 
 // CanSignMessage implements keystore.Keystore.
 func (keystore *keystore) CanSignMessage(code coin.Code) bool {
-	return code == coin.CodeBTC
+	return code == coin.CodeBTC || code == coin.CodeETH
 }
 
 // SignBTCMessage implements keystore.Keystore.
@@ -471,4 +471,9 @@ func (keystore *keystore) SignBTCMessage(message []byte, keypath signing.Absolut
 		message,
 	)
 	return electrum65, err
+}
+
+// SignETHMessage implements keystore.Keystore.
+func (keystore *keystore) SignETHMessage(message []byte, keypath signing.AbsoluteKeypath) ([]byte, error) {
+	return keystore.device.ETHSignMessage(messages.ETHCoin_ETH, keypath.ToUInt32(), message)
 }

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -90,6 +90,10 @@ type Keystore interface {
 	// required to compute and verify the address. The returned signature is a 65 byte signature in
 	// Electrum format.
 	SignBTCMessage(message []byte, keypath signing.AbsoluteKeypath, scriptType signing.ScriptType) ([]byte, error)
+	// SignETHMessage signs the message using thep rivate key at the keypath. The result contains a
+	// 65 byte signature. The first 64 bytes are the secp256k1 signature in / compact format (R and
+	// S values), and the last byte is the recoverable id (recid).
+	SignETHMessage(message []byte, keypath signing.AbsoluteKeypath) ([]byte, error)
 
 	// SignTransaction signs the given transaction proposal. Returns ErrSigningAborted if the user
 	// aborts.

--- a/backend/keystore/mocks/keystore.go
+++ b/backend/keystore/mocks/keystore.go
@@ -18,6 +18,7 @@ var (
 	lockKeystoreMockExtendedPublicKey          sync.RWMutex
 	lockKeystoreMockRootFingerprint            sync.RWMutex
 	lockKeystoreMockSignBTCMessage             sync.RWMutex
+	lockKeystoreMockSignETHMessage             sync.RWMutex
 	lockKeystoreMockSignTransaction            sync.RWMutex
 	lockKeystoreMockSupportsAccount            sync.RWMutex
 	lockKeystoreMockSupportsCoin               sync.RWMutex
@@ -55,6 +56,9 @@ var _ keystore.Keystore = &KeystoreMock{}
 //             },
 //             SignBTCMessageFunc: func(message []byte, keypath signing.AbsoluteKeypath, scriptType signing.ScriptType) ([]byte, error) {
 // 	               panic("mock out the SignBTCMessage method")
+//             },
+//             SignETHMessageFunc: func(message []byte, keypath signing.AbsoluteKeypath) ([]byte, error) {
+// 	               panic("mock out the SignETHMessage method")
 //             },
 //             SignTransactionFunc: func(in1 interface{}) error {
 // 	               panic("mock out the SignTransaction method")
@@ -104,6 +108,9 @@ type KeystoreMock struct {
 
 	// SignBTCMessageFunc mocks the SignBTCMessage method.
 	SignBTCMessageFunc func(message []byte, keypath signing.AbsoluteKeypath, scriptType signing.ScriptType) ([]byte, error)
+
+	// SignETHMessageFunc mocks the SignETHMessage method.
+	SignETHMessageFunc func(message []byte, keypath signing.AbsoluteKeypath) ([]byte, error)
 
 	// SignTransactionFunc mocks the SignTransaction method.
 	SignTransactionFunc func(in1 interface{}) error
@@ -162,6 +169,13 @@ type KeystoreMock struct {
 			Keypath signing.AbsoluteKeypath
 			// ScriptType is the scriptType argument value.
 			ScriptType signing.ScriptType
+		}
+		// SignETHMessage holds details about calls to the SignETHMessage method.
+		SignETHMessage []struct {
+			// Message is the message argument value.
+			Message []byte
+			// Keypath is the keypath argument value.
+			Keypath signing.AbsoluteKeypath
 		}
 		// SignTransaction holds details about calls to the SignTransaction method.
 		SignTransaction []struct {
@@ -391,6 +405,41 @@ func (mock *KeystoreMock) SignBTCMessageCalls() []struct {
 	lockKeystoreMockSignBTCMessage.RLock()
 	calls = mock.calls.SignBTCMessage
 	lockKeystoreMockSignBTCMessage.RUnlock()
+	return calls
+}
+
+// SignETHMessage calls SignETHMessageFunc.
+func (mock *KeystoreMock) SignETHMessage(message []byte, keypath signing.AbsoluteKeypath) ([]byte, error) {
+	if mock.SignETHMessageFunc == nil {
+		panic("KeystoreMock.SignETHMessageFunc: method is nil but Keystore.SignETHMessage was just called")
+	}
+	callInfo := struct {
+		Message []byte
+		Keypath signing.AbsoluteKeypath
+	}{
+		Message: message,
+		Keypath: keypath,
+	}
+	lockKeystoreMockSignETHMessage.Lock()
+	mock.calls.SignETHMessage = append(mock.calls.SignETHMessage, callInfo)
+	lockKeystoreMockSignETHMessage.Unlock()
+	return mock.SignETHMessageFunc(message, keypath)
+}
+
+// SignETHMessageCalls gets all the calls that were made to SignETHMessage.
+// Check the length with:
+//     len(mockedKeystore.SignETHMessageCalls())
+func (mock *KeystoreMock) SignETHMessageCalls() []struct {
+	Message []byte
+	Keypath signing.AbsoluteKeypath
+} {
+	var calls []struct {
+		Message []byte
+		Keypath signing.AbsoluteKeypath
+	}
+	lockKeystoreMockSignETHMessage.RLock()
+	calls = mock.calls.SignETHMessage
+	lockKeystoreMockSignETHMessage.RUnlock()
 	return calls
 }
 

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -244,3 +244,8 @@ func (keystore *Keystore) CanSignMessage(coin.Code) bool {
 func (keystore *Keystore) SignBTCMessage(message []byte, keypath signing.AbsoluteKeypath, scriptType signing.ScriptType) ([]byte, error) {
 	return nil, errp.New("unsupported")
 }
+
+// SignETHMessage implements keystore.Keystore.
+func (keystore *Keystore) SignETHMessage(message []byte, keypath signing.AbsoluteKeypath) ([]byte, error) {
+	return nil, errp.New("unsupported")
+}


### PR DESCRIPTION
Can test with https://testing.aopp.group/?asset=eth, but only after the site is updated a little later today - ~currently it has a bug in ETH signature verification that will be fixed.~ currently we don't know if the recoverable id in Ethereum Signed messages should be offset by 27 or not (MEW [accepts both](https://github.com/MyEtherWallet/MyEtherWallet/blob/052f697f3b269db4378f331dbb89d24b406bb7c7/src/components/VerifyMessageInput/VerifyMessageInput.vue#L118)) the AOPP demo site expects it currently)