### PR TITLE
rates: add support for swedish krona (sek)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Add a file picker dialog to choose where to export a CSV to
 - Fix display of server name and checking the server connection in 'Connect your own full node'
+- Add support for Swedish krona (SEK)
 
 ## 4.31.0 [tagged 2022-01-13]
 - Bundle BitBox02 firmware version v9.9.0

--- a/backend/rates/gecko.go
+++ b/backend/rates/gecko.go
@@ -99,6 +99,7 @@ var (
 		"HKD": "hkd",
 		"BRL": "brl",
 		"NOK": "nok",
+		"SEK": "sek",
 	}
 
 	// Copied from https://api.coingecko.com/api/v3/simple/supported_vs_currencies.
@@ -120,5 +121,6 @@ var (
 		"hkd": "HKD",
 		"brl": "BRL",
 		"nok": "NOK",
+		"sek": "SEK",
 	}
 )

--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -40,7 +40,7 @@ import (
 const (
 	// Latest rates are fetched for all these (coin, fiat) pairs.
 	simplePriceAllIDs        = "bitcoin,litecoin,ethereum,basic-attention-token,dai,chainlink,maker,sai,usd-coin,tether,0x,wrapped-bitcoin,pax-gold"
-	simplePriceAllCurrencies = "usd,eur,chf,gbp,jpy,krw,cny,rub,cad,aud,ils,btc,sgd,hkd,brl,nok"
+	simplePriceAllCurrencies = "usd,eur,chf,gbp,jpy,krw,cny,rub,cad,aud,ils,btc,sgd,hkd,brl,nok,sek"
 )
 
 const interval = time.Minute

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -22,7 +22,7 @@ export type CoinCode = 'btc' | 'tbtc' | 'ltc' | 'tltc' | 'eth' | 'teth' | 'reth'
 
 export type AccountCode = string;
 
-export type Fiat = 'AUD' | 'BRL' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'HKD' | 'ILS' | 'JPY' | 'KRW' | 'NOK' | 'RUB' | 'SGD' | 'USD';
+export type Fiat = 'AUD' | 'BRL' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'HKD' | 'ILS' | 'JPY' | 'KRW' | 'NOK' | 'RUB' | 'SEK' | 'SGD' | 'USD';
 
 export type MainnetCoin = 'BTC' | 'LTC' | 'ETH';
 

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -38,7 +38,7 @@ export interface SharedProps {
     selected: Fiat[];
 }
 
-export const currencies: Fiat[] = ['AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'EUR', 'GBP', 'HKD', 'ILS', 'JPY', 'KRW', 'NOK', 'RUB', 'SGD', 'USD', 'BTC'];
+export const currencies: Fiat[] = ['AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'EUR', 'GBP', 'HKD', 'ILS', 'JPY', 'KRW', 'NOK', 'RUB', 'SEK', 'SGD', 'USD', 'BTC'];
 
 export const store = new Store<SharedProps>({
     rates: undefined,

--- a/frontends/web/src/routes/account/send/feetargets.test.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.test.tsx
@@ -72,6 +72,7 @@ describe('routes/account/send/feetargets', () => {
                         JPY: '1.30',
                         KRW: '14.43',
                         RUB: '0.88',
+                        SEK: '0.1',
                         SGD: '32233',
                         USD: '0.02',
                         BTC: '0.02',


### PR DESCRIPTION
Add support for Swedish Krona (SEK), this is in the list of
currencies supported by CoinGecko:
- https://api.coingecko.com/api/v3/simple/supported_vs_currencies

Closes https://github.com/digitalbitbox/bitbox-wallet-app/issues/1600