### PR TITLE
frontend/aopp: ui update and stlying improvements for large screen

### DIFF
--- a/frontends/web/src/components/aopp/aopp.css
+++ b/frontends/web/src/components/aopp/aopp.css
@@ -17,9 +17,9 @@
 }
 
 .device {
-    max-width: 300px;
+    max-width: 264px;
     position: relative;
-    right: -18px;
+    right: -16px;
 }
 
 .largeIcon {
@@ -82,4 +82,13 @@
     font-size: var(--size-small);
     margin-top: var(--space-quarter);
     text-align: center;
+}
+
+@media (min-width: 1200px) {
+    .message {
+        --size-default: 18px;
+    }
+    .buttonInfoText {
+        --size-small: 14px;
+    }
 }

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -20,6 +20,7 @@ import * as aoppAPI from '../../api/aopp';
 import { subscribe } from '../../decorators/subscribe';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { equal } from '../../utils/equal';
+import { SimpleMarkup } from '../../utils/simplemarkup';
 import { Fullscreen, FullscreenHeader, FullscreenContent, FullscreenButtons } from '../fullscreen/fullscreen';
 import { Message } from '../message/message';
 import { Button, Field, Label, Select } from '../forms';
@@ -117,7 +118,9 @@ class Aopp extends Component<Props, State> {
                     <Fullscreen>
                         <FullscreenHeader title={t('aopp.title')} withAppLogo />
                         <FullscreenContent>
-                            <p>{t('aopp.addressRequest', { host: domain(aopp.callback) })}</p>
+                            <SimpleMarkup tagName="p" markup={t('aopp.addressRequest', {
+                                host: `<strong>${domain(aopp.callback)}</strong>`
+                            })}/>
                         </FullscreenContent>
                         <FullscreenButtons>
                             <Button primary onClick={aoppAPI.approve}>{t('button.continue')}</Button>
@@ -176,6 +179,16 @@ class Aopp extends Component<Props, State> {
                         </FullscreenHeader>
                         <FullscreenContent>
                             <p>{t('aopp.signing')}</p>
+                            <Field>
+                                <Label>{t('aopp.labelAddress')}</Label>
+                                <CopyableInput alignLeft flexibleHeight value={aopp.address} />
+                            </Field>
+                            <Field>
+                                <Label>{t('aopp.labelMessage')}</Label>
+                                <div className={styles.message}>
+                                    {aopp.message}
+                                </div>
+                            </Field>
                             <CaretDown className={styles.caret} />
                             <BitBox02Stylized className={styles.device} />
                         </FullscreenContent>

--- a/frontends/web/src/components/fullscreen/fullscreen.css
+++ b/frontends/web/src/components/fullscreen/fullscreen.css
@@ -25,6 +25,7 @@
     margin: auto;
     max-width: 100%;
     text-align: center;
+    width: 480px;
 }
 @media (max-width: 768px) {
     .inner {
@@ -32,6 +33,11 @@
         flex-direction: column;
         min-height: 100vh;
         margin: 0 auto;
+    }
+}
+@media (min-width: 1200px) {
+    .inner {
+        width: 580px;
     }
 }
 
@@ -77,6 +83,11 @@
         flex-shrink: 0;
     }
 }
+@media (min-width: 1200px) {
+    .content {
+        min-height: 130px;
+    }
+}
 
 .buttons {
     display: flex;
@@ -101,4 +112,20 @@
 
 .buttons > *:only-child {
     margin: 0 auto;
+}
+
+@media (min-width: 1200px) {
+    .title {
+        --size-subheader: 28px;
+    }
+    .fullscreen p {
+        --size-default: 20px;
+    }
+    .content input,
+    .content label,
+    .content select,
+    .content textarea,
+    .buttons button {
+        --size-default: 18px;
+    }
 }

--- a/frontends/web/src/components/fullscreen/fullscreen.tsx
+++ b/frontends/web/src/components/fullscreen/fullscreen.tsx
@@ -19,16 +19,14 @@ import { AppLogo } from '../icon';
 import * as style from './fullscreen.css';
 
 interface Props {
-    width?: number;
 }
 
 export function Fullscreen({
     children,
-    width = 480,
 }: RenderableProps<Props>) {
     return (
         <div className={style.fullscreen}>
-            <div className={style.inner} style={`width: ${width}px;`}>
+            <div className={style.inner}>
                 {children}
             </div>
         </div>
@@ -56,7 +54,7 @@ export function FullscreenHeader({
     const headerStyles = small ? `${style.header} ${style.smallHeader}` : style.header;
     return (
         <header className={headerStyles}>
-            {withAppLogo && <AppLogo style="margin-bottom: 0;" />}
+            {withAppLogo && <AppLogo />}
             <h1 className={style.title}>{title}</h1>
             {children}
         </header>


### PR DESCRIPTION
- show address and message on signing step
- fullscreen component: removed width prop and made it resposive
  using a bigger content area on large screen
- display domain name in bold on the first step
- adjust device image and display it slightly smaller so it matches
  the size of the real world device
- increase font sizes of labels, input fields, textareas, buttons
  and select dropdowns in aopp fullscreen component