### PR TITLE
frontend: prevent flicker when unlocking the device

### DIFF
--- a/frontends/web/src/routes/account/summary/accountssummary.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.css
@@ -62,6 +62,11 @@
     white-space: nowrap;
 }
 
+.table tr td.loadingAccounts {
+    color: var(--color-gray);
+    text-align: center;
+}
+
 .table tfoot th,
 .table tfoot td {
     background-color: var(--color-mediumgray);

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -244,7 +244,11 @@ class AccountsSummary extends Component<Props, State> {
                                         { accounts.length > 0 ? (
                                             accounts.map(account => this.balanceRow(account))
                                         ) : (
-                                            <p>{t('accountSummary.noAccount')}</p>
+                                            <tr>
+                                                <td colSpan={3} className={style.loadingAccounts}>
+                                                    {t('loading')}
+                                                </td>
+                                            </tr>
                                         )}
                                     </tbody>
                                     {(data && data.chartTotal) ? (

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -195,8 +195,7 @@ class BitBox02 extends Component<Props, State> {
                 errorText: undefined,
             });
             if (status === 'initialized' && unlockOnly && showWizard) {
-                // bitbox is unlocked, now route to / and wait for incoming accounts
-                route('/', true);
+                route('/account-summary', true);
             }
         });
     }


### PR DESCRIPTION
The BBApp did route back to / after unlocking the device, that
caused a quick flicker because it rendered the waiting view one
more time.

Unlocking can directly be routed to account-summary view, to
prevent flickering.

- removed noAccount on account summary in favor of loading msg
- updated buy.info.noAccount wording

TODO: update locize