### PR TITLE
frontend: fix send transaction confirmation amount and unit spacing

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -767,6 +767,7 @@ class Send extends Component<Props, State> {
                                     <p>
                                         <span key="proposedAmount">
                                             {(proposedAmount && proposedAmount.amount) || 'N/A'}
+                                            {' '}
                                             <small>{(proposedAmount && proposedAmount.unit) || 'N/A'}</small>
                                         </span>
                                         {
@@ -787,6 +788,7 @@ class Send extends Component<Props, State> {
                                     <p>
                                         <span key="amount">
                                             {(proposedFee && proposedFee.amount) || 'N/A'}
+                                            {' '}
                                             <small>{(proposedFee && proposedFee.unit) || 'N/A'}</small>
                                         </span>
                                         {proposedFee && proposedFee.conversions && (
@@ -820,6 +822,7 @@ class Send extends Component<Props, State> {
                                     <p>
                                         <span>
                                             <strong>{(proposedTotal && proposedTotal.amount) || 'N/A'}</strong>
+                                            {' '}
                                             <small>{(proposedTotal && proposedTotal.unit) || 'N/A'}</small>
                                         </span>
                                         {(proposedTotal && proposedTotal.conversions) && (


### PR DESCRIPTION
add space between coin amount and coin unit, this was a regression added on the react migration.

before: 
![Image Pasted at 2021-12-30 16-00](https://user-images.githubusercontent.com/4956754/147930942-039ea927-987f-47a9-9b1d-bd0cc2e4d9e0.png)

after:
![Screenshot from 2022-01-03 09-27-33](https://user-images.githubusercontent.com/4956754/147930978-1984bcff-e8b3-4087-9ac0-9f7f2d541cd9.png)

