### PR TITLE
backend: open CSV automatically after export

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -403,7 +403,8 @@ func (backend *Backend) createAndAddAccount(
 		GetNotifier: func(configurations signing.Configurations) accounts.Notifier {
 			return backend.notifier.ForAccount(code)
 		},
-		GetSaveFilename: backend.environment.GetSaveFilename,
+		GetSaveFilename:  backend.environment.GetSaveFilename,
+		UnsafeSystemOpen: backend.environment.SystemOpen,
 	}
 
 	switch specificCoin := coin.(type) {

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -57,6 +57,8 @@ type AccountConfig struct {
 	SigningConfigurations signing.Configurations
 	GetNotifier           func(signing.Configurations) Notifier
 	GetSaveFilename       func(suggestedFilename string) string
+	// Opens a file in a default application. The filename is not checked.
+	UnsafeSystemOpen func(filename string) error
 }
 
 // BaseAccount is an account struct with common functionality to all coin accounts.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -42,7 +41,6 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/software"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/rates"
-	utilConfig "github.com/digitalbitbox/bitbox-wallet-app/util/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
@@ -633,8 +631,7 @@ func (backend *Backend) NotifyUser(text string) {
 
 // SystemOpen opens the given URL using backend.environment.
 // It consults fixedURLWhitelist, matching the URL with each whitelist item.
-// If an item is a prefix of url, it is allowed to be openend. Otherwise, an ad-hoc
-// patter matching is performed for URLs like the CSV export download path.
+// If an item is a prefix of url, it is allowed to be openend.
 //
 // If none matched, an ad-hoc URL construction failed or opening a URL failed,
 // an error is returned.
@@ -642,17 +639,6 @@ func (backend *Backend) SystemOpen(url string) error {
 	backend.log.Infof("SystemOpen: attempting to open url: %v", url)
 	for _, whitelisted := range fixedURLWhitelist {
 		if strings.HasPrefix(url, whitelisted) {
-			return backend.environment.SystemOpen(url)
-		}
-	}
-
-	if runtime.GOOS != "android" { // TODO: fix DownloadsDir() for android
-		// Whitelist CSV export.
-		downloadDir, err := utilConfig.DownloadsDir()
-		if err != nil {
-			return err
-		}
-		if strings.HasPrefix(url, downloadDir) {
 			return backend.environment.SystemOpen(url)
 		}
 	}

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -196,7 +196,6 @@ func (handlers *Handlers) getAccountTransactions(_ *http.Request) (interface{}, 
 func (handlers *Handlers) postExportTransactions(_ *http.Request) (interface{}, error) {
 	type result struct {
 		Success      bool   `json:"success"`
-		Path         string `json:"path"`
 		ErrorMessage string `json:"errorMessage"`
 	}
 	name := fmt.Sprintf("%s-%s-export.csv", time.Now().Format("2006-01-02-at-15-04-05"), handlers.account.Config().Code)
@@ -232,7 +231,11 @@ func (handlers *Handlers) postExportTransactions(_ *http.Request) (interface{}, 
 		handlers.log.WithError(err).Error("error exporting account")
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
-	return result{Success: true, Path: path}, nil
+	if err := handlers.account.Config().UnsafeSystemOpen(path); err != nil {
+		handlers.log.WithError(err).Error("error exporting account")
+		return result{Success: false, ErrorMessage: err.Error()}, nil
+	}
+	return result{Success: true}, nil
 }
 
 func (handlers *Handlers) getAccountInfo(_ *http.Request) (interface{}, error) {

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -21,14 +21,12 @@ import A from '../../components/anchor/anchor';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { runningInAndroid } from '../../utils/env';
 import { Transaction } from './transaction';
-import { apiPost } from '../../utils/request';
 import style from './transactions.module.css';
 
 interface TransactionsProps {
     accountCode: string;
     explorerURL: string;
     transactions?: ITransaction[];
-    exported: string;
     handleExport: () => void;
 }
 
@@ -41,7 +39,6 @@ class Transactions extends Component<Props> {
             accountCode,
             explorerURL,
             transactions,
-            exported,
             handleExport,
         } = this.props;
         // We don't support CSV export on Android yet, as it's a tricky to deal with the Downloads
@@ -52,15 +49,8 @@ class Transactions extends Component<Props> {
                 <div className="flex flex-row flex-between flex-items-center">
                     <label className="labelXLarge">{t('accountSummary.transactionHistory')}</label>
                     { !csvExportDisabled && (
-                        exported ? (
-                            <A key="open" href="#" onClick={() => apiPost('open', exported)} className="labelXLarge labelLink">
-                                {t('account.openFile')}
-                            </A>
-                        ) : (
-                            <A key="export" href="#" onClick={handleExport} className="labelXLarge labelLink" title={t('account.exportTransactions')}>{t('account.export')}</A>
-                        )
-                    )
-                    }
+                          <A key="export" href="#" onClick={handleExport} className="labelXLarge labelLink" title={t('account.exportTransactions')}>{t('account.export')}</A>
+                    ) }
                 </div>
                 <div className={[style.columns, style.headers, style.showOnMedium].join(' ')}>
                     <div className={style.type}>{t('transaction.details.type')}</div>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -15,7 +15,6 @@
     },
     "initializing": "Getting information from the blockchain…",
     "maybeProxyError": "Tor proxy enabled. Ensure that your Tor proxy is running properly, or disable the proxy setting.",
-    "openFile": "Open file",
     "reconnecting": "Lost connection, trying to reconnect…",
     "syncedAddressesCount": "Scanned {{count}} addresses"
   },

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -65,7 +65,6 @@ interface State {
     transactions?: accountApi.ITransaction[];
     balance?: accountApi.IBalance;
     hasCard: boolean;
-    exported: string;
     accountInfo?: accountApi.ISigningConfigurationList;
     syncedAddressesCount?: number;
 }
@@ -78,7 +77,6 @@ class Account extends Component<Props, State> {
         transactions: undefined,
         balance: undefined,
         hasCard: false,
-        exported: '',
         accountInfo: undefined,
         syncedAddressesCount: undefined,
     };
@@ -218,7 +216,6 @@ class Account extends Component<Props, State> {
                 transactions: undefined,
             });
         }
-        this.setState({ exported: '' });
     }
 
     private export = () => {
@@ -227,12 +224,8 @@ class Account extends Component<Props, State> {
         }
         accountApi.exportAccount(this.props.code)
             .then(result => {
-                if (result !== null) {
-                    if (result.success) {
-                        this.setState({ exported: result.path });
-                    } else {
-                        alertUser(result.errorMessage);
-                    }
+                if (result !== null && !result.success) {
+                    alertUser(result.errorMessage);
                 }
             })
             .catch(console.error);
@@ -276,7 +269,6 @@ class Account extends Component<Props, State> {
             transactions,
             balance,
             hasCard,
-            exported,
             accountInfo,
             syncedAddressesCount,
         } = this.state;
@@ -360,7 +352,6 @@ class Account extends Component<Props, State> {
                                 ) : (
                                     <Transactions
                                         accountCode={code}
-                                        exported={exported}
                                         handleExport={this.export}
                                         explorerURL={account.blockExplorerTxPrefix}
                                         transactions={transactions}


### PR DESCRIPTION
SystemOpen() has a whitelist, but the whitelist does not cover
exported CSV files - only the Downloads folder, but the user can save
it somewhere else.

Instead of adding CSV export paths dynamically to the whitelist, it is
simpler to automatically open the CSV. This also avoids the clumsy
hack of converting the button from 'export' to 'open'.