### PR TITLE
frontend: prevent flicker on unlock

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -129,6 +129,7 @@ import { route, RouterWatcher } from './utils/route';
          const currentURL = window.location.pathname;
          const isIndex = currentURL === '/' || currentURL === '/index.html' || currentURL === '/android_asset/web/index.html';
          const inAccounts = currentURL.startsWith('/account/');
+         const inDevice = currentURL.startsWith('/device');
          const accounts = this.state.accounts;
  
          // QT and Android start their apps in '/index.html' and '/android_asset/web/index.html' respectively
@@ -152,8 +153,8 @@ import { route, RouterWatcher } from './utils/route';
              route('/', true);
              return;
          }
-         // if on index page and there is at least 1 account route to /account-summary
-         if (isIndex && accounts && accounts.length) {
+         // if on index page or device page and there is at least 1 account route to /account-summary
+         if ((isIndex || inDevice) && accounts && accounts.length) {
              route('/account-summary', true);
              return;
          }

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -193,10 +193,6 @@ class BitBox02 extends Component<Props, State> {
                 status,
                 errorText: undefined,
             });
-            if (status === 'initialized' && unlockOnly && showWizard) {
-                // bitbox is unlocked, now route to / and wait for incoming accounts
-                route('/', true);
-            }
         });
     }
 


### PR DESCRIPTION
After device has been connected, there is no need for
bitbox02.tsx to route into `/` or `/account-summary`
because `app.tsx` is already listening to device
and accounts status changes, and routing to `/account-summary`
when the device initializes.
This prevents the rendering of `/` before accounts list
has been synced.