### PR TITLE
frontend: wait-dialog should allow any children

### DIFF
--- a/frontends/web/src/components/wait-dialog/wait-dialog.tsx
+++ b/frontends/web/src/components/wait-dialog/wait-dialog.tsx
@@ -133,7 +133,7 @@ class WaitDialog extends Component<Props, State> {
             </div>
         );
 
-        const hasChildren = React.Children.toArray(children).filter(React.isValidElement).length > 0;
+        const hasChildren = React.Children.toArray(children).length > 0;
         return (
             <div
                 className={style.overlay}


### PR DESCRIPTION
The wait-dialog component has an interesting logic that checks if
there are no children in which case it displays a graphic that
shows how to confirm on a BitBox01.

The component should also allow just strings as children and then
display that without the BitBox01 graphic. Changed to just check
for children and removed the is valid react component filter.

Tested:
- that graphic shows on BB01 facroty reset
- that graphic doesn't show on go to startup settings or factory reset