### PR TITLE
backend: fix regression - close account

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -736,6 +736,7 @@ func (backend *Backend) uninitAccounts() {
 		if backend.onAccountUninit != nil {
 			backend.onAccountUninit(account)
 		}
+		account.Close()
 	}
 	backend.accounts = []accounts.Interface{}
 }


### PR DESCRIPTION
In c6b816aa35bfdf855662df12e3b9cb43d31a1b96, the account.Close() was
accidentally dropped. When reinitializing the accounts (e.g. after an
account rename), the old ones were not closed, blocking the database
files, so the new ones could not properly load.