### PR TITLE
qt: go back to software rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Verify the EIP-55 checksum in mixed-case Ethereum recipient addresses
+- Disable GPU acceleration introduced in v4.29.0 due to rendering artefacts on Windows
 
 ## 4.29.0 [released 2021-08-03]
 - Add support for the Address Ownership Proof Protocol (AOPP), i.e.: handle 'aopp:?...' URIs. See https://aopp.group/.
@@ -13,6 +14,7 @@
 - Prevent screen from turning off while the app is in foreground on Android
 - Allow entering the BitBox02 startup settings in 'Manage device' to toggle showing the firmware hash at any time
 - More user-friendly messages for first BitBox02 firmware install
+- Use hardware accelerated rendering in Qt if available
 
 ## 4.28.2 [released 2021-06-03]
 - Fix a conversion rates updater bug

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -163,6 +163,11 @@ int main(int argc, char *argv[])
     qputenv("DRAW_USE_LLVM", "0");
 #endif
 
+    // Force software rendering over GPU-accelerated rendering as various rendering artefact issues
+    // were observed on Windows and the app crashes on some Linux systems.
+    qputenv("QMLSCENE_DEVICE", "softwarecontext");
+    qputenv("QT_QUICK_BACKEND", "software");
+
 
     BitBoxApp a(argc, argv);
     // These three are part of the SingleApplication instance ID - if changed, the user should close


### PR DESCRIPTION
We attempted to use GPU accelerated rendering in a9823e9a3.

Some users had rendering artefacts on Windows, and at least one user
could not launch the app on Ubuntu 18.04 with:

```
ERROR:command_buffer_proxy_lmpl.cc Context Result::KTranslentFailure:Failed to send GpuChannelMsg_
CreateCommandBuffer.
Segmentation fault (core dumped)
```

To fix these issues, we revert the change and re-enable software rendering.

GPU acceleration was enabled to deal with a very laggy animation when
opening dialogs on Windows. We will deal with this by disabling such
animations in another commit.