### PR TITLE
backend/accounts: update existing accounts with taproot subaccount

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -494,8 +494,9 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 		return account.Configurations.ContainsRootFingerprint(fingerprint)
 	}
 	err := backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
-		if len(backend.filterAccounts(accountsConfig, belongsToKeystore)) != 0 {
-			return nil
+		accounts := backend.filterAccounts(accountsConfig, belongsToKeystore)
+		if len(accounts) != 0 {
+			return backend.updatePersistedAccounts(keystore, accounts)
 		}
 		return backend.persistDefaultAccountConfigs(keystore, accountsConfig)
 	})


### PR DESCRIPTION
If the keystore supports it (e.g. after upgrading BitBox02 to
v9.10.0), the persisted accounts are updated with the taproot
subaccount, to make taproot addresses available also for existing
accounts.

The order of the script configs in the account config at the moment
matters only in that the first entry is used as the default address
type for Moonpay, AOPP and as the default change address. Future PRs
will remove this implicit assumption so that the order does not matter.