### PR TITLE
frontend/aopp: remove cancel button during signing

### DIFF
--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -170,9 +170,6 @@ class Aopp extends Component<Props, State> {
                             <ArrowDown />
                             <BitBox02Stylized className={styles.device} />
                         </FullscreenContent>
-                        <FullscreenButtons>
-                            <Button secondary onClick={aoppAPI.cancel}>{t('dialog.cancel')}</Button>
-                        </FullscreenButtons>
                     </Fullscreen>
                 );
             case 'success':


### PR DESCRIPTION
It does nothing. The user has to cancel on the device.