### PR TITLE
eth: sync account when making a tx proposal

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -459,6 +459,9 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (*TxProposal, error
 		return nil, errp.WithStack(errors.ErrFeesNotAvailable)
 	}
 
+	// Make sure account.balance is up to date for calculations below.
+	account.Synchronizer.WaitSynchronized()
+
 	var value *big.Int
 	if args.Amount.SendAll() {
 		value = account.balance.BigInt() // set here only temporarily to estimate the gas


### PR DESCRIPTION
newTx() accesses account.balance to check if there are sufficient
funds, but that only works if the account is already synchronized.

The eth account unit test failed randomly due to this, as somtimes,
the tx proposal was made before the accoutn synced.

There is a separate issue to be addressed in a separate PR: the
account vars such as `balance` are written and read without a lock
from different goroutines.