### PR TITLE
frontend: disallow undefined value in controlled form inputs

### DIFF
--- a/frontends/web/src/components/forms/input.test.tsx
+++ b/frontends/web/src/components/forms/input.test.tsx
@@ -20,22 +20,22 @@ import Input from './input';
 
 describe('components/forms/input', () => {
     it('should preserve type attribute', () => {
-        const { container } = render(<Input type="password" />);
+        const { container } = render(<Input type="password" value="" />);
         expect(container.querySelector('[type="password"')).toBeTruthy();
     });
 
     it('should have children', () => {
-        render(<Input><span>label</span></Input>);
+        render(<Input value=""><span>label</span></Input>);
         expect(screen.getByText('label')).toBeTruthy();
     });
 
     it('should have a label', () => {
-        render(<Input id="myInput" label="Label" />);
+        render(<Input id="myInput" label="Label" value="" />);
         expect(screen.getByLabelText('Label')).toBeTruthy();
     });
 
     it('should preserve text', () => {
-        render(<Input label="Label" error="text too short" />);
+        render(<Input label="Label" error="text too short" value="" />);
         expect(screen.getByText('text too short')).toBeTruthy();
     });
 });

--- a/frontends/web/src/components/forms/input.tsx
+++ b/frontends/web/src/components/forms/input.tsx
@@ -38,7 +38,7 @@ export interface Props {
     title?: string;
     transparent?: boolean;
     type?: 'text' | 'password' | 'number';
-    value?: string | number;
+    value: string | number;
     maxLength?: number;
     labelSection?: JSX.Element | undefined;
 }

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -48,13 +48,13 @@ interface Options {
 }
 
 interface State {
-    feeTarget?: string;
+    feeTarget: string;
     options: Options[] | null;
 }
 
 class FeeTargets extends Component<Props, State> {
     public readonly state: State = {
-        feeTarget: undefined,
+        feeTarget: '',
         options: null,
     };
 
@@ -158,6 +158,7 @@ class FeeTargets extends Component<Props, State> {
                                 disabled
                                 label={t('send.priority')}
                                 placeholder={t('send.feeTarget.placeholder')}
+                                value=''
                                 transparent />
                         ) : (
                             <Select

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -62,12 +62,12 @@ interface State {
     balance?: accountApi.IBalance;
     proposedFee?: accountApi.IAmount;
     proposedTotal?: accountApi.IAmount;
-    recipientAddress?: string;
+    recipientAddress: string;
     proposedAmount?: accountApi.IAmount;
     valid: boolean;
-    amount?: string;
+    amount: string;
     data?: string;
-    fiatAmount?: string;
+    fiatAmount: string;
     fiatUnit: accountApi.Fiat;
     sendAll: boolean;
     feeTarget?: accountApi.FeeTargetCode;
@@ -106,6 +106,9 @@ class Send extends Component<Props, State> {
     private proposeTimeout: any = null;
 
     public readonly state: State = {
+        recipientAddress: '',
+        amount: '',
+        fiatAmount: '',
         valid: false,
         sendAll: false,
         isConfirming: false,
@@ -226,12 +229,12 @@ class Send extends Component<Props, State> {
                     sendAll: false,
                     isConfirming: false,
                     isSent: true,
-                    recipientAddress: undefined,
+                    recipientAddress: '',
                     proposedAmount: undefined,
                     proposedFee: undefined,
                     proposedTotal: undefined,
-                    fiatAmount: undefined,
-                    amount: undefined,
+                    fiatAmount: '',
+                    amount: '',
                     data: undefined,
                     note: '',
                     customFee: '',
@@ -411,7 +414,7 @@ class Send extends Component<Props, State> {
                     }
                 });
         } else {
-            this.setState({ fiatAmount: undefined });
+            this.setState({ fiatAmount: '' });
         }
     }
 
@@ -428,7 +431,7 @@ class Send extends Component<Props, State> {
                     }
                 });
         } else {
-            this.setState({ amount: undefined });
+            this.setState({ amount: '' });
         }
     }
 
@@ -479,7 +482,7 @@ class Send extends Component<Props, State> {
 
     private parseQRResult = uri => {
         let address;
-        let amount: string | undefined;
+        let amount = '';
         try {
             const url = new URL(uri);
             if (url.protocol !== 'bitcoin:' && url.protocol !== 'litecoin:') {
@@ -487,20 +490,20 @@ class Send extends Component<Props, State> {
                 return;
             }
             address = url.pathname;
-            amount = url.searchParams.get('amount') || undefined;
+            amount = url.searchParams.get('amount') || '';
         } catch {
             address = uri;
         }
         this.setState({
             recipientAddress: address,
             sendAll: false,
-            fiatAmount: undefined,
+            fiatAmount: '',
         });
         if (amount) {
             this.setState({ amount });
         }
         // TODO: similar to handleFormChange(). Refactor.
-        if (amount !== undefined) {
+        if (amount !== '') {
             this.convertToFiat(amount);
         }
         this.validateAndDisplayFee(true);
@@ -665,7 +668,7 @@ class Send extends Component<Props, State> {
                                                 onInput={this.handleFormChange}
                                                 disabled={sendAll}
                                                 error={amountError}
-                                                value={sendAll ? proposedAmount && proposedAmount.amount : amount}
+                                                value={sendAll ? (proposedAmount ? proposedAmount.amount : '') : amount}
                                                 placeholder={t('send.amount.placeholder')}
                                                 labelSection={
                                                     <Checkbox


### PR DESCRIPTION
In React, changing the value of a controlled form input from undefined
to a defined value makes it uncontrolled. A warning popped up in the
console and the send tranasction form broke: it could no be cleared
after sending a transaction (setState() did not affect the form
anymore), disabling send all didn't remove the input value again, etc.

This commit removes `undefined` in the use of controlled form elements.