### PR TITLE
frontend: renamed plural to v4

### DIFF
--- a/frontends/web/src/locales/bg/app.json
+++ b/frontends/web/src/locales/bg/app.json
@@ -808,8 +808,8 @@
   },
   "loading": "зареждане...",
   "notification": {
-    "newTxs": "Нова транзакция в {{accountName}}",
-    "newTxs_plural": "{{count}} нови транзакции в {{accountName}}"
+    "newTxs_one": "Нова транзакция в {{accountName}}",
+    "newTxs_other": "{{count}} нови транзакции в {{accountName}}"
   },
   "pairing": {
     "aborted": {

--- a/frontends/web/src/locales/de/app.json
+++ b/frontends/web/src/locales/de/app.json
@@ -1168,8 +1168,8 @@
     "title": "Notiz"
   },
   "notification": {
-    "newTxs": "Neue Transaktion in:  {{accountName}}",
-    "newTxs_plural": "{{count}} neue Transaktionen in: {{accountName}}"
+    "newTxs_one": "Neue Transaktion in:  {{accountName}}",
+    "newTxs_other": "{{count}} neue Transaktionen in: {{accountName}}"
   },
   "pairing": {
     "aborted": {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -952,8 +952,8 @@
     "title": "Note"
   },
   "notification": {
-    "newTxs": "New transaction in: {{accountName}}",
-    "newTxs_plural": "{{count}} new transactions in: {{accountName}}"
+    "newTxs_one": "New transaction in: {{accountName}}",
+    "newTxs_other": "{{count}} new transactions in: {{accountName}}"
   },
   "pairing": {
     "aborted": {

--- a/frontends/web/src/locales/es/app.json
+++ b/frontends/web/src/locales/es/app.json
@@ -1068,8 +1068,8 @@
     "title": "Nota"
   },
   "notification": {
-    "newTxs": "Nueva transacción en: {{accountName}}",
-    "newTxs_plural": "{{count}} nuevas transacciones en: {{accountName}}"
+    "newTxs_one": "Nueva transacción en: {{accountName}}",
+    "newTxs_other": "{{count}} nuevas transacciones en: {{accountName}}"
   },
   "pairing": {
     "aborted": {

--- a/frontends/web/src/locales/fr/app.json
+++ b/frontends/web/src/locales/fr/app.json
@@ -920,8 +920,8 @@
   },
   "loading": "chargement en cours…",
   "notification": {
-    "newTxs": "Nouvelle transaction dans : {{accountName}}",
-    "newTxs_plural": "{{count}} nouvelles transactions dans : {{accountName}}"
+    "newTxs_one": "Nouvelle transaction dans : {{accountName}}",
+    "newTxs_other": "{{count}} nouvelles transactions dans : {{accountName}}"
   },
   "pairing": {
     "aborted": {

--- a/frontends/web/src/locales/hi/app.json
+++ b/frontends/web/src/locales/hi/app.json
@@ -881,8 +881,8 @@
   },
   "loading": "लोड हो रहा है…",
   "notification": {
-    "newTxs": "{{accountName}} में इसमें नया ट्रांजेक्शन",
-    "newTxs_plural": "{{accountName}} में {{count}} नए ट्रांजेक्शंस"
+    "newTxs_one": "{{accountName}} में इसमें नया ट्रांजेक्शन",
+    "newTxs_other": "{{accountName}} में {{count}} नए ट्रांजेक्शंस"
   },
   "pairing": {
     "aborted": {

--- a/frontends/web/src/locales/it/app.json
+++ b/frontends/web/src/locales/it/app.json
@@ -867,8 +867,8 @@
     "title": "Nota"
   },
   "notification": {
-    "newTxs": "Nuova transazione in: {{accountName}}",
-    "newTxs_plural": "{{count}} nuove transazioni in: {{accountName}}"
+    "newTxs_one": "Nuova transazione in: {{accountName}}",
+    "newTxs_other": "{{count}} nuove transazioni in: {{accountName}}"
   },
   "pairing": {
     "aborted": {

--- a/frontends/web/src/locales/nl/app.json
+++ b/frontends/web/src/locales/nl/app.json
@@ -944,8 +944,8 @@
     "title": "Notitie"
   },
   "notification": {
-    "newTxs": "Nieuwe transactie in: {{accountName}}",
-    "newTxs_plural": "{{count}} nieuwe transacties in: {{accountName}}"
+    "newTxs_one": "Nieuwe transactie in: {{accountName}}",
+    "newTxs_other": "{{count}} nieuwe transacties in: {{accountName}}"
   },
   "pairing": {
     "aborted": {

--- a/frontends/web/src/locales/pt/app.json
+++ b/frontends/web/src/locales/pt/app.json
@@ -946,8 +946,8 @@
     "title": "Nota"
   },
   "notification": {
-    "newTxs": "Nova transação em: {{accountName}}",
-    "newTxs_plural": "{{count}} novas transações em: {{accountName}}"
+    "newTxs_one": "Nova transação em: {{accountName}}",
+    "newTxs_other": "{{count}} novas transações em: {{accountName}}"
   },
   "pairing": {
     "aborted": {

--- a/frontends/web/src/locales/tr/app.json
+++ b/frontends/web/src/locales/tr/app.json
@@ -880,8 +880,8 @@
   },
   "loading": "Yükleniyor…",
   "notification": {
-    "newTxs": " {{accountName}}'da yeni işlem",
-    "newTxs_plural": "{{count}} Yeni işlem: {{accountName}}"
+    "newTxs_one": " {{accountName}}'da yeni işlem",
+    "newTxs_other": "{{count}} Yeni işlem: {{accountName}}"
   },
   "pairing": {
     "aborted": {


### PR DESCRIPTION
i18next had a breaking change introduce new v4 json format:
- https://github.com/i18next/i18next/blob/master/CHANGELOG.md#2100

So key: 'item', key_pluar: 'items' does not work anymore, new
syntax is: key_one: 'item', key_other: 'items'.

Made locize pull, renamed key and will need to be updated
with locize-push.

Part of https://github.com/digitalbitbox/bitbox-wallet-app/pull/1550