### PR TITLE
frontend: remove unused translations

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1119,10 +1119,6 @@
       "title": "Confirm and send transaction",
       "total": "Total"
     },
-    "customFee": {
-      "label": "Converted fee",
-      "placeholder": "Converted fee"
-    },
     "data": {
       "label": "Optional data",
       "placeholder": "Enter hexadecimal data"


### PR DESCRIPTION
Seems send.customFee.label is not used anywhere, also checked
all occurences of '.placeholder' and '.label'.