### PR TITLE
frontend: migrate decorators sugar-syntax to HOC

### DIFF
--- a/frontends/web/src/components/password.jsx
+++ b/frontends/web/src/components/password.jsx
@@ -30,8 +30,7 @@ export function PasswordInput (props) {
     );
 }
 
-@translate(null, { withRef: true })
-export class PasswordSingleInput extends Component {
+class PasswordSingleInputClass extends Component {
     state = {
         password: '',
         seePlaintext: false,
@@ -147,8 +146,10 @@ export class PasswordSingleInput extends Component {
 
 }
 
-@translate(null, { withRef: true })
-export class PasswordRepeatInput extends Component {
+export const PasswordSingleInput = translate(null, { withRef: true })(PasswordSingleInputClass);
+
+
+class PasswordRepeatInputClass extends Component {
     state = {
         password: '',
         passwordRepeat: '',
@@ -294,6 +295,8 @@ export class PasswordRepeatInput extends Component {
         );
     }
 }
+
+export const PasswordRepeatInput = translate(null, { withRef: true })(PasswordRepeatInputClass);
 
 function MatchesPattern({ regex, value = '', text }) {
     if (!regex || !value.length || regex.test(value)) {

--- a/frontends/web/src/routes/device/bitbox01/bitbox01.jsx
+++ b/frontends/web/src/routes/device/bitbox01/bitbox01.jsx
@@ -46,8 +46,7 @@ const GOAL = Object.freeze({
     RESTORE: 'restore'
 });
 
-@translate()
-export default class Device extends Component {
+class Device extends Component {
     state = {
         firmwareVersion: null,
         deviceRegistered: false,
@@ -191,3 +190,5 @@ export default class Device extends Component {
         }
     }
 }
+
+export default translate()(Device);

--- a/frontends/web/src/routes/device/bitbox01/check.jsx
+++ b/frontends/web/src/routes/device/bitbox01/check.jsx
@@ -22,8 +22,7 @@ import { PasswordSingleInput } from '../../../components/password';
 import { apiPost } from '../../../utils/request';
 import * as style from '../../../components/dialog/dialog.css';
 
-@translate()
-export default class Check extends Component {
+class Check extends Component {
     state = {
         password: null,
         activeDialog: false,
@@ -126,3 +125,5 @@ export default class Check extends Component {
         );
     }
 }
+
+export default translate()(Check);

--- a/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
+++ b/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
@@ -23,8 +23,7 @@ import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
 import { apiGet, apiPost } from '../../../../utils/request';
 import { SettingsButton } from '../../../../components/settingsButton/settingsButton';
 
-@translate()
-export default class UpgradeFirmware extends Component {
+class UpgradeFirmware extends Component {
     state = {
         unlocked: false,
         newVersion: '',
@@ -133,3 +132,5 @@ export default class UpgradeFirmware extends Component {
         );
     }
 }
+
+export default translate()(UpgradeFirmware);

--- a/frontends/web/src/routes/device/bitbox01/create.jsx
+++ b/frontends/web/src/routes/device/bitbox01/create.jsx
@@ -23,8 +23,7 @@ import { apiPost } from '../../../utils/request';
 import { Dialog } from '../../../components/dialog/dialog';
 import * as style from '../../../components/dialog/dialog.css';
 
-@translate()
-export default class Create extends Component {
+class Create extends Component {
     state = {
         waiting: false,
         backupName: '',
@@ -119,3 +118,5 @@ export default class Create extends Component {
         );
     }
 }
+
+export default translate()(Create);

--- a/frontends/web/src/routes/device/bitbox01/settings/components/blink.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/blink.jsx
@@ -19,8 +19,7 @@ import { translate } from 'react-i18next';
 import { SettingsButton } from '../../../../../components/settingsButton/settingsButton';
 import { apiPost } from '../../../../../utils/request';
 
-@translate()
-export default class Blink extends Component {
+class Blink extends Component {
     blinkDevice = () => {
         apiPost('devices/' + this.props.deviceID + '/blink');
     };
@@ -31,3 +30,5 @@ export default class Blink extends Component {
         );
     }
 }
+
+export default translate()(Blink);

--- a/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
@@ -25,8 +25,7 @@ import { PasswordInput, PasswordRepeatInput } from '../../../../../components/pa
 import { apiPost } from '../../../../../utils/request';
 import { SettingsButton } from '../../../../../components/settingsButton/settingsButton';
 
-@translate()
-export default class ChangePIN extends Component {
+class ChangePIN extends Component {
     state = {
         oldPIN: null,
         newPIN: null,
@@ -131,3 +130,5 @@ export default class ChangePIN extends Component {
         );
     }
 }
+
+export default translate()(ChangePIN);

--- a/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
@@ -24,8 +24,7 @@ import { apiPost } from '../../../../../utils/request';
 import { SettingsButton } from '../../../../../components/settingsButton/settingsButton';
 import * as style from '../../../../../components/dialog/dialog.css';
 
-@translate()
-export default class DeviveLock extends Component {
+class DeviceLock extends Component {
     state = {
         isConfirming: false,
         activeDialog: false,
@@ -95,3 +94,5 @@ export default class DeviveLock extends Component {
         );
     }
 }
+
+export default translate()(DeviceLock);

--- a/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
@@ -26,8 +26,7 @@ import { apiPost } from '../../../../../utils/request';
 import { SimpleMarkup } from '../../../../../utils/simplemarkup';
 import { SettingsButton } from '../../../../../components/settingsButton/settingsButton';
 
-@translate()
-export default class HiddenWallet extends Component {
+class HiddenWallet extends Component {
     state = {
         password: null,
         pin: null,
@@ -138,3 +137,5 @@ export default class HiddenWallet extends Component {
         );
     }
 }
+
+export default translate()(HiddenWallet);

--- a/frontends/web/src/routes/device/bitbox01/settings/components/legacyhiddenwallet.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/legacyhiddenwallet.jsx
@@ -20,8 +20,7 @@ import { Button } from '../../../../../components/forms';
 import { alertUser } from '../../../../../components/alert/Alert';
 import { apiPost } from '../../../../../utils/request';
 
-@translate()
-export default class LegacyHiddenWallet extends Component {
+class LegacyHiddenWallet extends Component {
     toggle = () => {
         const newValue = !this.props.newHiddenWallet;
         apiPost('devices/' + this.props.deviceID + '/feature-set', {
@@ -54,3 +53,5 @@ export default class LegacyHiddenWallet extends Component {
         );
     }
 }
+
+export default translate()(LegacyHiddenWallet);

--- a/frontends/web/src/routes/device/bitbox01/settings/components/randomnumber.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/randomnumber.jsx
@@ -22,8 +22,7 @@ import { Dialog, DialogButtons } from '../../../../../components/dialog/dialog';
 import { CopyableInput } from '../../../../../components/copy/Copy';
 import { SettingsButton } from '../../../../../components/settingsButton/settingsButton';
 
-@translate()
-export default class RandomNumber extends Component {
+class RandomNumber extends Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -75,3 +74,5 @@ export default class RandomNumber extends Component {
         );
     }
 }
+
+export default translate()(RandomNumber);

--- a/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
@@ -27,8 +27,7 @@ import { alertUser } from '../../../../../components/alert/Alert';
 import * as style from '../../bitbox01.css';
 import { SettingsButton } from '../../../../../components/settingsButton/settingsButton';
 
-@translate()
-export default class Reset extends Component {
+class Reset extends Component {
     state = {
         pin: null,
         isConfirming: false,
@@ -123,3 +122,5 @@ export default class Reset extends Component {
         );
     }
 }
+
+export default translate()(Reset);

--- a/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
@@ -34,8 +34,7 @@ import UpgradeFirmware from '../components/upgradefirmware';
 import { SettingsButton } from '../../../../components/settingsButton/settingsButton';
 import { SettingsItem } from '../../../../components/settingsButton/settingsItem';
 
-@translate()
-export default class Settings extends Component {
+class Settings extends Component {
     state = {
         firmwareVersion: null,
         newVersion: null,
@@ -226,3 +225,5 @@ export default class Settings extends Component {
         );
     }
 }
+
+export default translate()(Settings);

--- a/frontends/web/src/routes/device/bitbox01/setup/goal.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/goal.jsx
@@ -21,8 +21,7 @@ import { SwissMadeOpenSource } from '../../../../components/icon/logo';
 import { Header } from '../../../../components/layout';
 import { LanguageSwitch } from '../../../../components/language/language';
 
-@translate()
-export default class Goal extends Component {
+class Goal extends Component {
     render({
         t,
         onCreate,
@@ -57,3 +56,5 @@ export default class Goal extends Component {
         );
     }
 }
+
+export default translate()(Goal);

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
@@ -34,8 +34,7 @@ const STATUS = Object.freeze({
     ERROR: 'error',
 });
 
-@translate()
-export default class SeedCreateNew extends Component {
+class SeedCreateNew extends Component {
     state = {
         showInfo: true,
         status: STATUS.CHECKING,
@@ -255,3 +254,5 @@ export default class SeedCreateNew extends Component {
         );
     }
 }
+
+export default translate()(SeedCreateNew);

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
@@ -33,8 +33,7 @@ const STATUS = Object.freeze({
     ERROR: 'error',
 });
 
-@translate()
-export default class SeedRestore extends Component {
+class SeedRestore extends Component {
     state = {
         showInfo: true,
         status: STATUS.CHECKING,
@@ -158,3 +157,5 @@ export default class SeedRestore extends Component {
         );
     }
 }
+
+export default translate()(SeedRestore);

--- a/frontends/web/src/routes/device/bitbox01/setup/success.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/success.jsx
@@ -23,8 +23,7 @@ import { Header } from '../../../../components/layout';
 import { Button } from '../../../../components/forms';
 import * as style from '../bitbox01.css';
 
-@translate()
-export default class Success extends Component {
+class Success extends Component {
 
     handleGetStarted = () => {
         route('/account-summary', true);
@@ -75,3 +74,5 @@ export default class Success extends Component {
         );
     }
 }
+
+export default translate()(Success);

--- a/frontends/web/src/routes/device/bitbox01/unlock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/unlock.jsx
@@ -33,8 +33,7 @@ const stateEnum = Object.freeze({
     ERROR: 'error'
 });
 
-@translate()
-export default class Unlock extends Component {
+class Unlock extends Component {
     state = {
         status: stateEnum.DEFAULT,
         errorMessage: '',
@@ -179,3 +178,5 @@ export default class Unlock extends Component {
         );
     }
 }
+
+export default translate()(Unlock);

--- a/frontends/web/src/routes/device/bitbox01/upgrade/bootloader.jsx
+++ b/frontends/web/src/routes/device/bitbox01/upgrade/bootloader.jsx
@@ -22,8 +22,7 @@ import { BitBox } from '../../../../components/icon/logo';
 import { Button } from '../../../../components/forms';
 import * as style from '../bitbox01.css';
 
-@translate()
-export default class Bootloader extends Component {
+class Bootloader extends Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -130,3 +129,5 @@ export default class Bootloader extends Component {
         );
     }
 }
+
+export default translate()(Bootloader);

--- a/frontends/web/src/routes/device/bitbox01/upgrade/require_upgrade.jsx
+++ b/frontends/web/src/routes/device/bitbox01/upgrade/require_upgrade.jsx
@@ -21,8 +21,7 @@ import UpgradeFirmware from '../components/upgradefirmware';
 import { BitBox } from '../../../../components/icon/logo';
 import * as style from '../bitbox01.css';
 
-@translate()
-export default class RequireUpgrade extends Component {
+class RequireUpgrade extends Component {
     state = {
         firmwareVersion: null
     }
@@ -51,3 +50,5 @@ export default class RequireUpgrade extends Component {
         );
     }
 }
+
+export default translate()(RequireUpgrade);

--- a/frontends/web/src/routes/device/bitbox02/setdevicename.jsx
+++ b/frontends/web/src/routes/device/bitbox02/setdevicename.jsx
@@ -24,8 +24,7 @@ import { alertUser } from '../../../components/alert/Alert';
 import { SettingsButton } from '../../../components/settingsButton/settingsButton';
 import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
 
-@translate()
-export class SetDeviceName extends Component {
+class SetDeviceNameClass extends Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -122,3 +121,5 @@ export class SetDeviceName extends Component {
         );
     }
 }
+
+export const SetDeviceName = translate()(SetDeviceNameClass);

--- a/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
+++ b/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
@@ -25,8 +25,7 @@ import { Backups } from '../bitbox01/backups';
 import { BackupsV2 } from '../bitbox02/backups';
 import { SDCardCheck } from '../bitbox02/sdcardcheck';
 
-@translate()
-export default class ManageBackups extends Component {
+class ManageBackups extends Component {
     hasDevice = () => {
         return !!this.props.devices[this.props.deviceID];
     }
@@ -120,3 +119,5 @@ export default class ManageBackups extends Component {
         );
     }
 }
+
+export default translate()(ManageBackups);

--- a/frontends/web/src/routes/settings/electrum.jsx
+++ b/frontends/web/src/routes/settings/electrum.jsx
@@ -26,8 +26,7 @@ import { alertUser } from '../../components/alert/Alert';
 import * as style from './electrum.css';
 import A from '../../components/anchor/anchor';
 
-@translate()
-class ElectrumServer extends Component {
+class ElectrumServerClass extends Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -214,8 +213,9 @@ class ElectrumServer extends Component {
     }
 }
 
-@translate()
-class ElectrumServers extends Component {
+export const ElectrumServer = translate()(ElectrumServerClass);
+
+class ElectrumServersClass extends Component {
     state = {
         electrumServers: [],
     }
@@ -299,8 +299,9 @@ class ElectrumServers extends Component {
     }
 }
 
-@translate()
-export default class ElectrumSettings extends Component {
+const ElectrumServers = translate()(ElectrumServersClass);
+
+class ElectrumSettings extends Component {
     state = {
         testing: false,
         activeTab: 'btc',
@@ -373,3 +374,5 @@ export default class ElectrumSettings extends Component {
         );
     }
 }
+
+export default translate()(ElectrumSettings);


### PR DESCRIPTION
Decorators are intentionally not supported in RCA and is recommended to not use them, see [https://create-react-app.dev/docs/can-i-use-decorators/](https://create-react-app.dev/docs/can-i-use-decorators/)

closes #1490