### PR TITLE
frontend: use link instead of anchor

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -304,10 +304,10 @@ class Account extends Component<Props, State> {
                     </Status>
                     <Header
                         title={<h2><span>{account.name}</span></h2>}>
-                        <a href={`/account/${code}/info`} title={t('accountInfo.title')} className="flex flex-row flex-items-center">
+                        <Link to={`/account/${code}/info`} title={t('accountInfo.title')} className="flex flex-row flex-items-center">
                             <Info className={style.accountIcon} />
                             <span>{t('accountInfo.label')}</span>
-                        </a>
+                        </Link>
                     </Header>
                     {status.synced && this.dataLoaded() && isBitcoinBased(account.coinCode) && <HeadersSync coinCode={account.coinCode} />}
                     <div className="innerContainer scrollableContainer">


### PR DESCRIPTION
A href links do not work in Qt app as a normal navigtion doesn't
find the index.html and will result in a 404.

This is different from webdev where every path returns the
index.html so that JavaScript can pick up and render.

cc @BrianCraig 