### PR TITLE
frontend: rewrite more form components to typescript

### DIFF
--- a/frontends/web/src/components/forms/field.tsx
+++ b/frontends/web/src/components/forms/field.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +15,15 @@
  * limitations under the License.
  */
 
-import { h } from 'preact';
+import { h, JSX } from 'preact';
+import * as style from './field.css';
 
-export default function Label({
-    className,
-    style,
-    children,
-    ...props
-}) {
-    const classes = ['label', className].join(' ');
+export function Field({
+    children, ...props
+}: JSX.IntrinsicElements['div']) {
     return (
-        <label className={classes} style={style} {...props}>
+        <div className={style.field} {...props}>
             {children}
-        </label>
+        </div>
     );
 }

--- a/frontends/web/src/components/forms/index.tsx
+++ b/frontends/web/src/components/forms/index.tsx
@@ -17,8 +17,8 @@
 export { default as Button } from './button';
 export { ButtonLink } from './button';
 export { default as Checkbox } from './checkbox';
-export { default as Radio } from './radio';
-export { default as Field } from './field';
+export { Radio } from './radio';
+export { Field } from './field';
 export { default as Input } from './input';
-export { default as Label } from './label';
+export { Label } from './label';
 export { default as Select } from './select';

--- a/frontends/web/src/components/forms/label.css
+++ b/frontends/web/src/components/forms/label.css
@@ -1,2 +1,3 @@
 .label {
+    text-align: left;
 }

--- a/frontends/web/src/components/forms/label.tsx
+++ b/frontends/web/src/components/forms/label.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +15,19 @@
  * limitations under the License.
  */
 
-import { h } from 'preact';
-import * as style from './field.css';
+import { h, JSX } from 'preact';
+import * as style from './label.css';
 
-export default function Field({
-    children, ...props
-}) {
+export function Label({
+    className,
+    children,
+    id, // TODO: change to htmlFor when mirgated away from preact@8.x
+    ...props
+}: JSX.IntrinsicElements['label']) {
+    const classes = [style.label, className].join(' ');
     return (
-        <div className={style.field} {...props}>
+        <label for={id} className={classes} {...props}>
             {children}
-        </div>
+        </label>
     );
 }

--- a/frontends/web/src/components/forms/radio.css
+++ b/frontends/web/src/components/forms/radio.css
@@ -6,14 +6,11 @@
 .radio input + label {
     display: inline-flex;
     flex-direction: column;
+    font-size: var(--size-default);
     line-height: 1.5;
     margin-right: var(--space-half);
     padding-left: calc(var(--space-half) + var(--space-quarter));
     position: relative;
-}
-
-.radio.textMedium input + label {
-    font-size: var(--size-default);
 }
 
 .radio input + label::before,
@@ -37,18 +34,13 @@
 .radio input + label::after {
     background: var(--color-blue);
     border-radius: 1em;
-    width: 6px;
-    height: 6px;
+    width: 10px;
+    height: 10px;
     position: absolute;
     top: 6px;
     left: 2px;
     opacity: 0;
     transform: scale(0);
-}
-
-.radio.textMedium input + label::after {
-    width: 10px;
-    height: 10px;
 }
 
 /* checked */

--- a/frontends/web/src/components/forms/radio.tsx
+++ b/frontends/web/src/components/forms/radio.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +15,18 @@
  * limitations under the License.
  */
 
-import { h } from 'preact';
+import { h, JSX } from 'preact';
 import * as style from './radio.css';
 
-export default function Radio({
+export function Radio({
     disabled = false,
     label,
     id,
     children,
-    sizeMedium,
     ...props
-}) {
+}: JSX.IntrinsicElements['input']) {
     return (
-        <span className={[style.radio, sizeMedium ? style.textMedium : ''].join(' ')}>
+        <span className={style.radio}>
             <input
                 type="radio"
                 id={id}

--- a/frontends/web/src/routes/device/bitbox01/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox01/backups.tsx
@@ -82,7 +82,8 @@ class Backups extends Component<Props, State> {
         this.setState({ selectedBackup: backupID });
     }
 
-    private scrollIntoView = ({ target }: { target: HTMLElement }) => {
+    private scrollIntoView = (event: Event) => {
+        const target = event.target as HTMLInputElement;
         const offsetTop = target.offsetTop;
         const offsetHeight = (target.parentNode as HTMLElement).offsetHeight;
         if (offsetTop > this.scrollableContainer.scrollTop + offsetHeight) {

--- a/frontends/web/src/routes/device/components/backup.tsx
+++ b/frontends/web/src/routes/device/components/backup.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +25,7 @@ interface BackupsListItemProps {
     backup: Backup;
     selectedBackup?: string;
     handleChange: (value: string) => void;
-    onFocus: ({ target }: { target: HTMLElement; }) => void;
+    onFocus: (event: Event) => void;
     radio: boolean;
 }
 
@@ -42,15 +43,14 @@ class BackupsListItem extends Component<Props> {
     ) {
         let date = '';
         if (backup.date && backup.date !== '') {
-            const options = {
+            date = new Date(backup.date).toLocaleString(this.context.i18n.language, {
                 weekday: 'long',
                 year: 'numeric',
                 month: 'long',
                 day: 'numeric',
                 hour: '2-digit',
                 minute: '2-digit',
-            };
-            date = new Date(backup.date).toLocaleString(this.context.i18n.language, options);
+            });
         } else {
             date = 'unknown';
         }
@@ -59,13 +59,12 @@ class BackupsListItem extends Component<Props> {
             <Radio
                 disabled={!!disabled}
                 checked={selectedBackup === backup.id}
-                onChange={event => handleChange(event.target.value)}
+                onChange={(event: Event) => handleChange((event.target as HTMLInputElement).value)}
                 id={backup.id}
                 label={backup.name && backup.name !== '' ? backup.name : backup.id}
                 value={backup.id}
                 onFocus={onFocus}
-                className={style.backupItem}
-                sizeMedium>
+                className={style.backupItem}>
                 <span className="text-small text-gray">{date}</span>
             </Radio> :
             <div>


### PR DESCRIPTION
- start using JSX.IntrinsicElements with 'div' or 'input' etc.
  so that rest props are type checked
- removed textMedium radio prop, this was always used, so it is
  now the default style
- fixed TypeScript recommendations in Backup component, the only
  component that actually uses the radio component (sometimes)