### PR TITLE
Frontend react fixes

### DIFF
--- a/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Component} from 'react';
+import { FunctionComponent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { load } from '../../../decorators/load';
-import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiPost } from '../../../utils/request';
 import { Toggle } from '../../toggle/toggle';
 
@@ -28,33 +28,36 @@ interface LoadedProps {
     enabled: boolean;
 }
 
-type Props = ToggleProps & LoadedProps & TranslateProps;
+type Props = ToggleProps & LoadedProps;
 
-class ToggleFWHash extends Component<Props, {}> {
-    private handleToggle = event => {
+const ToggleFWHash: FunctionComponent<Props> = ({ enabled, deviceID }) => {
+    const { t } = useTranslation();
+    const [enabledState, setEnabledState] = useState<boolean | undefined>();
+
+    const check = enabledState !== undefined ? enabledState : enabled;
+
+    const handleToggle = event => {
+        const enabled: boolean = event.target.checked;
         apiPost(
-            'devices/bitbox02-bootloader/' + this.props.deviceID + '/set-firmware-hash-enabled',
-            event.target.checked,
+            'devices/bitbox02-bootloader/' + deviceID + '/set-firmware-hash-enabled',
+            enabled,
         );
+        setEnabledState(enabled)
     }
 
-    public render() {
-        const { t, enabled } = this.props;
-        return (
-            <div className="box slim divide">
-                <div className="flex flex-row flex-between flex-items-center">
-                    <p className="m-none">{t('bb02Bootloader.advanced.toggleShowFirmwareHash')}</p>
-                    <Toggle
-                        checked={enabled}
-                        id="togggle-show-firmware-hash"
-                        onChange={this.handleToggle}
-                        className="text-medium" />
-                </div>
+    return (
+        <div className="box slim divide">
+            <div className="flex flex-row flex-between flex-items-center">
+                <p className="m-none">{t('bb02Bootloader.advanced.toggleShowFirmwareHash')}</p>
+                <Toggle
+                    checked={check}
+                    id="togggle-show-firmware-hash"
+                    onChange={handleToggle}
+                    className="text-medium" />
             </div>
-        );
-    }
+        </div>
+    );
 }
 
-const loadHOC = load<LoadedProps, ToggleProps & TranslateProps>(({ deviceID }) => ({ enabled: 'devices/bitbox02-bootloader/' + deviceID + '/show-firmware-hash-enabled' }))(ToggleFWHash);
-const HOC = translate()(loadHOC);
+const HOC = load<LoadedProps, ToggleProps>(({ deviceID }) => ({ enabled: 'devices/bitbox02-bootloader/' + deviceID + '/show-firmware-hash-enabled' }))(ToggleFWHash);
 export { HOC as ToggleShowFirmwareHash };

--- a/frontends/web/src/components/forms/input.tsx
+++ b/frontends/web/src/components/forms/input.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { forwardRef, Ref } from 'react';
+import { forwardRef } from 'react';
 import styles from './input.module.css';
 
 export interface Props {
@@ -25,7 +25,6 @@ export interface Props {
     className?: string;
     disabled?: boolean;
     error?: string | object;
-    inputRef?: Ref<HTMLInputElement>;
     id?: string;
     label?: string;
     min?: string;
@@ -51,7 +50,6 @@ export default forwardRef<HTMLInputElement, Props>(function Input({
     align = 'left',
     className = '',
     children,
-    inputRef,
     transparent = false,
     type = 'text',
     labelSection,
@@ -81,7 +79,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input({
                 spellCheck={false}
                 type={type}
                 id={id}
-                ref={ref || inputRef}
+                ref={ref}
                 {...props}
             />
             {children}

--- a/frontends/web/src/components/forms/select.tsx
+++ b/frontends/web/src/components/forms/select.tsx
@@ -29,14 +29,12 @@ type TSelectProps = {
     id: string;
     label?: string;
     options: TOption[];
-    selectedOption?: string;
 } & JSX.IntrinsicElements['select']
 
 export function Select({
     id,
     label,
     options = [],
-    selectedOption,
     ...props
 }: TSelectProps) {
     return (
@@ -45,7 +43,6 @@ export function Select({
             <select id={id} {...props}>
                 {options.map(({ value, text, disabled = false }) => (
                     <option
-                        defaultValue={selectedOption}
                         key={`${value}`}
                         value={value}
                         disabled={disabled}

--- a/frontends/web/src/components/password.jsx
+++ b/frontends/web/src/components/password.jsx
@@ -135,7 +135,7 @@ class PasswordSingleInputClass extends Component {
                 placeholder={placeholder}
                 onInput={this.handleFormChange}
                 onPaste={this.tryPaste}
-                inputRef={this.password}
+                ref={this.password}
                 value={password}
                 labelSection={
                     <Checkbox
@@ -262,7 +262,7 @@ class PasswordRepeatInputClass extends Component {
                     placeholder={placeholder}
                     onInput={this.handleFormChange}
                     onPaste={this.tryPaste}
-                    inputRef={this.password}
+                    ref={this.password}
                     value={password}>
                     {warning}
                 </Input>
@@ -280,7 +280,7 @@ class PasswordRepeatInputClass extends Component {
                     placeholder={repeatPlaceholder}
                     onInput={this.handleFormChange}
                     onPaste={this.tryPaste}
-                    inputRef={this.password}
+                    ref={this.password}
                     value={passwordRepeat}>
                     {warning}
                 </Input>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -235,7 +235,7 @@ class Transaction extends Component<Props, State> {
                                     value={newNote}
                                     maxLength={256}
                                     onInput={this.handleNoteInput}
-                                    inputRef={this.input}/>
+                                    ref={this.input}/>
                                 <button
                                     className={style.editButton}
                                     onClick={this.handleEdit}

--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -171,7 +171,7 @@ class AddAccount extends Component<Props, State> {
                 return (
                     <Input
                         autoFocus
-                        inputRef={this.ref}
+                        ref={this.ref}
                         id="accountName"
                         onInput={e => this.setState({ accountName: e.target.value })}
                         value={accountName} />

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -166,7 +166,6 @@ class FeeTargets extends Component<Props, State> {
                                 id="feeTarget"
                                 disabled={disabled}
                                 onChange={this.handleFeeTargetChange}
-                                selectedOption={feeTarget}
                                 value={feeTarget}
                                 options={options} />
                         )
@@ -179,7 +178,6 @@ class FeeTargets extends Component<Props, State> {
                                     id="feeTarget"
                                     disabled={disabled}
                                     onChange={this.handleFeeTargetChange}
-                                    selectedOption={feeTarget}
                                     value={feeTarget}
                                     options={options} />
                             </div>

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -141,6 +141,7 @@ class FeeTargets extends Component<Props, State> {
                     id="feetarget"
                     placeholder={t('send.feeTarget.placeholder')}
                     disabled
+                    value=""
                     transparent />
             );
         }
@@ -199,7 +200,7 @@ class FeeTargets extends Component<Props, State> {
                                     error={error}
                                     transparent
                                     onInput={this.handleCustomFee}
-                                    inputRef={this.input}
+                                    ref={this.input}
                                     value={customFee}
                                 >
                                     <span className={style.customFeeUnit}>

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
@@ -179,7 +179,7 @@ class SeedCreateNew extends Component {
                         label={t('seed.walletName.label')}
                         disabled={status === STATUS.CREATING}
                         onInput={this.handleFormChange}
-                        inputRef={this.walletNameInput}
+                        ref={this.walletNameInput}
                         value={walletName} />
                     <PasswordRepeatInput
                         label={t('seed.password.label')}

--- a/frontends/web/src/routes/device/bitbox02/setdevicename.jsx
+++ b/frontends/web/src/routes/device/bitbox02/setdevicename.jsx
@@ -97,7 +97,7 @@ class SetDeviceNameClass extends Component {
                                             pattern="^.{0,63}$"
                                             label={t('bitbox02Settings.deviceName.input')}
                                             onInput={this.handleChange}
-                                            inputRef={this.nameInput}
+                                            ref={this.nameInput}
                                             placeholder={t('bitbox02Settings.deviceName.placeholder')}
                                             value={deviceName}
                                             id="deviceName" />


### PR DESCRIPTION
- Simplify ref usage on `Input` to default `ref` prop 
- Fix a toggle that wasn't reflecting the status, and migrated it into FC
![Screenshot from 2021-12-09 11-11-58](https://user-images.githubusercontent.com/4956754/145411996-8a903070-06a4-47b0-bd17-b2b83a74237b.png)
- Remove unnescesary Select `selectOption` prop, use `value` instead
