### PR TITLE
frontend: use feerate or gas price for custom fee label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Fix an Android app crash when opening the app after first rejecting the USB permissions
+- Change label to show 'Fee rate' or 'Gas price' for custom fees
 
 ## 4.29.1 [tagged 2021-09-07, released 2021-09-08]
 - Verify the EIP-55 checksum in mixed-case Ethereum recipient addresses

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1137,6 +1137,8 @@
       "placeholder": "Not available"
     },
     "feeTarget": {
+      "customLabel": "Fee rate",
+      "customLabel_eth": "Gas price",
       "description": {
         "economy": "4 hours (24 blocks)",
         "economy_eth": "30 minutes or less",

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -20,7 +20,7 @@ import * as accountApi from '../../../api/account';
 import { Input, Select } from '../../../components/forms';
 import { load } from '../../../decorators/load';
 import { translate, TranslateProps } from '../../../decorators/translate';
-import { getCoinCode, customFeeUnit } from '../utils';
+import { customFeeUnit, getCoinCode, isEthereumBased } from '../utils';
 import * as style from './feetargets.css';
 
 interface LoadedProps {
@@ -182,7 +182,9 @@ class FeeTargets extends Component<Props, State> {
                                     align="right"
                                     className={`${style.fee} ${style.feeCustom}`}
                                     disabled={disabled}
-                                    label={t('send.fee.label')}
+                                    label={t('send.feeTarget.customLabel', {
+                                        context: isEthereumBased(coinCode) ? 'eth' : ''
+                                    })}
                                     id="proposedFee"
                                     placeholder={t('send.fee.customPlaceholder')}
                                     error={error}

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -783,7 +783,10 @@ class Send extends Component<Props, State> {
                                             </span>
                                         )}
                                         {customFee ? (
-                                            <span key="customFee"><br/><small>({customFee} { customFeeUnit(account.coinCode) } )</small></span>
+                                            <span key="customFee">
+                                                <br/>
+                                                <small>({customFee} {customFeeUnit(account.coinCode)})</small>
+                                            </span>
                                         ) : null}
                                     </p>
                                 </div>


### PR DESCRIPTION
Currently when selecting a custom fee, the label on top of the input
just says 'Network fee', but we use this label also for the total
amount of the estimated fee price below the selection.

Changed the custom fee label to display either 'Fee rate' or
'Gas price' depending on the coinCode of the selected account.