### PR TITLE
frontend: fix utxos reference unwrapping

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -40,7 +40,7 @@ import { apiWebsocket } from '../../../utils/websocket';
 import { isBitcoinBased, customFeeUnit } from '../utils';
 import { FeeTargets } from './feetargets';
 import style from './send.module.css';
-import { Props as UTXOsProps, SelectedUTXO, UTXOs } from './utxos';
+import { SelectedUTXO, UTXOs, UTXOsClass } from './utxos';
 import { route } from '../../../utils/route';
 
 interface SendProps {
@@ -94,7 +94,7 @@ interface State {
 }
 
 class Send extends Component<Props, State> {
-    private utxos = createRef<Component<UTXOsProps>>();
+    private utxos = createRef<UTXOsClass>();
     private selectedUTXOs: SelectedUTXO = {};
     private unsubscribe!: () => void;
     private qrCodeReader?: BrowserQRCodeReader;
@@ -237,11 +237,7 @@ class Send extends Component<Props, State> {
                     customFee: '',
                 });
                 if (this.utxos.current) {
-                    try {
-                        (this.utxos.current as any).getWrappedInstance().clear();
-                    } catch (e) {
-                        console.error(e);
-                    }
+                    this.utxos.current.clear();
                 }
                 setTimeout(() => this.setState({
                     isSent: false,
@@ -467,11 +463,7 @@ class Send extends Component<Props, State> {
     private toggleCoinControl = () => {
         this.setState(({ activeCoinControl }) => {
             if (activeCoinControl && this.utxos.current) {
-                try {
-                    (this.utxos.current as any).getWrappedInstance().clear();
-                } catch (e) {
-                    console.error(e);
-                }
+                this.utxos.current.clear();
             }
             return { activeCoinControl: !activeCoinControl };
         });

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -61,7 +61,7 @@ interface State {
     selectedUTXOs: SelectedUTXO;
 }
 
-class UTXOs extends Component<Props, State> {
+export class UTXOsClass extends Component<Props, State> {
     public readonly state: State = {
         utxos: [],
         selectedUTXOs: {},
@@ -172,5 +172,5 @@ class UTXOs extends Component<Props, State> {
     }
 }
 
-const TranslatedUTXOs = translate(undefined, { withRef: true })(UTXOs);
+const TranslatedUTXOs = translate(undefined, { withRef: true })(UTXOsClass);
 export { TranslatedUTXOs as UTXOs };


### PR DESCRIPTION
This fixes a `this.utxos.current.getWrappedInstance is not a function` error thrown on the `Send.tsx`

Send Component has a Ref to UTXOs Class Component, this reference was being unwrapped using getWrappedInstance, due 
 to using a translate HOC, which is not needed because the reference is already being forwarded by the HOC.
 
This difference may be because of using `withTranslation` from `i18n-react` after the React migration, which doesn't require the call to `getWrappedInstance()`, that the old `translate` HOC had. 