### PR TITLE
frontend: fix close dialog with esc js error

### DIFF
--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -119,13 +119,13 @@ class Dialog extends Component<Props, State> {
             return;
         }
         this.modal.current.classList.remove(style.activeModal);
+        this.overlay.current.classList.remove(style.activeOverlay);
         this.setState({ active: false, currentTab: 0 }, () => {
             document.removeEventListener('keydown', this.handleKeyDown);
             if (this.props.onClose) {
                 this.props.onClose();
             }
         });
-        this.overlay.current.classList.remove(style.activeOverlay);
     }
 
     private activate = () => {


### PR DESCRIPTION
Closing a confirm dialog with esc errors with:
> Cannot read properties of null (reading 'classList')

Seems that this is a regression from the Preact->React migration,
it looks like the setState callback is exectued earlier than in
Preact.

Moving updating the classList before setState fixes the error.

Test:
1) connect to own node
2) remove server
3) type esc