### PR TITLE
android: target api level 30, enforced by Google Play

### DIFF
--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -6,7 +6,7 @@ android {
     defaultConfig {
         applicationId "ch.shiftcrypto.bitboxapp"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 32
         versionName "android-4.30.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -140,6 +140,7 @@ public class MainActivity extends AppCompatActivity {
         vw.clearHistory();
         vw.getSettings().setJavaScriptEnabled(true);
         vw.getSettings().setAllowUniversalAccessFromFileURLs(true);
+        vw.getSettings().setAllowFileAccess(true);
         // For MoonPay WebRTC camera access.
         vw.getSettings().setMediaPlaybackRequiresUserGesture(false);
 


### PR DESCRIPTION
Google Play now enforces a minimum level of 30.

The `setAllowFileAccess` change is because it defaulted to true before
and is defaulting to false now.

See also: https://developer.android.com/reference/android/webkit/WebSettings#setAllowFileAccess(boolean)