### PR TITLE
frontend/transaction: make transaction ID copyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Show coin subtotals in 'My portfolio'
+- Transactio details: make transaction ID copyable without opening the block explorer
 
 ## 4.31.1 [2022-02-07]
 - Bundle BitBox02 Multi firmware version v9.9.1

--- a/frontends/web/src/components/copy/Copy.module.css
+++ b/frontends/web/src/components/copy/Copy.module.css
@@ -48,7 +48,7 @@
     height: 52px;
     margin-bottom: 0;
     min-width: 200px !important;
-    padding: var(--space-half) calc(var(--space-default) * 1.2) var(--space-half) calc(var(--space-half) * .5);
+    padding: var(--space-half) calc(var(--space-default) * 1.2 + 5px) var(--space-half) calc(var(--space-half) * .5);
     resize: none;
     width: 100%;
 }

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -373,10 +373,25 @@ class Transaction extends Component<Props, State> {
                                     </div>
                                 ) : null
                             }
-                            <div className={style.detail}>
+                            <div className={[style.detail, style.addresses].join(' ')}>
                                 <label>{t('transaction.explorer')}</label>
-                                <p className="text-break">
-                                    <A className={style.externalLink} href={ explorerURL + txID } title={t('transaction.explorerTitle')}>{txID}</A>
+                                <div className={style.detailAddresses}>
+                                    <CopyableInput
+                                            alignRight
+                                            borderLess
+                                            flexibleHeight
+                                            className={style.detailAddress}
+                                            value={txID} />
+                                </div>
+                            </div>
+                            <div className={[style.detail, 'flex-center'].join(' ')}>
+                                <p>
+                                    <A
+                                        className={style.externalLink}
+                                        href={explorerURL + txID}
+                                        title={t('transaction.explorerTitle') + '\n' + explorerURL + txID}>
+                                        {t('transaction.explorerTitle')}
+                                    </A>
                                 </p>
                             </div>
                         </Dialog>


### PR DESCRIPTION
And separate the link to the external block explorer. Users can then
more easily copy the txID without accidentally opening the explorer.

We add 5px of padding between the input and the copy button, otherwise
the input selection would overlap the button if there is a line break.