### PR TITLE
Frontend aopp small screen styling

### DIFF
--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -24,7 +24,7 @@ import { Fullscreen, FullscreenHeader, FullscreenContent, FullscreenButtons } fr
 import { Message } from '../message/message';
 import { Button, Field, Input, Label, Select } from '../forms';
 import { CopyableInput } from '../copy/Copy';
-import { AppLogo, ArrowDown, BitBox02Stylized, Cancel, Checked } from '../icon';
+import { ArrowDown, BitBox02Stylized, Cancel, Checked } from '../icon';
 import * as styles from './aopp.css';
 
 const Banner = ({ children }: RenderableProps<{}>) => (
@@ -105,8 +105,7 @@ class Aopp extends Component<Props, State> {
             case 'user-approval':
                 return (
                     <Fullscreen>
-                        <AppLogo />
-                        <FullscreenHeader title={t('aopp.title')} />
+                        <FullscreenHeader title={t('aopp.title')} withAppLogo />
                         <FullscreenContent>
                             <p>{t('aopp.addressRequest', { host: domain })}</p>
                         </FullscreenContent>
@@ -128,11 +127,11 @@ class Aopp extends Component<Props, State> {
                     };
                 });
                 return (
-                    <Fullscreen>
-                        <FullscreenHeader title={t('aopp.title')}>
-                            <p>{domain}</p>
-                        </FullscreenHeader>
-                        <form onSubmit={this.chooseAccount}>
+                    <form onSubmit={this.chooseAccount}>
+                        <Fullscreen>
+                            <FullscreenHeader title={t('aopp.title')}>
+                                <p>{domain}</p>
+                            </FullscreenHeader>
                             <FullscreenContent>
                                 <Select
                                     label={t('buy.info.selectLabel')}
@@ -146,8 +145,8 @@ class Aopp extends Component<Props, State> {
                                 <Button primary type="submit">{t('button.next')}</Button>
                                 <Button secondary onClick={aoppAPI.cancel}>{t('dialog.cancel')}</Button>
                             </FullscreenButtons>
-                        </form>
-                    </Fullscreen>
+                        </Fullscreen>
+                    </form>
                 );
             }
             case 'syncing':

--- a/frontends/web/src/components/forms/select.css
+++ b/frontends/web/src/components/forms/select.css
@@ -7,6 +7,7 @@
 .select label {
     display: block;
     margin-bottom: var(--space-quarter);
+    text-align: left;
 }
 
 .select select {

--- a/frontends/web/src/components/fullscreen/fullscreen.css
+++ b/frontends/web/src/components/fullscreen/fullscreen.css
@@ -14,25 +14,62 @@
     /* z-index between sidebar (~4000) and wait-dialog (~10000) */
     z-index: 5100;
 }
+@media (max-width: 768px) {
+    .fullscreen {
+        padding-bottom: 0;
+        padding-top: 0;
+    }
+}
 
 .inner {
     margin: auto;
     max-width: 100%;
     text-align: center;
 }
+@media (max-width: 768px) {
+    .inner {
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+        margin: 0 auto;
+    }
+}
 
 .header {
+    color: var(--color-gray);
     margin-bottom: var(--space-default);
+}
+@media (max-width: 768px) {
+    .header {
+        padding-top: var(--space-default);
+    }
+}
+@media (max-width: 768px) and (orientation: portrait) {
+    .header {
+        padding-top: var(--space-large);
+    }
 }
 
 .title {
-    font-weight: 400;
+    color: var(--color-default);
     font-size: var(--size-subheader);
-    margin-bottom: var(--space-default);
+    font-weight: 400;
+    margin-bottom: var(--space-quarter);
+}
+
+.header p {
+    margin-top: var(--space-quarter);
 }
 
 .content {
     min-height: 80px;
+}
+@media (max-width: 768px) {
+    .content {
+        flex-grow: 1;
+        flex-basis: auto;
+        flex-shrink: 0;
+    }
 }
 
 .buttons {
@@ -40,6 +77,17 @@
     flex-direction: row-reverse;
     justify-content: space-between;
     margin-top: var(--space-default);
+    padding-bottom: var(--space-default);
+}
+@media (max-width: 768px) and (orientation: portrait) {
+    .buttons {
+        align-items: stretch;
+        flex-direction: column;
+        flex-grow: 0;
+        gap: var(--space-half);
+        justify-content: flex-end;
+        margin-top: var(--space-half);
+    }
 }
 
 .buttons > *:only-child {

--- a/frontends/web/src/components/fullscreen/fullscreen.tsx
+++ b/frontends/web/src/components/fullscreen/fullscreen.tsx
@@ -15,6 +15,7 @@
  */
 
 import { h, RenderableProps } from 'preact';
+import { AppLogo } from '../icon';
 import * as style from './fullscreen.css';
 
 interface Props {
@@ -42,11 +43,13 @@ export function FullscreenContent({ children }: RenderableProps<{}>) {
 
 interface HeaderProps {
     title: string;
+    withAppLogo?: boolean;
 }
 
 export function FullscreenHeader(props: RenderableProps<HeaderProps>) {
     return (
         <header className={style.header}>
+            {props.withAppLogo && <AppLogo style="margin-bottom: 0;" />}
             <h1 className={style.title}>{props.title}</h1>
             {props.children}
         </header>


### PR DESCRIPTION
- always left align select dropdown labels
- rearrange forms that they do not interfere with fullscreen
  components so that flexbox properly works
- position fullscreen buttons at the bottom of the screen
  on smaller screens
- ensure bottons are pushed down by large content and that
  scroll works properly