### PR TITLE
android: prevent screen from turning off while in foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated to Qt 5.15 from Qt 5.12 for Linux, macOS and Windows
 - Revamped account-info view to show account keypath, scriptType etc.
 - Allow disabling accounts in 'Manage accounts'.
+- Prevent screen from turning off while the app is in foreground on Android
 
 ## 4.28.2 [released 2021-06-03]
 - Fix a conversion rates updater bug

--- a/frontends/android/BitBoxApp/app/src/main/res/layout/activity_main.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/layout/activity_main.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:keepScreenOn="true"
     tools:context="ch.shiftcrypto.bitboxapp.MainActivity">
 
     <WebView


### PR DESCRIPTION
This is a long requested feature to prevent the screen from turning off
which otherwise may happen often, for exapmle while inputting a
passphrase or confirming a transaction on the device.

The change uses no new app permissions such as WAKE_LOCK. It simply
tells the OS to keep the screen on as long as the app is visible in
the foreground. As soon as the app is gone off the screen, any
configured screen timeouts at the OS level resume normal operations.

The screen still locks normally using an regular action like pushing a
physical lock button on the phone.

See docs for more details:
https://developer.android.com/training/scheduling/wakelock#screen
