### PR TITLE
frontend: add useLoad and useSubscribe hooks

### DIFF
--- a/frontends/web/src/api/coins.ts
+++ b/frontends/web/src/api/coins.ts
@@ -1,5 +1,4 @@
 /**
- * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,19 +14,18 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useLoad } from '../../hooks/api';
-import { getVersion } from '../../api/version';
+import { subscribeEndpoint, SubscriptionCallback } from './subscribe';
+import { CoinCode } from './account';
 
-const Version: FunctionComponent = () => {
-    const { t } = useTranslation();
-    const version = useLoad(getVersion);
-
-    if (!version) {
-        return null;
-    }
-    return <p>{t('footer.appVersion')} {version}</p>;
+interface Status {
+    targetHeight: number;
+    tip: number;
+    tipAtInitTime: number;
+    tipHashHex: string;
 }
 
-export { Version };
+export const subscribeCoinHeaders = (coinCode: CoinCode) => (
+    (cb: SubscriptionCallback<Status>) => (
+        subscribeEndpoint(`coins/${coinCode}/headers/status`, cb)
+    )
+);

--- a/frontends/web/src/api/subscribe.ts
+++ b/frontends/web/src/api/subscribe.ts
@@ -17,16 +17,17 @@
 import { apiSubscribe, Event, Unsubscribe } from '../utils/event';
 import { apiGet } from '../utils/request';
 
+export type SubscriptionCallback<T> = (eventObject: T) => void
+
 /**
  * Subscribes the given function on an endpoint on which the backend
  * can push data through. This should be mostly used within api.
  * Note there is a subscibe-legacy.ts module that supports older events.
  */
 
-export function subscribeEndpoint(
+export function subscribeEndpoint<T>(
     endpoint: string,
-    // TODO: double check any type
-    cb: (eventObject: any) => any,
+    cb: SubscriptionCallback<T>,
 ): Unsubscribe {
     return apiSubscribe(endpoint, (event: Event) => {
         switch (event.action) {

--- a/frontends/web/src/hooks/api.ts
+++ b/frontends/web/src/hooks/api.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2021 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react'
+import { SubscriptionCallback } from '../api/subscribe';
+import { Unsubscribe } from '../utils/event';
+import { useMountedRef } from './utils';
+
+/**
+ * useSubscribe is a hook to subscribe to a subscription function.
+ * starts on first render, and returns undefined while there is no first response.
+ * re-renders on every update.
+ */
+export const useSubscribe = <T>(
+    subscription: ((callback: SubscriptionCallback<T>) => Unsubscribe)
+): (T | undefined) => {
+    const [respose, setResponse] = useState<T>();
+    const mounted = useMountedRef();
+    useEffect(
+        () => (
+            subscription((data) => {
+                if (mounted.current) {
+                    setResponse(data);
+                }
+            })
+        ), // we pass no dependencies because it's only suscribed once
+        [] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+    return respose;
+}
+
+
+/**
+ * useLoad is a hook to load a promise.
+ * gets fired on first render, and returns undefined while loading.
+ */
+export const useLoad = <T>(
+    apiCall: () => Promise<T>
+): (T | undefined) => {
+    const [respose, setResponse] = useState<T>();
+    const mounted = useMountedRef();
+    useEffect(
+        () => {
+            apiCall().then((data) => {
+                if (mounted.current) {
+                    setResponse(data);
+                }
+            });
+        }, // we pass no dependencies because it's only queried once
+        []); // eslint-disable-line react-hooks/exhaustive-deps
+    return respose;
+}

--- a/frontends/web/src/hooks/utils.ts
+++ b/frontends/web/src/hooks/utils.ts
@@ -1,5 +1,4 @@
 /**
- * Copyright 2018 Shift Devices AG
  * Copyright 2021 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,19 +14,17 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useLoad } from '../../hooks/api';
-import { getVersion } from '../../api/version';
+import { useRef, useEffect } from 'react';
 
-const Version: FunctionComponent = () => {
-    const { t } = useTranslation();
-    const version = useLoad(getVersion);
+/**
+ * useMountedRef returns a `react.Ref` with `ref.current` boolean defining if
+ * the component is actually mounted.
+ */
 
-    if (!version) {
-        return null;
-    }
-    return <p>{t('footer.appVersion')} {version}</p>;
+export const useMountedRef = () => {
+    const mounted = useRef(true);
+    useEffect(() => (
+        () => {mounted.current = false}
+    ), [])
+    return mounted;
 }
-
-export { Version };


### PR DESCRIPTION
- added an example of `useAsync` and `useSubscription`
- removed unnescesary hiding logic on `HeadersSync`, due to logic of being displayed already hides component on load.

Partially fixes #1536

@thisconnect What do you think about this?

