### PR TITLE
Migrate RefCallback to RefObject

### DIFF
--- a/frontends/web/src/components/copy/Copy.tsx
+++ b/frontends/web/src/components/copy/Copy.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { Check, Copy } from '../icon/icon';
 import * as style from './Copy.module.css';
@@ -41,7 +41,7 @@ class CopyableInput extends Component<Props, State> {
         success: false,
     }
 
-    private textArea!: HTMLTextAreaElement;
+    private textArea = createRef<HTMLTextAreaElement>();
 
     public componentDidMount() {
         this.setHeight();
@@ -52,15 +52,14 @@ class CopyableInput extends Component<Props, State> {
     }
 
     private setHeight() {
-        const textarea = this.textArea;
+        const textarea = this.textArea.current;
+        if (!textarea) {
+            return;
+        }
         const fontSize = window.getComputedStyle(textarea, null).getPropertyValue('font-size');
         const units = Number(fontSize.replace('px', '')) + 2;
         textarea.setAttribute('rows', '1');
         textarea.setAttribute('rows', String(Math.round((textarea.scrollHeight / units) - 2)));
-    }
-
-    private setRef = (textarea: HTMLTextAreaElement) => {
-        this.textArea = textarea;
     }
 
     private onFocus = (e: FocusEvent) => {
@@ -71,7 +70,7 @@ class CopyableInput extends Component<Props, State> {
     }
 
     private copy = () => {
-        this.textArea.select();
+        this.textArea.current?.select();
         if (document.execCommand('copy')) {
             this.setState({ success: true }, () => {
                 setTimeout(() => this.setState({ success: false }), 1500);
@@ -101,7 +100,7 @@ class CopyableInput extends Component<Props, State> {
                     readOnly
                     onFocus={this.onFocus}
                     value={value}
-                    ref={this.setRef}
+                    ref={this.textArea}
                     rows={1}
                     className={[
                         style.inputField,

--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, h, RenderableProps } from 'preact';
+import { Component, createRef, h, RenderableProps } from 'preact';
 import * as style from './dialog.module.css';
 
 interface Props {
@@ -36,9 +36,9 @@ interface State {
 }
 
 class Dialog extends Component<Props, State> {
-    private overlay?: HTMLDivElement | null;
-    private modal?: HTMLDivElement | null;
-    private modalContent?: HTMLDivElement | null;
+    private overlay = createRef<HTMLDivElement>();
+    private modal = createRef<HTMLDivElement>();
+    private modalContent = createRef<HTMLDivElement>();
     private focusableChildren!: NodeListOf<HTMLElement>;
 
     public readonly state: State = {
@@ -61,8 +61,8 @@ class Dialog extends Component<Props, State> {
     }
 
     private focusWithin = () => {
-        if (this.modalContent) {
-            this.focusableChildren = this.modalContent.querySelectorAll('a, button, input, textarea');
+        if (this.modalContent.current) {
+            this.focusableChildren = this.modalContent.current.querySelectorAll('a, button, input, textarea');
             const focusables = Array.from(this.focusableChildren);
             for (const c of focusables) {
                 c.classList.add('tabbable');
@@ -115,26 +115,26 @@ class Dialog extends Component<Props, State> {
     }
 
     private deactivate = () => {
-        if (!this.modal || !this.overlay) {
+        if (!this.modal.current || !this.overlay.current) {
             return;
         }
-        this.modal.classList.remove(style.activeModal);
+        this.modal.current.classList.remove(style.activeModal);
         this.setState({ active: false, currentTab: 0 }, () => {
             document.removeEventListener('keydown', this.handleKeyDown);
             if (this.props.onClose) {
                 this.props.onClose();
             }
         });
-        this.overlay.classList.remove(style.activeOverlay);
+        this.overlay.current.classList.remove(style.activeOverlay);
     }
 
     private activate = () => {
         this.setState({ active: true }, () => {
-            if (!this.modal || !this.overlay) {
+            if (!this.modal.current || !this.overlay.current) {
                 return;
             }
-            this.overlay.classList.add(style.activeOverlay);
-            this.modal.classList.add(style.activeModal);
+            this.overlay.current.classList.add(style.activeOverlay);
+            this.modal.current.classList.add(style.activeModal);
             this.focusWithin();
             this.focusFirst();
         });
@@ -158,10 +158,10 @@ class Dialog extends Component<Props, State> {
         const isSlim = slim ? style.slim : '';
         const isCentered = centered && !onClose ? style.centered : '';
         return (
-            <div className={style.overlay} ref={element => this.overlay = element}>
+            <div className={style.overlay} ref={this.overlay}>
                 <div
                     className={[style.modal, isSmall, isMedium, isLarge].join(' ')}
-                    ref={element => this.modal = element}>
+                    ref={this.modal}>
                     {
                         title && (
                             <div className={[style.header, isCentered].join(' ')}>
@@ -179,7 +179,7 @@ class Dialog extends Component<Props, State> {
                     }
                     <div
                         className={[style.contentContainer, isSlim].join(' ')}
-                        ref={element => this.modalContent = element}>
+                        ref={this.modalContent}>
                         <div className={style.content}>
                             {children}
                         </div>

--- a/frontends/web/src/components/forms/input.tsx
+++ b/frontends/web/src/components/forms/input.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { h, JSX, RenderableProps } from 'preact';
+import { h, JSX, Ref, RenderableProps,  } from 'preact';
 import * as styles from './input.module.css';
 
 export interface Props {
@@ -24,7 +24,7 @@ export interface Props {
     className?: string;
     disabled?: boolean;
     error?: string | object;
-    getRef?: (node: HTMLInputElement) => void;
+    inputRef?: Ref<HTMLInputElement>;
     id?: string;
     label?: string;
     min?: string;
@@ -53,7 +53,7 @@ export default function Input({
     className = '',
     style = '',
     children,
-    getRef,
+    inputRef,
     transparent = false,
     type = 'text',
     labelSection,
@@ -87,7 +87,7 @@ export default function Input({
                 spellcheck={false}
                 type={type}
                 id={id}
-                ref={getRef}
+                ref={inputRef}
                 {...props}
             />
             {children}

--- a/frontends/web/src/components/password.jsx
+++ b/frontends/web/src/components/password.jsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, h, createRef } from 'preact';
 import { translate } from 'react-i18next';
 import { Input, Checkbox, Field } from './forms';
 import { alertUser } from './alert/Alert';
@@ -36,6 +36,8 @@ class PasswordSingleInputClass extends Component {
         seePlaintext: false,
         capsLock: false
     }
+
+    password = createRef();
 
     idPrefix = () => {
         return this.props.idPrefix || '';
@@ -73,7 +75,7 @@ class PasswordSingleInputClass extends Component {
     }
 
     validate = () => {
-        if (this.regex && this.password && !this.password.validity.valid) {
+        if (this.regex && this.password.current && !this.password.current.validity.valid) {
             return this.props.onValidPassword(null);
         }
         if (this.state.password) {
@@ -130,7 +132,7 @@ class PasswordSingleInputClass extends Component {
                 placeholder={placeholder}
                 onInput={this.handleFormChange}
                 onPaste={this.tryPaste}
-                getRef={ref => this.password = ref}
+                inputRef={this.password}
                 value={password}
                 labelSection={
                     <Checkbox
@@ -158,6 +160,9 @@ class PasswordRepeatInputClass extends Component {
         seePlaintext: false,
         capsLock: false
     }
+
+    password = createRef();
+    passwordRepeat = createRef();
 
     idPrefix = () => {
         return this.props.idPrefix || '';
@@ -197,8 +202,8 @@ class PasswordRepeatInputClass extends Component {
 
     validate = () => {
         if (
-            this.regex && this.password && this.passwordRepeat
-            && (!this.password.validity.valid || !this.passwordRepeat.validity.valid)
+            this.regex && this.password.current && this.passwordRepeat.current
+            && (!this.password.current.validity.valid || !this.passwordRepeat.current.validity.valid)
         ) {
             return this.props.onValidPassword(null);
         }
@@ -260,7 +265,7 @@ class PasswordRepeatInputClass extends Component {
                     placeholder={placeholder}
                     onInput={this.handleFormChange}
                     onPaste={this.tryPaste}
-                    getRef={ref => this.password = ref}
+                    inputRef={this.password}
                     value={password}>
                     {warning}
                 </Input>
@@ -278,7 +283,7 @@ class PasswordRepeatInputClass extends Component {
                     placeholder={repeatPlaceholder}
                     onInput={this.handleFormChange}
                     onPaste={this.tryPaste}
-                    getRef={ref => this.passwordRepeat = ref}
+                    inputRef={this.password}
                     value={passwordRepeat}>
                     {warning}
                 </Input>

--- a/frontends/web/src/components/toast/Toast.jsx
+++ b/frontends/web/src/components/toast/Toast.jsx
@@ -37,10 +37,6 @@ export default class Toast extends Component {
         }
     }
 
-    setRef = ref => {
-        this.toast = ref;
-    }
-
     render() {
         const {
             theme,
@@ -50,7 +46,6 @@ export default class Toast extends Component {
         const { active } = this.state;
         return (
             <div
-                ref={this.setRef}
                 className={[style.toast, style[theme], active ? style.active : '', withGuide ? style.shifted : ''].join(' ')}>
                 <p>{children}</p>
             </div>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import * as accountApi from '../../api/account';
 import { Input } from '../../components/forms';
 import { translate, TranslateProps } from '../../decorators/translate';
@@ -44,8 +44,8 @@ interface TransactionProps extends accountApi.ITransaction {
 type Props = TransactionProps & TranslateProps;
 
 class Transaction extends Component<Props, State> {
-    private input!: HTMLInputElement;
-    private editButton!: HTMLButtonElement;
+    private input = createRef<HTMLInputElement>();
+    private editButton = createRef<HTMLButtonElement>();
 
     public readonly state: State = {
         transactionDialog: false,
@@ -58,7 +58,7 @@ class Transaction extends Component<Props, State> {
             year: 'numeric',
             month: 'numeric',
             day: 'numeric',
-        };
+        } as Intl.DateTimeFormatOptions;
         return new Date(Date.parse(time)).toLocaleString(this.context.i18n.language, options);
     }
 
@@ -96,21 +96,13 @@ class Transaction extends Component<Props, State> {
     }
 
     private focusEdit = () => {
-        if (this.editButton) {
-            this.editButton.blur();
+        if (this.editButton.current) {
+            this.editButton.current.blur();
         }
-        if (this.state.editMode && this.input) {
-            this.input.scrollLeft = this.input.scrollWidth;
-            this.input.focus();
+        if (this.state.editMode && this.input.current) {
+            this.input.current.scrollLeft = this.input.current.scrollWidth;
+            this.input.current.focus();
         }
-    }
-
-    private setInputRef = input => {
-        this.input = input;
-    }
-
-    private setEditButtonRef = button => {
-        this.editButton = button;
     }
 
     public render() {
@@ -243,13 +235,13 @@ class Transaction extends Component<Props, State> {
                                     value={newNote}
                                     maxLength={256}
                                     onInput={this.handleNoteInput}
-                                    getRef={this.setInputRef}/>
+                                    inputRef={this.input}/>
                                 <button
                                     className={style.editButton}
                                     onClick={this.handleEdit}
                                     title={t(`transaction.note.${editMode ? 'save' : 'edit'}`)}
                                     type="button"
-                                    ref={this.setEditButtonRef}>
+                                    ref={this.editButton}>
                                         {editMode ? <Save /> : <Edit />}
                                 </button>
                             </form>

--- a/frontends/web/src/components/wait-dialog/wait-dialog.tsx
+++ b/frontends/web/src/components/wait-dialog/wait-dialog.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, ComponentChild, h, JSX } from 'preact';
+import { Component, ComponentChild, createRef, h, JSX } from 'preact';
 import { translate, TranslateProps } from '../../decorators/translate';
 import approve from '../../assets/icons/hold.png';
 import reject from '../../assets/icons/tap.png';
@@ -36,8 +36,8 @@ interface State {
 }
 
 class WaitDialog extends Component<Props, State> {
-    private overlay?: HTMLDivElement;
-    private modal?: HTMLDivElement;
+    private overlay = createRef<HTMLDivElement>();
+    private modal = createRef<HTMLDivElement>();
 
     public readonly state: State = {
         active: false,
@@ -64,21 +64,13 @@ class WaitDialog extends Component<Props, State> {
         e.stopPropagation();
     }
 
-    private setOverlay = ref => {
-        this.overlay = ref;
-    }
-
-    private setModal = ref => {
-        this.modal = ref;
-    }
-
     private activate = () => {
         this.setState({ active: true }, () => {
-            if (!this.overlay || !this.modal) {
+            if (!this.overlay.current || !this.modal.current) {
                 return;
             }
-            this.overlay.classList.add(style.activeOverlay);
-            this.modal.classList.add(style.activeModal);
+            this.overlay.current.classList.add(style.activeOverlay);
+            this.modal.current.classList.add(style.activeModal);
         });
     }
 
@@ -144,9 +136,9 @@ class WaitDialog extends Component<Props, State> {
         return (
             <div
                 className={style.overlay}
-                ref={this.setOverlay}
+                ref={this.overlay}
                 style="z-index: 10001;">
-                <div className={style.modal} ref={this.setModal}>
+                <div className={style.modal} ref={this.modal}>
                     {
                         title && (
                             <div className={style.header}>

--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import { route } from 'preact-router';
 import * as accountApi from '../../../api/account';
 import * as backendAPI from '../../../api/backend';
@@ -58,6 +58,8 @@ class AddAccount extends Component<Props, State> {
         adding: false,
     };
 
+    private ref = createRef<HTMLInputElement>();
+
     private onlyOneSupportedCoin = (): boolean => {
         return this.state.supportedCoins.length === 1;
     }
@@ -75,6 +77,13 @@ class AddAccount extends Component<Props, State> {
                     this.setState({ accountName: coins[0].suggestedAccountName });
                 }
             });
+        this.ref.current?.focus();
+    }
+
+    public componentDidUpdate(_prevProps, prevState: State) {
+        if ((prevState.step !== this.state.step) && (this.state.step === 'choose-name')){
+            this.ref.current?.focus();
+        }
     }
 
     private back = () => {
@@ -147,15 +156,6 @@ class AddAccount extends Component<Props, State> {
         }
     }
 
-    private focusRef = (ref) => {
-        setTimeout(() => {
-            if (ref === document.activeElement) {
-                return;
-            }
-            ref?.focus();
-        }, 0);
-    }
-
     private renderContent = () => {
         const { t } = this.props;
         const { accountName, coinCode, step, supportedCoins} = this.state;
@@ -171,7 +171,7 @@ class AddAccount extends Component<Props, State> {
                 return (
                     <Input
                         autoFocus
-                        getRef={this.focusRef}
+                        inputRef={this.ref}
                         id="accountName"
                         onInput={e => this.setState({ accountName: e.target.value })}
                         value={accountName} />

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import * as accountApi from '../../../api/account';
 import { Input, Select } from '../../../components/forms';
 import { load } from '../../../decorators/load';
@@ -58,8 +58,11 @@ class FeeTargets extends Component<Props, State> {
         options: null,
     };
 
+    private input = createRef<HTMLInputElement & {autofocus: boolean}>();
+
     public componentDidMount() {
         this.updateFeeTargets(this.props.accountCode);
+        this.focusInput();
     }
 
     public componentWillReceiveProps({ accountCode }) {
@@ -110,6 +113,12 @@ class FeeTargets extends Component<Props, State> {
         const { amount, unit, conversions } = this.props.proposedFee;
         const fiatUnit = this.props.fiatUnit;
         return `${amount} ${unit} ${conversions ? ` = ${conversions[fiatUnit]} ${fiatUnit}` : ''}`;
+    }
+
+    private focusInput = () => {
+        if (!this.props.disabled && this.input.current && this.input.current.autofocus) {
+            this.input.current.focus();
+        }
     }
 
     public render() {
@@ -190,13 +199,7 @@ class FeeTargets extends Component<Props, State> {
                                     error={error}
                                     transparent
                                     onInput={this.handleCustomFee}
-                                    getRef={input => {
-                                        setTimeout(() => {
-                                            if (!disabled && input && input.autofocus) {
-                                                input.focus();
-                                            }
-                                        });
-                                    }}
+                                    inputRef={this.input}
                                     value={customFee}
                                 >
                                     <span className={style.customFeeUnit}>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import { route } from 'preact-router';
 import { BrowserQRCodeReader } from '@zxing/library';
 import * as accountApi from '../../../api/account';
@@ -94,7 +94,7 @@ interface State {
 }
 
 class Send extends Component<Props, State> {
-    private utxos!: Component<UTXOsProps>;
+    private utxos = createRef<Component<UTXOsProps>>();
     private selectedUTXOs: SelectedUTXO = {};
     private unsubscribe!: () => void;
     private qrCodeReader?: BrowserQRCodeReader;
@@ -236,8 +236,12 @@ class Send extends Component<Props, State> {
                     note: '',
                     customFee: '',
                 });
-                if (this.utxos) {
-                    (this.utxos as any).getWrappedInstance().clear();
+                if (this.utxos.current) {
+                    try {
+                        (this.utxos.current as any).getWrappedInstance().clear();
+                    } catch (e) {
+                        console.error(e);
+                    }
                 }
                 setTimeout(() => this.setState({
                     isSent: false,
@@ -462,15 +466,15 @@ class Send extends Component<Props, State> {
 
     private toggleCoinControl = () => {
         this.setState(({ activeCoinControl }) => {
-            if (activeCoinControl && this.utxos) {
-                (this.utxos as any).getWrappedInstance().clear();
+            if (activeCoinControl && this.utxos.current) {
+                try {
+                    (this.utxos.current as any).getWrappedInstance().clear();
+                } catch (e) {
+                    console.error(e);
+                }
             }
             return { activeCoinControl: !activeCoinControl };
         });
-    }
-
-    private setUTXOsRef = (ref: Component<UTXOsProps>) => {
-        this.utxos = ref;
     }
 
     private parseQRResult = uri => {
@@ -612,7 +616,7 @@ class Send extends Component<Props, State> {
                                         explorerURL={account.blockExplorerTxPrefix}
                                         onClose={this.deactivateCoinControl}
                                         onChange={this.onSelectedUTXOsChange}
-                                        ref={this.setUTXOsRef}
+                                        ref={this.utxos}
                                     />
                                 )
                             }

--- a/frontends/web/src/routes/device/bitbox01/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox01/backups.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet } from '../../../utils/request';
 import { SimpleMarkup } from '../../../utils/markup';
@@ -46,7 +46,7 @@ interface State {
 }
 
 class Backups extends Component<Props, State> {
-    private scrollableContainer!: HTMLElement;
+    private scrollableContainer = createRef<HTMLElement>();
 
     constructor(props) {
         super(props);
@@ -83,18 +83,17 @@ class Backups extends Component<Props, State> {
     }
 
     private scrollIntoView = (event: Event) => {
+        if (!this.scrollableContainer.current){
+            return;
+        }
         const target = event.target as HTMLInputElement;
         const offsetTop = target.offsetTop;
         const offsetHeight = (target.parentNode as HTMLElement).offsetHeight;
-        if (offsetTop > this.scrollableContainer.scrollTop + offsetHeight) {
+        if (offsetTop > this.scrollableContainer.current.scrollTop + offsetHeight) {
             return;
         }
-        const top = Math.max((offsetTop + offsetHeight) - this.scrollableContainer.offsetHeight, 0);
-        this.scrollableContainer.scroll({ top, behavior: 'smooth' });
-    }
-
-    private setScrollableContainerRef = (ref: HTMLElement) => {
-        this.scrollableContainer = ref;
+        const top = Math.max((offsetTop + offsetHeight) - this.scrollableContainer.current.offsetHeight, 0);
+        this.scrollableContainer.current.scroll({ top, behavior: 'smooth' });
     }
 
     public render() {
@@ -130,7 +129,7 @@ class Backups extends Component<Props, State> {
         return (
             <div className="box large m-top-default">
                 <SimpleMarkup tagName="p" markup={t('backup.description')} />
-                <div className={style.backupsList} ref={this.setScrollableContainerRef}>
+                <div className={style.backupsList} ref={this.scrollableContainer}>
                     <div className={style.listContainer}>
                         {
                             backupList.length ? backupList.map(backup => (

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import { Button } from '../../../../components/forms';
 import { SwissMadeOpenSource } from '../../../../components/icon/logo';
 import { LanguageSwitch } from '../../../../components/language/language';
@@ -49,7 +49,7 @@ interface State {
 }
 
 class Initialize extends Component<Props, State> {
-    private passwordInput!: HTMLInputElement;
+    private passwordInput = createRef<HTMLInputElement>();
 
     constructor(props) {
         super(props);
@@ -84,14 +84,14 @@ class Initialize extends Component<Props, State> {
                     errorMessage: data.errorMessage,
                 });
             }
-            if (this.passwordInput) {
-                (this.passwordInput as any).getWrappedInstance().clear();
+            if (this.passwordInput.current) {
+                try {
+                    (this.passwordInput.current as any).getWrappedInstance().clear();
+                } catch (e) {
+                    console.error(e);
+                }
             }
         });
-    }
-
-    private setPasswordInputRef = (ref: HTMLInputElement) => {
-        this.passwordInput = ref;
     }
 
     private setValidPassword = password => {
@@ -149,7 +149,7 @@ class Initialize extends Component<Props, State> {
                     label={t('initialize.input.label')}
                     repeatLabel={t('initialize.input.labelRepeat')}
                     repeatPlaceholder={t('initialize.input.placeholderRepeat')}
-                    ref={this.setPasswordInputRef}
+                    ref={this.passwordInput}
                     disabled={status === stateEnum.WAITING}
                     onValidPassword={this.setValidPassword} />
                 <div className="buttons">

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import { translate } from 'react-i18next';
 import { apiGet, apiPost } from '../../../../utils/request';
 import { PasswordRepeatInput } from '../../../../components/password';
@@ -48,13 +48,15 @@ class SeedCreateNew extends Component {
         },
     }
 
+    walletNameInput = createRef();
+    backupPasswordInput = createRef();
+
     componentDidMount () {
         this.checkSDcard();
     }
 
     validate = () => {
-        // @ts-ignore
-        if (!this.walletNameInput || !this.walletNameInput.validity.valid || !this.validAgreements()) {
+        if (!this.walletNameInput.current || !this.walletNameInput.current.validity.valid || !this.validAgreements()) {
             return false;
         }
         return this.state.backupPassword && this.state.walletName !== '';
@@ -84,8 +86,8 @@ class SeedCreateNew extends Component {
             } else {
                 this.props.onSuccess();
             }
-            if (this.backupPasswordInput) {
-                this.backupPasswordInput.getWrappedInstance().clear();
+            if (this.backupPasswordInput.current) {
+                this.backupPasswordInput.current.getWrappedInstance().clear();
             }
             this.setState({ backupPassword: '' });
         });
@@ -181,12 +183,12 @@ class SeedCreateNew extends Component {
                         label={t('seed.walletName.label')}
                         disabled={status === STATUS.CREATING}
                         onInput={this.handleFormChange}
-                        getRef={ref => this.walletNameInput = ref}
+                        inputRef={this.walletNameInput}
                         value={walletName} />
                     <PasswordRepeatInput
                         label={t('seed.password.label')}
                         repeatPlaceholder={t('seed.password.repeatPlaceholder')}
-                        ref={ref => this.backupPasswordInput = ref}
+                        ref={this.backupPasswordInput}
                         disabled={status === STATUS.CREATING}
                         onValidPassword={this.setValidBackupPassword} />
                 </div>

--- a/frontends/web/src/routes/device/bitbox01/unlock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/unlock.jsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import { translate } from 'react-i18next';
 import { route } from 'preact-router';
 import { apiGet, apiPost } from '../../../utils/request';
@@ -43,6 +43,8 @@ class Unlock extends Component {
         password: '',
     }
 
+    passwordInput = createRef();
+
     componentDidMount() {
         this.focus();
     }
@@ -52,8 +54,8 @@ class Unlock extends Component {
     }
 
     focus() {
-        if (this.passwordInput) {
-            this.passwordInput.focus();
+        if (this.passwordInput.current) {
+            this.passwordInput.current.focus();
         }
     }
 
@@ -143,7 +145,7 @@ class Unlock extends Component {
                                             <div className="m-top-default">
                                                 <PasswordSingleInput
                                                     autoFocus
-                                                    getRef={ref => this.passwordInput = ref}
+                                                    ref={this.passwordInput}
                                                     id="password"
                                                     type="password"
                                                     label={t('unlock.input.label')}

--- a/frontends/web/src/routes/device/bitbox02/setdevicename.jsx
+++ b/frontends/web/src/routes/device/bitbox02/setdevicename.jsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, h } from 'preact';
+import { Component, createRef, h } from 'preact';
 import { translate } from 'react-i18next';
 import { Button, Input } from '../../../components/forms';
 import { apiPost } from '../../../utils/request';
@@ -33,6 +33,8 @@ class SetDeviceNameClass extends Component {
             inProgress: false,
         };
     }
+
+    nameInput = createRef();
 
     setName = () => {
         this.setState({ inProgress: true });
@@ -67,8 +69,7 @@ class SetDeviceNameClass extends Component {
     }
 
     validate = () => {
-        // @ts-ignore
-        if (!this.nameInput || !this.nameInput.validity.valid || !this.state.deviceName) {
+        if (!this.nameInput.current || !this.nameInput.current.validity.valid || !this.state.deviceName) {
             return false;
         }
         return true;
@@ -96,7 +97,7 @@ class SetDeviceNameClass extends Component {
                                             pattern="^.{0,63}$"
                                             label={t('bitbox02Settings.deviceName.input')}
                                             onInput={this.handleChange}
-                                            getRef={ref => this.nameInput = ref}
+                                            inputRef={this.nameInput}
                                             placeholder={t('bitbox02Settings.deviceName.placeholder')}
                                             value={deviceName}
                                             id="deviceName" />

--- a/frontends/web/test/components/forms/input.test.tsx
+++ b/frontends/web/test/components/forms/input.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import 'jest';
-import { h } from 'preact';
+import { h, createRef } from 'preact';
 import { deep, shallow } from 'preact-render-spy';
 
 import Input, { Props } from '../../../src/components/forms/input';
@@ -32,10 +32,10 @@ describe('components/forms/input', () => {
         expect(input.children()[0]).toEqual(<span>label</span>);
     });
 
-    it('should return the input node with getRef', () => {
-        shallow(<Input getRef={node => {
-            expect(node.nodeName).toEqual('INPUT');
-        }} />);
+    it('should set the input ref with inputRef', () => {
+        let inputRef = createRef<HTMLInputElement>();
+        shallow(<Input inputRef={inputRef} />);
+        expect(inputRef.current!.nodeName).toEqual('INPUT');
     });
 
     it('should preserve text', () => {


### PR DESCRIPTION
Migrate usages of RefCallback to RefObject for compatibility with React 17.x
```typescript
type RefObject<T> = { current?: T | null };
type RefCallback<T> = (instance: T | null) => void;
```