### PR TITLE
android: request USB permission if not automatically granted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Fix an Android app crash when opening the app after first rejecting the USB permissions
 
 ## 4.29.1 [tagged 2021-09-07, released 2021-09-08]
 - Verify the EIP-55 checksum in mixed-case Ethereum recipient addresses

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
@@ -55,6 +55,10 @@ public class GoViewModel extends AndroidViewModel {
                 }
                 UsbManager usbManager = (UsbManager) getApplication().getSystemService(Context.USB_SERVICE);
                 final UsbDeviceConnection connection = usbManager.openDevice(device);
+                if (connection == null) {
+                    Util.log("could not open device");
+                    return null;
+                }
                 connection.claimInterface(intf, true);
 
                 return new GoReadWriteCloserInterface(){

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
@@ -7,16 +7,13 @@ import goserver.GoAPIInterface;
 import goserver.Goserver;
 
 import android.content.Context;
-import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Message;
 import android.os.Handler;
 import android.app.Application;
-import android.content.Context;
 import android.hardware.usb.UsbConstants;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbDeviceConnection;
@@ -26,8 +23,6 @@ import android.hardware.usb.UsbManager;
 
 import androidx.lifecycle.AndroidViewModel;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Locale;
 
 public class GoViewModel extends AndroidViewModel {
@@ -110,27 +105,8 @@ public class GoViewModel extends AndroidViewModel {
 
         private GoDeviceInfoInterface device;
 
-        // Triggered by usb device attached intent and usb device detached broadcast events from
-        // MainActivity.
-        public void updateDeviceList() {
-            this.device = null;
-            UsbManager manager = (UsbManager) getApplication().getSystemService(Context.USB_SERVICE);
-            HashMap<String, UsbDevice> deviceList = manager.getDeviceList();
-            Iterator<UsbDevice> deviceIterator = deviceList.values().iterator();
-            while (deviceIterator.hasNext()){
-                UsbDevice device = deviceIterator.next();
-                // One other instance where we filter vendor/product IDs is in
-                // @xml/device_filter resource, which is used for USB_DEVICE_ATTACHED
-                // intent to launch the app when a device is plugged and the app is still
-                // closed. This filter, on the other hand, makes sure we feed only valid
-                // devices to the Go backend once the app is launched or opened.
-                //
-                // BitBox02 Vendor ID: 0x03eb, Product ID: 0x2403.
-                if (device.getVendorId() == 1003 && device.getProductId() == 9219) {
-                    this.device = new GoDeviceInfo(device);
-                    break; // only one device supported for now
-                }
-            }
+        public void setDevice(GoDeviceInfo device) {
+            this.device = device;
         }
 
         public GoDeviceInfoInterface deviceInfo() {
@@ -219,7 +195,11 @@ public class GoViewModel extends AndroidViewModel {
         this.goAPI.setMessageHandlers(callResponseHandler, pushNotificationHandler);
     }
 
-    public void updateDeviceList() {
-        this.goEnvironment.updateDeviceList();
+    public void setDevice(UsbDevice device) {
+        if (device == null) {
+            this.goEnvironment.setDevice(null);
+            return;
+        }
+        this.goEnvironment.setDevice(new GoDeviceInfo(device));
     }
 }

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -33,7 +33,6 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.webkit.WebChromeClient;
 import android.webkit.ConsoleMessage;
-import android.util.Log;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -101,7 +100,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        log("lifecycle: onCreate");
+        Util.log("lifecycle: onCreate");
 
         getSupportActionBar().hide(); // hide title bar with app name.
         setContentView(R.layout.activity_main);
@@ -155,7 +154,7 @@ public class MainActivity extends AppCompatActivity {
                     if (mimeType != null) {
                         return new WebResourceResponse(mimeType, "UTF-8", inputStream);
                     }
-                    log("Unknown MimeType: " + url);
+                    Util.log("Unknown MimeType: " + url);
                 } catch(Exception e) {
                 }
                 return super.shouldInterceptRequest(view, request);
@@ -174,7 +173,7 @@ public class MainActivity extends AppCompatActivity {
                     }
                 } catch(Exception e) {
                 }
-                log("Blocked: " + url);
+                Util.log("Blocked: " + url);
                 return true;
             }
         });
@@ -183,7 +182,7 @@ public class MainActivity extends AppCompatActivity {
         vw.setWebChromeClient(new WebChromeClient() {
             @Override
             public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
-                log(consoleMessage.message() + " -- From line "
+                Util.log(consoleMessage.message() + " -- From line "
                         + consoleMessage.lineNumber() + " of "
                         + consoleMessage.sourceId());
                 return super.onConsoleMessage(consoleMessage);
@@ -222,10 +221,6 @@ public class MainActivity extends AppCompatActivity {
         this.updateDevice();
     }
 
-    private void log(String msg) {
-        Log.d("ch.shiftcrypto.bitboxapp", "XYZ: " + msg);
-    }
-
     @Override
     protected void onNewIntent(Intent intent) {
         // This is only called reliably when intents are received (e.g. USB is attached or when
@@ -238,13 +233,13 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        log("lifecycle: onStart");
+        Util.log("lifecycle: onStart");
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        log("lifecycle: onResume");
+        Util.log("lifecycle: onResume");
         // This is only called reliably when USB is attached with android:launchMode="singleTop"
 
         // Usb device list is updated on ATTACHED / DETACHED intents.
@@ -267,7 +262,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        log("lifecycle: onPause");
+        Util.log("lifecycle: onPause");
         unregisterReceiver(this.usbStateReceiver);
         unregisterReceiver(this.networkStateReceiver);
     }
@@ -279,21 +274,21 @@ public class MainActivity extends AppCompatActivity {
                 UsbDevice device = (UsbDevice) intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
                 if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
                     if (device != null) {
-                        log("usb: permission granted");
+                        Util.log("usb: permission granted");
                         final GoViewModel goViewModel = ViewModelProviders.of(this).get(GoViewModel.class);
                         goViewModel.setDevice(device);
                     }
                 } else {
-                    log("usb: permission denied");
+                    Util.log("usb: permission denied");
                 }
             }
         }
         if (intent.getAction().equals(UsbManager.ACTION_USB_DEVICE_ATTACHED)) {
-            log("usb: attached");
+            Util.log("usb: attached");
             this.updateDevice();
         }
         if (intent.getAction().equals(UsbManager.ACTION_USB_DEVICE_DETACHED)) {
-            log("usb: detached");
+            Util.log("usb: detached");
             this.updateDevice();
         }
         // Handle 'aopp:' URIs. This is called when the app is launched and also if it is already
@@ -339,13 +334,13 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onStop() {
         super.onStop();
-        log("lifecycle: onStop");
+        Util.log("lifecycle: onStop");
     }
 
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        log("lifecycle: onDestroy");
+        Util.log("lifecycle: onDestroy");
     }
 
     @Override

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -260,18 +260,8 @@ public class MainActivity extends AppCompatActivity {
         // Listen on changes in the network connection. We are interested in if the user is connected to a mobile data connection.
         registerReceiver(this.networkStateReceiver, new IntentFilter(android.net.ConnectivityManager.CONNECTIVITY_ACTION));
 
-        // Handle 'aopp:' URIs. This is called when the app is launched and also if it is already
-        // running and brought to the foreground.
         Intent intent = getIntent();
         handleIntent(intent);
-        if(Intent.ACTION_VIEW.equals(intent.getAction())) {
-            Uri uri = intent.getData();
-            if (uri != null) {
-                if (uri.getScheme().equals("aopp")) {
-                    Goserver.handleURI(uri.toString());
-                }
-            }
-        }
     }
 
     @Override
@@ -305,6 +295,16 @@ public class MainActivity extends AppCompatActivity {
         if (intent.getAction().equals(UsbManager.ACTION_USB_DEVICE_DETACHED)) {
             log("usb: detached");
             this.updateDevice();
+        }
+        // Handle 'aopp:' URIs. This is called when the app is launched and also if it is already
+        // running and brought to the foreground.
+        if (intent.getAction().equals(Intent.ACTION_VIEW)) {
+            Uri uri = intent.getData();
+            if (uri != null) {
+                if (uri.getScheme().equals("aopp")) {
+                    Goserver.handleURI(uri.toString());
+                }
+            }
         }
     }
 

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/Util.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/Util.java
@@ -3,6 +3,7 @@ package ch.shiftcrypto.bitboxapp;
 import android.app.Application;
 import android.content.Intent;
 import android.net.Uri;
+import android.util.Log;
 
 public class Util {
     public static void systemOpen(Application application, String url) throws Exception {
@@ -12,5 +13,9 @@ public class Util {
         if (intent.resolveActivity(application.getPackageManager()) != null) {
             application.startActivity(intent);
         }
+    }
+
+    public static void log(String msg) {
+        Log.d("ch.shiftcrypto.bitboxapp", msg);
     }
 }


### PR DESCRIPTION
There are these scenarios to cover:

- App is closed, user inserts device:

In this case, the user is prompted with all apps that register intent
filters for the device, including the BitBoxApp.

a) If the BitBoxApp is chosen, the app is launched with the
`ACTION_USB_DEVICE_ATTACHED` intent. Previously we would simply update
the device list in `onResume()` without checking the intent, which
included this case. Now we explicitly check the intent in
`onResume()` to avoid endlessly asking the user for permission (see below).

b) If the app is not chosen, permission is denied. If the user then
opens the app (without USB permission granted automatically like
above), previously the app would crash because of it. In this commit,
we request permission in `onCreate()` (by calling
`updateDevice()`). We do it newly in `onCreate()` instead of
`onResume()` because if permission is denied, `onResume()` is called
again, asking the user again for permission endlessly.

- App is opened, user inserts device:

App chooser is shown to the user like above. If they choose the same
BitBoxApp, `onResume()` is called with the intent, same as above.

If they reject, the app remains open without any further action.

- User opens app while the device is already connected

This only happens if the user rejects to open the BitBoxApp after
being prompted.

In this case, `onCreate()` calls `updateDevice()` which asks for USB permission.