### PR TITLE
CHANGELOG: finalize 4.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 4.31.0 [tagged 2022-01-13]
 - Bundle BitBox02 firmware version v9.9.0
 - Support sending to Bitcoin taproot addresses
 - Fix opening 'transactions export' CSV file


### PR DESCRIPTION
Release date is in the future, so for now we just mention the tagged date.