### PR TITLE
frontend: fix white screen if passwords do not match during setup

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -276,6 +276,8 @@ class BitBox02 extends Component<Props, State> {
                 }, () => {
                     this.setPassword();
                 });
+                // show noPasswordMatch error and do NOT continue to createBackup
+                return;
             }
             this.setState({ settingPassword: false, createWalletStatus: 'createBackup' });
         });


### PR DESCRIPTION
Regression from Reacht migration, the app currently shows a white
screen when password do not match. Reason setState callback fires
earlier it is unclear which setState sets createWalletStatus.

Test:
- factory reset
- create new wallet, enter name
- enter 2 different passwords
- expect password do not match error

Found in https://github.com/digitalbitbox/bitbox-wallet-app/pull/1601