### PR TITLE
frontend/aopp: remove reverify info text

### DIFF
--- a/frontends/web/src/components/aopp/aopp.css
+++ b/frontends/web/src/components/aopp/aopp.css
@@ -68,23 +68,8 @@
     width: 100%;
     white-space: pre-line;
 }
-
-.buttonWithInfo {
-    display: flex;
-    flex-direction: column;
-}
-
-.buttonInfoText {
-    font-size: var(--size-small);
-    margin-top: var(--space-quarter);
-    text-align: center;
-}
-
 @media (min-width: 1200px) {
     .message {
         --size-default: 18px;
-    }
-    .buttonInfoText {
-        --size-small: 14px;
     }
 }

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -224,16 +224,10 @@ class Aopp extends Component<Props, State> {
                         </FullscreenContent>
                         <FullscreenButtons>
                             <Button primary onClick={aoppAPI.cancel}>{t('button.done')}</Button>
-                            <div className={styles.buttonWithInfo}>
-                                <VerifyAddress
-                                    accountCode={accountCode}
-                                    address={aopp.address}
-                                    addressID={aopp.addressID}
-                                />
-                                <div className={styles.buttonInfoText}>
-                                    {t('aopp.reverifyInfoText')}
-                                </div>
-                            </div>
+                            <VerifyAddress
+                                accountCode={accountCode}
+                                address={aopp.address}
+                                addressID={aopp.addressID} />
                         </FullscreenButtons>
                     </Fullscreen>
                 );


### PR DESCRIPTION
Removed info text below the verify button on the AOPP success
screen, as we don't need it.