### PR TITLE
frontend: fix electrum ui initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Add a file picker dialog to choose where to export a CSV to
+- Fix display of server name and checking the server connection in 'Connect your own full node'
 
 ## 4.31.0 [tagged 2022-01-13]
 - Bundle BitBox02 firmware version v9.9.0

--- a/frontends/web/src/routes/settings/electrum.jsx
+++ b/frontends/web/src/routes/settings/electrum.jsx
@@ -27,21 +27,21 @@ import style from './electrum.module.css';
 import A from '../../components/anchor/anchor';
 
 class ElectrumServerClass extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            valid: false,
-            electrumServer: '',
-            electrumCert: '',
-            tls: false,
-            loadingCheck: false,
-            loadingCert: false,
-        };
-        if (props.server !== null) {
+    state = {
+        valid: false,
+        electrumServer: '',
+        electrumCert: '',
+        tls: false,
+        loadingCheck: false,
+        loadingCert: false,
+    }
+
+    componentDidMount() {
+        if (this.props.server !== null) {
             this.setState({
-                electrumServer: props.server.server,
-                electrumCert: props.server.pemCert,
-                tls: props.server.tls,
+                electrumServer: this.props.server.server,
+                electrumCert: this.props.server.pemCert,
+                tls: this.props.server.tls,
             });
         }
     }


### PR DESCRIPTION
There was a regression that the configured nodes only showed
TLS, but not what the actual address/domain is.

The problem was that the default state of the servers was
initialized based on props in the constructor. Using setState in
the constructor worked in Preact, but fails in React without an
error or warning.

Changed to intialize the state late in componentDidMount callback
so it shows now correct server settings.

Fixes https://github.com/digitalbitbox/bitbox-wallet-app/issues/1603