### PR TITLE
Frontend: remove `selectedOption` from `Select`

### DIFF
--- a/frontends/web/src/components/forms/select.tsx
+++ b/frontends/web/src/components/forms/select.tsx
@@ -24,19 +24,15 @@ type TOptionTextContent = {
 type TOption = JSX.IntrinsicElements['option'] & TOptionTextContent
 
 type TSelectProps = {
-    // Temp add defaultValue, see https://github.com/preactjs/preact/issues/2668
-    defaultValue?: string;
     id: string;
     label?: string;
     options: TOption[];
-    selectedOption?: string;
 } & JSX.IntrinsicElements['select']
 
 export function Select({
     id,
     label,
     options = [],
-    selectedOption,
     ...props
 }: TSelectProps) {
     return (
@@ -45,7 +41,6 @@ export function Select({
             <select id={id} {...props}>
                 {options.map(({ value, text, disabled = false }) => (
                     <option
-                        defaultValue={selectedOption}
                         key={`${value}`}
                         value={value}
                         disabled={disabled}

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -165,7 +165,6 @@ class FeeTargets extends Component<Props, State> {
                                 id="feeTarget"
                                 disabled={disabled}
                                 onChange={this.handleFeeTargetChange}
-                                selectedOption={feeTarget}
                                 value={feeTarget}
                                 options={options} />
                         )
@@ -178,7 +177,6 @@ class FeeTargets extends Component<Props, State> {
                                     id="feeTarget"
                                     disabled={disabled}
                                     onChange={this.handleFeeTargetChange}
-                                    selectedOption={feeTarget}
                                     value={feeTarget}
                                     options={options} />
                             </div>


### PR DESCRIPTION
Unnescesary and duplicated prop, removed in favour of `defaultValue`