### PR TITLE
Taproot receive/sign

### DIFF
--- a/backend/coins/btc/addresses/address.go
+++ b/backend/coins/btc/addresses/address.go
@@ -36,6 +36,8 @@ import (
 type AccountAddress struct {
 	btcutil.Address
 
+	// AccountConfiguration is the account level configuration from which this address was derived.
+	AccountConfiguration *signing.Configuration
 	// Configuration contains the absolute keypath and the extended public keys of the address.
 	Configuration *signing.Configuration
 
@@ -148,11 +150,12 @@ func NewAccountAddress(
 	}
 
 	return &AccountAddress{
-		Address:       address,
-		Configuration: configuration,
-		HistoryStatus: "",
-		redeemScript:  redeemScript,
-		log:           log,
+		Address:              address,
+		AccountConfiguration: accountConfiguration,
+		Configuration:        configuration,
+		HistoryStatus:        "",
+		redeemScript:         redeemScript,
+		log:                  log,
 	}
 }
 

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -78,7 +78,18 @@ func (keystore *keystore) SupportsCoin(coin coin.Coin) bool {
 
 // SupportsAccount implements keystore.Keystore.
 func (keystore *keystore) SupportsAccount(coin coin.Coin, meta interface{}) bool {
-	return keystore.SupportsCoin(coin)
+	if !keystore.SupportsCoin(coin) {
+		return false
+	}
+	switch coin.(type) {
+	case *btc.Coin:
+		scriptType := meta.(signing.ScriptType)
+		return scriptType == signing.ScriptTypeP2PKH ||
+			scriptType == signing.ScriptTypeP2WPKHP2SH ||
+			scriptType == signing.ScriptTypeP2WPKH
+	default:
+		return false
+	}
 }
 
 // SupportsUnifiedAccounts implements keystore.Keystore.

--- a/backend/devices/bitbox02/protobuf.go
+++ b/backend/devices/bitbox02/protobuf.go
@@ -33,6 +33,7 @@ var btcMsgCoinMap = map[coin.Code]messages.BTCCoin{
 var btcMsgScriptTypeMap = map[signing.ScriptType]messages.BTCScriptConfig_SimpleType{
 	signing.ScriptTypeP2WPKHP2SH: messages.BTCScriptConfig_P2WPKH_P2SH,
 	signing.ScriptTypeP2WPKH:     messages.BTCScriptConfig_P2WPKH,
+	signing.ScriptTypeP2TR:       messages.BTCScriptConfig_P2TR,
 }
 
 var ethMsgCoinMap = map[coin.Code]messages.ETHCoin{

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -104,7 +104,18 @@ func (keystore *Keystore) SupportsCoin(coin coin.Coin) bool {
 
 // SupportsAccount implements keystore.Keystore.
 func (keystore *Keystore) SupportsAccount(coin coin.Coin, meta interface{}) bool {
-	return keystore.SupportsCoin(coin)
+	if !keystore.SupportsCoin(coin) {
+		return false
+	}
+	switch coin.(type) {
+	case *btc.Coin:
+		scriptType := meta.(signing.ScriptType)
+		return scriptType == signing.ScriptTypeP2PKH ||
+			scriptType == signing.ScriptTypeP2WPKHP2SH ||
+			scriptType == signing.ScriptTypeP2WPKH
+	default:
+		return false
+	}
 }
 
 // SupportsUnifiedAccounts implements keystore.Keystore.


### PR DESCRIPTION
This PR updates the bitbox02 keystore to enable taproot receive&sign. This PR does not add or enable any taproot accounts yet.