### PR TITLE
frontend: remove ignore eslint no-mixed-operators

### DIFF
--- a/frontends/web/src/components/forms/button.jsx
+++ b/frontends/web/src/components/forms/button.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-mixed-operators */
 /**
  * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
@@ -32,11 +31,12 @@ export function ButtonLink({
     ...props
 }) {
     const classNames = [
-        style[primary && 'primary'
-        || secondary && 'secondary'
-        || transparent && 'transparent'
-        || danger && 'danger'
-        || 'button'
+        style[
+            (primary && 'primary')
+            || (secondary && 'secondary')
+            || (transparent && 'transparent')
+            || (danger && 'danger')
+            || 'button'
         ], className
     ].join(' ');
 

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-mixed-operators */
 /**
  * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
@@ -339,12 +338,13 @@ class Account extends Component<Props, State> {
                             {
                                 !status.synced || offlineErrorTextLines.length || !this.dataLoaded() || status.fatalError ? (
                                     <Spinner text={
-                                        status.fatalError && t('account.fatalError') ||
-                                        offlineErrorTextLines.join('\n') ||
-                                        !status.synced && (
+                                        (status.fatalError && t('account.fatalError'))
+                                        || offlineErrorTextLines.join('\n')
+                                        || (!status.synced &&
                                             t('account.initializing')
                                             + initializingSpinnerText
-                                        ) || ''
+                                        )
+                                        || ''
                                     } />
                                 ) : (
                                     <Transactions

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-mixed-operators */
 /**
  * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
@@ -766,7 +765,10 @@ class Send extends Component<Props, State> {
                                 <div className={style.confirmItem}>
                                     <label>{t('send.amount.label')}</label>
                                     <p>
-                                        <span>{proposedAmount && proposedAmount.amount || 'N/A'} <small>{proposedAmount && proposedAmount.unit || 'N/A'}</small></span>
+                                        <span key="proposedAmount">
+                                            {(proposedAmount && proposedAmount.amount) || 'N/A'}
+                                            <small>{(proposedAmount && proposedAmount.unit) || 'N/A'}</small>
+                                        </span>
                                         {
                                             proposedAmount && proposedAmount.conversions && (
                                                 <span> <span className="text-gray">/</span> {proposedAmount.conversions[fiatUnit]} <small>{fiatUnit}</small></span>
@@ -783,7 +785,10 @@ class Send extends Component<Props, State> {
                                 <div className={style.confirmItem}>
                                     <label>{t('send.fee.label')}{feeTarget ? ' (' + t(`send.feeTarget.label.${feeTarget}`) + ')' : ''}</label>
                                     <p>
-                                        <span key="amount">{proposedFee && proposedFee.amount || 'N/A'} <small>{proposedFee && proposedFee.unit || 'N/A'}</small></span>
+                                        <span key="amount">
+                                            {(proposedFee && proposedFee.amount) || 'N/A'}
+                                            <small>{(proposedFee && proposedFee.unit) || 'N/A'}</small>
+                                        </span>
                                         {proposedFee && proposedFee.conversions && (
                                             <span key="conversation">
                                                 <span className="text-gray"> / </span>
@@ -813,7 +818,10 @@ class Send extends Component<Props, State> {
                                 <div className={[style.confirmItem, style.total].join(' ')}>
                                     <label>{t('send.confirm.total')}</label>
                                     <p>
-                                        <span><strong>{proposedTotal && proposedTotal.amount || 'N/A'}</strong> <small>{proposedTotal && proposedTotal.unit || 'N/A'}</small></span>
+                                        <span>
+                                            <strong>{(proposedTotal && proposedTotal.amount) || 'N/A'}</strong>
+                                            <small>{(proposedTotal && proposedTotal.unit) || 'N/A'}</small>
+                                        </span>
                                         {(proposedTotal && proposedTotal.conversions) && (
                                             <span> <span className="text-gray">/</span> <strong>{proposedTotal.conversions[fiatUnit]}</strong> <small>{fiatUnit}</small></span>
                                         )}


### PR DESCRIPTION
Some parts of the code used `condition && something || else`, the
default create-react-app eslint rules have no-mixed-operators,
which improves readability of the code.

Added parentheses to group and make the code more logical to read.