### PR TITLE
Frontend waiting refactor II

### DIFF
--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -49,3 +49,7 @@ export const renameAccount = (accountCode: AccountCode, name: string): Promise<I
 export const reinitializeAccounts = (): Promise<null> => {
     return apiPost('accounts/reinitialize');
 };
+
+export const getTesting = (): Promise<boolean> => {
+    return apiGet('testing');
+};

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -14,71 +14,62 @@
  * limitations under the License.
  */
 
-import { Component} from 'react';
+import { FunctionComponent, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLoad } from '../../hooks/api';
+import { getTesting } from '../../api/backend';
 import { Entry } from '../../components/guide/entry';
 import { Guide, store as panelStore } from '../../components/guide/guide';
 import { AppLogo, SwissMadeOpenSource } from '../../components/icon/logo';
 import { Footer, Header } from '../../components/layout';
 import { setSidebarStatus } from '../../components/sidebar/sidebar';
-import { load } from '../../decorators/load';
-import { translate, TranslateProps } from '../../decorators/translate';
 import { debug } from '../../utils/env';
-import style from './bitbox01/bitbox01.module.css';
 import { SkipForTesting } from './components/skipfortesting';
+import style from './bitbox01/bitbox01.module.css';
 
-interface TestingProps {
-    testing?: boolean;
-}
+export const Waiting: FunctionComponent = () => {
+    const { t } = useTranslation();
+    const testing = useLoad(debug ? getTesting : () => Promise.resolve(false));
 
-type WaitingProps = TestingProps & TranslateProps;
-
-class Waiting extends Component<WaitingProps> {
-    public UNSAFE_componentWillMount() {
+    useEffect(() => {
         const { sidebarStatus } = panelStore.state;
         if (['forceCollapsed', 'forceHidden'].includes(sidebarStatus)) {
             setSidebarStatus('');
         }
-    }
+    }, []);
 
-    public render() {
-        const { t, testing } = this.props;
-        return (
-            <div className="contentWithGuide">
-                <div className="container">
-                    <Header title={<h2>{t('welcome.title')}</h2>} />
-                    <div className="content padded narrow isVerticallyCentered">
-                        <div>
-                            <AppLogo />
-                            <div className="box large">
-                                <h3 className={style.waitingText}>{t('welcome.insertDevice')}</h3>
-                                <p className={style.waitingDescription}>{t('welcome.insertBitBox02')}</p>
-                            </div>
-                            {
-                                testing && (
-                                    <div className={style.testingContainer}>
-                                        <SkipForTesting show={!!testing} />
-                                    </div>
-                                )
-                            }
+    return (
+        <div className="contentWithGuide">
+            <div className="container">
+                <Header title={<h2>{t('welcome.title')}</h2>} />
+                <div className="content padded narrow isVerticallyCentered">
+                    <div>
+                        <AppLogo />
+                        <div className="box large">
+                            <h3 className={style.waitingText}>{t('welcome.insertDevice')}</h3>
+                            <p className={style.waitingDescription}>{t('welcome.insertBitBox02')}</p>
                         </div>
+                        {
+                            testing && (
+                                <div className={style.testingContainer}>
+                                    <SkipForTesting show />
+                                </div>
+                            )
+                        }
                     </div>
-                    <Footer>
-                        <SwissMadeOpenSource />
-                    </Footer>
                 </div>
-                <Guide>
-                    <Entry entry={t('guide.waiting.welcome')} shown={true} />
-                    <Entry entry={t('guide.waiting.getDevice')} />
-                    <Entry entry={t('guide.waiting.lostDevice')} />
-                    <Entry entry={t('guide.waiting.internet')} />
-                    <Entry entry={t('guide.waiting.deviceNotRecognized')} />
-                    <Entry entry={t('guide.waiting.useWithoutDevice')} />
-                </Guide>
+                <Footer>
+                    <SwissMadeOpenSource />
+                </Footer>
             </div>
-        );
-    }
-}
-
-const loadHOC = load<TestingProps, TranslateProps>(() => debug ? { testing: 'testing' } : {})(Waiting);
-const translateHOC = translate()(loadHOC);
-export { translateHOC as Waiting };
+            <Guide>
+                <Entry entry={t('guide.waiting.welcome')} shown={true} />
+                <Entry entry={t('guide.waiting.getDevice')} />
+                <Entry entry={t('guide.waiting.lostDevice')} />
+                <Entry entry={t('guide.waiting.internet')} />
+                <Entry entry={t('guide.waiting.deviceNotRecognized')} />
+                <Entry entry={t('guide.waiting.useWithoutDevice')} />
+            </Guide>
+        </div>
+    );
+};


### PR DESCRIPTION
- Migrate ClassComponent to FunctionComponent
- Migrate HOCs to hooks

This replaces https://github.com/digitalbitbox/bitbox-wallet-app/pull/1610
Added `testing` again, so testnet has the "skip for testing" see my comment https://github.com/digitalbitbox/bitbox-wallet-app/pull/1610#discussion_r792509146