### PR TITLE
Frontend: update unsafe class methods

### DIFF
--- a/frontends/web/src/components/password.jsx
+++ b/frontends/web/src/components/password.jsx
@@ -43,7 +43,7 @@ class PasswordSingleInputClass extends Component {
         return this.props.idPrefix || '';
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         window.addEventListener('keydown', this.handleCheckCaps);
     }
 
@@ -171,7 +171,7 @@ class PasswordRepeatInputClass extends Component {
         return this.props.idPrefix || '';
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         window.addEventListener('keydown', this.handleCheckCaps);
     }
 

--- a/frontends/web/src/components/qrcode/qrcode.tsx
+++ b/frontends/web/src/components/qrcode/qrcode.tsx
@@ -41,7 +41,7 @@ class QRCode extends Component<Props, State> {
         this.update(this.props.data);
     }
 
-    public componentWillReceiveProps({ data }) {
+    public UNSAFE_componentWillReceiveProps({ data }) {
         if (this.props.data !== data) {
             this.update(data);
         }

--- a/frontends/web/src/components/spinner/Spinner.tsx
+++ b/frontends/web/src/components/spinner/Spinner.tsx
@@ -30,7 +30,7 @@ type Props = SpinnerProps & TranslateProps & SharedProps;
 
 class Spinner extends Component<Props> {
 
-    public componentWillMount() {
+    public UNSAFE_componentWillMount() {
         document.addEventListener('keydown', this.handleKeyDown);
     }
 

--- a/frontends/web/src/components/wait-dialog/wait-dialog.tsx
+++ b/frontends/web/src/components/wait-dialog/wait-dialog.tsx
@@ -44,7 +44,7 @@ class WaitDialog extends Component<Props, State> {
         active: false,
     }
 
-    public componentWillMount() {
+    public UNSAFE_componentWillMount() {
         document.body.addEventListener('keydown', this.handleKeyDown);
     }
 

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -97,7 +97,7 @@ class Account extends Component<Props, State> {
         unsubscribe(this.subscribtions);
     }
 
-    public componentWillReceiveProps(nextProps) {
+    public UNSAFE_componentWillReceiveProps(nextProps) {
         if (nextProps.code && nextProps.code !== this.props.code) {
             this.setState({
                 status: undefined,

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -48,7 +48,7 @@ class Info extends Component<Props, State> {
         getInfo(this.props.code).then(info => this.setState({ info }));
     }
 
-    public componentWillMount() {
+    public UNSAFE_componentWillMount() {
         document.addEventListener('keydown', this.handleKeyDown);
     }
 

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -75,7 +75,7 @@ class Receive extends Component<Props, State> {
         }
     }
 
-    public componentWillMount() {
+    public UNSAFE_componentWillMount() {
         this.registerEvents();
     }
 

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -65,7 +65,7 @@ class FeeTargets extends Component<Props, State> {
         this.focusInput();
     }
 
-    public componentWillReceiveProps({ accountCode }) {
+    public UNSAFE_componentWillReceiveProps({ accountCode }) {
         if (this.props.accountCode !== accountCode) {
             this.updateFeeTargets(accountCode);
         }

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -167,7 +167,7 @@ class Send extends Component<Props, State> {
         });
     }
 
-    public componentWillMount() {
+    public UNSAFE_componentWillMount() {
         this.registerEvents();
         const account = this.getAccount();
         if (account && !account.coinCode.startsWith('eth-erc20-') && account.coinCode !== 'eth') {

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -109,7 +109,7 @@ class BitBox02 extends Component<Props, State> {
 
     private unsubscribe!: () => void;
 
-    public componentWillMount() {
+    public UNSAFE_componentWillMount() {
         const { sidebarStatus } = panelStore.state;
         if (['', 'forceCollapsed'].includes(sidebarStatus)) {
             setSidebarStatus('forceHidden');

--- a/frontends/web/src/routes/device/bitbox02/components/steps/step.tsx
+++ b/frontends/web/src/routes/device/bitbox02/components/steps/step.tsx
@@ -25,7 +25,7 @@ class Step extends Component<StepProps, State> {
         };
     }
 
-    public componentWillReceiveProps(nextProps) {
+    public UNSAFE_componentWillReceiveProps(nextProps) {
         const { empty, order, activeStep } = nextProps;
         this.setState({
             isComplete: empty || order < activeStep,

--- a/frontends/web/src/routes/device/bitbox02/components/steps/steps.tsx
+++ b/frontends/web/src/routes/device/bitbox02/components/steps/steps.tsx
@@ -13,7 +13,7 @@ class Steps extends Component<{}, State> {
         };
     }
 
-    public componentWillReceiveProps(nextProps) {
+    public UNSAFE_componentWillReceiveProps(nextProps) {
         const step = this.getActiveStep(nextProps.children);
         if (this.state.activeStep !== step) {
             this.setState({ activeStep: step });

--- a/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
+++ b/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
@@ -30,7 +30,7 @@ class ManageBackups extends Component {
         return !!this.props.devices[this.props.deviceID];
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         if (!this.hasDevice()) {
             route('/', true);
         }

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -33,7 +33,7 @@ interface TestingProps {
 type WaitingProps = TestingProps & TranslateProps;
 
 class Waiting extends Component<WaitingProps> {
-    public componentWillMount() {
+    public UNSAFE_componentWillMount() {
         const { sidebarStatus } = panelStore.state;
         if (['forceCollapsed', 'forceHidden'].includes(sidebarStatus)) {
             setSidebarStatus('');


### PR DESCRIPTION
Due to the react migration, some Class Components methods
are beingg deprecated around 18.x, see
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

This commit will ignore warnings, but components need
to be migrated if an react 18.x update is done