### PR TITLE
Improve speed of calling /transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add support for BIP-86 taproot receive addresses
 - Show coin subtotals in 'My portfolio'
 - Transaction details: make transaction ID copyable without opening the block explorer
+- Improve account loading speed when there are many transactions in the account
 
 ## 4.31.1 [2022-02-07]
 - Bundle BitBox02 Multi firmware version v9.9.1

--- a/backend/coins/btc/addresses/addresschain_test.go
+++ b/backend/coins/btc/addresses/addresschain_test.go
@@ -87,7 +87,7 @@ func (s *addressChainTestSuite) TestLookupByScriptHashHex() {
 		require.Equal(s.T(), address,
 			s.addresses.LookupByScriptHashHex(address.PubkeyScriptHashHex()))
 	}
-	// Produce addresses beyond  the gapLimit to ensure the gapLimit does not confuse Contains().
+	// Produce addresses beyond the gapLimit to ensure the gapLimit does not confuse Contains().
 	newAddresses[0].HistoryStatus = blockchain.TxHistory{tx1}.Status()
 	newAddresses = s.addresses.EnsureAddresses()
 	require.Len(s.T(), newAddresses, 1)

--- a/backend/coins/btc/db/transactionsdb/transactionsdb.go
+++ b/backend/coins/btc/db/transactionsdb/transactionsdb.go
@@ -166,6 +166,7 @@ func (tx *Tx) TxInfo(txHash chainhash.Hash) (
 	if _, err := readJSON(tx.bucketTransactions, txHash[:], walletTx); err != nil {
 		return nil, err
 	}
+	walletTx.TxHash = txHash
 	return walletTx, nil
 }
 

--- a/backend/coins/btc/transactions/db.go
+++ b/backend/coins/btc/transactions/db.go
@@ -31,6 +31,11 @@ type DBTxInfo struct {
 	Verified         *bool           `json:"Verified"`
 	HeaderTimestamp  *time.Time      `json:"ts"`
 	CreatedTimestamp *time.Time      `json:"created"`
+
+	// TxHash is the same as Tx.TxHash(), but since we already have this value in the database, it
+	// is faster to access it this way than to recompute it.  It is not serialized and stored in the
+	// database.
+	TxHash chainhash.Hash `json:"-"`
 }
 
 // DBTxInterface needs to be implemented to persist all wallet/transaction related data.

--- a/backend/coins/btc/transactions/transactions.go
+++ b/backend/coins/btc/transactions/transactions.go
@@ -404,7 +404,6 @@ func (transactions *Transactions) txInfo(
 	dbTx DBTxInterface,
 	txInfo *DBTxInfo,
 	isChange func(blockchain.ScriptHashHex) bool) *accounts.TransactionData {
-	defer transactions.RLock()()
 	var sumOurInputs btcutil.Amount
 	var result btcutil.Amount
 	allInputsOurs := true
@@ -427,7 +426,7 @@ func (transactions *Transactions) txInfo(
 	for index, txOut := range txInfo.Tx.TxOut {
 		sumAllOutputs += btcutil.Amount(txOut.Value)
 		output, err := dbTx.Output(wire.OutPoint{
-			Hash:  txInfo.Tx.TxHash(),
+			Hash:  txInfo.TxHash,
 			Index: uint32(index),
 		})
 		if err != nil {
@@ -504,8 +503,8 @@ func (transactions *Transactions) txInfo(
 	return &accounts.TransactionData{
 		Fee:                      feeP,
 		Timestamp:                txInfo.HeaderTimestamp,
-		TxID:                     txInfo.Tx.TxHash().String(),
-		InternalID:               txInfo.Tx.TxHash().String(),
+		TxID:                     txInfo.TxHash.String(),
+		InternalID:               txInfo.TxHash.String(),
 		NumConfirmations:         numConfirmations,
 		NumConfirmationsComplete: numConfirmationsComplete,
 		Height:                   txInfo.Height,


### PR DESCRIPTION
With lots of transactions in an account, loading them via the /transactions endpoint was very slow. The two main reasons (in order) were:

- many re-computations of the transaction hash (once for every input in each tx, plus a few times more per tx)
- slow lookup of addresses in the address chain to determine if an output is a change output

Fixing both reduces the time for calling the endpoint from ~20s to ~0s with around 700 transactions in the db.