### PR TITLE
backend/aopp: always start with aoppStateUserApproval

### DIFF
--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -60,8 +60,8 @@ const (
 
 	// Nothing is happening, we are waiting for an AOPP request.
 	aoppStateInactive aoppState = "inactive"
-	// The user is prompted to continue or cancel a new AOPP request. This state is skipped if there
-	// is no connected keystore, in which case we go straight to aoppStateAwaitingKeystore.
+	// The user is prompted to continue or cancel a new AOPP request. This is always the first state
+	// when a new AOPP request is is handled.
 	aoppStateUserApproval aoppState = "user-approval"
 	// No keystore is connected, so we are waiting for the user to insert and unlock their
 	// device. This state is skipped if a keystore already exists.
@@ -231,11 +231,6 @@ func (backend *Backend) handleAOPP(uri url.URL) {
 
 	backend.aopp.format = q.Get("format")
 
-	if backend.keystore == nil {
-		backend.aopp.State = aoppStateAwaitingKeystore
-		backend.notifyAOPP()
-		return
-	}
 	backend.aopp.State = aoppStateUserApproval
 	backend.notifyAOPP()
 }

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -161,6 +161,19 @@ func TestAOPPSuccess(t *testing.T) {
 			b.HandleURI("aopp:?" + params.Encode())
 			require.Equal(t,
 				AOPP{
+					State:        aoppStateUserApproval,
+					CallbackHost: callbackHost,
+					coinCode:     test.coinCode,
+					format:       test.format,
+					message:      dummyMsg,
+					callback:     callback,
+				},
+				b.AOPP(),
+			)
+
+			b.AOPPApprove()
+			require.Equal(t,
+				AOPP{
 					State:        aoppStateAwaitingKeystore,
 					CallbackHost: callbackHost,
 					coinCode:     test.coinCode,
@@ -318,6 +331,7 @@ func TestAOPPFailures(t *testing.T) {
 		defer b.Close()
 		params := defaultParams()
 		b.HandleURI("aopp:?" + params.Encode())
+		b.AOPPApprove()
 		ks2 := ks
 		ks2.CanSignMessageFunc = func(coinpkg.Code) bool {
 			return false
@@ -343,6 +357,7 @@ func TestAOPPFailures(t *testing.T) {
 		params := defaultParams()
 		params.Set("format", "p2pkh")
 		b.HandleURI("aopp:?" + params.Encode())
+		b.AOPPApprove()
 		b.registerKeystore(&ks)
 		require.Equal(t, aoppStateError, b.AOPP().State)
 		require.Equal(t, errAOPPUnsupportedFormat, b.AOPP().ErrorCode)
@@ -352,6 +367,7 @@ func TestAOPPFailures(t *testing.T) {
 		defer b.Close()
 		params := defaultParams()
 		b.HandleURI("aopp:?" + params.Encode())
+		b.AOPPApprove()
 		ks2 := ks
 		ks2.SignBTCMessageFunc = func([]byte, signing.AbsoluteKeypath, signing.ScriptType) ([]byte, error) {
 			return nil, firmware.NewError(firmware.ErrUserAbort, "")
@@ -373,6 +389,7 @@ func TestAOPPFailures(t *testing.T) {
 		params := defaultParams()
 		params.Set("callback", server.URL)
 		b.HandleURI("aopp:?" + params.Encode())
+		b.AOPPApprove()
 		b.registerKeystore(&ks)
 		b.AOPPChooseAccount("v0-55555555-btc-0")
 		require.Equal(t, aoppStateError, b.AOPP().State)


### PR DESCRIPTION
We changed our minds and will always ask the user if they want to
continue. Before, we only asked if there was already an unlocked
BitBox02.