### PR TITLE
Frontend passphrase fullscreen styling

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -142,6 +142,7 @@ class App extends Component<Props, State> {
             currentURL.startsWith('/account-summary')
             || currentURL.startsWith('/add-account')
             || currentURL.startsWith('/settings/manage-accounts')
+            || currentURL.startsWith('/passphrase')
         )) {
             route('/', true);
             return;

--- a/frontends/web/src/components/aopp/aopp.css
+++ b/frontends/web/src/components/aopp/aopp.css
@@ -7,17 +7,6 @@
     text-align: center;
 }
 
-.caret {
-    display: block;
-    margin: 0 auto;
-}
-
-.device {
-    max-width: 264px;
-    position: relative;
-    right: -16px;
-}
-
 .largeIcon {
     margin: 0 0 var(--space-default) 0;
     width: 50%;

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -25,7 +25,7 @@ import { View, ViewHeader, ViewContent, ViewButtons } from '../view/view';
 import { Message } from '../message/message';
 import { Button, Field, Label, Select } from '../forms';
 import { CopyableInput } from '../copy/Copy';
-import { BitBox02Stylized, Cancel, CaretDown, Checked } from '../icon';
+import { Cancel, Checked, PointToBitBox02 } from '../icon';
 import { VerifyAddress } from './verifyaddress';
 import { Vasp } from './vasp';
 import * as styles from './aopp.css';
@@ -96,7 +96,7 @@ class Aopp extends Component<Props, State> {
         switch (aopp.state) {
             case 'error':
                 return (
-                    <View center position="fullscreen">
+                    <View fullscreen textCenter>
                         <ViewHeader title={t('aopp.errorTitle')}>
                             <p>{domain(aopp.callback)}</p>
                         </ViewHeader>
@@ -116,7 +116,7 @@ class Aopp extends Component<Props, State> {
                 return null;
             case 'user-approval':
                 return (
-                    <View center position="fullscreen">
+                    <View fullscreen textCenter>
                         <ViewHeader title={t('aopp.title')} withAppLogo />
                         <ViewContent>
                             <Vasp prominent
@@ -147,7 +147,7 @@ class Aopp extends Component<Props, State> {
                 });
                 return (
                     <form onSubmit={this.chooseAccount}>
-                        <View center position="fullscreen">
+                        <View fullscreen textCenter>
                             <ViewHeader title={t('aopp.title')}>
                                 <Vasp hostname={domain(aopp.callback)} />
                             </ViewHeader>
@@ -170,7 +170,7 @@ class Aopp extends Component<Props, State> {
             }
             case 'syncing':
                 return (
-                    <View center position="fullscreen">
+                    <View fullscreen textCenter>
                         <ViewHeader title={t('aopp.title')}>
                             <Vasp hostname={domain(aopp.callback)} />
                         </ViewHeader>
@@ -184,7 +184,7 @@ class Aopp extends Component<Props, State> {
                 );
             case 'signing':
                 return (
-                    <View center position="fullscreen">
+                    <View fullscreen textCenter>
                         <ViewHeader small title={t('aopp.title')}>
                             <Vasp hostname={domain(aopp.callback)} />
                         </ViewHeader>
@@ -200,14 +200,13 @@ class Aopp extends Component<Props, State> {
                                     {aopp.message}
                                 </div>
                             </Field>
-                            <CaretDown className={styles.caret} />
-                            <BitBox02Stylized className={styles.device} />
+                            <PointToBitBox02 />
                         </ViewContent>
                     </View>
                 );
             case 'success':
                 return (
-                    <View center position="fullscreen">
+                    <View fullscreen textCenter>
                         <ViewContent>
                             <Checked className={styles.largeIcon} />
                             <p className={styles.successText}>{t('aopp.success.title')}</p>

--- a/frontends/web/src/components/forms/checkbox.css
+++ b/frontends/web/src/components/forms/checkbox.css
@@ -30,6 +30,18 @@
     border-radius: 2px;
     top: -1px;
 }
+.success input + label::before {
+    border-color: var(--color-white);
+    outline: 1px solid var(--color-success);
+}
+.warning input + label::before {
+    border-color: var(--color-white);
+    outline: 1px solid var(--color-warning);
+}
+.info input + label::before {
+    border-color: var(--color-white);
+    outline: 1px solid var(--color-info);
+}
 
 .checkbox input + label::after {
     background: transparent;
@@ -54,6 +66,24 @@
     border-color: var(--color-blue);
 }
 
+.success input:checked + label::before {
+    background-color: var(--color-success);
+    border-color: var(--color-success);
+    color: var(--color-white);
+}
+
+.warning input:checked + label::before {
+    background-color: var(--color-warning);
+    border-color: var(--color-warning);
+    color: var(--color-white);
+}
+
+.info input:checked + label::before {
+    background-color: var(--color-info);
+    border-color: var(--color-info);
+    color: var(--color-white);
+}
+
 .checkbox input:checked + label::after {
     opacity: 1;
     transform: scale(1) rotate(37deg);
@@ -70,6 +100,13 @@
 .checkbox input[type="checkbox"]:checked:focus + label::before {
     outline: 2px solid var(--color-blue);
     outline-offset: -1px;
+}
+
+:is(.success, .warning, .info) input[type="checkbox"]:focus + label::before,
+:is(.success, .warning, .info) input[type="checkbox"]:checked:focus + label::before {
+    border-color: transparent;
+    outline: 2px solid var(--color-blue);
+    outline-offset: 0;
 }
 
 /* disabled */

--- a/frontends/web/src/components/forms/checkbox.tsx
+++ b/frontends/web/src/components/forms/checkbox.tsx
@@ -15,13 +15,14 @@
  */
 
 import { h, JSX, RenderableProps } from 'preact';
-import * as style from './checkbox.css';
+import * as styles from './checkbox.css';
 
 type CheckboxProps = JSX.IntrinsicElements['input'] & {
     className?: string;
     disabled?: boolean;
     label?: string;
     id: string;
+    style?: 'default' | 'info' | 'warning' | 'success';
 }
 
 export default function Checkbox({
@@ -30,10 +31,11 @@ export default function Checkbox({
     id,
     className = '',
     children,
+    style = 'default',
     ...props
 }: RenderableProps<CheckboxProps>) {
     return (
-        <span className={`${style.checkbox} ${className}`}>
+        <span className={`${styles.checkbox} ${className} ${styles[style] || ''}`}>
             <input
                 type="checkbox"
                 id={id}

--- a/frontends/web/src/components/icon/combined.css
+++ b/frontends/web/src/components/icon/combined.css
@@ -1,0 +1,15 @@
+.point2bitbox02 {
+    text-align: center;
+}
+
+.caret {
+    display: block;
+    margin: 0 auto;
+}
+
+.bitbox02 {
+    display: inline-block;
+    max-width: 264px;
+    position: relative;
+    right: -16px;
+}

--- a/frontends/web/src/components/icon/combined.tsx
+++ b/frontends/web/src/components/icon/combined.tsx
@@ -1,5 +1,4 @@
 /**
- * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,13 @@
  * limitations under the License.
  */
 
-export { Header } from './header';
-export { Main } from './main';
-export { Footer } from './footer';
+import { h } from 'preact';
+import { BitBox02Stylized, CaretDown } from './icon';
+import * as style from './combined.css';
+
+export const PointToBitBox02 = () => (
+    <div className={style.point2bitbox02}>
+        <CaretDown className={style.caret} />
+        <BitBox02Stylized className={style.bitbox02} />
+    </div>
+);

--- a/frontends/web/src/components/icon/index.jsx
+++ b/frontends/web/src/components/icon/index.jsx
@@ -1,2 +1,0 @@
-export * from './icon';
-export * from './logo';

--- a/frontends/web/src/components/icon/index.tsx
+++ b/frontends/web/src/components/icon/index.tsx
@@ -1,5 +1,4 @@
 /**
- * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,6 @@
  * limitations under the License.
  */
 
-export { Header } from './header';
-export { Main } from './main';
-export { Footer } from './footer';
+export * from './icon';
+export * from './logo';
+export * from './combined';

--- a/frontends/web/src/components/layout/main.css
+++ b/frontends/web/src/components/layout/main.css
@@ -1,0 +1,9 @@
+.main {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    flex-shrink: 1;
+    overflow-x: inherit;
+    overflow-y: auto;
+    position: relative;
+}

--- a/frontends/web/src/components/layout/main.tsx
+++ b/frontends/web/src/components/layout/main.tsx
@@ -1,5 +1,4 @@
 /**
- * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,15 @@
  * limitations under the License.
  */
 
-export { Header } from './header';
-export { Main } from './main';
-export { Footer } from './footer';
+import { h, RenderableProps } from 'preact';
+import * as style from './main.css';
+
+type MainProps = {}
+
+export function Main({ children }: RenderableProps<MainProps>) {
+    return (
+        <main className={style.main}>
+            {children}
+        </main>
+    );
+}

--- a/frontends/web/src/components/message/message.css
+++ b/frontends/web/src/components/message/message.css
@@ -28,8 +28,8 @@
 
 .info {
     composes: message;
-    color: var(--color-default);
-    border-color: var(--color-default);
+    color: var(--color-blue);
+    border-color: var(--color-blue);
 }
 
 .warning {

--- a/frontends/web/src/components/status/status.css
+++ b/frontends/web/src/components/status/status.css
@@ -11,22 +11,28 @@
 
 .status {
     font-size: var(--size-subheader);
-    max-width: 90%;
+    max-width: 800px;
     text-align: left;
 }
 
 .success {
     background-color: var(--color-success);
-    color: var(--color-white);
 }
 
 .warning {
     background-color: var(--color-warning);
-    color: var(--color-white);
 }
 
 .info {
     background-color: var(--color-info);
+}
+
+.success,
+.warning,
+.info,
+.success label, /* also force label elements to use color white */
+.warning label,
+.info label {
     color: var(--color-white);
 }
 
@@ -58,11 +64,13 @@
 }
 
 @media (max-width: 768px) {
-    .container {
-        padding: calc(var(--space-half) * 1.5);
-    }
-
     .status {
         font-size: var(--size-subheader-mobile);
+    }
+}
+
+@media (max-width: 1199px) {
+    .container {
+        padding: calc(var(--space-half) * 1.5);
     }
 }

--- a/frontends/web/src/components/view/view.css
+++ b/frontends/web/src/components/view/view.css
@@ -7,7 +7,7 @@
     left: 0;
     overflow-x: inherit;
     overflow-y: auto;
-    position: absolute;
+    position: fixed;
     right: 0;
     top: 0;
     /* z-index between sidebar (~4000) and wait-dialog (~10000) */
@@ -28,6 +28,9 @@
 }
 
 .inner {
+    display: flex;
+    flex-direction: column;
+
     margin: 0 auto;
     max-width: 100%;
     padding-bottom: var(--space-half);
@@ -37,14 +40,17 @@
 .center {
     margin-bottom: auto;
     margin-top: auto;
+}
+.textCenter {
     text-align: center;
 }
 .inner:not(.center) {
     display: flex;
     flex-direction: column;
-    justify-content: flex-end;
     max-height: 100%;
-    min-height: 600px;
+    flex-shrink: 0;
+    padding-bottom: var(--space-large);
+    padding-top: 17vh;
 }
 @media (max-width: 768px) {
     .inner {
@@ -52,9 +58,11 @@
         display: flex;
         flex-direction: column;
         margin: 0 auto;
+        min-height: auto !important;
     }
-    .center {
-        flex-grow: 0;
+    .inner:not(.center) {
+        padding-bottom: var(--space-half);
+        padding-top: 2vh;
     }
 }
 @media (min-width: 1200px) {
@@ -70,20 +78,22 @@
 }
 @media (max-width: 768px) {
     .header {
-        padding-left: 22px;
+        padding-left: var(--space-half);
         padding-top: var(--space-default);
-        padding-right: 22px;
+        padding-right: var(--space-half);
+        margin-bottom: 0;
     }
-}
-@media (max-width: 768px) and (orientation: portrait) {
-    .header {
-        padding-top: var(--space-large);
-    }
-}
-@media (max-width: 768px) {
     .smallHeader {
         margin-bottom: var(--space-half);
         padding-top: var(--space-half);
+    }
+}
+@media (max-width: 1199px) {
+    .header {
+        padding-top: var(--space-large);
+    }
+    .smallHeader {
+        padding-top: 0;
     }
 }
 
@@ -91,7 +101,7 @@
     color: var(--color-default);
     font-size: var(--size-subheader);
     font-weight: 400;
-    margin-bottom: var(--space-quarter);
+    margin-bottom: var(--space-half);
 }
 
 .header p {
@@ -111,6 +121,8 @@
 }
 
 .content {
+    flex-grow: 1;
+    flex-shrink: 0;
     min-height: 80px;
 }
 @media (max-width: 768px) {
@@ -118,7 +130,7 @@
         flex-grow: 1;
         flex-basis: auto;
         flex-shrink: 0;
-        padding: 0 22px;
+        padding: 0 var(--space-half);
     }
     .content.fullWidth {
         padding: 0;
@@ -131,7 +143,13 @@
 }
 
 .content ul {
+    font-size: var(--size-default);
     line-height: 1.625;
+    padding-left: 1.4em;
+}
+
+.content label {
+    color: var(--color-default);
 }
 
 .buttons {
@@ -141,6 +159,11 @@
     margin-top: var(--space-default);
     padding-bottom: var(--space-half);
 }
+@media (max-width: 768px) {
+    .buttons {
+        padding: 0 var(--space-half);
+    }
+}
 @media (max-width: 768px) and (orientation: portrait) {
     .buttons {
         align-items: stretch;
@@ -148,14 +171,13 @@
         flex-grow: 0;
         justify-content: flex-end;
         margin-top: var(--space-half);
-        padding: 0 var(--space-half);
     }
     .buttons > *:not(:last-child) {
         margin-bottom: var(--space-half);
     }
 }
-
-.buttons > *:only-child {
+.textCenter .buttons > *:only-child {
+    justify-self: flex-end;
     margin: 0 auto;
 }
 
@@ -167,11 +189,7 @@
     .inner p {
         --size-default: 20px;
     }
-    .content input,
-    .content label,
-    .content select,
-    .content textarea,
-    .buttons button {
+    .fullscreen {
         --size-default: 18px;
     }
     .inner footer p {

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -21,28 +21,43 @@ import { SwissMadeOpenSource } from '../icon/logo';
 import { Close } from '../icon/icon';
 import * as style from './view.css';
 
-type Props = {
-    center?: boolean;
+type ViewProps = {
+    fullscreen?: boolean;
+    minHeight?: string;
+    top?: boolean;
     onClose?: () => void;
-    position?: 'fill' | 'fullscreen';
+    position?: 'fill' | '';
+    textCenter?: boolean;
     width?: string;
     withBottomBar?: boolean;
 }
 
 export function View({
-    center = false,
+    fullscreen,
+    top = false,
     children,
+    minHeight,
     onClose,
-    position = 'fill',
+    textCenter,
     width,
     withBottomBar,
-}: RenderableProps<Props>) {
-    const styles = width ? { style: `width: ${width}` } : undefined;
+}: RenderableProps<ViewProps>) {
+    let classNames = style.inner;
+    if (!top) {
+        classNames += ` ${style.center}`;
+    }
+    if (textCenter) {
+        classNames += ` ${style.textCenter}`;
+    }
+    const inlineStyles = {
+        ...(minHeight && { minHeight }),
+        ...(width && { width }),
+    };
     return (
-        <div className={position === 'fullscreen' ? style.fullscreen : style.fill}>
+        <div className={fullscreen ? style.fullscreen : style.fill}>
             <div
-                className={center ? `${style.inner} ${style.center}` : style.inner}
-                {...styles}>
+                className={classNames}
+                style={inlineStyles}>
                 {children}
             </div>
             {onClose && (
@@ -68,10 +83,11 @@ type ViewContentProps = {
 export function ViewContent({
     children,
     fullWidth,
+    ...props
 }: RenderableProps<ViewContentProps>) {
     const classes = `${style.content} ${fullWidth ? style.fullWidth : ''}`;
     return (
-        <div className={classes}>{children}</div>
+        <div className={classes} {...props}>{children}</div>
     );
 }
 
@@ -97,7 +113,9 @@ export function ViewHeader({
     );
 }
 
-export function ViewButtons({ children }) {
+type ViewButtonsProps = {}
+
+export function ViewButtons({ children }: RenderableProps<ViewButtonsProps>) {
     return (
         <div className={style.buttons}>
             {children}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1027,6 +1027,7 @@
     },
     "successDisabled": {
       "message": "Optional passphrase <strong>successfully enabled</strong>!\nYou’ll be asked to provide a passphrase from now on.",
+      "messageEnd": "Please replug the BitBox02 now.",
       "title": "Passphrase enabled"
     },
     "successEnabled": {

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -437,8 +437,8 @@ class BitBox02 extends Component<Props, State> {
                         <Steps>
                             { (status === 'connected') ? (
                                 <View
-                                    center
-                                    position="fullscreen"
+                                    fullscreen
+                                    textCenter
                                     withBottomBar
                                     width="600px">
                                     <ViewHeader title={t('button.unlock')}>

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -20,12 +20,26 @@ import { route } from 'preact-router';
 import { getDeviceInfo, setMnemonicPassphraseEnabled } from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { SimpleMarkup } from '../../../utils/simplemarkup';
-import { Header } from '../../../components/layout';
+// This is the first time we use <View> in a <Main> component
+// keeping guide and header as example in the code
+import { /* Header, */ Main } from '../../../components/layout';
 import { Button, Checkbox } from '../../../components/forms';
 import { alertUser } from '../../../components/alert/Alert';
-import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
-import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
-import { Message } from '../../../components/message/message';
+import { View, ViewButtons, ViewContent, ViewHeader } from '../../../components/view/view';
+import { PointToBitBox02 } from '../../../components/icon';
+import Status from '../../../components/status/status';
+// keeing as example for using guides in the new main component
+// import { Guide } from '../../../components/guide/guide';
+// import { Entry } from '../../../components/guide/entry';
+
+// enabling has 6 dialogs with information
+const INFO_STEPS_ENABLE = 5;
+
+// disabling passphrase shows only 1 info dialog
+const INFO_STEPS_DISABLE = 0;
+
+const CONTENT_MIN_HEIGHT = '34em';
+const CONTENT_WIDTH = '740px';
 
 interface MnemonicPassphraseButtonProps {
     deviceID: string;
@@ -47,8 +61,8 @@ class Passphrase extends Component<Props, State> {
         // each page has a continue button that jumps to the next or finally toggles passphrase
         // infoStep counts down in decreasing order
         infoStep: this.props.passphrase === 'enabled'
-            ? 0 // disabling passphrase shows only 1 info dialog
-            : 5, // enabling has 6 dialogs with information,
+            ? INFO_STEPS_DISABLE
+            : INFO_STEPS_ENABLE,
         status: 'info',
         passphraseEnabled: this.props.passphrase === 'enabled',
         understood: false,
@@ -84,105 +98,166 @@ class Passphrase extends Component<Props, State> {
         this.setState(({ infoStep }) => ({ infoStep: infoStep - 1 }));
     }
 
+    private backInfo = () => {
+        const enabled = this.state.passphraseEnabled;
+        if (
+            (!enabled && this.state.infoStep >= INFO_STEPS_ENABLE)
+            || (enabled && this.state.infoStep >= INFO_STEPS_DISABLE)
+        ) {
+            this.stopInfo();
+            return;
+        }
+        this.setState(({ infoStep }) => ({ infoStep: infoStep + 1 }));
+    }
+
     private renderEnableInfo = () => {
         const { infoStep, understood } = this.state;
         const { t } = this.props;
         switch (infoStep) {
             case 5:
                 return (
-                    <Dialog key="step-intro" medium title={t('passphrase.intro.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.intro.message'))}
-                        <DialogButtons>
+                    <View
+                        key="step-intro"
+                        fullscreen
+                        minHeight={CONTENT_MIN_HEIGHT}
+                        onClose={this.stopInfo}
+                        width={CONTENT_WIDTH}>
+                        <ViewHeader title={t('passphrase.intro.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.intro.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.what.button')}
                             </Button>
-                            <Button transparent onClick={this.stopInfo}>
+                            <Button transparent onClick={this.backInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 4:
                 return (
-                    <Dialog key="step-what" medium title={t('passphrase.what.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.what.message'))}
-                        <DialogButtons>
+                    <View
+                        key="step-what"
+                        fullscreen
+                        minHeight={CONTENT_MIN_HEIGHT}
+                        onClose={this.stopInfo}
+                        width={CONTENT_WIDTH}>
+                        <ViewHeader title={t('passphrase.what.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.what.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.why.button')}
                             </Button>
-                            <Button transparent onClick={this.stopInfo}>
+                            <Button transparent onClick={this.backInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 3:
                 return (
-                    <Dialog key="step-why" medium title={t('passphrase.why.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.why.message'))}
-                        <DialogButtons>
+                    <View
+                        key="step-why"
+                        fullscreen
+                        minHeight={CONTENT_MIN_HEIGHT}
+                        onClose={this.stopInfo}
+                        width={CONTENT_WIDTH}>
+                        <ViewHeader title={t('passphrase.why.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.why.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.considerations.button')}
                             </Button>
-                            <Button transparent onClick={this.stopInfo}>
+                            <Button transparent onClick={this.backInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 2:
                 return (
-                    <Dialog key="step-considerations" medium title={t('passphrase.considerations.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.considerations.message'))}
-                        <DialogButtons>
+                    <View
+                        key="step-considerations"
+                        fullscreen
+                        minHeight={CONTENT_MIN_HEIGHT}
+                        onClose={this.stopInfo}
+                        width={CONTENT_WIDTH}>
+                        <ViewHeader title={t('passphrase.considerations.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.considerations.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.how.button')}
                             </Button>
-                            <Button transparent onClick={this.stopInfo}>
+                            <Button transparent onClick={this.backInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 1:
                 return (
-                    <Dialog key="step-how" medium title={t('passphrase.how.title')} onClose={this.stopInfo}>
-                        {this.renderMultiLine(t('passphrase.how.message'))}
-                        <DialogButtons>
+                    <View
+                        key="step-how"
+                        fullscreen
+                        minHeight={CONTENT_MIN_HEIGHT}
+                        onClose={this.stopInfo}
+                        width={CONTENT_WIDTH}>
+                        <ViewHeader title={t('passphrase.how.title')} />
+                        <ViewContent>
+                            {this.renderMultiLine(t('passphrase.how.message'))}
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo}>
                                 {t('passphrase.summary.button')}
                             </Button>
-                            <Button transparent onClick={this.stopInfo}>
+                            <Button transparent onClick={this.backInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             case 0:
                 return (
-                    <Dialog key="step-summary" medium title={t('passphrase.summary.title')} onClose={this.stopInfo}>
-                        <ul style="padding-left: var(--space-default);">
-                            <SimpleMarkup key="info-1" tagName="li" markup={t('passphrase.summary.understandList.0')} />
-                            <SimpleMarkup key="info-2" tagName="li" markup={t('passphrase.summary.understandList.1')} />
-                            <SimpleMarkup key="info-3" tagName="li" markup={t('passphrase.summary.understandList.2')} />
-                            <SimpleMarkup key="info-4" tagName="li" markup={t('passphrase.summary.understandList.3')} />
-                        </ul>
-                        <Message type="message">
-                            <Checkbox
-                                onChange={e => this.setState({ understood: (e.target as HTMLInputElement)?.checked })}
-                                id="understood"
-                                checked={understood}
-                                label={t('passphrase.summary.understand')} />
-                        </Message>
-                        <DialogButtons>
+                    <View
+                        key="step-summary"
+                        fullscreen
+                        minHeight={CONTENT_MIN_HEIGHT}
+                        onClose={this.stopInfo}
+                        width={CONTENT_WIDTH}>
+                        <ViewHeader title={t('passphrase.summary.title')} />
+                        <ViewContent>
+                            <ul>
+                                <SimpleMarkup key="info-1" tagName="li" markup={t('passphrase.summary.understandList.0')} />
+                                <SimpleMarkup key="info-2" tagName="li" markup={t('passphrase.summary.understandList.1')} />
+                                <SimpleMarkup key="info-3" tagName="li" markup={t('passphrase.summary.understandList.2')} />
+                                <SimpleMarkup key="info-4" tagName="li" markup={t('passphrase.summary.understandList.3')} />
+                            </ul>
+                            <Status type={understood ? 'success' : 'warning'}>
+                                <Checkbox
+                                    onChange={e => this.setState({ understood: (e.target as HTMLInputElement)?.checked })}
+                                    id="understood"
+                                    checked={understood}
+                                    label={t('passphrase.summary.understand')}
+                                    style={understood ? 'success' : 'warning'} />
+                            </Status>
+                        </ViewContent>
+                        <ViewButtons>
                             <Button primary onClick={this.continueInfo} disabled={!understood}>
                                 {t('passphrase.enable')}
                             </Button>
-                            <Button transparent onClick={this.stopInfo}>
+                            <Button transparent onClick={this.backInfo}>
                                 {t('button.back')}
                             </Button>
-                        </DialogButtons>
-                    </Dialog>
+                        </ViewButtons>
+                    </View>
                 );
             default:
                 console.error(`invalid infoStep ${infoStep}`);
@@ -197,17 +272,25 @@ class Passphrase extends Component<Props, State> {
     private renderDisableInfo = () => {
         const { t } = this.props;
         return (
-            <Dialog key="step-disable-info1" medium title={t('passphrase.disable')} onClose={this.stopInfo}>
-                {this.renderMultiLine(t('passphrase.disableInfo.message'))}
-                <DialogButtons>
+            <View
+                key="step-disable-info1"
+                fullscreen
+                minHeight={CONTENT_MIN_HEIGHT}
+                onClose={this.stopInfo}
+                width={CONTENT_WIDTH}>
+                <ViewHeader title={t('passphrase.disable')} />
+                <ViewContent>
+                    {this.renderMultiLine(t('passphrase.disableInfo.message'))}
+                </ViewContent>
+                <ViewButtons>
                     <Button primary onClick={this.continueInfo}>
                         {t('passphrase.disableInfo.button')}
                     </Button>
-                    <Button transparent onClick={this.stopInfo}>
+                    <Button transparent onClick={this.backInfo}>
                         {t('button.back')}
                     </Button>
-                </DialogButtons>
-            </Dialog>
+                </ViewButtons>
+            </View>
         );
     }
 
@@ -216,30 +299,47 @@ class Passphrase extends Component<Props, State> {
         { passphraseEnabled, status }: State,
     ) {
         return (
-            <div class="container">
-                <Header title="Passphrase" />
-                <div className="innerContainer scrollableContainer">
-                    <div className="content padded">
-                    {status === 'info' && (
-                        passphraseEnabled
-                            ? this.renderDisableInfo()
-                            : this.renderEnableInfo()
-                    )}
-                    {status === 'progress' && (
-                        <WaitDialog
+            <Main>
+                {/* <Header /> */}
+                {status === 'info' && (
+                    passphraseEnabled
+                        ? this.renderDisableInfo()
+                        : this.renderEnableInfo()
+                )}
+                {status === 'progress' && (
+                    <View
+                        key="progress"
+                        fullscreen
+                        minHeight={CONTENT_MIN_HEIGHT}
+                        textCenter
+                        width={CONTENT_WIDTH}>
+                        <ViewHeader
                             title={t(passphraseEnabled
                                 ? 'passphrase.progressDisable.title'
                                 : 'passphrase.progressEnable.title')}>
-                            {t(passphraseEnabled
+                            <SimpleMarkup
+                                tagName="p"
+                                markup={t(passphraseEnabled
                                 ? 'passphrase.progressDisable.message'
-                                : 'passphrase.progressEnable.message')}
-                        </WaitDialog>
-                    )}
-                    {status === 'success' && (
-                        <WaitDialog
+                                : 'passphrase.progressEnable.message')} />
+                        </ViewHeader>
+                        <ViewContent>
+                            <PointToBitBox02 />
+                        </ViewContent>
+                    </View>
+                )}
+                {status === 'success' && (
+                    <View
+                        key="progress"
+                        fullscreen
+                        width={CONTENT_WIDTH}>
+                        <ViewHeader
+                            small
                             title={t(passphraseEnabled
                                 ? 'passphrase.successDisabled.title'
                                 : 'passphrase.successEnabled.title')} >
+                        </ViewHeader>
+                        <ViewContent>
                             {this.renderMultiLine(
                                 t(passphraseEnabled
                                     ? 'passphrase.successDisabled.message'
@@ -251,11 +351,17 @@ class Passphrase extends Component<Props, State> {
                                     <SimpleMarkup key="tip-2" tagName="li" markup={t('passphrase.successEnabled.tipsList.1')} />
                                 </ul>
                             )}
-                        </WaitDialog>
-                    )}
-                    </div>
-                </div>
-            </div>
+                            <SimpleMarkup tagName="p" markup={t(
+                                passphraseEnabled
+                                    ? 'passphrase.successDisabled.messageEnd'
+                                    : 'passphrase.successEnabled.messageEnd')} />
+                        </ViewContent>
+                    </View>
+                )}
+                {/* <Guide>
+                    <Entry key="whatisapassphrase" entry={t('guide.passphrase.whatisapassphrase')} />
+                </Guide> */}
+            </Main>
         );
     }
 }


### PR DESCRIPTION
Continuation from https://github.com/digitalbitbox/bitbox-wallet-app/pull/1475#issuecomment-974635933

When enabling or disabling the passphrase setting users should
fully focus on the information shown and not be distracted by other
elements on the page, therefore the view in fullscreen is more
suitable than just a dialog.

Changed:

Introduced a new <Main> component for contents of the page, this
component should replace <div class="container">. Also left example
code of how <Header> and <Guide> components can be used.

- changed back button to go 1 step back in the passphrase infos
  instead of going back to the settings view
- turned caret pointing to bb02 device into a shared component, so
  it can be re-used in different places like AOPP.
- changed View component's default, fullscreen and textCenter props
  are now opt-in
- added minHeight prop so the height of the view content can be
  controlled so that the buttons are always in the same position
- nicer styling for understood checkbox, now in a red box that
  changes to green once toggled
- improved positioning of the content area, buttons should now
  always be in the same position
- passphrase enable/disable success should disappear once the
  device is unplugged
- added missing successDisabled.messageEnd translation

Tested:

- different breakpoints small (portrait and landscape), medium
  screen centered and large screen with bigger font
- retesting unlock and AOPP workflow as those also use the view
  component
- tested that content is always scrollable if screen height is
  smaller than the content
- checked paddings and overall look