### PR TITLE
frontend: reword restore-from-mnemonic instruction

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -173,7 +173,8 @@
     "confirmDateText": "This date will be used to create your backup.",
     "confirmName": "Confirm name on BitBox02",
     "followInstructions": "Please follow the instructions on your BitBox02.",
-    "followInstructionsMnemonic": "Please follow the instructions on your BitBox02 to restore from recovery words."
+    "followInstructionsMnemonic": "Please follow the instructions on your BitBox02 to restore from recovery words.",
+    "followInstructionsMnemonicTitle": "Restore from recovery words"
   },
   "bitbox02Settings": {
     "deviceName": {

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -344,7 +344,7 @@ class BitBox02 extends Component<Props, State> {
 
     private restoreFromMnemonic = () => {
         this.setState({ waitDialog: {
-            title: this.props.t('bitbox02Interact.followInstructions'),
+            title: this.props.t('bitbox02Interact.followInstructionsMnemonicTitle'),
             text: this.props.t('bitbox02Interact.followInstructionsMnemonic'),
         } });
         apiPost('devices/bitbox02/' + this.props.deviceID + '/restore-from-mnemonic').then(({ success }) => {


### PR DESCRIPTION
Before the popup when restoring from mnemonic words repeated
itself:
- Title: Please follow the instructions on your BitBox02
- Text: Please follow the i… to restore from recovery words

Reason: the title used a generic follow-instrucitons
translation which is used in many places. Fixed by adding
a custom followInstructionsMnemonicTitle translation.