### PR TITLE
frontend: fix select dropdown styling

### DIFF
--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -34,7 +34,7 @@
   },
   "browserslist": {
     "production": [
-      "chrome >= 87"
+      "chrome >= 83"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
The dropdowns in the Qt app had 2 arrows, this is a regression
introduced when we changed to the new build.
    
BitBoxApp is using Qt 5.15.2 that is actually using Chromium 83
- https://wiki.qt.io/QtWebEngine/ChromiumVersions
    
Changing browserlist to build for 83 fixes the styling as the
reset has to be prefixed with -webkit, see:
- https://caniuse.com/css-appearance