### PR TITLE
backend/aopp: add user-approval state 

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -98,6 +98,7 @@ type Backend interface {
 	RenameAccount(accountCode accounts.Code, name string) error
 	AOPP() backend.AOPP
 	AOPPCancel()
+	AOPPApprove()
 	AOPPChooseAccount(code accounts.Code)
 }
 
@@ -201,6 +202,7 @@ func NewHandlers(
 	getAPIRouter(apiRouter)("/exchange/moonpay/buy/{code}", handlers.getExchangeMoonpayBuy).Methods("GET")
 	getAPIRouter(apiRouter)("/aopp", handlers.getAOPPHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/aopp/cancel", handlers.postAOPPCancelHandler).Methods("POST")
+	getAPIRouter(apiRouter)("/aopp/approve", handlers.postAOPPApproveHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/aopp/choose-account", handlers.postAOPPChooseAccountHandler).Methods("POST")
 
 	devicesRouter := getAPIRouter(apiRouter.PathPrefix("/devices").Subrouter())
@@ -975,5 +977,10 @@ func (handlers *Handlers) postAOPPChooseAccountHandler(r *http.Request) (interfa
 
 func (handlers *Handlers) postAOPPCancelHandler(r *http.Request) (interface{}, error) {
 	handlers.backend.AOPPCancel()
+	return nil, nil
+}
+
+func (handlers *Handlers) postAOPPApproveHandler(r *http.Request) (interface{}, error) {
+	handlers.backend.AOPPApprove()
 	return nil, nil
 }

--- a/frontends/web/src/api/aopp.ts
+++ b/frontends/web/src/api/aopp.ts
@@ -24,7 +24,7 @@ export interface Account {
 
 export interface Aopp {
     // See backend/aopp.go for a description of the states.
-    state: 'error' | 'inactive' | 'awaiting-keystore' | 'choosing-account' | 'syncing' | 'signing' | 'success';
+    state: 'error' | 'inactive' | 'user-approval' | 'awaiting-keystore' | 'choosing-account' | 'syncing' | 'signing' | 'success';
     accounts: Account[];
     // See backend/errors.go for a description of the errors.
     errorCode: '' | 'aoppUnsupportedAsset' | 'aoppVersion' | 'aoppInvalidRequest' | 'aoppNoAccounts' | 'aoppUnsupportedKeystore' | 'aoppUnknown' | 'aoppSigningAborted' | 'aoppCallback';
@@ -34,6 +34,10 @@ export interface Aopp {
 
 export const cancel = (): Promise<null> => {
     return apiPost('aopp/cancel');
+};
+
+export const approve = (): Promise<null> => {
+    return apiPost('aopp/approve');
 };
 
 export const chooseAccount = (accountCode: AccountCode): Promise<null> => {

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -56,6 +56,16 @@ class Aopp extends Component<Props, State> {
             case 'inactive':
                 // Inactive, waiting for action.
                 return null;
+            case 'user-approval':
+                return (
+                    <div>
+                        <p>{ t('aopp.addressRequested', { host: aopp.callbackHost }) }</p>
+                        <p>Do you want to continue?</p>
+                        <Button onclick={aoppAPI.cancel}>Cancel</Button>
+                        <Button primary onclick={aoppAPI.approve}>Continue</Button>
+                    </div>
+                );
+
             case 'awaiting-keystore':
                 return (
                     <div>


### PR DESCRIPTION
If an AOPP link is clicked while no BitBox is connected, we do as
before and ask the user to insert and unlock.

However, if the BitBox is already inserted and unlocked, we don't want
a link click to immediately go to the account-chooser, but have an
intro dialog first asking the user if they want to proceed.

Builds on https://github.com/digitalbitbox/bitbox-wallet-app/pull/1365