### PR TITLE
frontend: fix settingsbutton linking

### DIFF
--- a/frontends/web/src/components/settingsButton/settingsButton.tsx
+++ b/frontends/web/src/components/settingsButton/settingsButton.tsx
@@ -1,77 +1,38 @@
-import React, { Component} from 'react';
+import { FunctionComponent} from 'react';
 import * as style from './settingsButton.module.css';
 
 interface SettingsButtonProps {
     onClick?: () => void;
-    link?: boolean;
-    href?: string;
     danger?: boolean;
     optionalText?: string;
     secondaryText?: string;
     disabled?: boolean;
 }
 
-class SettingsButton extends Component<SettingsButtonProps> {
-    private handleLink = (e: React.SyntheticEvent) => {
-        if (this.props.disabled) {
-            e.preventDefault();
-        }
-    }
-
-    public render() {
-        const {
-            onClick,
-            link,
-            href,
-            danger,
-            optionalText,
-            secondaryText,
-            disabled,
-            children,
-        } = this.props;
-        if (link) {
-            return (
-                <a className={[style.container, danger ? style.danger : '', disabled ? style.disabled : ''].join(' ')} href={disabled ? '#' : href} onClick={this.handleLink}>
-                    <span className={style.children}>
-                        {children}
-                        { secondaryText ? (
-                            <span className={style.secondaryText}>{secondaryText}</span>
-                        ) : null }
-                    </span>
-                    { optionalText ? (
-                        <span className={style.optionalText}>{optionalText}</span>
-                    ) : null }
-                    <svg
-                        style={secondaryText ? {marginLeft: 'auto'} : {}}
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round">
-                        <polyline points="9 18 15 12 9 6"></polyline>
-                    </svg>
-                </a>
-            );
-        }
-        return (
-            <button className={[style.container, danger ? style.danger : '', disabled ? style.disabled : ''].join(' ')} onClick={!disabled ? onClick : undefined}>
-                <span className={style.children}>
-                    {children}
-                    { secondaryText ? (
-                        <span className={style.secondaryText}>{secondaryText}</span>
-                    ) : null }
-                </span>
-                { optionalText ? (
-                    <span className={style.optionalText}>{optionalText}</span>
+const SettingsButton: FunctionComponent<SettingsButtonProps> = ({
+    onClick,
+    danger,
+    optionalText,
+    secondaryText,
+    disabled,
+    children,
+}) => {
+    return (
+        <button className={[style.container, danger ? style.danger : '', disabled ? style.disabled : ''].join(' ')} onClick={!disabled ? onClick : undefined}>
+            <span className={style.children}>
+                {children}
+                { secondaryText ? (
+                    <span className={style.secondaryText}>{secondaryText}</span>
                 ) : null }
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <polyline points="9 18 15 12 9 6"></polyline>
-                </svg>
-            </button>
-        );
-    }
+            </span>
+            { optionalText ? (
+                <span className={style.optionalText}>{optionalText}</span>
+            ) : null }
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+        </button>
+    );
 }
 
 export { SettingsButton };

--- a/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
@@ -137,7 +137,7 @@ class Settings extends Component {
                                     <div className="column column-1-2">
                                         <h3 className="subTitle">{t('deviceSettings.secrets.title')}</h3>
                                         <div className="box slim divide">
-                                            <SettingsButton href={() => route(`/manage-backups/${deviceID}`)}>
+                                            <SettingsButton onClick={() => route(`/manage-backups/${deviceID}`)}>
                                                 {t('deviceSettings.secrets.manageBackups')}
                                             </SettingsButton>
                                             <ChangePIN deviceID={deviceID} />

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -268,7 +268,9 @@ class Settings extends Component<Props, State> {
                                                                 </Dialog>
                                                             )
                                                         }
-                                                        <SettingsButton link href="/settings/electrum">{t('settings.expert.electrum.title')}</SettingsButton>
+                                                        <SettingsButton onClick={() => route('/settings/electrum', true)}>
+                                                            {t('settings.expert.electrum.title')}
+                                                        </SettingsButton>
                                                     </div>
                                                 </div>
                                             </div>


### PR DESCRIPTION
In the Qt app we shouldn't use normal anchors with href attributes
to link to different views. Reason this works in webdev, is that
react-scripts always serves the index.html with main JavaScript,
so after navigation and a full page reload occured the script can
pick up and continue. In the Qt app the index.html isn't served
and therefore something like a 404 happens.

Fixed by changing all remaining href on settings buttons to onClick
using the deprecated route method.

Refactored the settings component to a function components.