### PR TITLE
backend/coins/eth: add fee targets based on EthGasStation

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -415,7 +415,7 @@ func (backend *Backend) createAndAddAccount(
 		)
 		backend.addAccount(account)
 	case *eth.Coin:
-		account = eth.NewAccount(accountConfig, specificCoin, backend.log)
+		account = eth.NewAccount(accountConfig, specificCoin, backend.httpClient, backend.log)
 		backend.addAccount(account)
 
 		// Load ERC20 tokens enabled with this Ethereum account.

--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -32,8 +32,7 @@ type AddressList []Address
 type TxProposalArgs struct {
 	RecipientAddress string
 	Amount           coin.SendAmount
-	// Only applies to BTC/LTC.
-	FeeTargetCode FeeTargetCode
+	FeeTargetCode    FeeTargetCode
 	// Only applies to BTC/LTC and if FeeTargetCode == Custom. Technically it is vKb (virtual Kb)
 	// since fees are computed from a transaction's weight (measured in weight units or virtual
 	// bytes), but we keep the `Kb` unit to be consistent with the rest of the codebase and Bitcoin

--- a/backend/accounts/errors/errors.go
+++ b/backend/accounts/errors/errors.go
@@ -26,6 +26,8 @@ func (err TxValidationError) Error() string {
 }
 
 var (
+	// ErrFeesNotAvailable is returned when there was an error estimating fees.
+	ErrFeesNotAvailable = TxValidationError("feesNotAvailable")
 	// ErrInvalidAddress is used when the recipient address is invalid or does not match the correct
 	// network.
 	ErrInvalidAddress = TxValidationError("invalidAddress")

--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -158,9 +158,8 @@ func (coin *Coin) Decimals(isFee bool) uint {
 
 // FormatAmount implements coin.Coin.
 func (coin *Coin) FormatAmount(amount coin.Amount, isFee bool) string {
-	return strings.TrimRight(strings.TrimRight(
-		new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(unitSatoshi)).FloatString(8),
-		"0"), ".")
+	s := new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(unitSatoshi)).FloatString(8)
+	return strings.TrimRight(strings.TrimRight(s, "0"), ".")
 }
 
 // ToUnit implements coin.Coin.

--- a/backend/coins/btc/feetarget_test.go
+++ b/backend/coins/btc/feetarget_test.go
@@ -1,0 +1,56 @@
+// Copyright 2021 Shift Devices AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package btc
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcutil"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeeTarget(t *testing.T) {
+	require.Equal(t,
+		accounts.FeeTargetCodeLow,
+		(&FeeTarget{code: accounts.FeeTargetCodeLow}).Code(),
+	)
+
+	amt := func(v uint64) *btcutil.Amount {
+		x := btcutil.Amount(v)
+		return &x
+	}
+	require.Equal(t,
+		"0.123 sat/vB",
+		(&FeeTarget{feeRatePerKb: amt(123)}).FormattedFeeRate(),
+	)
+	require.Equal(t,
+		"123.456 sat/vB",
+		(&FeeTarget{feeRatePerKb: amt(123456)}).FormattedFeeRate(),
+	)
+	require.Equal(t,
+		"1 sat/vB",
+		(&FeeTarget{feeRatePerKb: amt(1000)}).FormattedFeeRate(),
+	)
+	require.Equal(t,
+		"10 sat/vB",
+		(&FeeTarget{feeRatePerKb: amt(10000)}).FormattedFeeRate(),
+	)
+	require.Equal(t,
+		"10.001 sat/vB",
+		(&FeeTarget{feeRatePerKb: amt(10001)}).FormattedFeeRate(),
+	)
+}

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -48,7 +48,7 @@ var pollInterval = 60 * time.Second
 
 // ethGasStationAPIKey is used to access the API of https://ethgasstation.info.
 // See https://docs.ethgasstation.info/.
-const ethGasStationAPIKey = "289ea7884cb5903dcb50af9a81cd9518ae000ff9088af5182b5bc8b87385"
+const ethGasStationAPIKey = "3a61bee56f554cc14db4f49e2ace053b3086d3c323aefec83e5ff25ca485"
 
 // Account is an Ethereum account, with one address.
 type Account struct {

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -132,9 +132,8 @@ func (coin *Coin) unitFactor(isFee bool) *big.Int {
 // FormatAmount implements coin.Coin.
 func (coin *Coin) FormatAmount(amount coin.Amount, isFee bool) string {
 	factor := coin.unitFactor(isFee)
-	return strings.TrimRight(strings.TrimRight(
-		new(big.Rat).SetFrac(amount.BigInt(), factor).FloatString(18),
-		"0"), ".")
+	s := new(big.Rat).SetFrac(amount.BigInt(), factor).FloatString(18)
+	return strings.TrimRight(strings.TrimRight(s, "0"), ".")
 }
 
 // ToUnit implements coin.Coin.

--- a/backend/coins/eth/coin_test.go
+++ b/backend/coins/eth/coin_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eth
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoin(t *testing.T) {
+	c := NewCoin(
+		nil,
+		coin.CodeETH,
+		"Ethereum",
+		"ETH",
+		"ETH",
+		params.MainnetChainConfig,
+		"",
+		nil,
+		nil,
+	)
+
+	require.Equal(t,
+		"0.000000000000000001",
+		c.FormatAmount(coin.NewAmountFromInt64(1), false),
+	)
+	require.Equal(t,
+		"0.000000000001",
+		c.FormatAmount(coin.NewAmountFromInt64(1000000), false),
+	)
+	require.Equal(t,
+		"1",
+		c.FormatAmount(coin.NewAmountFromInt64(1e18), false),
+	)
+	require.Equal(t,
+		"100",
+		c.FormatAmount(coin.NewAmount(new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil)), false),
+	)
+	require.Equal(t,
+		"1.234",
+		c.FormatAmount(coin.NewAmountFromInt64(1.234e18), false),
+	)
+}

--- a/backend/coins/eth/feetarget.go
+++ b/backend/coins/eth/feetarget.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eth
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+)
+
+// feeTarget contains the gas price for a specific fee target.
+type feeTarget struct {
+	// Code is the identifier for the UI.
+	code accounts.FeeTargetCode
+	// gasPrice is the estimated gas price to be used in the fee calculation, in Wei.
+	gasPrice *big.Int
+}
+
+// Code returns the btc fee target.
+func (f *feeTarget) Code() accounts.FeeTargetCode {
+	return f.code
+}
+
+// FormattedFeeRate returns a string showing the fee rate.
+func (f *feeTarget) FormattedFeeRate() string {
+	if f.gasPrice == nil {
+		return ""
+	}
+	factor := big.NewInt(1e9)
+	return strings.TrimRight(strings.TrimRight(
+		new(big.Rat).SetFrac(f.gasPrice, factor).FloatString(9),
+		"0"), ".") + " Gwei"
+}

--- a/backend/coins/eth/feetarget.go
+++ b/backend/coins/eth/feetarget.go
@@ -41,7 +41,6 @@ func (f *feeTarget) FormattedFeeRate() string {
 		return ""
 	}
 	factor := big.NewInt(1e9)
-	return strings.TrimRight(strings.TrimRight(
-		new(big.Rat).SetFrac(f.gasPrice, factor).FloatString(9),
-		"0"), ".") + " Gwei"
+	s := new(big.Rat).SetFrac(f.gasPrice, factor).FloatString(9)
+	return strings.TrimRight(strings.TrimRight(s, "0"), ".") + " Gwei"
 }

--- a/backend/coins/eth/feetarget_test.go
+++ b/backend/coins/eth/feetarget_test.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eth
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeeTarget(t *testing.T) {
+	require.Equal(t,
+		accounts.FeeTargetCodeLow,
+		(&feeTarget{code: accounts.FeeTargetCodeLow, gasPrice: big.NewInt(21.9e9)}).Code(),
+	)
+	require.Equal(t,
+		"21.9 Gwei",
+		(&feeTarget{code: accounts.FeeTargetCodeLow, gasPrice: big.NewInt(21.9e9)}).FormattedFeeRate(),
+	)
+	require.Equal(t,
+		"21 Gwei",
+		(&feeTarget{code: accounts.FeeTargetCodeLow, gasPrice: big.NewInt(21e9)}).FormattedFeeRate(),
+	)
+	require.Equal(t,
+		"210 Gwei",
+		(&feeTarget{code: accounts.FeeTargetCodeLow, gasPrice: big.NewInt(21e10)}).FormattedFeeRate(),
+	)
+	require.Equal(t,
+		"0.123 Gwei",
+		(&feeTarget{code: accounts.FeeTargetCodeLow, gasPrice: big.NewInt(0.123e9)}).FormattedFeeRate(),
+	)
+}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1121,6 +1121,7 @@
     },
     "error": {
       "feeTooLow": "fee too low",
+      "feesNotAvailable": "Could not estimate fees",
       "insufficientFunds": "insufficient funds",
       "invalidAddress": "invalid address",
       "invalidAmount": "invalid amount",
@@ -1134,12 +1135,16 @@
     "feeTarget": {
       "description": {
         "economy": "4 hours (24 blocks)",
+        "economy_eth": "30 minutes or less",
         "economy_ltc": "1 hour (24 blocks)",
         "high": "20 minutes (2 blocks)",
+        "high_eth": "30 seconds or less",
         "high_ltc": "5 minutes (2 blocks)",
         "low": "2 hours (12 blocks)",
+        "low_eth": "5 minutes or less",
         "low_ltc": "30 minutes (12 blocks)",
         "normal": "1 hour (6 blocks)",
+        "normal_eth": "2 minutes or less",
         "normal_ltc": "15 minutes (6 blocks)"
       },
       "estimate": "Estimated confirmation time:",

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -354,6 +354,9 @@ class Send extends Component<Props, State> {
                 case 'feeTooLow':
                     this.setState({ feeError: this.props.t('send.error.feeTooLow') });
                     break;
+                case 'feesNotAvailable':
+                    this.setState({ feeError: this.props.t('send.error.feesNotAvailable') });
+                    break;
                 default:
                     this.setState({ proposedFee: undefined });
                     if (errorCode) {


### PR DESCRIPTION
https://ethgasstation.info/ provides gas price estimates for different
priorities.

We use these to give the user fee options.

If the service is not available, we fall back to the previous gas
price estimation provided by the eth_gasPrice RPC call to the ETH
node (currently etherscan proxy).

FeeTargets() is currently doing all the work whenever it is called,
which should be once when the send screen is loaded and every time a
tx proposal is made (every time the user changes something in the send
screen). This could be optimized with a cache that is invalidated
regularly (or when a new block arrives).

Custom gas price option to be added later.