### PR TITLE
frontend/bitbox02: show backup info while restoring

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox02/backups.tsx
@@ -37,7 +37,7 @@ interface BackupsProps {
     showRestore?: boolean;
     showCreate?: boolean;
     showRadio: boolean;
-    backupOnBeforeRestore?: () => void;
+    backupOnBeforeRestore?: (backup: Backup) => void;
     backupOnAfterRestore?: (success: boolean) => void;
 }
 
@@ -61,12 +61,16 @@ class Backups extends Component<Props, State> {
     }
 
     private restore = () => {
-        if (!this.state.selectedBackup) {
+        if (!this.state.selectedBackup || !this.props.backups.backups) {
+            return;
+        }
+        const backup = this.props.backups.backups.find(b => b.id === this.state.selectedBackup);
+        if (!backup) {
             return;
         }
         this.setState({ restoring: true });
         if (this.props.backupOnBeforeRestore) {
-            this.props.backupOnBeforeRestore();
+            this.props.backupOnBeforeRestore(backup);
         }
         apiPost(
             'devices/bitbox02/' + this.props.deviceID + '/backups/restore',

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { Component} from 'react';
+import { Backup, BackupsListItem } from '../components/backup';
 import { route } from '../../../utils/route';
 import warning from '../../../assets/icons/warning.png';
 import { AppUpgradeRequired } from '../../../components/appupgraderequired';
@@ -79,6 +80,7 @@ interface State {
         title: string;
         text?: string;
     };
+    selectedBackup?: Backup;
 }
 
 class BitBox02 extends Component<Props, State> {
@@ -286,9 +288,10 @@ class BitBox02 extends Component<Props, State> {
         });
     }
 
-    private backupOnBeforeRestore = () => {
+    private backupOnBeforeRestore = (backup: Backup) => {
         this.setState({
             restoreBackupStatus: 'setPassword',
+            selectedBackup: backup,
         });
     }
 
@@ -296,6 +299,7 @@ class BitBox02 extends Component<Props, State> {
         if (!success) {
             this.restoreBackup();
         }
+        this.setState({ selectedBackup: undefined });
     }
 
     private createBackup = () => {
@@ -713,7 +717,7 @@ class BitBox02 extends Component<Props, State> {
                                         key="set-password"
                                         width={700}
                                         active={status !== 'initialized' && restoreBackupStatus === 'setPassword'}
-                                        title={t('bitbox02Wizard.stepPassword.title')}>
+                                        title={t('backup.restore.confirmTitle')}>
                                         <div className={style.stepContext}>
                                             {
                                                 errorText && (
@@ -722,6 +726,14 @@ class BitBox02 extends Component<Props, State> {
                                                     </Toast>
                                                 )
                                             }
+                                            { this.state.selectedBackup ? (
+
+                                                  <BackupsListItem
+                                                      backup={this.state.selectedBackup}
+                                                      handleChange={() => {}}
+                                                      onFocus={() => {}}
+                                                      radio={false} />
+                                            ) : null }
                                             <p className="text-center">{t('bitbox02Wizard.stepPassword.useControls')}</p>
                                             <PasswordEntry />
                                         </div>

--- a/frontends/web/src/routes/device/components/backup.tsx
+++ b/frontends/web/src/routes/device/components/backup.tsx
@@ -65,6 +65,7 @@ class BackupsListItem extends Component<Props> {
                 onFocus={onFocus}
                 className={style.backupItem}>
                 <span className="text-small text-gray">{date}</span>
+                <span className="text-small text-gray">ID: {backup.id}</span>
             </Radio> :
             <div>
                 <div className="text-medium m-bottom-quarter">{backup.name}</div>


### PR DESCRIPTION
After selecting a backup to restore and proceeding, the selected
backup is not visible anymore. We now show the selected backup during
restoring, so that the user knows they selected the right backup.