### PR TITLE
frontend/qt: bundle more DLLs in Windows installer

### DIFF
--- a/frontends/qt/compile_windows.bat
+++ b/frontends/qt/compile_windows.bat
@@ -5,5 +5,10 @@ cd build
 qmake ..\BitBox.pro
 nmake
 COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\msvcp140.dll" windows\
+COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\msvcp140_1.dll" windows\
+COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\msvcp140_2.dll" windows\
+COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\msvcp140_atomic_wait.dll" windows\
+COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\msvcp140_codecvt_ids.dll" windows\
 COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\vccorlib140.dll" windows\
 COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\vcruntime140.dll" windows\
+COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\vcruntime140_1.dll" windows\


### PR DESCRIPTION
A user reported that installation failed with errors that
msvcp140_1.dll and vcruntime140_1.dll was misisng.

We bundle all DLLs that exist with the msvcp140 and vcruntime140
prefix to solve this problem.