### PR TITLE
Android: hide download button

### DIFF
--- a/frontends/web/src/components/update/update.tsx
+++ b/frontends/web/src/components/update/update.tsx
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from 'react';
+import { FunctionComponent } from 'react';
+import { useTranslation } from 'react-i18next';
 import { load } from '../../decorators/load';
-import { translate, TranslateProps } from '../../decorators/translate';
+import { runningInAndroid } from '../../utils/env';
 import A from '../anchor/anchor';
 import Status from '../status/status';
 
@@ -30,13 +31,14 @@ interface File {
     description: string;
 }
 
-interface LoadedProps {
+interface Props {
     file: File | null;
 }
 
-type Props = LoadedProps & TranslateProps;
-
-function Update({ file, t }: PropsWithChildren<Props>): JSX.Element | null {
+const Update: FunctionComponent<Props> = ({ file }) => {
+    const { t } = useTranslation();
+    const downloadElement = <A href="https://shiftcrypto.ch/download/?source=bitboxapp">{t('button.download')}</A>;
+    
     return file && (
         <Status dismissable={`update-${file.version}`} type="info">
             {t('app.upgrade', {
@@ -45,13 +47,12 @@ function Update({ file, t }: PropsWithChildren<Props>): JSX.Element | null {
             })}
             {file.description}
             {' '}
-            <A href="https://shiftcrypto.ch/download/?source=bitboxapp">
-                {t('button.download')}
-            </A>
+            {/* Don't show download link on Android because they should update from stores */}
+            {!runningInAndroid() && downloadElement}
         </Status>
     );
 }
 
-const HOC = translate()(load<LoadedProps, TranslateProps>({ file: 'update' })(Update));
+const HOC = load<Props>({ file: 'update' })(Update);
 
 export { HOC as Update };


### PR DESCRIPTION
This hides the download button because Android users usually auto-update their app through a store.

This should be added again with a download button that opens up the store where the app has been downloaded. #1571

![Screenshot_1641200313](https://user-images.githubusercontent.com/4956754/147914568-0b22843d-5330-45ad-9431-f8c4bc8e33d2.png)

