### PR TITLE
frontend: show errors from qr scanner

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -518,7 +518,10 @@ class Send extends Component<Props, State> {
                         this.qrCodeReader.reset(); // release camera
                     }
                 })
-                .catch(() => {
+                .catch((error) => {
+                    if (error) {
+                        alertUser(error.message || error);
+                    }
                     this.setState({ activeScanQR: false });
                 });
         });


### PR DESCRIPTION
If the app does not have permissions to use the camera the library
returns 'Could not start video source' error.

This change shows the library error to the user in cases something
went wrong, but also if the scaning is aborted and no code has
been detected in that case the library returns 'Video stream has
ended before any code could be detected'.