### PR TITLE
frontend: show tips on success enable only

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/mnemonicpassphrase.tsx
@@ -255,10 +255,12 @@ class MnemonicPassphraseButton extends Component<Props, State> {
                                 ? 'passphrase.successDisabled.message'
                                 : 'passphrase.successEnabled.message')
                         )}
-                        <ul style="padding-left: var(--space-default);">
-                            <SimpleMarkup key="tip-1" tagName="li" markup={t('passphrase.successEnabled.tipsList.0')} />
-                            <SimpleMarkup key="tip-2" tagName="li" markup={t('passphrase.successEnabled.tipsList.1')} />
-                        </ul>
+                        {passphraseEnabled && (
+                            <ul style="padding-left: var(--space-default);">
+                                <SimpleMarkup key="tip-1" tagName="li" markup={t('passphrase.successEnabled.tipsList.0')} />
+                                <SimpleMarkup key="tip-2" tagName="li" markup={t('passphrase.successEnabled.tipsList.1')} />
+                            </ul>
+                        )}
                         <SimpleMarkup tagName="p" markup={t('passphrase.successEnabled.messageEnd')} />
                     </WaitDialog>
                 )}


### PR DESCRIPTION
The tips should only be shown on the succes enabled view, but
not on the success disabled view.

This has been fixed in 95d6f2dd0b43040ac72a8ee6d38332699fb3b301
but was forgotten to backport this to master.