### PR TITLE
frontend: start bitbox02 specific device api

### DIFF
--- a/backend/devices/bitbox02/handlers/handlers.go
+++ b/backend/devices/bitbox02/handlers/handlers.go
@@ -134,7 +134,10 @@ func (handlers *Handlers) getDeviceInfo(_ *http.Request) (interface{}, error) {
 	if err != nil {
 		return maybeBB02Err(err, handlers.log), nil
 	}
-	return deviceInfo, nil
+	return map[string]interface{}{
+		"success":    true,
+		"deviceInfo": deviceInfo,
+	}, nil
 }
 
 func (handlers *Handlers) postSetDeviceName(r *http.Request) (interface{}, error) {

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apiGet } from '../utils/request';
+import { TSuccess, TFail } from './response';
+
+export type TDeviceInfo = {
+    initialized: boolean;
+    mnemonicPassphraseEnabled: boolean;
+    name: string;
+    securechipModel: string;
+    version: string;
+}
+
+interface IDeviceInfo extends TSuccess {
+    deviceInfo: TDeviceInfo;
+}
+
+export const getDeviceInfo = (
+    deviceID: string
+): Promise<IDeviceInfo | TFail> => {
+    return apiGet(`devices/bitbox02/${deviceID}/info`);
+};

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -15,9 +15,9 @@
  */
 
 import { apiGet, apiPost } from '../utils/request';
-import { TSuccess, TFail } from './response';
+import { SuccessResponse, FailResponse } from './response';
 
-export type TDeviceInfo = {
+export type DeviceInfo = {
     initialized: boolean;
     mnemonicPassphraseEnabled: boolean;
     name: string;
@@ -25,19 +25,19 @@ export type TDeviceInfo = {
     version: string;
 }
 
-interface IDeviceInfo extends TSuccess {
-    deviceInfo: TDeviceInfo;
-}
+type DeviceInfoResponse = SuccessResponse & {
+    deviceInfo: DeviceInfo;
+};
 
 export const getDeviceInfo = (
     deviceID: string
-): Promise<IDeviceInfo | TFail> => {
+): Promise<DeviceInfoResponse | FailResponse> => {
     return apiGet(`devices/bitbox02/${deviceID}/info`);
 };
 
 export const setMnemonicPassphraseEnabled = (
     deviceID: string,
     enabled: boolean,
-): Promise<TSuccess | TFail> => {
+): Promise<SuccessResponse | FailResponse> => {
     return apiPost(`devices/bitbox02/${deviceID}/set-mnemonic-passphrase-enabled`, enabled);
 };

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -31,9 +31,16 @@ type DeviceInfoResponse = SuccessResponse & {
 
 export const getDeviceInfo = (
     deviceID: string
-): Promise<DeviceInfoResponse | FailResponse> => {
-    return apiGet(`devices/bitbox02/${deviceID}/info`);
+): Promise<DeviceInfo> => {
+    return apiGet(`devices/bitbox02/${deviceID}/info`)
+        .then((response: DeviceInfoResponse | FailResponse) => {
+            if (!response.success) {
+                return Promise.reject(response);
+            }
+            return Promise.resolve(response.deviceInfo);
+        });
 };
+
 
 export const setMnemonicPassphraseEnabled = (
     deviceID: string,

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { apiGet } from '../utils/request';
+import { apiGet, apiPost } from '../utils/request';
 import { TSuccess, TFail } from './response';
 
 export type TDeviceInfo = {
@@ -33,4 +33,11 @@ export const getDeviceInfo = (
     deviceID: string
 ): Promise<IDeviceInfo | TFail> => {
     return apiGet(`devices/bitbox02/${deviceID}/info`);
+};
+
+export const setMnemonicPassphraseEnabled = (
+    deviceID: string,
+    enabled: boolean,
+): Promise<TSuccess | TFail> => {
+    return apiPost(`devices/bitbox02/${deviceID}/set-mnemonic-passphrase-enabled`, enabled);
 };

--- a/frontends/web/src/api/response.ts
+++ b/frontends/web/src/api/response.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-export type TSuccess = {
+export type SuccessResponse = {
     success: true;
 }
 
 // if the backend uses maybeBB02Err
-export type TFail = {
+export type FailResponse = {
     code?: number;
     message?: string;
     success: false;

--- a/frontends/web/src/api/response.ts
+++ b/frontends/web/src/api/response.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type TSuccess = {
+    success: true;
+}
+
+// if the backend uses maybeBB02Err
+export type TFail = {
+    code?: number;
+    message?: string;
+    success: false;
+}

--- a/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
@@ -42,11 +42,8 @@ class MnemonicPassphraseButton extends Component<Props, State> {
     }
 
     private getDeviceInfo = () => {
-        getDeviceInfo(this.props.deviceID).then(response => {
-            if (response.success) {
-                this.setState({ deviceInfo: response.deviceInfo });
-            }
-        });
+        getDeviceInfo(this.props.deviceID)
+            .then(deviceInfo => this.setState({ deviceInfo }));
     }
 
     private toggle = () => {

--- a/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
@@ -16,7 +16,7 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
-import { getDeviceInfo, setMnemonicPassphraseEnabled, TDeviceInfo } from '../../../api/bitbox02';
+import { getDeviceInfo, setMnemonicPassphraseEnabled, DeviceInfo } from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { SimpleMarkup } from '../../../utils/simplemarkup';
 import { alertUser } from '../../../components/alert/Alert';
@@ -25,17 +25,17 @@ import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
 
 interface MnemonicPassphraseButtonProps {
     deviceID: string;
-    deviceInfo: TDeviceInfo;
+    deviceInfo: DeviceInfo;
 }
 
 interface State {
     inProgress: boolean;
-    deviceInfo: TDeviceInfo;
+    deviceInfo: DeviceInfo;
 }
 
 type Props = MnemonicPassphraseButtonProps & TranslateProps;
 
-class MnemonicPassphraseButton  extends Component<Props, State> {
+class MnemonicPassphraseButton extends Component<Props, State> {
     public readonly state: State = {
         inProgress: false,
         deviceInfo: this.props.deviceInfo,

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -48,11 +48,8 @@ class Settings extends Component<Props, State> {
     }
 
     private getInfo = () => {
-        getDeviceInfo(this.props.deviceID).then(response => {
-            if (response.success) {
-                this.setState({ deviceInfo: response.deviceInfo });
-            }
-        });
+        getDeviceInfo(this.props.deviceID)
+            .then(deviceInfo => this.setState({ deviceInfo }));
     }
 
     public componentDidMount() {

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -16,7 +16,7 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
-import { getDeviceInfo, TDeviceInfo } from '../../../api/bitbox02';
+import { getDeviceInfo, DeviceInfo } from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet } from '../../../utils/request';
 import { SwissMadeOpenSource } from '../../../components/icon/logo';
@@ -37,7 +37,7 @@ interface SettingsProps {
 
 interface State {
     versionInfo?: VersionInfo;
-    deviceInfo?: TDeviceInfo;
+    deviceInfo?: DeviceInfo;
 }
 
 type Props = SettingsProps & TranslateProps;

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -16,6 +16,7 @@
  */
 
 import { Component, h, RenderableProps } from 'preact';
+import { getDeviceInfo, TDeviceInfo } from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet } from '../../../utils/request';
 import { SwissMadeOpenSource } from '../../../components/icon/logo';
@@ -36,13 +37,7 @@ interface SettingsProps {
 
 interface State {
     versionInfo?: VersionInfo;
-    deviceInfo?: {
-        name: string;
-        initialized: boolean;
-        version: string;
-        mnemonicPassphraseEnabled: boolean;
-        securechipModel: string;
-    };
+    deviceInfo?: TDeviceInfo;
 }
 
 type Props = SettingsProps & TranslateProps;
@@ -53,8 +48,10 @@ class Settings extends Component<Props, State> {
     }
 
     private getInfo = () => {
-        apiGet(this.apiPrefix() + '/info').then(response => {
-            this.setState({ deviceInfo: response.deviceInfo });
+        getDeviceInfo(this.props.deviceID).then(response => {
+            if (response.success) {
+                this.setState({ deviceInfo: response.deviceInfo });
+            }
         });
     }
 

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,8 +53,8 @@ class Settings extends Component<Props, State> {
     }
 
     private getInfo = () => {
-        apiGet(this.apiPrefix() + '/info').then(deviceInfo => {
-            this.setState({ deviceInfo });
+        apiGet(this.apiPrefix() + '/info').then(response => {
+            this.setState({ deviceInfo: response.deviceInfo });
         });
     }
 

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -145,9 +145,8 @@ class Settings extends Component<Props, State> {
                                         </div>
                                         <div className="box slim divide">
                                             <MnemonicPassphraseButton
-                                                apiPrefix={this.apiPrefix()}
-                                                mnemonicPassphraseEnabled={deviceInfo.mnemonicPassphraseEnabled}
-                                                getInfo={this.getInfo} />
+                                                deviceID={this.props.deviceID}
+                                                deviceInfo={deviceInfo} />
                                             { versionInfo && versionInfo.canGotoStartupSettings ? (
                                                   <GotoStartupSettings apiPrefix={this.apiPrefix()} />
                                             ) : null


### PR DESCRIPTION
- added api/response with success and fail union type
- added api/bitbox02 specifc for BitBox02
  (is similar to api/devices)
- added getDeviceInfo and setMnemonicPassphraseEnabled
- changed device info response to always include the success field
- refactored mnemonicpassphrase component, so it doesn't need
  to use callback function and works on its own