### PR TITLE
config: change default fiat currency to usd

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -215,7 +215,7 @@ func NewDefaultAppConfig() AppConfig {
 			},
 			// Copied from frontend/web/src/components/rates/rates.tsx.
 			FiatList: []string{"USD", "EUR", "CHF"},
-			MainFiat: "CHF",
+			MainFiat: "USD",
 		},
 	}
 }

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -42,7 +42,7 @@ export const currencies: Fiat[] = ['AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'EUR', 'GB
 
 export const store = new Store<SharedProps>({
     rates: undefined,
-    active: 'CHF',
+    active: 'USD',
     selected: ['USD', 'EUR', 'CHF'],
 });
 


### PR DESCRIPTION
Currently the fiat currency default is Swiss Franc (CHF), but many
people don't know CHF or this default is not very useful for most.

Changed default to US Dollar (USD) as it is the most widely used
pair with Bitcoin and ohter crypto currencies. Kept Euro and CHF
as enabled secondary fiat currencies.