### PR TITLE
ci: pin nodejs to version 16 on windows (appveyor)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 image: Visual Studio 2019
 
 environment:
+  nodejs_version: "16"
   matrix:
     - QT: C:\Qt\5.15.2\msvc2019_64
       GOROOT: C:\go116


### PR DESCRIPTION
Unfortunately the ci fails on windows when just using the latest
node version. Pinned to current LTS version.