### PR TITLE
Add Buy CTA on Account Info #1473

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Add Buy CTA on empty Account overview and summary views
 - Fix an Android app crash when opening the app after first rejecting the USB permissions
 - Change label to show 'Fee rate' or 'Gas price' for custom fees
 - Change label 'Send all' label to 'Send selected coins' if there is a coin selection

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -21,6 +21,14 @@
   },
   "accountInfo": {
     "address": "Address",
+    "buyCTA": {
+      "buy": "Buy {{unit}}",
+      "buyCrypto": "Buy Crypto",
+      "information": {
+        "looksEmpty": "Looks like this wallet is empty.",
+        "start": "Get started by depositing some coins to the wallet or buying directly in the BitBoxApp."
+      }
+    },
     "extendedPublicKey": "Extended public key",
     "label": "Account info",
     "title": "Account information",

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -33,6 +33,7 @@ import { Transactions } from '../../components/transactions/transactions';
 import { load } from '../../decorators/load';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { apiGet } from '../../utils/request';
+import { BuyCTA } from './info/buyCTA';
 import * as style from './account.module.css';
 import { isBitcoinBased } from './utils';
 
@@ -310,6 +311,7 @@ class Account extends Component<Props, State> {
                     {status.synced && this.dataLoaded() && isBitcoinBased(account.coinCode) && <HeadersSync coinCode={account.coinCode} />}
                     <div className="innerContainer scrollableContainer">
                         <div className="content padded">
+                            { this.supportsBuy() && balance && (balance.available.amount === '0') && <BuyCTA code={code} unit={balance.available.unit} /> }
                             <Status
                                 className="m-bottom-default"
                                 hidden={!WithCoinTypeInfo.includes(code)}

--- a/frontends/web/src/routes/account/info/buyCTA.module.css
+++ b/frontends/web/src/routes/account/info/buyCTA.module.css
@@ -1,0 +1,9 @@
+.main {
+    margin-bottom: calc(var(--space-default) * 2);
+}
+
+.main > * {
+    margin-right: 0 !important;
+    text-align: center;
+    font-weight: 400;
+}

--- a/frontends/web/src/routes/account/info/buyCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyCTA.tsx
@@ -1,0 +1,44 @@
+import { FunctionalComponent, h } from 'preact';
+import { route } from 'preact-router';
+import { Coin } from '../../../api/account';
+import { Button } from '../../../components/forms';
+import { translate, TranslateProps } from '../../../decorators/translate';
+import { Balances } from '../summary/accountssummary';
+import * as styles from './buyCTA.module.css';
+
+interface BuyCTAProps {
+    code?: string;
+    unit?: string;
+}
+
+type Props = BuyCTAProps & TranslateProps;
+
+const BuyCTAComponent: FunctionalComponent<Props> = ({code, unit, t}) => {
+    const onCTA = () => route(code ? `/buy/info/${code}` : `/buy/info`);
+    return (
+    <div className={`${styles.main} columns-container`}>
+        <h3 className="column">{t('accountInfo.buyCTA.information.looksEmpty')}</h3>
+        <h3 className="column">{t('accountInfo.buyCTA.information.start')}</h3>
+        <div className="column">
+            <Button primary onClick={onCTA}>{unit ? t('accountInfo.buyCTA.buy', {unit}) : t('accountInfo.buyCTA.buyCrypto')}</Button>
+        </div>
+    </div>);
+};
+
+export const BuyCTA = translate<BuyCTAProps>()(BuyCTAComponent);
+
+const isBitcoinCoin = (coin: Coin) => (coin === 'BTC') || (coin === 'TBTC');
+
+export const AddBuyOnEmptyBalances: FunctionalComponent<{balances?: Balances}> = ({balances}) => {
+    if (balances === undefined) {
+        return null;
+    }
+    const balanceList = Object.entries(balances);
+    if (balanceList.some(entry => entry[1].available.amount !== '0')) {
+        return null;
+    }
+    if (balanceList.map(entry => entry[1].available.unit).every(isBitcoinCoin)) {
+        return <BuyCTA code={balanceList[0][0]} unit={'BTC'} />;
+    }
+    return <BuyCTA />;
+};

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -30,13 +30,14 @@ import Spinner from '../../../components/spinner/ascii';
 import { debug } from '../../../utils/env';
 import { apiWebsocket } from '../../../utils/websocket';
 import { Chart } from './chart';
+import { AddBuyOnEmptyBalances } from '../info/buyCTA';
 import * as style from './accountssummary.module.css';
 
 interface AccountSummaryProps {
     accounts: accountApi.IAccount[];
 }
 
-interface Balances {
+export interface Balances {
     [code: string]: accountApi.IBalance;
 }
 
@@ -189,7 +190,7 @@ class AccountsSummary extends Component<Props, State> {
 
     public render() {
         const { t, accounts } = this.props;
-        const { exported, data } = this.state;
+        const { exported, data, balances } = this.state;
         return (
             <div className="contentWithGuide">
                 <div className="container">
@@ -215,6 +216,7 @@ class AccountsSummary extends Component<Props, State> {
                     </Header>
                     <div className="innerContainer scrollableContainer">
                         <div className="content padded">
+                            { ( accounts.length === Object.keys(balances || {}).length ) && <AddBuyOnEmptyBalances balances={balances} /> }
                             {data ? (
                                 <Chart
                                     dataDaily={data.chartDataMissing ? undefined : data.chartDataDaily}


### PR DESCRIPTION
Adds a buy CTA action for available to buy coins if the amount is 0
![screencapture-localhost-8080-account-v0-6d908ae1-teth-0-2021-11-23-22_45_43](https://user-images.githubusercontent.com/4956754/143156382-7da77c94-dff3-4550-9a2d-52d5dec97f43.png)

Closes #1473 
