### PR TITLE
qt: decrease minimum width for qt on desktop

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -226,7 +226,7 @@ int main(int argc, char *argv[])
 
     view = new WebEngineView();
     view->setGeometry(0, 0, a.devicePixelRatio() * view->width(), a.devicePixelRatio() * view->height());
-    view->setMinimumSize(650, 375);
+    view->setMinimumSize(360, 375);
 
     // Bring the primary instance to the foreground.
     QObject::connect(


### PR DESCRIPTION
This change decreases the minimum width of the BBApp window to 360px, which allows a user to see the mobile version of the UI on desktop if they wish.