### PR TITLE
qt: add BITBOXAPP_RENDER environment var to configure rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Show coin subtotals in 'My portfolio'
 - Transaction details: make transaction ID copyable without opening the block explorer
 - Improve account loading speed when there are many transactions in the account
+- Desktop: add a configuration option using the environment variable `BITBOXAPP_RENDER` to enable
+  users to turn off forced software rendering. Use `BITBOXAPP_RENDER=auto` to use Qt's default
+  rendering backend.
 
 ## 4.31.1 [2022-02-07]
 - Bundle BitBox02 Multi firmware version v9.9.1


### PR DESCRIPTION
We switched to forced software rendering in
daaf2319afb3f5813a4bddd67e13b300590414e5 due to some users suffering
rendering artefacts and crashes with the default rendering backend.

The downside is that the app can be very slow on some machines,
especially when maximized with high resolution.

This env variable is a workaround to enable users to improve their
experience and try the default rendering, which is normally hardware
accelerated.

Closes https://github.com/digitalbitbox/bitbox-wallet-app/issues/1662