### PR TITLE
frontend: change sendall label when there is coin selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Fix an Android app crash when opening the app after first rejecting the USB permissions
 - Change label to show 'Fee rate' or 'Gas price' for custom fees
+- Change label 'Send all' label to 'Send selected coins' if there is a coin selection
 
 ## 4.29.1 [tagged 2021-09-07, released 2021-09-08]
 - Verify the EIP-55 checksum in mixed-case Ethereum recipient addresses

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1169,6 +1169,7 @@
       "placeholder": "Calculating fee…"
     },
     "maximum": "Send all",
+    "maximumSelectedCoins": "Send selected coins",
     "priority": "Priority",
     "scanQR": "Scan QR code",
     "signprogress": {

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -449,6 +449,10 @@ class Send extends Component<Props, State> {
         this.validateAndDisplayFee(true);
     }
 
+    private hasSelectedUTXOs = (): boolean => {
+        return Object.keys(this.selectedUTXOs).length !== 0;
+    }
+
     private getAccount = (): accountApi.IAccount | undefined => {
         if (!this.props.accounts) {
             return undefined;
@@ -662,7 +666,7 @@ class Send extends Component<Props, State> {
                                                 placeholder={t('send.amount.placeholder')}
                                                 labelSection={
                                                     <Checkbox
-                                                        label={t('send.maximum')}
+                                                        label={t(this.hasSelectedUTXOs() ? 'send.maximumSelectedCoins' : 'send.maximum')}
                                                         id="sendAll"
                                                         onChange={this.handleFormChange}
                                                         checked={sendAll}
@@ -791,7 +795,7 @@ class Send extends Component<Props, State> {
                                     </p>
                                 </div>
                                 {
-                                    Object.keys(this.selectedUTXOs).length !== 0 && (
+                                    this.hasSelectedUTXOs() && (
                                         <div className={[style.confirmItem].join(' ')}>
                                             <label>{t('send.confirm.selected-coins')}</label>
                                             {


### PR DESCRIPTION
If coins are selected and sendall is checked the sendall label is
confusing. Changed the label to 'Send selected coins' to assure
only the selection is sent and not all coins.