### PR TITLE
frontend/bitbox02: add button to go to startup settings

### DIFF
--- a/backend/devices/bitbox02/handlers/handlers.go
+++ b/backend/devices/bitbox02/handlers/handlers.go
@@ -51,6 +51,7 @@ type BitBox02 interface {
 	ShowMnemonic() error
 	RestoreFromMnemonic() error
 	Product() bitbox02common.Product
+	GotoStartupSettings() error
 }
 
 // Handlers provides a web API to the Bitbox.
@@ -86,6 +87,7 @@ func NewHandlers(
 	handleFunc("/reset", handlers.postResetHandler).Methods("POST")
 	handleFunc("/show-mnemonic", handlers.postShowMnemonicHandler).Methods("POST")
 	handleFunc("/restore-from-mnemonic", handlers.postRestoreFromMnemonicHandler).Methods("POST")
+	handleFunc("/goto-startup-settings", handlers.postGotoStartupSettings).Methods("POST")
 	return handlers
 }
 
@@ -297,6 +299,14 @@ func (handlers *Handlers) postShowMnemonicHandler(_ *http.Request) (interface{},
 
 func (handlers *Handlers) postRestoreFromMnemonicHandler(_ *http.Request) (interface{}, error) {
 	err := handlers.device.RestoreFromMnemonic()
+	if err != nil {
+		return maybeBB02Err(err, handlers.log), nil
+	}
+	return map[string]interface{}{"success": true}, nil
+}
+
+func (handlers *Handlers) postGotoStartupSettings(_ *http.Request) (interface{}, error) {
+	err := handlers.device.GotoStartupSettings()
 	if err != nil {
 		return maybeBB02Err(err, handlers.log), nil
 	}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -154,6 +154,10 @@
       "placeholder": "New device name",
       "title": "Set BitBox02 name"
     },
+    "gotoStartupSettings": {
+      "description": "This will reboot your BitBox02 and enter the startup settings.",
+      "title": "Go to startup settings"
+    },
     "mnemonicPassphrase": {
       "description": "This allows you to enter an optional passphrase after unlocking your BitBox02.\n\n<strong>NOTE:</strong> any passphrase derives a new separate wallet.\nKeep your passphrase <strong>secure</strong>.\n<strong>A loss of the passphrase is NOT RECOVERABLE.</strong>",
       "disable": "Disable optional passphrase",

--- a/frontends/web/src/routes/device/bitbox02/gotostartupsettings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/gotostartupsettings.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, h, RenderableProps } from 'preact';
+import { translate, TranslateProps } from '../../../decorators/translate';
+import { apiPost } from '../../../utils/request';
+import { SettingsButton } from '../../../components/settingsButton/settingsButton';
+import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
+
+interface GotoStartupSettingsProps {
+    apiPrefix: string;
+}
+
+type Props = GotoStartupSettingsProps & TranslateProps;
+
+interface State {
+    isConfirming: boolean;
+}
+
+class GotoStartupSettings extends Component<Props, State> {
+    public readonly state: State = {
+        isConfirming: false,
+    };
+
+    private gotoStartupSettings = (): void => {
+        this.setState({ isConfirming: true });
+        apiPost(this.props.apiPrefix + '/goto-startup-settings').then(() => {
+            this.setState({ isConfirming: false });
+        });
+    }
+
+    public render(
+        { t }: RenderableProps<Props>,
+        { isConfirming }: State) {
+        return (
+            <div>
+                <SettingsButton
+                    onClick={this.gotoStartupSettings}>
+                    {t('bitbox02Settings.gotoStartupSettings.title')}
+                </SettingsButton>
+                {
+                    isConfirming && (
+                        <WaitDialog
+                            title={t('bitbox02Settings.gotoStartupSettings.title')} >
+                            {t('bitbox02Settings.gotoStartupSettings.description')}
+                        </WaitDialog>
+                    )
+                }
+            </div>
+        );
+    }
+}
+
+const HOC = translate<GotoStartupSettingsProps>()(GotoStartupSettings);
+export { HOC as GotoStartupSettings };

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -22,6 +22,7 @@ import { Footer } from '../../../components/layout';
 import { Header } from '../../../components/layout/header';
 import { SettingsButton } from '../../../components/settingsButton/settingsButton';
 import { SettingsItem } from '../../../components/settingsButton/settingsItem';
+import { GotoStartupSettings } from './gotostartupsettings';
 import { MnemonicPassphraseButton } from './mnemonicpassphrase';
 import { Reset } from './reset';
 import { SetDeviceName } from './setdevicename';
@@ -149,6 +150,7 @@ class Settings extends Component<Props, State> {
                                                 apiPrefix={this.apiPrefix()}
                                                 mnemonicPassphraseEnabled={deviceInfo.mnemonicPassphraseEnabled}
                                                 getInfo={this.getInfo} />
+                                            <GotoStartupSettings apiPrefix={this.apiPrefix()} />
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
So users can toggle the startup firmware hash display.

The acutal bootloader page in the app needs to be improved to not show
the firmware upgrade if it is already up to date. This follows in
another commit.