### PR TITLE
frontend: sdcardcheck component should not render before check

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
+++ b/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
@@ -50,6 +50,11 @@ class SDCardCheck extends Component<Props, State> {
             deviceID,
         } = this.props;
         const { sdCardInserted } = this.state;
+
+        // pending check-sdcard request
+        if (sdCardInserted === undefined) {
+            return null;
+        }
         if (!sdCardInserted) {
             return (
                 <Dialog title="Check your device" small>


### PR DESCRIPTION
Currently the sdcardcheck component quickly flickers a dialog,
before the response of the check endpoint resolved.

Changed to not render at all until there is a response, once there
is a response if it is false, the dialog should show asking to
insert an sdcard and if true it should render its children
(the backup list fetched from the sdcard).