### PR TITLE
frontend: improve information about using the passphrase feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix an Android app crash when opening the app after first rejecting the USB permissions
 - Change label to show 'Fee rate' or 'Gas price' for custom fees
 - Change label 'Send all' label to 'Send selected coins' if there is a coin selection
+- Improve information about using the passphrase feature
 
 ## 4.29.1 [tagged 2021-09-07, released 2021-09-08]
 - Verify the EIP-55 checksum in mixed-case Ethereum recipient addresses

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -174,13 +174,6 @@
     "gotoStartupSettings": {
       "description": "This will reboot your BitBox02 and enter the startup settings.",
       "title": "Go to startup settings"
-    },
-    "mnemonicPassphrase": {
-      "description": "This allows you to enter an optional passphrase after unlocking your BitBox02.\n\n<strong>NOTE:</strong> any passphrase derives a new separate wallet.\nKeep your passphrase <strong>secure</strong>.\n<strong>A loss of the passphrase is NOT RECOVERABLE.</strong>",
-      "disable": "Disable optional passphrase",
-      "enable": "Enable optional passphrase",
-      "successDisable": "Optional passphrase successfully disabled",
-      "successEnable": "Optional passphrase successfully enabled.\n\nFrom now on you can insert a passphrase after having unlocked your BitBox02. \n\nIf you don't know what a passphrase is, please deactivate this option. It is an advanced user's option. \n\n\n<strong>Warning:</strong> every passphrase generates a valid wallet. \nYou need to make sure your passphrase is <strong>secure and that you don't lose it.</strong>\n\n<strong>If you lose your passphrase, you will not be able to access your coins. That means your coins will be lost.</strong>"
     }
   },
   "bitbox02Wizard": {
@@ -485,7 +478,8 @@
     "enable_false": "Disable",
     "enable_true": "Enable",
     "enabled_false": "Disabled",
-    "enabled_true": "Enabled"
+    "enabled_true": "Enabled",
+    "success": "Success"
   },
   "genericError": "An error occurred. If you notice any issues, please restart the application.",
   "goal": {
@@ -939,11 +933,6 @@
     "settingsButtonDescription": "Add and show/hide accounts",
     "title": "Manage accounts"
   },
-  "mnemonicPassphrase": {
-    "error": {
-      "e104": "Changing the passphrase setting was aborted."
-    }
-  },
   "mobile": {
     "usingMobileDataWarning": "Mobile data usage: this app may download up to a few hundred megabytes of blockchain header data after unlocking an account. Please connect to Wi-Fi to avoid using mobile data. After dismissing it, this message won't be shown again."
   },
@@ -1003,6 +992,67 @@
       "title": "Timeout"
     },
     "title": "Mobile pairing"
+  },
+  "passphrase": {
+    "considerations": {
+      "button": "Backup considerations",
+      "message": "The passphrase protects your wallet backups. Which means if someone has access to your backup (microSD card or 24 words) they will also need the passphrase to access your wallet.\n\nHowever, this means you cannot restore your wallet with only the backup (microSD card or 24 words). In case your BitBox is lost or broken, you will need <strong>both</strong> the passphrase and backup to recover your wallet. If you forgot or lost your passphrase, all the coins on that wallet will be lost.\n\nWhen storing your passphrase, consider not putting it in the same location as your backup. That way if someone finds your backup they don’t find your passphrase as well.",
+      "title": "Backup considerations"
+    },
+    "disable": "Disable passphrase",
+    "disableInfo": {
+      "button": "Disable",
+      "message": "After disabling the passphrase, you will no longer be asked to enter a passphrase after unlocking your BitBox02. Therefore, you will enter your default wallet.\n\nAny coins on your passphrase-wallet will still be on that wallet, however you won’t be able to access them because after unlocking your BitBox02, you will open your default wallet.\n\nTo access your passphrase-wallets again, simply re-enable the passphrase feature and enter the relevant passphrase after unlocking the BitBox02.\n\n<strong>Tip:</strong> You can still enter your original wallet by leaving the passphrase empty."
+    },
+    "enable": "Enable passphrase",
+    "error": {
+      "e104": "Changing the passphrase setting was aborted."
+    },
+    "how": {
+      "button": "What it looks like",
+      "message": "This passphrase doesn’t work like a password that you’re used to. You will not get a ’wrong password’ error if you enter a different passphrase. This is because every passphrase creates a different, yet valid, wallet. This means you can use multiple passphrases as many wallets on your BitBox as you want. But they can only be accessed when typing in the corresponding passphrase.\n\nWhen plugging in your BitBox, you’ll be prompted for the password as usual. After that, you’ll be asked to enter a passphrase on the device. After entering the passphrase, you’ll be shown the passphrase you entered. This is so you can confirm you entered it in correctly. Every passphrase creates a valid and separate wallet. If you mistype your passphrase, you will not be notified. We suggest sending a small amount to the passphrase wallet. Then unplug and replug the BitBox02 and enter your password and passphrase. If you entered the passphrase correctly, you should see the coins in your wallet.\n\n<strong>Tip:</strong> If you want to enter your original wallet without a passphrase, you can still do this by entering nothing when prompted to enter the passphrase. Or you can disable the passphrase feature.",
+      "title": "How it works?"
+    },
+    "intro": {
+      "message": "A passphrase provides better security, but first learn what it is and how to properly use it to not lock yourself out of your funds.",
+      "title": "Setup passphrase"
+    },
+    "progressDisable": {
+      "message": "Confirm on your BitBox that you want to disable the optional passphrase",
+      "title": "Confirm on device"
+    },
+    "progressEnable": {
+      "message": "Confirm on your BitBox that you want to enable the optional passphrase",
+      "title": "Confirm on device"
+    },
+    "successDisabled": {
+      "message": "Optional passphrase <strong>successfully enabled</strong>!\nYou’ll be asked to provide a passphrase from now on.\nPlease replug your BitBox02 now.",
+      "title": "Passphrase enabled"
+    },
+    "successEnabled": {
+      "message": "Optional passphrase <strong>successfully disabled</strong>!\nYou will not be asked to provide a passphrase anymore.\nPlease replug your BitBox02 now.",
+      "title": "Passphrase disabled"
+    },
+    "summary": {
+      "button": "Enable passphrase",
+      "title": "Summary",
+      "understand": "I understand how the passphrase works and the risks associated with it.",
+      "understandList": [
+        "The passphrase is an additional layer of security on top of your backup.",
+        "Entering a different passphrase will always generate a different wallet.",
+        "To restore your wallet you need <strong>both the passphrase and backup</strong>."
+      ]
+    },
+    "what": {
+      "button": "How does this work?",
+      "message": "A wallet is created (derived) from a very big random number, also known as seed or wallet-seed. It is created when you first set up your BitBox02 and is backed up with the microSD cards or 24 words. Anyone who has access to the seed has full control over the funds on that wallet, therefore the seed is a secret.\n\nA passphrase is an optional secret, added to the seed, to create a completely different wallet based on seed + passphrase. A passphrase can be anything: letters, words, special characters.\n\nTo restore your passphrase enabled wallet you will need the passphrase + wallet backup. If you forget your passphrase, you will not be able to access your wallet, even if you have your backup!",
+      "title": "What is a Passphrase?"
+    },
+    "why": {
+      "button": "Why use a passphrase?",
+      "message": "The BitBox02 protects the seed against extraction, but the backup (microSD card or 24 words) gives full access to your wallet. That is why it should be stored in a secure location!\n\nWhen using a passphrase, each passphrase unlocks a new wallet. A different passphrase will create a different wallet.",
+      "title": "Why use a passphrase?"
+    }
   },
   "password": {
     "show": "Show {{label}}",

--- a/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
@@ -19,86 +19,243 @@ import { Component, h, RenderableProps } from 'preact';
 import { getDeviceInfo, setMnemonicPassphraseEnabled } from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { SimpleMarkup } from '../../../utils/simplemarkup';
+import { Button, Checkbox } from '../../../components/forms';
 import { alertUser } from '../../../components/alert/Alert';
 import { SettingsButton } from '../../../components/settingsButton/settingsButton';
+import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
 import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
+import { Message } from '../../../components/message/message';
 
 interface MnemonicPassphraseButtonProps {
     deviceID: string;
-    mnemonicPassphraseEnabled: boolean;
+    passphraseEnabled: boolean;
 }
 
 interface State {
-    inProgress: boolean;
-    mnemonicPassphraseEnabled: boolean;
+    infoStep: number;
+    passphraseEnabled: boolean;
+    status: 'idle' | 'info' | 'progress' | 'success';
+    understood: boolean;
 }
 
 type Props = MnemonicPassphraseButtonProps & TranslateProps;
 
 class MnemonicPassphraseButton extends Component<Props, State> {
     public readonly state: State = {
-        inProgress: false,
-        mnemonicPassphraseEnabled: this.props.mnemonicPassphraseEnabled,
+        infoStep: 5,
+        status: 'idle',
+        passphraseEnabled: this.props.passphraseEnabled,
+        understood: false,
     }
 
-    private getDeviceInfo = () => {
-        getDeviceInfo(this.props.deviceID)
-            .then(({ mnemonicPassphraseEnabled }) => this.setState({ mnemonicPassphraseEnabled }));
-    }
-
-    private toggle = () => {
+    private togglePassphrase = () => {
         const { t } = this.props;
-        const enable = !this.state.mnemonicPassphraseEnabled;
-        this.setState({ inProgress: true });
+        const enable = !this.state.passphraseEnabled;
+        this.setState({ status: 'progress' });
         setMnemonicPassphraseEnabled(this.props.deviceID, enable)
-            .then(() => {
-                this.setState({ inProgress: false });
-                if (enable) {
-                    alertUser(t('bitbox02Settings.mnemonicPassphrase.successEnable'));
-                } else {
-                    alertUser(t('bitbox02Settings.mnemonicPassphrase.successDisable'));
-                }
-                this.getDeviceInfo();
+            .then(() => getDeviceInfo(this.props.deviceID))
+            .then(({ mnemonicPassphraseEnabled }) => {
+                this.setState({
+                    passphraseEnabled: mnemonicPassphraseEnabled,
+                    status: 'success',
+                });
             })
             .catch((e) => {
-                this.setState({ inProgress: false });
-                alertUser(t(`mnemonicPassphrase.error.e${e.code}`, {
+                this.setState({ status: 'idle' });
+                alertUser(t(`passphrase.error.e${e.code}`, {
                     defaultValue: e.message || t('genericError'),
                 }));
             });
     }
 
-    private renderLine = (line: string, i: number) => (
-        <span key={`${line}-${i}`}>
-            <SimpleMarkup tagName="span" markup={line} /><br/>
-        </span>
-    )
+    private startInfo = () => {
+        const { passphraseEnabled } = this.state;
+        this.setState({
+            // before enabling/disabling we show 1 or more pages to inform about the feature
+            // each page has a continue button that jumps to the next or finally toggles passphrase
+            // infoStep counts down in decreasing order
+            infoStep: passphraseEnabled
+                ? 0 // disabling passphrase shows only 1 info dialog
+                : 5, // enabling has 6 dialogs with information
+            status: 'info',
+            understood: false,
+        });
+    }
+
+    private stopInfo = () => this.setState({ status: 'idle' })
+
+    private continueInfo = () => {
+        if (this.state.infoStep === 0) {
+            this.togglePassphrase();
+            return;
+        }
+        this.setState(({ infoStep }) => ({ infoStep: infoStep - 1 }));
+    }
+
+    private renderEnableInfo = () => {
+        const { infoStep, understood } = this.state;
+        const { t } = this.props;
+        switch (infoStep) {
+            case 5:
+                return (
+                    <Dialog key="step-intro" medium title={t('passphrase.intro.title')} onClose={this.stopInfo}>
+                        {this.renderMultiLine(t('passphrase.intro.message'))}
+                        <DialogButtons>
+                            <Button primary onClick={this.continueInfo}>
+                                {t('passphrase.what.button')}
+                            </Button>
+                            <Button transparent onClick={this.stopInfo}>
+                                {t('button.back')}
+                            </Button>
+                        </DialogButtons>
+                    </Dialog>
+                );
+            case 4:
+                return (
+                    <Dialog key="step-what" medium title={t('passphrase.what.title')} onClose={this.stopInfo}>
+                        {this.renderMultiLine(t('passphrase.what.message'))}
+                        <DialogButtons>
+                            <Button primary onClick={this.continueInfo}>
+                                {t('passphrase.why.button')}
+                            </Button>
+                            <Button transparent onClick={this.stopInfo}>
+                                {t('button.back')}
+                            </Button>
+                        </DialogButtons>
+                    </Dialog>
+                );
+            case 3:
+                return (
+                    <Dialog key="step-why" medium title={t('passphrase.why.title')} onClose={this.stopInfo}>
+                        {this.renderMultiLine(t('passphrase.why.message'))}
+                        <DialogButtons>
+                            <Button primary onClick={this.continueInfo}>
+                                {t('passphrase.considerations.button')}
+                            </Button>
+                            <Button transparent onClick={this.stopInfo}>
+                                {t('button.back')}
+                            </Button>
+                        </DialogButtons>
+                    </Dialog>
+                );
+            case 2:
+                return (
+                    <Dialog key="step-considerations" medium title={t('passphrase.considerations.title')} onClose={this.stopInfo}>
+                        {this.renderMultiLine(t('passphrase.considerations.message'))}
+                        <DialogButtons>
+                            <Button primary onClick={this.continueInfo}>
+                                {t('passphrase.how.button')}
+                            </Button>
+                            <Button transparent onClick={this.stopInfo}>
+                                {t('button.back')}
+                            </Button>
+                        </DialogButtons>
+                    </Dialog>
+                );
+            case 1:
+                return (
+                    <Dialog key="step-how" medium title={t('passphrase.how.title')} onClose={this.stopInfo}>
+                        {this.renderMultiLine(t('passphrase.how.message'))}
+                        <DialogButtons>
+                            <Button primary onClick={this.continueInfo}>
+                                {t('passphrase.summary.button')}
+                            </Button>
+                            <Button transparent onClick={this.stopInfo}>
+                                {t('button.back')}
+                            </Button>
+                        </DialogButtons>
+                    </Dialog>
+                );
+            case 0:
+                return (
+                    <Dialog key="step-summary" medium title={t('passphrase.summary.title')} onClose={this.stopInfo}>
+                        <ul style="padding-left: var(--space-default);">
+                            <SimpleMarkup key="info-1" tagName="li" markup={t('passphrase.summary.understandList.0')} />
+                            <SimpleMarkup key="info-2" tagName="li" markup={t('passphrase.summary.understandList.1')} />
+                            <SimpleMarkup key="info-3" tagName="li" markup={t('passphrase.summary.understandList.2')} />
+                        </ul>
+                        <Message type="message">
+                            <Checkbox
+                                onChange={e => this.setState({ understood: e.target?.checked })}
+                                id="understood"
+                                checked={understood}
+                                label={t('passphrase.summary.understand')} />
+                        </Message>
+                        <DialogButtons>
+                            <Button primary onClick={this.continueInfo} disabled={!understood}>
+                                {t('passphrase.enable')}
+                            </Button>
+                            <Button transparent onClick={this.stopInfo}>
+                                {t('button.back')}
+                            </Button>
+                        </DialogButtons>
+                    </Dialog>
+                );
+            default:
+                console.error(`invalid infoStep ${infoStep}`);
+                return;
+        }
+    }
+
+    private renderMultiLine = text => text.split('\n').map((line: string, i: number) => (
+        <SimpleMarkup key={`${line}-${i}`} tagName="p" markup={line} />
+    ))
+
+    private renderDisableInfo = () => {
+        const { t } = this.props;
+        return (
+            <Dialog key="step-disable-info1" medium title={t('passphrase.disable')} onClose={this.stopInfo}>
+                {this.renderMultiLine(t('passphrase.disableInfo.message'))}
+                <DialogButtons>
+                    <Button primary onClick={this.continueInfo}>
+                        {t('passphrase.disableInfo.button')}
+                    </Button>
+                    <Button transparent onClick={this.stopInfo}>
+                        {t('button.back')}
+                    </Button>
+                </DialogButtons>
+            </Dialog>
+        );
+    }
 
     public render(
         { t }: RenderableProps<Props>,
-        { mnemonicPassphraseEnabled, inProgress }: State,
+        { passphraseEnabled, status }: State,
     ) {
-        const title = mnemonicPassphraseEnabled ? t('bitbox02Settings.mnemonicPassphrase.disable') : t('bitbox02Settings.mnemonicPassphrase.enable');
-        const message = t('bitbox02Settings.mnemonicPassphrase.description');
         return (
             <div>
-                <SettingsButton onClick={this.toggle}>{title}</SettingsButton>
-                { inProgress && (
-                    <WaitDialog title={title}>
-                        <div className="columnsContainer half">
-                            <div className="columns">
-                                <div className="column">
-                                    { !mnemonicPassphraseEnabled && message && (
-                                        <p>
-                                            { message.split('\n').map(this.renderLine) }
-                                        </p>
-                                    ) }
-                                    <p>{t('bitbox02Interact.followInstructions')}</p>
-                                </div>
-                            </div>
-                        </div>
+                <SettingsButton onClick={this.startInfo}>
+                    {passphraseEnabled
+                        ? t('passphrase.disable')
+                        : t('passphrase.enable')}
+                </SettingsButton>
+                {status === 'info' && (
+                    passphraseEnabled
+                        ? this.renderDisableInfo()
+                        : this.renderEnableInfo()
+                )}
+                {status === 'progress' && (
+                    <WaitDialog
+                        title={t(passphraseEnabled
+                            ? 'passphrase.progressDisable.title'
+                            : 'passphrase.progressEnable.title')}>
+                        {t(passphraseEnabled
+                            ? 'passphrase.progressDisable.message'
+                            : 'passphrase.progressEnable.message')}
                     </WaitDialog>
-                ) }
+                )}
+                {status === 'success' && (
+                    <WaitDialog
+                        title={t(passphraseEnabled
+                            ? 'passphrase.successDisabled.title'
+                            : 'passphrase.successEnabled.title')} >
+                        {this.renderMultiLine(
+                            t(passphraseEnabled
+                                ? 'passphrase.successDisabled.message'
+                                : 'passphrase.successEnabled.message')
+                        )}
+                    </WaitDialog>
+                )}
             </div>
         );
     }

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -30,6 +30,7 @@ import { Reset } from './reset';
 import { SetDeviceName } from './setdevicename';
 import { ShowMnemonic } from './showmnemonic';
 import { UpgradeButton, VersionInfo } from './upgradebutton';
+import { alertUser } from '../../../components/alert/Alert';
 
 interface SettingsProps {
     deviceID: string;
@@ -49,7 +50,11 @@ class Settings extends Component<Props, State> {
 
     private getInfo = () => {
         getDeviceInfo(this.props.deviceID)
-            .then(deviceInfo => this.setState({ deviceInfo }));
+            .then(deviceInfo => this.setState({ deviceInfo }))
+            .catch(error => {
+                console.error(error);
+                alertUser(this.props.t('genericError'));
+            });
     }
 
     public componentDidMount() {
@@ -143,7 +148,7 @@ class Settings extends Component<Props, State> {
                                         <div className="box slim divide">
                                             <MnemonicPassphraseButton
                                                 deviceID={this.props.deviceID}
-                                                mnemonicPassphraseEnabled={deviceInfo.mnemonicPassphraseEnabled} />
+                                                passphraseEnabled={deviceInfo.mnemonicPassphraseEnabled} />
                                             { versionInfo && versionInfo.canGotoStartupSettings ? (
                                                   <GotoStartupSettings apiPrefix={this.apiPrefix()} />
                                             ) : null


### PR DESCRIPTION
It is a regular occurrence that a user asks for support on Telegram
about funds or transactions missing, because they had used a
passphrase and did not understand what it meant. Often the issue
pops up when restoring a wallet (passphrase needs to be activated
and entered again), and also some users simply deactivate the
passphrase and are confused why the funds are gone.

Users considering enabling passphrase should be well informed and
know about the advantages and risks.

Added what, why, how, backup infos explanations on different pages
to inform and improve using the passphrase feature.

Made the success step blocking with a prompt to force replug the
BitBox. This is so that the changed settings take effect.