### PR TITLE
frontend: control select component

### DIFF
--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -154,7 +154,6 @@ class Aopp extends Component<Props, State> {
                                 <Select
                                     label={t('buy.info.selectLabel')}
                                     options={options}
-                                    defaultValue={options[0].value}
                                     value={accountCode}
                                     onChange={e => this.setState({ accountCode: (e.target as HTMLSelectElement)?.value })}
                                     id="account" />

--- a/frontends/web/src/routes/account/add/components/coin-dropdown.tsx
+++ b/frontends/web/src/routes/account/add/components/coin-dropdown.tsx
@@ -51,7 +51,6 @@ function CoinDropDown({
             onInput={e => onChange(supportedCoins.find(c => {
                 return c.coinCode === (e.target as HTMLSelectElement).value;
             }) as backendAPI.ICoin)}
-            defaultValue={'choose'}
             placeholder={t('buy.info.selectPlaceholder')}
             value={value}
             id="coinCodeDropDown" />

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -216,8 +216,7 @@ class BuyInfo extends Component<Props, State> {
                                             ...options]
                                         }
                                         onChange={(e: React.SyntheticEvent) => this.setState({ selected: (e.target as HTMLSelectElement).value})}
-                                        value={selected}
-                                        defaultValue={'choose'}
+                                        value={selected || 'choose'}
                                         id="coinAndAccountCode"
                                     />
                                     <div className="buttons text-center m-bottom-xxlarge">


### PR DESCRIPTION
React has a defaultValue property on select dropdowns to set the
default value, but this is intendet to be used with uncontrolled
components. To control a select element React uses value.
Using both defaultValue and value triggers a warning: Select
elements must be either controlled or uncontrolled (specify
either the value prop, or the defaultValue prop, but not both).

AOPP, buy/choose-account and manage-accounts/select-coin all had
a defaultValue and a value props. As far as I can see they could
be all uncontrolled as there is no other form field or other
data that could change the select.
Decided to go with controlled component using value and removing
defaultValue, because I stlightly prefer controlled, i.e. if we
ever add another field that may change the value in the future.