### PR TITLE
frontend: fix deactivated account links to empty screen

### DIFF
--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -107,8 +107,8 @@ class ManageAccounts extends Component<Props, State> {
             return (
                 <div key={account.code} className={style.setting}>
                     <div
-                        className={`${style.acccountLink} ${style.accountActive}`}
-                        onClick={() => route(`/account/${account.code}`)}>
+                        className={`${style.acccountLink} ${active ? style.accountActive : ''}`}
+                        onClick={() => active && route(`/account/${account.code}`)}>
                         <Logo className={`${style.coinLogo} m-right-half`} coinCode={account.coinCode} alt={account.coinUnit} />
                         <span className={style.accountName}>
                             {account.name}


### PR DESCRIPTION
When clicking a deactivated account (Bitcoin, Litecoin, Ethereum)
the content area turns gray.

Added a check to test if the account is active before routing.
Tokens already had this check.