### PR TITLE
frontend: update i18next & activated tests

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@zxing/library": "0.18.3",
-        "i18next": "20.6.0",
+        "i18next": "21.6.3",
         "lightweight-charts": "3.1.5",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "react-i18next": "11.11.4",
+        "react-i18next": "11.15.1",
         "react-router-dom": "6.0.2"
       },
       "devDependencies": {
@@ -8359,8 +8359,7 @@
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
@@ -8534,9 +8533,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "20.6.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.0.tgz",
-      "integrity": "sha512-sgt7AkvxUQbW5dsA7p5AYq7tBOIdm9K7c4wAppsbt5l0Hynqs7FTsa0bA0Exy+PUR17+IOcg3KVCaILc1OAOxQ==",
+      "version": "21.6.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.3.tgz",
+      "integrity": "sha512-2uuRGslNQ8m7TRllsVs4cZuei5X9OgoPRB/Sj5oadUpxZaW+NYv3srn7zR+h8bCMhkux9z8HtnJdQM5Mz+Govw==",
       "dependencies": {
         "@babel/runtime": "^7.12.0"
       }
@@ -13162,11 +13161,12 @@
       "dev": true
     },
     "node_modules/react-i18next": {
-      "version": "11.11.4",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.11.4.tgz",
-      "integrity": "sha512-ayWFlu8Sc7GAxW1PzMaPtzq+yiozWMxs0P1WeITNVzXAVRhC0Httkzw/IiODBta6seJRBCLrtUeFUSXhAIxlRg==",
+      "version": "11.15.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.15.1.tgz",
+      "integrity": "sha512-lnje1uKu5XeM5MLvfbt1oygF+nEIZnpOM4Iu8bkx5ECD4XRYgi3SJDmolrp0EDxDHeK2GgFb+vEEK0hsZ9sjeA==",
       "dependencies": {
         "@babel/runtime": "^7.14.5",
+        "html-escaper": "^2.0.2",
         "html-parse-stringify": "^3.0.1"
       },
       "peerDependencies": {
@@ -22574,8 +22574,7 @@
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "html-minifier-terser": {
       "version": "6.1.0",
@@ -22710,9 +22709,9 @@
       "dev": true
     },
     "i18next": {
-      "version": "20.6.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.0.tgz",
-      "integrity": "sha512-sgt7AkvxUQbW5dsA7p5AYq7tBOIdm9K7c4wAppsbt5l0Hynqs7FTsa0bA0Exy+PUR17+IOcg3KVCaILc1OAOxQ==",
+      "version": "21.6.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.3.tgz",
+      "integrity": "sha512-2uuRGslNQ8m7TRllsVs4cZuei5X9OgoPRB/Sj5oadUpxZaW+NYv3srn7zR+h8bCMhkux9z8HtnJdQM5Mz+Govw==",
       "requires": {
         "@babel/runtime": "^7.12.0"
       }
@@ -26069,11 +26068,12 @@
       "dev": true
     },
     "react-i18next": {
-      "version": "11.11.4",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.11.4.tgz",
-      "integrity": "sha512-ayWFlu8Sc7GAxW1PzMaPtzq+yiozWMxs0P1WeITNVzXAVRhC0Httkzw/IiODBta6seJRBCLrtUeFUSXhAIxlRg==",
+      "version": "11.15.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.15.1.tgz",
+      "integrity": "sha512-lnje1uKu5XeM5MLvfbt1oygF+nEIZnpOM4Iu8bkx5ECD4XRYgi3SJDmolrp0EDxDHeK2GgFb+vEEK0hsZ9sjeA==",
       "requires": {
         "@babel/runtime": "^7.14.5",
+        "html-escaper": "^2.0.2",
         "html-parse-stringify": "^3.0.1"
       }
     },

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -19,11 +19,11 @@
   },
   "dependencies": {
     "@zxing/library": "0.18.3",
-    "i18next": "20.6.0",
+    "i18next": "21.6.3",
     "lightweight-charts": "3.1.5",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-i18next": "11.11.4",
+    "react-i18next": "11.15.1",
     "react-router-dom": "6.0.2"
   },
   "eslintConfig": {

--- a/frontends/web/src/i18n/i18n.js
+++ b/frontends/web/src/i18n/i18n.js
@@ -16,7 +16,6 @@
  */
 
 import i18n from 'i18next';
-import { initReactI18next } from 'react-i18next';
 import appTranslationsDE from '../locales/de/app.json';
 import appTranslationsEN from '../locales/en/app.json';
 import appTranslationsFR from '../locales/fr/app.json';
@@ -41,7 +40,6 @@ import { setConfig } from '../utils/config';
 const locizeProjectID = 'fe4e5a24-e4a2-4903-96fc-3d62c11fc502';
 
 let i18Init = i18n
-    .use(initReactI18next)
     .use(languageFromConfig);
 
 i18Init.init({
@@ -59,7 +57,6 @@ i18Init.init({
     },
 
     react: {
-        wait: true,
         useSuspense : true, // Not using Suspense you will need to handle the not ready state yourself
     },
 


### PR DESCRIPTION
Updated i18n library, removing unnescesary
i18next-react config in `src/i18n/i18n.js` implementation
because we already are using `I18nextProvider`.

Re-added `i18n.test.tsx`, removing `i18n` mock for a
more integral test.

closes #1543