### PR TITLE
frontend: link update button directly to download page

### DIFF
--- a/frontends/web/src/components/appupgraderequired.tsx
+++ b/frontends/web/src/components/appupgraderequired.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +30,7 @@ function AppUpgradeRequired({ t }: RenderableProps<Props>): JSX.Element {
                         <div className="box large">
                             <p className="m-top-none">{t('device.appUpradeRequired')}</p>
                             <div className="buttons m-top-half">
-                                <A href="https://shiftcrypto.ch/start" className="text-medium text-blue">
+                                <A href="https://shiftcrypto.ch/download/?source=bitboxapp" className="text-medium text-blue">
                                     {t('button.download')}
                                 </A>
                             </div>

--- a/frontends/web/src/components/update/update.tsx
+++ b/frontends/web/src/components/update/update.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +45,7 @@ function Update({ file, t }: RenderableProps<Props>): JSX.Element | null {
             })}
             {file.description}
             {' '}
-            <A href="https://shiftcrypto.ch/start">
+            <A href="https://shiftcrypto.ch/download/?source=bitboxapp">
                 {t('button.download')}
             </A>
         </Status>


### PR DESCRIPTION
There is no reason to go through the '/start' redirect, which
could also be used to add custom welcome-to-bitbox banner on the
download page or a custom upgrade-the-bitboxapp instruction.