### PR TITLE
frontend: initialize class components state with `{}`

### DIFF
--- a/frontends/web/src/decorators/load.tsx
+++ b/frontends/web/src/decorators/load.tsx
@@ -41,6 +41,8 @@ export function load<LoadedProps extends ObjectButNotFunction, ProvidedProps ext
         WrappedComponent: ComponentType<LoadedProps & ProvidedProps>,
     ) {
         return class Load extends Component<ProvidedProps & Partial<LoadedProps>, LoadedProps> {
+            public readonly state = {} as LoadedProps;
+
             public static displayName = `Load(${getDisplayName(WrappedComponent as any)})`;
 
             private determineEndpoints(): EndpointsObject<LoadedProps> {
@@ -100,7 +102,7 @@ export function load<LoadedProps extends ObjectButNotFunction, ProvidedProps ext
             private allEndpointsLoaded(): boolean {
                 if (this.endpoints === undefined) { return false; }
                 for (const key of Object.keys(this.endpoints) as KeysOf<LoadedProps>) {
-                    if ((this.state === null) || (this.state[key] === undefined)) {
+                    if (this.state[key] === undefined) {
                         return false;
                     }
                 }

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -37,12 +37,14 @@ interface LoadedBuyProps {
 }
 
 interface State {
-    height: number;
+    height?: number;
 }
 
 type Props = LoadedBuyProps & BuyProps & TranslateProps;
 
 class Moonpay extends Component<Props, State> {
+    public readonly state: State = {};
+
     private ref = createRef<HTMLDivElement>();
     private resizeTimerID?: any;
 
@@ -85,7 +87,7 @@ class Moonpay extends Component<Props, State> {
 
     public render() {
         const { moonpay, t } = this.props;
-        const { height } = this.state || { height: 500 }; //Check why state is null (Load HOC?)
+        const { height } = this.state;
         const account = this.getAccount();
         if (!account || moonpay.url === '') {
             return null;

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -44,6 +44,8 @@ interface State {
 type Props = SettingsProps & TranslateProps;
 
 class Settings extends Component<Props, State> {
+    public readonly state: State = {};
+
     private apiPrefix = () => {
         return 'devices/bitbox02/' + this.props.deviceID;
     }
@@ -73,9 +75,6 @@ class Settings extends Component<Props, State> {
             deviceID,
             t,
         } = this.props;
-        if(this.state === null) {
-            return null
-        }
         const {
             versionInfo,
             deviceInfo,


### PR DESCRIPTION
why: on preact class components initialize with `{}`
but react initializes with `null`, so we must assing
the state to `{}` on the construction.