### PR TITLE
qt: let it use default rendering backend

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -162,10 +162,6 @@ int main(int argc, char *argv[])
     qputenv("QV4_FORCE_INTERPRETER", "1");
     qputenv("DRAW_USE_LLVM", "0");
 #endif
-#if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
-    qputenv("QMLSCENE_DEVICE", "softwarecontext");
-    qputenv("QT_QUICK_BACKEND", "software");
-#endif
 
 
     BitBoxApp a(argc, argv);


### PR DESCRIPTION
Commit a82a85020f164a705495bf21e689d93c7476e4cc forced Qt render in software mode, referring to some attack surface reduction. I could not find any existing vulnerabilities or advisory notes as to why and how exactly this helps in practical terms here.

OTOH, letting Qt use hardware acceleration, where available, improves user experience on Windows by far.

Until there's a reasonable and practical explanation why exactly software rendering yields more pro than cons in this context, I propose to switch back to Qt default backend rendering.

See Qt docs about backend renderers:
https://doc.qt.io/qt-5/qtquick-visualcanvas-adaptations.html

/cc @jadzeidan @thisconnect 