### PR TITLE
frontend/aopp: remove unused/wrong state

### DIFF
--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -34,16 +34,6 @@ interface SubscribedProps {
 type Props = SubscribedProps & AoppProps & TranslateProps;
 
 class Aopp extends Component<Props, State> {
-    public readonly state: State = {
-        aopp: {
-            state: 'inactive',
-            accounts: [],
-            errorCode: '',
-            address: '',
-            callbackHost: '',
-        },
-    };
-
     private chooseAccount = (code: AccountCode) => {
         aoppAPI.chooseAccount(code);
     }


### PR DESCRIPTION
Was a leftover from a previous version before putting the state into
the SubscribedProps.