### PR TITLE
Add support for NOK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Support sending to Bitcoin taproot addresses
+- Add support for Norwegian krone (NOK)
 
 ## 4.30.0 [released 2021-11-17]
 - Add Buy CTA on empty Account overview and summary views

--- a/backend/rates/gecko.go
+++ b/backend/rates/gecko.go
@@ -98,6 +98,7 @@ var (
 		"SGD": "sgd",
 		"HKD": "hkd",
 		"BRL": "brl",
+		"NOK": "nok",
 	}
 
 	// Copied from https://api.coingecko.com/api/v3/simple/supported_vs_currencies.
@@ -118,5 +119,6 @@ var (
 		"sgd": "SGD",
 		"hkd": "HKD",
 		"brl": "BRL",
+		"nok": "NOK",
 	}
 )

--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -40,7 +40,7 @@ import (
 const (
 	// Latest rates are fetched for all these (coin, fiat) pairs.
 	simplePriceAllIDs        = "bitcoin,litecoin,ethereum,basic-attention-token,dai,chainlink,maker,sai,usd-coin,tether,0x,wrapped-bitcoin,pax-gold"
-	simplePriceAllCurrencies = "usd,eur,chf,gbp,jpy,krw,cny,rub,cad,aud,ils,btc,sgd,hkd,brl"
+	simplePriceAllCurrencies = "usd,eur,chf,gbp,jpy,krw,cny,rub,cad,aud,ils,btc,sgd,hkd,brl,nok"
 )
 
 const interval = time.Minute

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -22,7 +22,7 @@ export type CoinCode = 'btc' | 'tbtc' | 'ltc' | 'tltc' | 'eth' | 'teth' | 'reth'
 
 export type AccountCode = string;
 
-export type Fiat = 'AUD' | 'BRL' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'HKD' | 'ILS' | 'JPY' | 'KRW' | 'RUB' | 'SGD' | 'USD';
+export type Fiat = 'AUD' | 'BRL' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'HKD' | 'ILS' | 'JPY' | 'KRW' | 'NOK' | 'RUB' | 'SGD' | 'USD';
 
 export type MainnetCoin = 'BTC' | 'LTC' | 'ETH';
 

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -38,7 +38,7 @@ export interface SharedProps {
     selected: Fiat[];
 }
 
-export const currencies: Fiat[] = ['AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'EUR', 'GBP', 'HKD', 'ILS', 'JPY', 'KRW', 'RUB', 'SGD', 'USD', 'BTC'];
+export const currencies: Fiat[] = ['AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'EUR', 'GBP', 'HKD', 'ILS', 'JPY', 'KRW', 'NOK', 'RUB', 'SGD', 'USD', 'BTC'];
 
 export const store = new Store<SharedProps>({
     rates: undefined,

--- a/frontends/web/src/routes/account/send/feetargets.test.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.test.tsx
@@ -67,6 +67,7 @@ describe('routes/account/send/feetargets', () => {
                         EUR: '0.02',
                         GBP: '0.02',
                         HKD: '19880',
+                        NOK: '0.02',
                         ILS: '0.02',
                         JPY: '1.30',
                         KRW: '14.43',


### PR DESCRIPTION
Closes #1564.

@x1ddos The changes I‘ve done are a replica of https://github.com/digitalbitbox/bitbox-wallet-app/pull/1335. However, I get some errors when running `make servewallet`:

ERRO[0000] updateLast                                    error="bad response code 400 > github.com/digitalbitbox/bitbox-wallet-app/backend/rates.(*RateUpdater).updateLast.func1 > /Users/schjonhaug/go/src/github.com/digitalbitbox/bitbox-wallet-app/backend/rates/rates.go:247 > github.com/digitalbitbox/bitbox-wallet-app/util/ratelimit.(*LimitedCall).Call > /Users/schjonhaug/go/src/github.com/digitalbitbox/bitbox-wallet-app/util/ratelimit/ratelimit.go:111 > github.com/digitalbitbox/bitbox-wallet-app/backend/rates.(*RateUpdater).updateLast > /Users/schjonhaug/go/src/github.com/digitalbitbox/bitbox-wallet-app/backend/rates/rates.go:238 > github.com/digitalbitbox/bitbox-wallet-app/backend/rates.(*RateUpdater).lastUpdateLoop > /Users/schjonhaug/go/src/github.com/digitalbitbox/bitbox-wallet-app/backend/rates/rates.go:214 > runtime.goexit > /usr/local/opt/go/libexec/src/runtime/asm_amd64.s:1581" group=rates

I’m no Go developer, so it’s unclear what is wrong here. I am able to see and select NOK in the web UI, but fiat currenciy amounts (including USD) are not being shown at all due to this error.

Also, not sure which value to use in `feetargets.test.tsx`, please advice.