### PR TITLE
frontend: add warning if taproot is selected as receive address

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1096,6 +1096,7 @@
       "p2wpkh-p2sh": "Wrapped Segwit (compatible format)"
     },
     "showFull": "Show and verify full address on device",
+    "taprootWarning": "Note: Taproot is a new Bitcoin feature and is not yet widely adopted. Funds received on Taproot addresses may not be visible in third party watch-only wallets. Many wallets and exchanges are not yet able to send to Taproot addresses.",
     "title": "Get {{accountName}}",
     "verify": "Verify address securely",
     "verifyBitBox01": "Verify address on mobile app",

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -34,6 +34,7 @@ import { apiGet } from '../../../utils/request';
 import { getScriptName, isEthereumBased } from '../utils';
 import style from './receive.module.css';
 import { ArrowCirlceLeft, ArrowCirlceLeftActive, ArrowCirlceRight, ArrowCirlceRightActive } from '../../../components/icon';
+import { Message } from '../../../components/message/message';
 
 interface ReceiveProps {
     code?: string;
@@ -261,7 +262,7 @@ class Receive extends Component<Props, State> {
                             addressDialog: undefined,
                         }));
                     }}>
-                        <Dialog small title={t('receive.changeScriptType')} >
+                        <Dialog medium title={t('receive.changeScriptType')} >
                             {this.availableScriptTypes.map((scriptType, i) => (
                                 <div key={scriptType}>
                                     <Radio
@@ -272,6 +273,11 @@ class Receive extends Component<Props, State> {
                                         title={getScriptName(scriptType)}>
                                         {t(`receive.scriptType.${scriptType}`)}
                                     </Radio>
+                                    {scriptType === 'p2tr' && addressDialog.addressType === i && (
+                                        <Message type="warning">
+                                            {t('receive.taprootWarning')}
+                                        </Message>
+                                    )}
                                 </div>
                             ))}
                             <DialogButtons>


### PR DESCRIPTION
Taproot is still new and not supported by all wallets, i.e. funds
might not show up in 3rd party watch-only wallets or not all
exchanges support it yet.

Adding a warning if taproot is selected.