### PR TITLE
Frontend passphrase text

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -996,7 +996,7 @@
   "passphrase": {
     "considerations": {
       "button": "Backup considerations",
-      "message": "The passphrase protects your wallet backups. Which means if someone has access to your backup (microSD card or 24 words) they will also need the passphrase to access your wallet.\n\nHowever, this means you cannot restore your wallet with only the backup (microSD card or 24 words). In case your BitBox is lost or broken, you will need <strong>both</strong> the passphrase and backup to recover your wallet. If you forgot or lost your passphrase, all the coins on that wallet will be lost.\n\nWhen storing your passphrase, consider not putting it in the same location as your backup. That way if someone finds your backup they don’t find your passphrase as well.",
+      "message": "The passphrase adds a layer of protection to your wallet backup (microSD card or 24 words). If someone has access to your backup they will also need the passphrase to access your wallet.\n\nHowever, this means you will need <strong>both the passphrase + wallet backup</strong> to restore your passphrase-enabled wallet, in case your BitBox02 is lost or broken. If you forget or lose your passphrase, you will lose access to all the coins on that wallet.\n\n\nWhen storing your passphrase, consider putting it in a separate location than your backup. That way if someone finds your backup they don’t find your passphrase as well.\n",
       "title": "Backup considerations"
     },
     "disable": "Disable passphrase",
@@ -1010,11 +1010,11 @@
     },
     "how": {
       "button": "What it looks like",
-      "message": "This passphrase doesn’t work like a password that you’re used to. You will not get a ’wrong password’ error if you enter a different passphrase. This is because every passphrase creates a different, yet valid, wallet. This means you can use multiple passphrases as many wallets on your BitBox as you want. But they can only be accessed when typing in the corresponding passphrase.\n\nWhen plugging in your BitBox, you’ll be prompted for the password as usual. After that, you’ll be asked to enter a passphrase on the device. After entering the passphrase, you’ll be shown the passphrase you entered. This is so you can confirm you entered it in correctly. Every passphrase creates a valid and separate wallet. If you mistype your passphrase, you will not be notified. We suggest sending a small amount to the passphrase wallet. Then unplug and replug the BitBox02 and enter your password and passphrase. If you entered the passphrase correctly, you should see the coins in your wallet.\n\n<strong>Tip:</strong> If you want to enter your original wallet without a passphrase, you can still do this by entering nothing when prompted to enter the passphrase. Or you can disable the passphrase feature.",
-      "title": "How it works?"
+      "message": "A passphrase doesn’t work like a password that you’re used to. If you mistype your passphrase, you will not be notified. This is because <strong>every passphrase creates a different, yet valid, wallet</strong>. This means you can use multiple passphrases for as many wallets as you want. But each wallet can only be accessed when typing in the corresponding passphrase.\n\nWhen plugging in your BitBox02, you’ll be prompted for the device password as usual. After that, you’ll be asked to enter a passphrase on the device.\n\nAfter entering the passphrase, you’ll be shown the passphrase you entered. This is so you can confirm you entered it correctly.",
+      "title": "How does it work"
     },
     "intro": {
-      "message": "A passphrase provides better security, but first learn what it is and how to properly use it to not lock yourself out of your funds.",
+      "message": "A passphrase provides an additional layer of security on top of your wallet. Let’s learn how it works.",
       "title": "Setup passphrase"
     },
     "progressDisable": {
@@ -1030,13 +1030,13 @@
       "title": "Passphrase enabled"
     },
     "successEnabled": {
-      "message": "Optional passphrase <strong>successfully disabled</strong>!\nYou will not be asked to provide a passphrase anymore.\nPlease replug your BitBox02 now.",
+      "message": "Optional passphrase <strong>successfully disabled</strong>!\n\nYou will not be asked to provide a passphrase anymore. Please replug your BitBox02 now.",
       "title": "Passphrase disabled"
     },
     "summary": {
       "button": "Enable passphrase",
       "title": "Summary",
-      "understand": "I understand how the passphrase works and the risks associated with it.",
+      "understand": "",
       "understandList": [
         "The passphrase is an additional layer of security on top of your backup.",
         "Entering a different passphrase will always generate a different wallet.",
@@ -1044,13 +1044,13 @@
       ]
     },
     "what": {
-      "button": "How does this work?",
-      "message": "A wallet is created (derived) from a very big random number, also known as seed or wallet-seed. It is created when you first set up your BitBox02 and is backed up with the microSD cards or 24 words. Anyone who has access to the seed has full control over the funds on that wallet, therefore the seed is a secret.\n\nA passphrase is an optional secret, added to the seed, to create a completely different wallet based on seed + passphrase. A passphrase can be anything: letters, words, special characters.\n\nTo restore your passphrase enabled wallet you will need the passphrase + wallet backup. If you forget your passphrase, you will not be able to access your wallet, even if you have your backup!",
-      "title": "What is a Passphrase?"
+      "button": "Learn how this works",
+      "message": "A wallet is created (derived) from a very big random number, also known as a seed. This seed is created when you first set up your BitBox02 and is backed up with the microSD card or 24 words. Anyone who has access to the seed has full control over the funds on that wallet.\n\nA passphrase is an <strong>optional secret</strong>, added to the seed. When using a passphrase, each passphrase creates a new wallet based on the seed + passphrase (optional secret). A passphrase can be anything: letters, words, special characters or it can even be empty. The default wallet is in fact derived from the seed + empty passphrase.",
+      "title": "What is a passphrase?"
     },
     "why": {
-      "button": "Why use a passphrase?",
-      "message": "The BitBox02 protects the seed against extraction, but the backup (microSD card or 24 words) gives full access to your wallet. That is why it should be stored in a secure location!\n\nWhen using a passphrase, each passphrase unlocks a new wallet. A different passphrase will create a different wallet.",
+      "button": "Why use a passphrase",
+      "message": "The BitBox02 protects the seed against extraction from the device itself, but the backup (microSD card or 24 words) gives full access to the wallet. That is why it should be stored in a secure location!\n\nSince a passphrase creates a new wallet using your existing seed, the passphrase-wallet requires both your <strong>backup AND passphrase to restore</strong>. The benefit of this is if someone finds your backup, they still need the passphrase to access the passphrase-wallet.\n\nAdditionally, the passphrase feature allows you to create multiple wallets on the same device, or “hidden wallets” in addition to the default one.\n",
       "title": "Why use a passphrase?"
     }
   },

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1031,6 +1031,12 @@
     },
     "successEnabled": {
       "message": "Optional passphrase <strong>successfully disabled</strong>!\n\nYou will not be asked to provide a passphrase anymore. Please replug your BitBox02 now.",
+      "messageEnd": "Please replug your BitBox02 now.",
+      "tips": "Tips",
+      "tipsList": [
+        "We suggest sending a small amount to the passphrase wallet first. Then unplug and replug the BitBox02 and enter your password and passphrase. If you entered the passphrase correctly, you should see the coins in your wallet.",
+        "If you want to enter your original wallet without a passphrase, you can still do this by entering nothing when prompted to enter the passphrase. Or you can disable the passphrase feature."
+      ],
       "title": "Passphrase disabled"
     },
     "summary": {
@@ -1040,7 +1046,8 @@
       "understandList": [
         "The passphrase is an additional layer of security on top of your backup.",
         "Entering a different passphrase will always generate a different wallet.",
-        "To restore your wallet you need <strong>both the passphrase and backup</strong>."
+        "To restore your wallet you need <strong>both the passphrase and backup</strong>.",
+        "If you forget your passphrase, you can no longer access your coins."
       ]
     },
     "what": {

--- a/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
@@ -173,6 +173,7 @@ class MnemonicPassphraseButton extends Component<Props, State> {
                             <SimpleMarkup key="info-1" tagName="li" markup={t('passphrase.summary.understandList.0')} />
                             <SimpleMarkup key="info-2" tagName="li" markup={t('passphrase.summary.understandList.1')} />
                             <SimpleMarkup key="info-3" tagName="li" markup={t('passphrase.summary.understandList.2')} />
+                            <SimpleMarkup key="info-4" tagName="li" markup={t('passphrase.summary.understandList.3')} />
                         </ul>
                         <Message type="message">
                             <Checkbox
@@ -254,6 +255,11 @@ class MnemonicPassphraseButton extends Component<Props, State> {
                                 ? 'passphrase.successDisabled.message'
                                 : 'passphrase.successEnabled.message')
                         )}
+                        <ul style="padding-left: var(--space-default);">
+                            <SimpleMarkup key="tip-1" tagName="li" markup={t('passphrase.successEnabled.tipsList.0')} />
+                            <SimpleMarkup key="tip-2" tagName="li" markup={t('passphrase.successEnabled.tipsList.1')} />
+                        </ul>
+                        <SimpleMarkup tagName="p" markup={t('passphrase.successEnabled.messageEnd')} />
                     </WaitDialog>
                 )}
             </div>


### PR DESCRIPTION
- cherry-picked https://github.com/digitalbitbox/bitbox-wallet-app/pull/1458/commits/af49d2b0b489bb71088382a5d64c8b5aeb1dd7ed
- add missing translations 

On the passphrase summary view:
Summary should mention that the coins cannot be accessed if the
passphrase is forgotten.

On enabled success view:
Success view now contains 2 tips to try and test with a small
amount and how to unlock the default wallet (by leaving the
passphrase empty).
