### PR TITLE
frontend: add missing state initialization

### DIFF
--- a/frontends/web/src/components/aopp/verifyaddress.tsx
+++ b/frontends/web/src/components/aopp/verifyaddress.tsx
@@ -33,6 +33,10 @@ interface VerifyAddressProps {
 type Props = VerifyAddressProps & TranslateProps;
 
 class VerifyAddress extends Component<Props, State> {
+    public readonly state: State = {
+        verifying: false,
+    };
+
     private verifyAddress = () => {
         this.setState({ verifying: true });
         accountAPI.verifyAddress(this.props.accountCode, this.props.addressID).then(() => {

--- a/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
+++ b/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
@@ -45,6 +45,11 @@ interface State {
 }
 
 class UpgradeButton extends Component<Props, State> {
+    public readonly state: State = {
+        activeDialog: false,
+        confirming: false,
+    };
+
     private upgradeFirmware = () => {
         this.setState({ confirming: true });
         apiPost(this.props.apiPrefix + '/upgrade-firmware').then(() => {


### PR DESCRIPTION
One difference to Preact 8 is that in React the state is null if
it was not properly initialized. This could lead to error:
Cannot descructure property ... of 'this.state' as it is null.

Checked all components that use setState and added missing state
initialization.