### PR TITLE
Portfolio: support showing subtotals on account summary (portfolio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Show coin subtotals in 'My portfolio'
 
 ## 4.31.1 [2022-02-07]
 - Bundle BitBox02 Multi firmware version v9.9.1

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -34,6 +35,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/banners"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
 	accountHandlers "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/handlers"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
@@ -179,6 +181,7 @@ func NewHandlers(
 	getAPIRouter(apiRouter)("/account-add", handlers.postAddAccountHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/keystores", handlers.getKeystoresHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/accounts", handlers.getAccountsHandler).Methods("GET")
+	getAPIRouter(apiRouter)("/accounts/total-balance", handlers.getAccountsTotalBalanceHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/set-account-active", handlers.postSetAccountActiveHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/set-token-active", handlers.postSetTokenActiveHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/rename-account", handlers.postRenameAccountHandler).Methods("POST")
@@ -486,6 +489,43 @@ func (handlers *Handlers) getAccountsHandler(_ *http.Request) (interface{}, erro
 		accounts = append(accounts, newAccountJSON(account, activeTokens))
 	}
 	return accounts, nil
+}
+
+func (handlers *Handlers) getAccountsTotalBalanceHandler(_ *http.Request) (interface{}, error) {
+	totalPerCoin := make(map[coin.Code]*big.Int)
+	for _, account := range handlers.backend.Accounts() {
+		if !account.Config().Active {
+			continue
+		}
+		if account.FatalError() {
+			continue
+		}
+		err := account.Initialize()
+		if err != nil {
+			return nil, err
+		}
+		coinCode := account.Coin().Code()
+		b, err := account.Balance()
+		if err != nil {
+			return nil, err
+		}
+		amount := b.Available()
+		if _, ok := totalPerCoin[coinCode]; !ok {
+			totalPerCoin[coinCode] = amount.BigInt()
+		} else {
+			totalPerCoin[coinCode] = new(big.Int).Add(totalPerCoin[coinCode], amount.BigInt())
+		}
+	}
+
+	formattedTotalPerCoint := make(map[coin.Code]string)
+	for k, v := range totalPerCoin {
+		currentCoin, err := handlers.backend.Coin(k)
+		if err != nil {
+			return nil, err
+		}
+		formattedTotalPerCoint[k] = currentCoin.FormatAmount(coin.NewAmount(v), false)
+	}
+	return formattedTotalPerCoint, nil
 }
 
 func (handlers *Handlers) postSetAccountActiveHandler(r *http.Request) (interface{}, error) {

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -51,6 +51,14 @@ export const getAccounts = (): Promise<IAccount[]> => {
     return apiGet('accounts');
 };
 
+export interface ITotalBalance {
+    [key: string]: string;
+}
+
+export const getAccountsTotalBalance = (): Promise<ITotalBalance> => {
+    return apiGet('accounts/total-balance');
+}
+
 export interface IStatus {
     disabled: boolean;
     synced: boolean;

--- a/frontends/web/src/components/rates/rates.module.css
+++ b/frontends/web/src/components/rates/rates.module.css
@@ -1,8 +1,11 @@
 .rates {
     cursor: default;
     margin: 0;
-    /*font-size: 14px;*/
     line-height: 1;
+}
+
+.unit {
+    font-weight: 400;
 }
 
 .unit,

--- a/frontends/web/src/components/transactions/transaction.module.css
+++ b/frontends/web/src/components/transactions/transaction.module.css
@@ -225,7 +225,7 @@
 
 @media (max-width: 1080px), (min-width: 1200px) and (max-width: 1322px) {
     .container {
-        margin: 0 0 var(--space-half) 0;
+        margin: 0 0 var(--space-quarter) 0;
     }
 
     .container.first {

--- a/frontends/web/src/components/transactions/transactions.module.css
+++ b/frontends/web/src/components/transactions/transactions.module.css
@@ -15,18 +15,19 @@
 }
 
 .columns {
-  width: 100%;
+  align-items: center;
+  background-color: var(--color-white);
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-  align-items: center;
-  background-color: var(--color-mediumgray);
+  margin-bottom: 1px;
+  width: 100%;
 }
 
 .headers {
-  height: 48px;
   color: var(--color-softblack);
-  text-transform: uppercase;
+  font-weight: bold;
+  height: 48px;
 }
 
 .columns >  *,
@@ -34,7 +35,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  font-size: var(--size-small);
+  font-size: var(--size-default);
   padding: 0 var(--space-quarter);
 }
 
@@ -169,7 +170,7 @@
 @media (max-width: 666px) {
   .columns >  *,
   .columnGroup > * {
-    padding: 0 calc(var(--space-quarter) / 2);
+    padding: 0 var(--space-eight);
   }
 
   .type {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -46,6 +46,7 @@
     "fiatBalance": "Fiat balance",
     "name": "Account name",
     "noAccount": "There are no accounts to show.",
+    "subtotalWithCoinName": "Total ({{coinName}})",
     "title": "My portfolio",
     "total": "Total",
     "transactionHistory": "Transaction history"

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -47,11 +47,25 @@
     text-align: right;
 }
 
+.table thead th {
+    border-bottom: solid 1px var(--color-mediumgray);
+}
+
 .table thead th,
 .table tfoot th {
-    font-size: var(--size-small);
-    background-color: var(--color-mediumgray);
-    color: var(--color-default);
+    background-color: var(--color-white);
+    color: var(--color-softblack);
+    font-size: var(--size-default);
+    font-weight: bold;
+}
+
+.table strong {
+    color: var(--color-softblack);
+}
+
+.table thead th:first-child,
+.table tfoot th:first-child {
+    padding-left: calc(24px + var(--space-default));
 }
 
 .table tr td,
@@ -64,13 +78,18 @@
     background-color: var(--color-white);
 }
 
+.clickable {
+    cursor: pointer;
+}
+
 .summaryTableBalance {
     white-space: nowrap;
 }
 
 .table tfoot th,
 .table tfoot td {
-    background-color: var(--color-mediumgray);
+    background-color: var(--color-white);
+    padding-bottom: calc(var(--space-quarter) + var(--space-half));
 }
 
 .coinName {
@@ -97,7 +116,23 @@
 .table progress::-webkit-progress-value {
 }
 
+.showOnTableView {
+    display: block;
+}
+
+.showInCollapsedView {
+    display: none;
+}
+
 @media (max-width: 640px) {
+
+    .showOnTableView {
+        display: none;
+    }
+    .showInCollapsedView {
+        display: block;
+    }
+
     .table tr td,
     .table tr th {
       padding: var(--spacing-default);
@@ -115,9 +150,13 @@
     }
 
     .table tfoot tr {
-        background-color: var(--color-mediumgray);
+        background-color: var(--color-white);
         display: flex;
         justify-content: space-between;
+    }
+
+    .table tfoot th:first-child {
+        padding-left: var(--space-half);
     }
 
     .table tbody td {
@@ -130,6 +169,10 @@
     .table tbody td::before {
         content: attr(data-label);
         white-space: nowrap;
+    }
+
+    .subTotal td::before {
+        font-weight: bold;
     }
 
     .table tbody td:last-child {


### PR DESCRIPTION
- add subtotal row if there is more that one account of the same coin
- fix styling and labels
- as this also changes table headers of the account summary there is also changes to table headers of account overview

Everything can be squashed into 1 commit IMO.

TODO:
- review backend implementation