### PR TITLE
frontend: use dialog to select receive address script type

### DIFF
--- a/frontends/web/src/components/forms/radio.tsx
+++ b/frontends/web/src/components/forms/radio.tsx
@@ -35,7 +35,6 @@ export function Radio({
             <input
                 type="radio"
                 id={id}
-                name={id}
                 disabled={disabled}
                 {...props}
             />

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1084,15 +1084,16 @@
     "description": "Your BitBox generated the following {{bits}}-bit random number:"
   },
   "receive": {
+    "changeScriptType": "Change address type",
     "label": "Your address",
     "onlyThisCoin": {
       "description": "To receive other tokens, enable them in the settings. If you deposit other tokens, they might not be accessible.",
       "warning": "Make sure to only receive {{coinName}} on this address."
     },
     "scriptType": {
-      "p2tr": "change to modern address (taproot)",
-      "p2wpkh": "change back to standard address (recommended)",
-      "p2wpkh-p2sh": "change to compatible address (segwit)"
+      "p2tr": "Taproot (newest format)",
+      "p2wpkh": "Native Segwit (default)",
+      "p2wpkh-p2sh": "Wrapped Segwit (compatible format)"
     },
     "showFull": "Show and verify full address on device",
     "title": "Get {{accountName}}",


### PR DESCRIPTION
Toggling/cycling through 3 receive address script types is
confusing now that Taproot is supported, as it is unclear which
script type is currently selected and what the choices are.

Moving to a list of input radios gives a better overview. Using
radio inputs was anyway planed in an upcoming receive revamp.

Adding a addressDialog property to the receive view, that is
either false (do not show the dialog) or is a temporary object
containing the new addressType if the dialog is confirmed.

![Screen Shot 2022-02-22 at 12 48 40 PM](https://user-images.githubusercontent.com/546900/155126563-07bedfb0-4724-4165-88d3-5f094db8cf5b.png)
