### PR TITLE
frontend: fix bb01 seed creation

### DIFF
--- a/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
@@ -51,7 +51,7 @@ class SecurityInformation extends Component<Props, State> {
         const { t, goBack, goal, children } = this.props;
         const { showInfo } = this.state;
         if (!showInfo) {
-            return children![0];
+            return children;
         }
         return (
             <div className="contentWithGuide">


### PR DESCRIPTION
On bb01 there is a bug where `SecurityInformation` doesn't render it's children because `children` works different in `preact` than `react`. 
This is involved in the `bb01` seed creation.
This bug was introduced on the `react` migration.