### PR TITLE
backend/accounts: abort on error instead of continue

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -516,7 +516,7 @@ func (backend *Backend) persistBTCAccountConfig(
 		if err != nil {
 			log.WithError(err).Errorf(
 				"Could not derive xpub at keypath %s", cfg.keypath.Encode())
-			continue
+			return err
 		}
 
 		signingConfiguration := signing.NewBitcoinConfiguration(


### PR DESCRIPTION
When adding an account, the account config is created by getting the
xpubs. If this fails for one of the xpubs, no account should be added,
because:

- either the account is not "complete" (has a missing signing config
which it should have)
- or if all of them fail, the resulting account will have a
configurations entry that is `nil`, which means the account does not
load at all.

This was discovered by a user that had a `null` entry in the
configurations in accounts.json, and when they tried to add another
account, it would fail with the error that the account already
existed (based on the same account code).