### PR TITLE
frontend: fix tx progress icon

### DIFF
--- a/frontends/web/src/components/progressRing/progressRing.tsx
+++ b/frontends/web/src/components/progressRing/progressRing.tsx
@@ -43,6 +43,7 @@ const ProgressRing = ({
             className={[style.container, className ? className : ''].join(' ')}
             width={width}
             height={width}
+            style={{ minWidth: width }}
             viewBox={`0 0 ${width} ${width}`}>
             <circle
                 className={style.background}


### PR DESCRIPTION
Some longer tx statusText translations pushed the progress
ring icon, so that it was rendered smaller than the specified width.
This only happens in a app size that sows the tx overview as table.

Added an inline style to set a min-width and prevent longer
texts shrinking the icon. Longer statusText will overlap slightly
on the right side.