### PR TITLE
backend/bitbox02: log communication errors

### DIFF
--- a/backend/devices/bitbox02/handlers/handlers.go
+++ b/backend/devices/bitbox02/handlers/handlers.go
@@ -112,6 +112,8 @@ func maybeBB02Err(err error, log *logrus.Entry) map[string]interface{} {
 		result["code"] = bb02Error.Code
 		result["message"] = bb02Error.Message
 		log.WithField("bitbox02-error", bb02Error.Code).Warning("Received an error from Bitbox02")
+	} else {
+		log.WithField("error", err).Error("Received an error from when querying the BitBox02")
 	}
 
 	return result


### PR DESCRIPTION
Some errors were not logged nor displayed in the app, making debugging
issues harder. The errors here could unexpected BitBox02 communication errors.