### PR TITLE
qt: release non-posix malloc'ed memory with a compatible free

### DIFF
--- a/frontends/qt/libserver.h
+++ b/frontends/qt/libserver.h
@@ -22,6 +22,14 @@ typedef char* (*getSaveFilenameCallback) (const char*);
 static char* getSaveFilename(getSaveFilenameCallback f, const char* suggestedfilename) {
     return f(suggestedfilename);
 }
+
+// equivalent to C.free but suitable for releasing a memory malloc'ed
+// in a non-posix portable environment, incompatible with cgo.
+// this is especially important on windows where the standard C runtime
+// memory management used by cgo and mingw is different from win32 API used
+// when compiling C++ code with MSVC. hence, the memory allocated with malloc
+// in C++ must always be freed by this function in Go instead of C.free.
+typedef void (*cppHeapFree) (void* ptr);
 #endif
 
 #ifdef __cplusplus
@@ -34,6 +42,7 @@ extern void backendCall(int p0, char* p1);
 extern void handleURI(char* p0);
 
 extern void serve(
+    cppHeapFree cppHeapFreeFn,
     pushNotificationsCallback pushNotificationsFn,
     responseCallback responseFn,
     notifyUserCallback notifyUserFn,

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -266,6 +266,8 @@ int main(int argc, char *argv[])
     workerThread.start();
 
     serve(
+        // cppHeapFree
+        [](void* ptr) { ::free(ptr); },
         // pushNotificationsCallback
         [](const char* msg) {
             if (!pageLoaded) return;
@@ -304,7 +306,7 @@ int main(int argc, char *argv[])
             // free the memory.
             std::string stdString = filename.toStdString();
             const char* cString = stdString.c_str();
-            char* result = (char*)malloc(strlen(cString)+1);
+            char* result = (char*)::malloc(strlen(cString)+1); // Go must free with C.customHeapFree
             memcpy(result, cString, strlen(cString)+1);
             return result;
         });

--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -41,6 +41,12 @@ static char* getSaveFilename(getSaveFilenameCallback f, const char* suggestedfil
     return f(suggestedfilename);
 }
 
+// see frontends/qt/libserver.h for doc comments
+typedef void (*cppHeapFree) (void* ptr);
+static void customHeapFree(cppHeapFree f, void* ptr) {
+	f(ptr);
+}
+
 #endif
 */
 import "C"
@@ -87,6 +93,7 @@ func handleURI(uri *C.char) {
 
 //export serve
 func serve(
+	cppHeapFreeFn C.cppHeapFree,
 	pushNotificationsFn C.pushNotificationsCallback,
 	responseFn C.responseCallback,
 	notifyUserFn C.notifyUserCallback,
@@ -157,7 +164,7 @@ func serve(
 				if cFilename == nil {
 					return ""
 				}
-				defer C.free(unsafe.Pointer(cFilename))
+				defer C.customHeapFree(cppHeapFreeFn, unsafe.Pointer(cFilename))
 				filename := C.GoString(cFilename)
 				return filename
 			},


### PR DESCRIPTION
This ensures the app doesn't crash after invoking getSaveFilename
dialog, for example when exporting transactions to CSV file, due to
memory release method incompatible with the one used during allocation.

Windows has different memory management models [1]. Relevant to this
case are: the C++ new/malloc which invokes HeapAlloc [2] and g++ mingw
malloc from portable C runtime. While malloc called from the Qt
frontend's main.cpp uses the former, Go's C.free uses the latter.

In fact, win32 docs state:

> Because the different heap allocators provide distinctive
> functionality by using different mechanisms, you must free memory
> with the correct function.

Before the filepicker dialog, we've always malloc'ed memory with cgo
functions like C.CString and released with the compatible C.free.
The filepicker was the first instance of a memory malloc'ed in C++ and
free'd from cgo. So, never had this problem before.

Linux and macOS seem to be happy either way. But of course a compatible
way is the above quote from win32 docs.

[1]: https://docs.microsoft.com/en-us/windows/win32/memory/comparing-memory-allocation-methods
[2]: http://msdn.microsoft.com/en-us/library/aa366597%28v=vs.85%29.aspx

please try on all: windows, linux and macOS
