### PR TITLE
frontend/bitbox02/bootloader: don't show upgrade if there is no upgrade

### DIFF
--- a/backend/devices/bitbox02bootloader/handlers/handlers.go
+++ b/backend/devices/bitbox02bootloader/handlers/handlers.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox02bootloader"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox02-api-go/api/bootloader"
 	"github.com/gorilla/mux"
@@ -31,7 +32,7 @@ type BitBox02Bootloader interface {
 	Reboot() error
 	ShowFirmwareHashEnabled() (bool, error)
 	SetShowFirmwareHashEnabled(bool) error
-	Erased() (bool, error)
+	VersionInfo() (*bitbox02bootloader.VersionInfo, error)
 	ScreenRotate() error
 }
 
@@ -53,7 +54,7 @@ func NewHandlers(
 	handleFunc("/reboot", handlers.postRebootHandler).Methods("POST")
 	handleFunc("/show-firmware-hash-enabled", handlers.getShowFirmwareHashEnabledHandler).Methods("GET")
 	handleFunc("/set-firmware-hash-enabled", handlers.postSetShowFirmwareHashEnabledHandler).Methods("POST")
-	handleFunc("/erased", handlers.getErasedHandler).Methods("GET")
+	handleFunc("/version-info", handlers.getVersionInfoHandler).Methods("GET")
 	handleFunc("/screen-rotate", handlers.postScreenRotateHandler).Methods("POST")
 
 	return handlers
@@ -96,8 +97,8 @@ func (handlers *Handlers) postSetShowFirmwareHashEnabledHandler(r *http.Request)
 	return nil, handlers.device.SetShowFirmwareHashEnabled(enabled)
 }
 
-func (handlers *Handlers) getErasedHandler(_ *http.Request) (interface{}, error) {
-	return handlers.device.Erased()
+func (handlers *Handlers) getVersionInfoHandler(_ *http.Request) (interface{}, error) {
+	return handlers.device.VersionInfo()
 }
 
 func (handlers *Handlers) postScreenRotateHandler(_ *http.Request) (interface{}, error) {

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -29,10 +29,14 @@ interface BitBox02BootloaderProps {
 }
 
 interface LoadedProps {
-    // Indicates whether the device has any firmware already installed on it.
-    // It is considered "erased" if there's no firmware, and it also happens
-    // to be the state in which BitBox02 is shipped to customers.
-    erased: boolean;
+    versionInfo: {
+        // Indicates whether the device has any firmware already installed on it.
+        // It is considered "erased" if there's no firmware, and it also happens
+        // to be the state in which BitBox02 is shipped to customers.
+        erased: boolean;
+        // Indicates whether the user can install/upgrade firmware.
+        canUpgrade: boolean;
+    };
 }
 
 type Props = BitBox02BootloaderProps & LoadedProps & TranslateProps;
@@ -106,7 +110,7 @@ class BitBox02Bootloader extends Component<Props, State> {
     public render(
         { t,
           deviceID,
-          erased,
+          versionInfo,
         }: RenderableProps<Props>,
         { status,
         }: State,
@@ -119,7 +123,7 @@ class BitBox02Bootloader extends Component<Props, State> {
                         <p style="margin-bottom: 0;">
                             {t('bb02Bootloader.success', {
                                 rebootSeconds: status.rebootSeconds.toString(),
-                                context: (erased ? 'install' : ''),
+                                context: (versionInfo.erased ? 'install' : ''),
                             })}
                         </p>
                     </div>
@@ -132,7 +136,7 @@ class BitBox02Bootloader extends Component<Props, State> {
                         <p style="margin-bottom: 0;">
                             {t('bootloader.progress', {
                                 progress: value.toString(),
-                                context: (erased ? 'install' : ''),
+                                context: (versionInfo.erased ? 'install' : ''),
                             })}
                         </p>
                     </div>
@@ -141,7 +145,7 @@ class BitBox02Bootloader extends Component<Props, State> {
         } else {
             contents = (
                 <div className="box large" style="min-height: 390px">
-                    {erased && (
+                    {versionInfo.erased && (
                         <div class="subHeaderContainer first">
                             <div class="subHeader">
                               <h2>{t('welcome.title')}</h2>
@@ -153,9 +157,9 @@ class BitBox02Bootloader extends Component<Props, State> {
                         <Button
                             primary
                             onClick={this.upgradeFirmware}>
-                            {t('bootloader.button', { context: (erased ? 'install' : '') })}
+                            {t('bootloader.button', { context: (versionInfo.erased ? 'install' : '') })}
                         </Button>
-                        { !erased && (
+                        { !versionInfo.erased && (
                             <Button
                                 transparent
                                 onClick={this.reboot}>
@@ -194,6 +198,6 @@ class BitBox02Bootloader extends Component<Props, State> {
     }
 }
 
-const loadHOC = load<LoadedProps, BitBox02BootloaderProps & TranslateProps>(({ deviceID }) => ({ erased: 'devices/bitbox02-bootloader/' + deviceID + '/erased' }))(BitBox02Bootloader);
+const loadHOC = load<LoadedProps, BitBox02BootloaderProps & TranslateProps>(({ deviceID }) => ({ versionInfo: 'devices/bitbox02-bootloader/' + deviceID + '/version-info' }))(BitBox02Bootloader);
 const HOC = translate<BitBox02BootloaderProps>()(loadHOC);
 export { HOC as BitBox02Bootloader };

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -154,16 +154,18 @@ class BitBox02Bootloader extends Component<Props, State> {
                         </div>
                     )}
                     <div className="buttons">
-                        <Button
-                            primary
-                            onClick={this.upgradeFirmware}>
-                            {t('bootloader.button', { context: (versionInfo.erased ? 'install' : '') })}
-                        </Button>
+                        { versionInfo.canUpgrade ? (
+                            <Button
+                                primary
+                                onClick={this.upgradeFirmware}>
+                                {t('bootloader.button', { context: (versionInfo.erased ? 'install' : '') })}
+                            </Button>
+                            ) : null }
                         { !versionInfo.erased && (
                             <Button
                                 transparent
                                 onClick={this.reboot}>
-                                {t('bb02Bootloader.abort')}
+                                {t('bb02Bootloader.abort', { context: !versionInfo.canUpgrade ? 'noUpgrade' : '' })}
                             </Button>
                         )}
                     </div>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -123,6 +123,7 @@
   },
   "bb02Bootloader": {
     "abort": "Don't upgrade – take me back",
+    "abort_noUpgrade": "Take me back",
     "advanced": {
       "label": "Advanced settings",
       "toggleShowFirmwareHash": "Show the firmware hash every time on startup"


### PR DESCRIPTION
If 'Go to startup settings' is clicked but there is no firmware upgrade to be done, the button to upgrade should not be shown.