### PR TITLE
frontend/guide: add entry that plugout is ok after send and receive

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -738,6 +738,10 @@
         "text": "For the BitBox01, click on the BitBox icon in the sidebar on the left and see the Pairing section. The guide will update and you can continue following the instructions from there.\nFor the BitBox02, you can verify addresses directly on the device during the send/receive process.",
         "title": "How can I verify an address securely?"
       },
+      "plugout": {
+        "text": "No, once you sent coins to your BitBox address, you do not need to leave your BitBox plugged in. You are free to disconnect your BitBox.",
+        "title": "Do I need to leave my BitBox plugged in while receiving?"
+      },
       "why20": {
         "text": "During start-up the app generates addresses derived from your seed to see if they have received funds. As the app can generate an almost infinite number of addresses, it could spend years determining the balance. To limit this search it stops after it sees 20 addresses that have never received funds. This is the \"gap limit\" and 20 is a de-facto standard though the number is arbitrary. These are the 20 addresses you can choose from.",
         "title": "Why only 20 addresses?"
@@ -755,6 +759,10 @@
       "fee": {
         "text": "The fee is based on the transaction data size and not its amount. The fee targets are calculated by Bitcoin Core's fee estimation algorithm for each network priority you chose. They are shown if they have a different value from the target below.\nEconomy: 24 blocks (around 4 hours for Bitcoin, 1 hour for Litecoin)\nLow: 12 blocks (around 2 hours for Bitcoin, 30 minutes for Litecoin)\nNormal: 6 blocks (around 1 hour for Bitcoin, 15 minutes for Litecoin)\nHigh: 2 blocks (around 20 minutes for Bitcoin, 5 minutes for Litecoin)\n(A block takes on average ten minutes for Bitcoin (2.5 minutes in Litecoin) to mine and the network load may vary considerably in the above periods.)",
         "title": "How is the fee determined?"
+      },
+      "plugout": {
+        "text": "No, once you have made a transaction, you do not need to leave your BitBox plugged in. You are free to disconnect your BitBox.",
+        "title": "Do I need to leave my BitBox plugged in while sending?"
       },
       "priority": {
         "text": "The higher fee you are willing to pay, the faster your transaction is typically confirmed by the network.",

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -338,6 +338,7 @@ class Receive extends Component<Props, State> {
                     <Entry key="guide.receive.address" entry={t('guide.receive.address')} />
                     <Entry key="guide.receive.whyVerify" entry={t('guide.receive.whyVerify')} />
                     <Entry key="guide.receive.howVerify" entry={t('guide.receive.howVerify')} />
+                    <Entry key="guide.receive.plugout" entry={t('guide.receive.plugout')} />
                     {currentAddresses.length > 1 && <Entry key="guide.receive.whyMany" entry={t('guide.receive.whyMany')} />}
                     {currentAddresses.length > 1 && <Entry key="guide.receive.why20" entry={t('guide.receive.why20')} />}
                     {currentAddresses.length > 1 && <Entry key="guide.receive.addressChange" entry={t('guide.receive.addressChange')} />}

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -865,6 +865,7 @@ class Send extends Component<Props, State> {
                         )
                     }
                     <Entry key="guide.send.revert" entry={t('guide.send.revert')} />
+                    <Entry key="guide.send.plugout" entry={t('guide.send.plugout')} />
                 </Guide>
             </div>
         );


### PR DESCRIPTION
There was some confusion that people are unsure if the BitBox has
to stay plugged in when receiving or sending.

Added guide entry that it is save to plugout the device after send
or creating a receive address.