### PR TITLE
qt: use a file picker dialog to choose where to export a CSV to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Add a file picker dialog to choose where to export a CSV to
+
 ## 4.31.0 [tagged 2022-01-13]
 - Bundle BitBox02 firmware version v9.9.0
 - Support sending to Bitcoin taproot addresses

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -403,6 +403,7 @@ func (backend *Backend) createAndAddAccount(
 		GetNotifier: func(configurations signing.Configurations) accounts.Notifier {
 			return backend.notifier.ForAccount(code)
 		},
+		GetSaveFilename: backend.environment.GetSaveFilename,
 	}
 
 	switch specificCoin := coin.(type) {

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -56,6 +56,7 @@ type AccountConfig struct {
 	RateUpdater           *rates.RateUpdater
 	SigningConfigurations signing.Configurations
 	GetNotifier           func(signing.Configurations) Notifier
+	GetSaveFilename       func(suggestedFilename string) string
 }
 
 // BaseAccount is an account struct with common functionality to all coin accounts.

--- a/backend/accounts/baseaccount_test.go
+++ b/backend/accounts/baseaccount_test.go
@@ -64,7 +64,8 @@ func TestBaseAccount(t *testing.T) {
 			signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
 			signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
 		},
-		GetNotifier: nil,
+		GetNotifier:     nil,
+		GetSaveFilename: func(suggestedFilename string) string { return suggestedFilename },
 	}
 	// The long ID in the filename is the legacy hash of the configurations above (unified and split).
 	// This tests notes migration from v4.27.0 to v4.28.0.

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -28,6 +28,7 @@ import (
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/usb"
 	keystoremock "github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/mocks"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/software"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
@@ -202,6 +203,31 @@ const (
 	regtestDisabled = false
 )
 
+type environment struct{}
+
+func (e environment) NotifyUser(msg string) {
+}
+
+func (e environment) DeviceInfos() []usb.DeviceInfo {
+	return []usb.DeviceInfo{}
+}
+
+func (e environment) SystemOpen(url string) error {
+	return nil
+}
+
+func (e environment) UsingMobileData() bool {
+	return false
+}
+
+func (e environment) NativeLocale() string {
+	return ""
+}
+
+func (e environment) GetSaveFilename(string) string {
+	return ""
+}
+
 func newBackend(t *testing.T, testing, regtest bool) *Backend {
 	t.Helper()
 	b, err := NewBackend(
@@ -210,7 +236,7 @@ func newBackend(t *testing.T, testing, regtest bool) *Backend {
 			testing, regtest,
 			false, false,
 			&types.GapLimits{Receive: 20, Change: 6}),
-		nil,
+		environment{},
 	)
 	b.ratesUpdater.SetCoingeckoURL("unused") // avoid hitting real API
 	require.NoError(t, err)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -134,6 +134,10 @@ type Environment interface {
 	// to return empty string or unsupported value, in which case the app will use
 	// English by default.
 	NativeLocale() string
+	// Invoke a file picker dialog for the user to select a destination to store a file.
+	// `suggestedFilename` is the proposed/default destination.
+	// The function should return the empty string if the user aborted the process.
+	GetSaveFilename(suggestedFilename string) string
 }
 
 // Backend ties everything together and is the main starting point to use the BitBox wallet library.

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -143,7 +143,8 @@ type BackendEnvironment struct {
 	UsingMobileDataFunc func() bool
 	// NativeLocaleFunc is used by the backend to query native app layer for user
 	// preferred UI language.
-	NativeLocaleFunc func() string
+	NativeLocaleFunc    func() string
+	GetSaveFilenameFunc func(string) string
 }
 
 // NotifyUser implements backend.Environment.
@@ -181,6 +182,14 @@ func (env *BackendEnvironment) UsingMobileData() bool {
 func (env *BackendEnvironment) NativeLocale() string {
 	if env.NativeLocaleFunc != nil {
 		return env.NativeLocaleFunc()
+	}
+	return ""
+}
+
+// GetSaveFilename implements backend.Environment.
+func (env *BackendEnvironment) GetSaveFilename(suggestedFilename string) string {
+	if env.GetSaveFilenameFunc != nil {
+		return env.GetSaveFilenameFunc(suggestedFilename)
 	}
 	return ""
 }

--- a/backend/bridgecommon/bridgecommon_test.go
+++ b/backend/bridgecommon/bridgecommon_test.go
@@ -57,6 +57,10 @@ func (e environment) NativeLocale() string {
 	return ""
 }
 
+func (e environment) GetSaveFilename(string) string {
+	return ""
+}
+
 // TestServeShutdownServe checks that you can call Serve twice in a row.
 func TestServeShutdownServe(t *testing.T) {
 	bridgecommon.Serve(

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -73,6 +73,7 @@ func TestAccount(t *testing.T) {
 			RateUpdater:           nil,
 			SigningConfigurations: signingConfigurations,
 			GetNotifier:           func(signing.Configurations) accounts.Notifier { return nil },
+			GetSaveFilename:       func(suggestedFilename string) string { return suggestedFilename },
 		},
 		coin, nil,
 		logging.Get().WithGroup("account_test"),

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -199,7 +199,11 @@ func (handlers *Handlers) postExportTransactions(_ *http.Request) (interface{}, 
 	if err != nil {
 		return nil, err
 	}
-	path := filepath.Join(downloadsDir, name)
+	suggestedPath := filepath.Join(downloadsDir, name)
+	path := handlers.account.Config().GetSaveFilename(suggestedPath)
+	if path == "" {
+		return nil, nil
+	}
 	handlers.log.Infof("Export transactions to %s.", path)
 
 	transactions, err := handlers.account.Transactions()

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -194,10 +194,16 @@ func (handlers *Handlers) getAccountTransactions(_ *http.Request) (interface{}, 
 }
 
 func (handlers *Handlers) postExportTransactions(_ *http.Request) (interface{}, error) {
+	type result struct {
+		Success      bool   `json:"success"`
+		Path         string `json:"path"`
+		ErrorMessage string `json:"errorMessage"`
+	}
 	name := fmt.Sprintf("%s-%s-export.csv", time.Now().Format("2006-01-02-at-15-04-05"), handlers.account.Config().Code)
 	downloadsDir, err := config.DownloadsDir()
 	if err != nil {
-		return nil, err
+		handlers.log.WithError(err).Error("error exporting account")
+		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	suggestedPath := filepath.Join(downloadsDir, name)
 	path := handlers.account.Config().GetSaveFilename(suggestedPath)
@@ -208,21 +214,25 @@ func (handlers *Handlers) postExportTransactions(_ *http.Request) (interface{}, 
 
 	transactions, err := handlers.account.Transactions()
 	if err != nil {
-		return nil, err
+		handlers.log.WithError(err).Error("error exporting account")
+		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 
 	file, err := os.Create(path)
 	if err != nil {
-		return nil, errp.WithStack(err)
+		handlers.log.WithError(err).Error("error exporting account")
+		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	if err := handlers.account.ExportCSV(file, transactions); err != nil {
 		_ = file.Close()
-		return nil, err
+		handlers.log.WithError(err).Error("error exporting account")
+		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	if err := file.Close(); err != nil {
-		return nil, err
+		handlers.log.WithError(err).Error("error exporting account")
+		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
-	return path, nil
+	return result{Success: true, Path: path}, nil
 }
 
 func (handlers *Handlers) getAccountInfo(_ *http.Request) (interface{}, error) {

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -89,6 +89,7 @@ func newAccount(t *testing.T) *Account {
 			RateUpdater:           nil,
 			SigningConfigurations: signingConfigurations,
 			GetNotifier:           func(signing.Configurations) accounts.Notifier { return nil },
+			GetSaveFilename:       func(suggestedFilename string) string { return suggestedFilename },
 		},
 		coin,
 		&http.Client{},

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -832,7 +832,11 @@ func (handlers *Handlers) postExportAccountSummary(_ *http.Request) (interface{}
 	if err != nil {
 		return nil, err
 	}
-	path := filepath.Join(downloadsDir, name)
+	suggestedPath := filepath.Join(downloadsDir, name)
+	path := handlers.backend.Environment().GetSaveFilename(suggestedPath)
+	if path == "" {
+		return nil, nil
+	}
 	handlers.log.Infof("Export account summary %s.", path)
 
 	file, err := os.Create(path)

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -54,6 +54,7 @@ func (e *backendEnv) SystemOpen(string) error       { return nil }
 func (e *backendEnv) DeviceInfos() []usb.DeviceInfo { return nil }
 func (e *backendEnv) UsingMobileData() bool         { return false }
 func (e *backendEnv) NativeLocale() string          { return e.Locale }
+func (e *backendEnv) GetSaveFilename(string) string { return "" }
 
 func TestGetNativeLocale(t *testing.T) {
 	const ptLocale = "pt"

--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -93,6 +93,11 @@ func (webdevEnvironment) NativeLocale() string {
 	return strings.Split(v, ".")[0]
 }
 
+// GetSaveFilename implements backend.Environment.
+func (webdevEnvironment) GetSaveFilename(suggestedFilename string) string {
+	return suggestedFilename
+}
+
 func main() {
 	config.SetAppDir("appfolder.dev")
 

--- a/frontends/android/goserver/goserver.go
+++ b/frontends/android/goserver/goserver.go
@@ -166,6 +166,10 @@ func Serve(dataDir string, environment GoEnvironmentInterface, goAPI GoAPIInterf
 			SystemOpenFunc:      environment.SystemOpen,
 			UsingMobileDataFunc: environment.UsingMobileData,
 			NativeLocaleFunc:    environment.NativeLocale,
+			GetSaveFilenameFunc: func(suggestedFilename string) string {
+				// On Android, we don't yet support exporting files. Implement this once needed.
+				return ""
+			},
 		},
 	)
 }

--- a/frontends/qt/BitBox.pro
+++ b/frontends/qt/BitBox.pro
@@ -59,9 +59,10 @@ unix:!macx {
 }
 
 SOURCES += \
-        main.cpp
+        main.cpp \
+        filedialog.cpp
 
-HEADERS += libserver.h webclass.h
+HEADERS += libserver.h webclass.h filedialog.h
 
 unix:macx {
     # Those frameworks are needed for Go's http/net packages.

--- a/frontends/qt/filedialog.cpp
+++ b/frontends/qt/filedialog.cpp
@@ -1,0 +1,47 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "filedialog.h"
+
+#include <QFileDialog>
+#include <QCoreApplication>
+#include <QString>
+#include <QThread>
+#include <QWidget>
+
+FileDialogCaller::FileDialogCaller(QObject* parent) : QObject(parent) {
+    // The helper object will live in the GUI thread
+    moveToThread(QCoreApplication::instance()->thread());
+}
+
+QString FileDialogCaller::getSaveFileName(QWidget* parent, const QString& caption, const QString& dir) {
+    QString fileName;
+
+    // Not in GUI thread
+    if (QThread::currentThread() != QCoreApplication::instance()->thread()->thread()) {
+        QMetaObject::invokeMethod(this, "getSaveFileName_", Qt::BlockingQueuedConnection,
+                                  Q_RETURN_ARG(QString, fileName),
+                                  Q_ARG(QWidget*, parent),
+                                  Q_ARG(QString, caption),
+                                  Q_ARG(QString, dir));
+    } else { // in GUI thread, direct call
+        fileName = getSaveFileName_(parent, caption, dir);
+    }
+
+    return fileName;
+}
+
+QString FileDialogCaller::getSaveFileName_(QWidget* parent, const QString& caption, const QString& dir) {
+    return QFileDialog::getSaveFileName(parent, caption, dir);
+}

--- a/frontends/qt/filedialog.h
+++ b/frontends/qt/filedialog.h
@@ -12,18 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <QApplication>
+#include <QObject>
+#include <QString>
+#include <QWidget>
 
-#include "libserver.h"
-
-class WebClass : public QObject
-{
+// A class wrapping QFileDialog so it can be forced to the GUI thread. If QFileDialog is used
+// outside the GUI thread, there can be segfaults/crashes.
+// Based on: https://stackoverflow.com/a/47092405
+class FileDialogCaller : public QObject {
     Q_OBJECT
-public slots:
-    void call(int queryID, const QString& query) {
-        backendCall(queryID, const_cast<char*>(query.toStdString().c_str()));
-    }
-signals:
-    void gotResponse(int queryID, QString response);
-    void pushNotify(QString msg);
+
+public:
+    FileDialogCaller(QObject* parent = 0);
+
+    QString getSaveFileName(QWidget* parent, const QString& caption, const QString& dir);
+
+private:
+    Q_INVOKABLE
+    QString getSaveFileName_(QWidget* parent, const QString& caption, const QString& dir);
 };

--- a/frontends/qt/libserver.h
+++ b/frontends/qt/libserver.h
@@ -17,6 +17,11 @@ typedef void (*notifyUserCallback) (const char*);
 static void notifyUser(notifyUserCallback f, const char* msg) {
     f(msg);
 }
+
+typedef char* (*getSaveFilenameCallback) (const char*);
+static char* getSaveFilename(getSaveFilenameCallback f, const char* suggestedfilename) {
+    return f(suggestedfilename);
+}
 #endif
 
 #ifdef __cplusplus
@@ -29,10 +34,11 @@ extern void backendCall(int p0, char* p1);
 extern void handleURI(char* p0);
 
 extern void serve(
-    pushNotificationsCallback p0,
-    responseCallback p1,
-    notifyUserCallback p2,
-    const char* preferredLocale
+    pushNotificationsCallback pushNotificationsFn,
+    responseCallback responseFn,
+    notifyUserCallback notifyUserFn,
+    const char* preferredLocale,
+    getSaveFilenameCallback getSaveFilenameFn
 );
 
 extern void systemOpen(char* p0);

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -1,5 +1,20 @@
+// Copyright 2021 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <singleapplication.h>
 #include <QApplication>
+#include <QCoreApplication>
 #include <QWebEngineView>
 #include <QWebEngineProfile>
 #include <QWebEnginePage>
@@ -22,8 +37,11 @@
 
 #include <iostream>
 #include <set>
+#include <stdlib.h>
 #include <string>
+#include <string.h>
 
+#include "filedialog.h"
 #include "libserver.h"
 #include "webclass.h"
 
@@ -275,8 +293,21 @@ int main(int argc, char *argv[])
                                       Q_ARG(QString, msg));
         },
         // user preferred UI language
-        preferredLocale.toStdString().c_str()
-        );
+        preferredLocale.toStdString().c_str(),
+        // getSaveFilenameCallback
+        [](const char* suggestedFilename) {
+            QString filename = FileDialogCaller().getSaveFileName(
+                view,
+                "Save File",
+                suggestedFilename);
+            // Copy the string to an area allocated by malloc. The caller of this function has to
+            // free the memory.
+            std::string stdString = filename.toStdString();
+            const char* cString = stdString.c_str();
+            char* result = (char*)malloc(strlen(cString)+1);
+            memcpy(result, cString, strlen(cString)+1);
+            return result;
+        });
 
     RequestInterceptor interceptor;
     view->page()->profile()->setRequestInterceptor(&interceptor);

--- a/frontends/qt/setup.nsi
+++ b/frontends/qt/setup.nsi
@@ -1,3 +1,17 @@
+# Copyright 2021 Shift Crypto AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 Name "BitBoxApp"
 
 # Need admin privileges for writing to $PROGRAMFILES64 and HKLM.

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -172,7 +172,14 @@ export const getTransactionList = (code: AccountCode): Promise<ITransaction[]> =
     return apiGet(`account/${code}/transactions`);
 };
 
-export const exportAccount = (code: AccountCode): Promise<string> => {
+
+export interface IExport {
+    success: boolean;
+    path: string;
+    errorMessage: string;
+}
+
+export const exportAccount = (code: AccountCode): Promise<IExport | null> => {
     return apiPost(`account/${code}/export`);
 };
 

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -21,6 +21,7 @@ import { syncAddressesCount } from '../../api/accountsync';
 import { TDevices } from '../../api/devices';
 import { unsubscribe, UnsubscribeList } from '../../utils/subscriptions';
 import { statusChanged, syncdone } from '../../api/subscribe-legacy';
+import { alertUser } from '../../components/alert/Alert';
 import { Balance } from '../../components/balance/balance';
 import { Entry } from '../../components/guide/entry';
 import { Guide } from '../../components/guide/guide';
@@ -225,7 +226,15 @@ class Account extends Component<Props, State> {
             return;
         }
         accountApi.exportAccount(this.props.code)
-            .then(exported => this.setState({ exported }))
+            .then(result => {
+                if (result !== null) {
+                    if (result.success) {
+                        this.setState({ exported: result.path });
+                    } else {
+                        alertUser(result.errorMessage);
+                    }
+                }
+            })
             .catch(console.error);
     }
 


### PR DESCRIPTION
The default export path to the Downloads folder can fail if e.g. the
directory does not exist. It is also better UX to let the user choose
where to store the file.