### PR TITLE
frontend: show passphrase configuration in fullscreen

### DIFF
--- a/frontends/web/src/components/aopp/aopp.css
+++ b/frontends/web/src/components/aopp/aopp.css
@@ -7,17 +7,6 @@
     text-align: center;
 }
 
-.caret {
-    display: block;
-    margin: 0 auto;
-}
-
-.device {
-    max-width: 264px;
-    position: relative;
-    right: -16px;
-}
-
 .largeIcon {
     margin: 0 0 var(--space-default) 0;
     width: 50%;

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -25,7 +25,7 @@ import { View, ViewHeader, ViewContent, ViewButtons } from '../view/view';
 import { Message } from '../message/message';
 import { Button, Field, Label, Select } from '../forms';
 import { CopyableInput } from '../copy/Copy';
-import { BitBox02Stylized, Cancel, CaretDown, Checked } from '../icon';
+import { Cancel, Checked, PointToBitBox02 } from '../icon';
 import { VerifyAddress } from './verifyaddress';
 import { Vasp } from './vasp';
 import * as styles from './aopp.css';
@@ -200,8 +200,7 @@ class Aopp extends Component<Props, State> {
                                     {aopp.message}
                                 </div>
                             </Field>
-                            <CaretDown className={styles.caret} />
-                            <BitBox02Stylized className={styles.device} />
+                            <PointToBitBox02 />
                         </ViewContent>
                     </View>
                 );

--- a/frontends/web/src/components/icon/combined.css
+++ b/frontends/web/src/components/icon/combined.css
@@ -1,0 +1,15 @@
+.point2bitbox02 {
+    text-align: center;
+}
+
+.caret {
+    display: block;
+    margin: 0 auto;
+}
+
+.bitbox02 {
+    display: inline-block;
+    max-width: 264px;
+    position: relative;
+    right: -16px;
+}

--- a/frontends/web/src/components/icon/combined.tsx
+++ b/frontends/web/src/components/icon/combined.tsx
@@ -1,5 +1,4 @@
 /**
- * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,13 @@
  * limitations under the License.
  */
 
-export { Header } from './header';
-export { Main } from './main';
-export { Footer } from './footer';
+import { h } from 'preact';
+import { BitBox02Stylized, CaretDown } from './icon';
+import * as style from './combined.css';
+
+export const PointToBitBox02 = () => (
+    <div className={style.point2bitbox02}>
+        <CaretDown className={style.caret} />
+        <BitBox02Stylized className={style.bitbox02} />
+    </div>
+);

--- a/frontends/web/src/components/icon/index.jsx
+++ b/frontends/web/src/components/icon/index.jsx
@@ -1,2 +1,0 @@
-export * from './icon';
-export * from './logo';

--- a/frontends/web/src/components/icon/index.tsx
+++ b/frontends/web/src/components/icon/index.tsx
@@ -1,5 +1,4 @@
 /**
- * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,6 @@
  * limitations under the License.
  */
 
-export { Header } from './header';
-export { Main } from './main';
-export { Footer } from './footer';
+export * from './icon';
+export * from './logo';
+export * from './combined';

--- a/frontends/web/src/components/layout/main.css
+++ b/frontends/web/src/components/layout/main.css
@@ -1,0 +1,9 @@
+.main {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    flex-shrink: 1;
+    overflow-x: inherit;
+    overflow-y: auto;
+    position: relative;
+}

--- a/frontends/web/src/components/layout/main.tsx
+++ b/frontends/web/src/components/layout/main.tsx
@@ -1,5 +1,4 @@
 /**
- * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,15 @@
  * limitations under the License.
  */
 
-export { Header } from './header';
-export { Main } from './main';
-export { Footer } from './footer';
+import { h, RenderableProps } from 'preact';
+import * as style from './main.css';
+
+type MainProps = {}
+
+export function Main({ children }: RenderableProps<MainProps>) {
+    return (
+        <main className={style.main}>
+            {children}
+        </main>
+    );
+}

--- a/frontends/web/src/components/view/view.css
+++ b/frontends/web/src/components/view/view.css
@@ -7,7 +7,7 @@
     left: 0;
     overflow-x: inherit;
     overflow-y: auto;
-    position: absolute;
+    position: fixed;
     right: 0;
     top: 0;
     /* z-index between sidebar (~4000) and wait-dialog (~10000) */
@@ -42,9 +42,10 @@
 .inner:not(.center) {
     display: flex;
     flex-direction: column;
-    justify-content: flex-end;
     max-height: 100%;
-    min-height: 600px;
+    flex-shrink: 0;
+    padding-bottom: var(--space-large);
+    padding-top: 17vh;
 }
 @media (max-width: 768px) {
     .inner {
@@ -55,6 +56,10 @@
     }
     .center {
         flex-grow: 0;
+    }
+    .inner:not(.center) {
+        padding-bottom: var(--space-half);
+        padding-top: 2vh;
     }
 }
 @media (min-width: 1200px) {
@@ -91,7 +96,7 @@
     color: var(--color-default);
     font-size: var(--size-subheader);
     font-weight: 400;
-    margin-bottom: var(--space-quarter);
+    margin-bottom: var(--space-half);
 }
 
 .header p {

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -21,7 +21,7 @@ import { SwissMadeOpenSource } from '../icon/logo';
 import { Close } from '../icon/icon';
 import * as style from './view.css';
 
-type Props = {
+type ViewProps = {
     center?: boolean;
     onClose?: () => void;
     position?: 'fill' | 'fullscreen';
@@ -36,7 +36,7 @@ export function View({
     position = 'fill',
     width,
     withBottomBar,
-}: RenderableProps<Props>) {
+}: RenderableProps<ViewProps>) {
     const styles = width ? { style: `width: ${width}` } : undefined;
     return (
         <div className={position === 'fullscreen' ? style.fullscreen : style.fill}>
@@ -97,7 +97,9 @@ export function ViewHeader({
     );
 }
 
-export function ViewButtons({ children }) {
+type ViewButtonsProps = {}
+
+export function ViewButtons({ children }: RenderableProps<ViewButtonsProps>) {
     return (
         <div className={style.buttons}>
             {children}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1027,6 +1027,7 @@
     },
     "successDisabled": {
       "message": "Optional passphrase <strong>successfully enabled</strong>!\nYou’ll be asked to provide a passphrase from now on.",
+      "messageEnd": "Please replug your BitBox02 now.",
       "title": "Passphrase enabled"
     },
     "successEnabled": {

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -20,12 +20,16 @@ import { route } from 'preact-router';
 import { getDeviceInfo, setMnemonicPassphraseEnabled } from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { SimpleMarkup } from '../../../utils/simplemarkup';
-import { Header } from '../../../components/layout';
+// This is the first time we use <View> in a <Main> component
+// keeping guide and header as example in the code
+import { /* Header, */ Main } from '../../../components/layout';
 import { Button, Checkbox } from '../../../components/forms';
 import { alertUser } from '../../../components/alert/Alert';
-import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
-import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
 import { Message } from '../../../components/message/message';
+import { View, ViewButtons, ViewContent, ViewHeader } from '../../../components/view/view';
+// keeing as example for using guides in the new main component
+// import { Guide } from '../../../components/guide/guide';
+// import { Entry } from '../../../components/guide/entry';
 
 interface MnemonicPassphraseButtonProps {
     deviceID: string;
@@ -90,99 +94,117 @@ class Passphrase extends Component<Props, State> {
         switch (infoStep) {
             case 5:
                 return (
-                    <Dialog key="step-intro" medium title={t('passphrase.intro.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.intro.message'))}
-                        <DialogButtons>
+                    <View key="step-intro" onClose={this.stopInfo}>
+                        <ViewHeader title={t('passphrase.intro.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.intro.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.what.button')}
                             </Button>
                             <Button transparent onClick={this.stopInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 4:
                 return (
-                    <Dialog key="step-what" medium title={t('passphrase.what.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.what.message'))}
-                        <DialogButtons>
+                    <View key="step-what" onClose={this.stopInfo}>
+                        <ViewHeader title={t('passphrase.what.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.what.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.why.button')}
                             </Button>
                             <Button transparent onClick={this.stopInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 3:
                 return (
-                    <Dialog key="step-why" medium title={t('passphrase.why.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.why.message'))}
-                        <DialogButtons>
+                    <View key="step-why" onClose={this.stopInfo}>
+                        <ViewHeader title={t('passphrase.why.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.why.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.considerations.button')}
                             </Button>
                             <Button transparent onClick={this.stopInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 2:
                 return (
-                    <Dialog key="step-considerations" medium title={t('passphrase.considerations.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.considerations.message'))}
-                        <DialogButtons>
+                    <View key="step-considerations" onClose={this.stopInfo}>
+                        <ViewHeader title={t('passphrase.considerations.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.considerations.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.how.button')}
                             </Button>
                             <Button transparent onClick={this.stopInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 1:
                 return (
-                    <Dialog key="step-how" medium title={t('passphrase.how.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.how.message'))}
-                        <DialogButtons>
+                    <View key="step-how" onClose={this.stopInfo}>
+                        <ViewHeader title={t('passphrase.how.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.how.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.summary.button')}
                             </Button>
                             <Button transparent onClick={this.stopInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 0:
                 return (
-                    <Dialog key="step-summary" medium title={t('passphrase.summary.title')} onClose={this.stopInfo}>
-                        <ul style="padding-left: var(--space-default);">
-                            <SimpleMarkup key="info-1" tagName="li" markup={t('passphrase.summary.understandList.0')} />
-                            <SimpleMarkup key="info-2" tagName="li" markup={t('passphrase.summary.understandList.1')} />
-                            <SimpleMarkup key="info-3" tagName="li" markup={t('passphrase.summary.understandList.2')} />
-                            <SimpleMarkup key="info-4" tagName="li" markup={t('passphrase.summary.understandList.3')} />
-                        </ul>
-                        <Message type="message">
-                            <Checkbox
-                                onChange={e => this.setState({ understood: (e.target as HTMLInputElement)?.checked })}
-                                id="understood"
-                                checked={understood}
-                                label={t('passphrase.summary.understand')} />
-                        </Message>
-                        <DialogButtons>
+                    <View key="step-summary" onClose={this.stopInfo}>
+                        <ViewHeader title={t('passphrase.summary.title')} />
+                        <ViewContent>
+                            <ul style="padding-left: var(--space-default);">
+                                <SimpleMarkup key="info-1" tagName="li" markup={t('passphrase.summary.understandList.0')} />
+                                <SimpleMarkup key="info-2" tagName="li" markup={t('passphrase.summary.understandList.1')} />
+                                <SimpleMarkup key="info-3" tagName="li" markup={t('passphrase.summary.understandList.2')} />
+                                <SimpleMarkup key="info-4" tagName="li" markup={t('passphrase.summary.understandList.3')} />
+                            </ul>
+                            <Message type="message">
+                                <Checkbox
+                                    onChange={e => this.setState({ understood: (e.target as HTMLInputElement)?.checked })}
+                                    id="understood"
+                                    checked={understood}
+                                    label={t('passphrase.summary.understand')} />
+                            </Message>
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo} disabled={!understood}>
                                 {t('passphrase.enable')}
                             </Button>
                             <Button transparent onClick={this.stopInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             default:
                 console.error(`invalid infoStep ${infoStep}`);
@@ -197,17 +219,20 @@ class Passphrase extends Component<Props, State> {
     private renderDisableInfo = () => {
         const { t } = this.props;
         return (
-            <Dialog key="step-disable-info1" medium title={t('passphrase.disable')} onClose={this.stopInfo}>
-                {this.renderMultiLine(t('passphrase.disableInfo.message'))}
-                <DialogButtons>
+            <View key="step-disable-info1" onClose={this.stopInfo}>
+                <ViewHeader title={t('passphrase.disable')} />
+                <ViewContent>
+                    {this.renderMultiLine(t('passphrase.disableInfo.message'))}
+                </ViewContent>
+                <ViewButtons>
                     <Button primary onClick={this.continueInfo}>
                         {t('passphrase.disableInfo.button')}
                     </Button>
                     <Button transparent onClick={this.stopInfo}>
                         {t('button.back')}
                     </Button>
-                </DialogButtons>
-            </Dialog>
+                </ViewButtons>
+            </View>
         );
     }
 
@@ -216,30 +241,34 @@ class Passphrase extends Component<Props, State> {
         { passphraseEnabled, status }: State,
     ) {
         return (
-            <div class="container">
-                <Header title="Passphrase" />
-                <div className="innerContainer scrollableContainer">
-                    <div className="content padded">
-                    {status === 'info' && (
-                        passphraseEnabled
-                            ? this.renderDisableInfo()
-                            : this.renderEnableInfo()
-                    )}
-                    {status === 'progress' && (
-                        <WaitDialog
+            <Main>
+                {/* <Header /> */}
+                {status === 'info' && (
+                    passphraseEnabled
+                        ? this.renderDisableInfo()
+                        : this.renderEnableInfo()
+                )}
+                {status === 'progress' && (
+                    <View key="progress" position="fullscreen">
+                        <ViewHeader
                             title={t(passphraseEnabled
                                 ? 'passphrase.progressDisable.title'
                                 : 'passphrase.progressEnable.title')}>
                             {t(passphraseEnabled
                                 ? 'passphrase.progressDisable.message'
                                 : 'passphrase.progressEnable.message')}
-                        </WaitDialog>
-                    )}
-                    {status === 'success' && (
-                        <WaitDialog
+                        </ViewHeader>
+                        <ViewContent />
+                    </View>
+                )}
+                {status === 'success' && (
+                    <View key="progress" position="fullscreen">
+                        <ViewHeader
                             title={t(passphraseEnabled
                                 ? 'passphrase.successDisabled.title'
                                 : 'passphrase.successEnabled.title')} >
+                        </ViewHeader>
+                        <ViewContent>
                             {this.renderMultiLine(
                                 t(passphraseEnabled
                                     ? 'passphrase.successDisabled.message'
@@ -251,11 +280,15 @@ class Passphrase extends Component<Props, State> {
                                     <SimpleMarkup key="tip-2" tagName="li" markup={t('passphrase.successEnabled.tipsList.1')} />
                                 </ul>
                             )}
-                        </WaitDialog>
-                    )}
-                    </div>
-                </div>
-            </div>
+                            <SimpleMarkup tagName="p" markup={t('passphrase.successEnabled.messageEnd')} />
+
+                        </ViewContent>
+                    </View>
+                )}
+                {/* <Guide>
+                    <Entry key="whatisapassphrase" entry={t('guide.passphrase.whatisapassphrase')} />
+                </Guide> */}
+            </Main>
         );
     }
 }


### PR DESCRIPTION
When enabling or disabling the passphrase setting users should
fully focus on the information shown and not be distracted by other
elements on the page, therefore the view in fullscreen is more
suitable than just a dialog.

Move call to replug-the-device to be the last message of the
success view.

Introduced a new `<Main>` component for contents of the page, this
component should replace `<div class="container">`. Also left example
code of how `<Header>` and `<Guide>` components can be used.

Made also sure the `<View>` content is scrollable inside `<Main>`.

Sometimes the BitBoxApp requires the user to focus on the device
and confirm or reject something on the BitBox02.

Turned caret pointing to bb02 device into a shared component, so
it can be re-used in different places like AOPP.