### PR TITLE
qt/server: free C strings again

### DIFF
--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -124,16 +124,20 @@ func serve(
 		&nativeCommunication{
 			respond: func(queryID int, response string) {
 				cResponse := C.CString(response)
+				defer C.free(unsafe.Pointer(cResponse))
 				C.respond(responseFn, C.int(queryID), cResponse)
-				C.free(unsafe.Pointer(cResponse))
 			},
 			pushNotify: func(msg string) {
-				C.pushNotify(pushNotificationsFn, C.CString(msg))
+				cMsg := C.CString(msg)
+				defer C.free(unsafe.Pointer(cMsg))
+				C.pushNotify(pushNotificationsFn, cMsg)
 			},
 		},
 		&bridgecommon.BackendEnvironment{
 			NotifyUserFunc: func(text string) {
-				C.notifyUser(notifyUserFn, C.CString(text))
+				cText := C.CString(text)
+				defer C.free(unsafe.Pointer(cText))
+				C.notifyUser(notifyUserFn, cText)
 			},
 			DeviceInfosFunc:     usb.DeviceInfos,
 			SystemOpenFunc:      system.Open,


### PR DESCRIPTION
According to the cgo docs (https://pkg.go.dev/cmd/cgo):

```
// Go string to C string
// The C string is allocated in the C heap using malloc.
// It is the caller's responsibility to arrange for it to be
// freed, such as by calling C.free (be sure to include stdlib.h
// if C.free is needed).
func C.CString(string) *C.char
```