### PR TITLE
frontend: support copying tx address from tx details

### DIFF
--- a/frontends/web/src/components/copy/Copy.css
+++ b/frontends/web/src/components/copy/Copy.css
@@ -1,21 +1,21 @@
 .button {
+    align-items: center;
     background-color: var(--color-white);
-    position: absolute;
-    top: 10px;
-    right: var(--spacing-default);
     border: none;
-    width: 18px;
-    height: 18px;
-    min-width: 18px !important;
-    padding: 0;
     border-radius: 50%;
+    cursor: pointer;
     display: flex;
     flex-direction: row;
+    height: 18px;
     justify-content: center;
-    align-items: center;
     margin-top: var(--spacing-half);
-    cursor: pointer;
+    min-width: 18px !important;
+    padding: 0;
+    position: absolute;
+    right: var(--spacing-default);
+    top: 10px;
     transition: background-color ease 0.2s;
+    width: 18px;
     will-change: background-color;
 }
 
@@ -40,17 +40,17 @@
 }
 
 .inputField {
+    border: 1px solid var(--color-mediumgray);
+    border-radius: 2px;
     flex: 1;
-    margin-bottom: 0;
     font-size: var(--size-default);
     font-weight: 400;
-    min-width: 200px !important;
-    width: 100%;
-    padding: var(--space-half) calc(var(--space-default) * 1.2) var(--space-half) calc(var(--space-half) * .5);
     height: 52px;
-    border-radius: 2px;
-    border: 1px solid var(--color-mediumgray);
+    margin-bottom: 0;
+    min-width: 200px !important;
+    padding: var(--space-half) calc(var(--space-default) * 1.2) var(--space-half) calc(var(--space-half) * .5);
     resize: none;
+    width: 100%;
 }
 
 @media screen and (min-width: 640px) {
@@ -75,4 +75,15 @@
 
 .alignLeft {
     text-align: left;
+}
+
+.alignRight {
+    text-align: right;
+}
+
+.borderLess,
+.borderLess:focus {
+    border: none;
+    border-radius: 0;
+    outline: none;
 }

--- a/frontends/web/src/components/copy/Copy.tsx
+++ b/frontends/web/src/components/copy/Copy.tsx
@@ -21,10 +21,12 @@ import { Check, Copy } from '../icon/icon';
 import * as style from './Copy.css';
 
 interface CopyableInputProps {
+    alignLeft?: boolean;
+    alignRight?: boolean;
+    borderLess?: boolean;
     className?: string;
     disabled?: boolean;
     flexibleHeight?: boolean;
-    alignLeft?: boolean;
     value: string;
 }
 
@@ -78,7 +80,7 @@ class CopyableInput extends Component<Props, State> {
     }
 
     public render(
-        { alignLeft, t, value, className, disabled, flexibleHeight }: RenderableProps<Props>,
+        { alignLeft, alignRight, borderLess, t, value, className, disabled, flexibleHeight }: RenderableProps<Props>,
         { success }: State,
     ) {
         const copyButton = disabled ? null : (
@@ -90,7 +92,11 @@ class CopyableInput extends Component<Props, State> {
             </button>
         );
         return (
-            <div class={['flex flex-row flex-start flex-items-start', style.container, className ? className : ''].join(' ')}>
+            <div class={[
+                'flex flex-row flex-start flex-items-start',
+                style.container,
+                className ? className : ''
+            ].join(' ')}>
                 <textarea
                     disabled={disabled}
                     readOnly
@@ -101,7 +107,9 @@ class CopyableInput extends Component<Props, State> {
                     className={[
                         style.inputField,
                         flexibleHeight && style.flexibleHeight,
-                        alignLeft && style.alignLeft
+                        alignLeft && style.alignLeft,
+                        alignRight && style.alignRight,
+                        borderLess && style.borderLess,
                     ].join(' ')} />
                 {copyButton}
             </div>

--- a/frontends/web/src/components/dialog/dialog.css
+++ b/frontends/web/src/components/dialog/dialog.css
@@ -44,7 +44,7 @@
 
 .modal.medium {
     /* long enough to fit a bc1... address in the receive screen on desktop */
-    max-width: 455px;
+    max-width: 520px;
     width: 100%;
 }
 

--- a/frontends/web/src/components/transactions/transaction.css
+++ b/frontends/web/src/components/transactions/transaction.css
@@ -204,21 +204,23 @@
     line-height: 1;
 }
 
-.detail.addresses > span {
-    margin-left: auto;
-    max-width: 100%;
+.detail.addresses {
+    align-items: baseline;
+    padding-bottom: 0;
+    padding-right: 0;
+    padding-top: 0;
 }
 
-.detail.addresses.multi > div {
-    align-self: flex-end;
+.addresses label {
+    padding: var(--space-half) 0;
 }
 
-.detail.addresses > div > p {
-    word-break: break-all;
+.detailAddresses {
+    flex-grow: 1;
 }
 
-.detail.addresses p:not(:first-child) {
-    margin-top: var(--space-quarter);
+.detailAddress + .detailAddress {
+    margin-top: calc(var(--space-quarter) * -1);
 }
 
 @media (max-width: 1080px), (min-width: 1200px) and (max-width: 1322px) {

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -21,6 +21,7 @@ import { Input } from '../../components/forms';
 import { translate, TranslateProps } from '../../decorators/translate';
 import A from '../anchor/anchor';
 import { Dialog } from '../dialog/dialog';
+import { CopyableInput } from '../copy/Copy';
 import { ExpandIcon } from '../icon/icon';
 import { ProgressRing } from '../progressRing/progressRing';
 import { FiatConversion } from '../rates/rates';
@@ -315,13 +316,17 @@ class Transaction extends Component<Props, State> {
                             </div>
                             <div className={[style.detail, style.addresses].join(' ')}>
                                 <label>{t('transaction.details.address')}</label>
-                                <span>
-                                    {
-                                        addresses.map(address => (
-                                            <p key={address} className="text-break">{address}</p>
-                                        ))
-                                    }
-                                </span>
+                                <div className={style.detailAddresses}>
+                                    { addresses.map((address) => (
+                                        <CopyableInput
+                                            key={address}
+                                            alignRight
+                                            borderLess
+                                            flexibleHeight
+                                            className={style.detailAddress}
+                                            value={address} />
+                                    )) }
+                                </div>
                             </div>
                             {
                                 gas ? (


### PR DESCRIPTION
- increased width of tx detail dialog
- added options to style the copyinput component without border
  and with right aligned text

<img width="324" alt="Screen Shot 2021-08-03 at 10 22 10 AM" src="https://user-images.githubusercontent.com/546900/127983971-bf9da388-4f3e-4908-9e5f-226684f5591c.png"> ![Screen Shot 2021-08-03 at 10 13 09 AM](https://user-images.githubusercontent.com/546900/127983984-99010866-7b74-4e8b-812d-b99ec014553e.png)

<img width="727" alt="Screen Shot 2021-08-03 at 10 13 29 AM" src="https://user-images.githubusercontent.com/546900/127984055-231eaf4f-b0cc-4c3d-a4d7-01c94e7559c4.png">
