### PR TITLE
Dockerfile: update npm in the docker image

### DIFF
--- a/scripts/docker_install.sh
+++ b/scripts/docker_install.sh
@@ -42,6 +42,7 @@ apt-get install -y --no-install-recommends \
         libxkbcommon-x11-dev \
         libxrandr-dev
 
+npm install -g npm@8.3.0
 npm install -g locize-cli
 
 mkdir -p /opt/go_dist

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -14,7 +14,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     # Which docker image to use to run the CI. Defaults to Docker Hub.
     # Overwrite with CI_IMAGE=docker/image/path environment variable.
     # Keep this in sync with .github/workflows/ci.yml.
-    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:11}"
+    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:12}"
     # Time image pull to compare in the future.
     time docker pull "$CI_IMAGE"
 


### PR DESCRIPTION
The package-lock.json file is at version 2, which requires a higher
npm version than previously installed. It was built and committed
outside of Docker, hence the mismatch.