### PR TITLE
frontend: rewrite receive to functional component

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -214,8 +214,10 @@ export interface ReceiveAddressList {
     addresses: IReceiveAddress[];
 }
 
-export const getReceiveAddressList = (code: AccountCode): Promise<ReceiveAddressList[]> => {
-    return apiGet(`account/${code}/receive-addresses`);
+export const getReceiveAddressList = (code: AccountCode) => {
+    return (): Promise<ReceiveAddressList[]> => {
+        return apiGet(`account/${code}/receive-addresses`);
+    };
 };
 
 export interface ISendTx {
@@ -278,4 +280,15 @@ export interface UTXO {
 
 export const getUTXOs = (code: AccountCode): Promise<UTXO[]> => {
     return apiGet(`account/${code}/utxos`);
+};
+
+type TSecureOutput = {
+    hasSecureOutput: boolean;
+    optional: boolean;
+};
+
+export const hasSecureOutput = (code: AccountCode) => {
+    return (): Promise<TSecureOutput> => {
+        return apiGet(`account/${code}/has-secure-output`);
+    };
 };

--- a/frontends/web/src/api/devices.ts
+++ b/frontends/web/src/api/devices.ts
@@ -16,7 +16,7 @@
 
 import { apiGet } from '../utils/request';
 
-type TProductName = 'bitbox' | 'bitbox02' | 'bitbox02-bootloader';
+export type TProductName = 'bitbox' | 'bitbox02' | 'bitbox02-bootloader';
 
 export type TDevices = {
     readonly [key in string]: TProductName;

--- a/frontends/web/src/api/devices.ts
+++ b/frontends/web/src/api/devices.ts
@@ -25,3 +25,9 @@ export type TDevices = {
 export const getDeviceList = (): Promise<TDevices> => {
     return apiGet('devices/registered');
 };
+
+export const hasMobileChannel = (deviceID: string) => {
+    return (): Promise<boolean> => {
+        return apiGet(`devices/${deviceID}/has-mobile-channel`);
+    };
+};

--- a/frontends/web/src/routes/account/receive/components/bb01paired.tsx
+++ b/frontends/web/src/routes/account/receive/components/bb01paired.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FunctionComponent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLoad } from '../../../../hooks/api';
+import { hasMobileChannel } from '../../../../api/devices';
+import Status from '../../../../components/status/status';
+
+type Props = {
+    deviceID: string;
+}
+
+export const PairedWarning: FunctionComponent<Props> = ({
+    deviceID,
+}) => {
+    const { t } = useTranslation();
+    const paired = useLoad(hasMobileChannel(deviceID));
+    if (paired) {
+        return null;
+    }
+    return (
+        <Status type="warning" hidden={paired !== false}>
+            {t('warning.receivePairing')}
+        </Status>
+    );
+};

--- a/frontends/web/src/routes/account/receive/components/verfiybutton.tsx
+++ b/frontends/web/src/routes/account/receive/components/verfiybutton.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FunctionComponent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TProductName } from '../../../../api/devices';
+import { Button } from '../../../../components/forms';
+
+export const useVerfiyLabel = (device?: TProductName): string => {
+    const { t } = useTranslation();
+    if (device === 'bitbox') {
+        return t('receive.verifyBitBox01');
+    } else if (device === 'bitbox02') {
+        return t('receive.verifyBitBox02');
+    }
+    return t('receive.verify'); // fallback
+};
+
+type Props = JSX.IntrinsicElements['button'] & {
+    device?: TProductName;
+    forceVerification: boolean;
+};
+
+export const VerifyButton: FunctionComponent<Props> = ({
+    device,
+    forceVerification,
+    ...props
+}) => {
+    const { t } = useTranslation();
+    const verifyLabel = useVerfiyLabel(device);
+    return (
+        <Button primary {...props}>
+            { forceVerification ? t('receive.showFull') : verifyLabel }
+        </Button>
+    );
+};

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -31,8 +31,9 @@ import { Entry } from '../../../components/guide/entry';
 import { Guide } from '../../../components/guide/guide';
 import { Header } from '../../../components/layout';
 import { QRCode } from '../../../components/qrcode/qrcode';
-import { PairedWarning } from './components/bb01paired';
 import { ArrowCirlceLeft, ArrowCirlceLeftActive, ArrowCirlceRight, ArrowCirlceRightActive } from '../../../components/icon';
+import { PairedWarning } from './components/bb01paired';
+import { useVerfiyLabel, VerifyButton } from './components/verfiybutton';
 import style from './receive.module.css';
 
 interface Props {
@@ -76,6 +77,7 @@ export const Receive: FunctionComponent<Props> = ({
 
     const device = deviceIDs.length ? devices[deviceIDs[0]] : undefined;
     const account = accounts.find(({ code: accountCode }) => accountCode === code);
+    const verifyLabel = useVerfiyLabel(device);
 
     // first array index: address types. second array index: unused addresses of that address type.
     const receiveAddresses = useLoad(accountApi.getReceiveAddressList(code));
@@ -143,13 +145,6 @@ export const Receive: FunctionComponent<Props> = ({
     // enable copying only after verification has been invoked if verification is possible and not optional.
     const forceVerification = secureOutput === undefined ? true : (secureOutput.hasSecureOutput && !secureOutput.optional);
     const enableCopy = !forceVerification;
-
-    let verifyLabel = t('receive.verify'); // fallback
-    if (device === 'bitbox') {
-        verifyLabel = t('receive.verifyBitBox01');
-    } else if (device === 'bitbox02') {
-        verifyLabel = t('receive.verifyBitBox02');
-    }
 
     let uriPrefix = '';
     if (account) {
@@ -252,22 +247,11 @@ export const Receive: FunctionComponent<Props> = ({
                                     </form>
                                 )}
                                 <div className="buttons">
-                                    { forceVerification && (
-                                        <Button
-                                            primary
-                                            disabled={verifying || secureOutput === undefined}
-                                            onClick={() => verifyAddress(currentAddressIndex)}>
-                                            {t('receive.showFull')}
-                                        </Button>
-                                    )}
-                                    { !forceVerification && (
-                                        <Button
-                                            primary
-                                            disabled={verifying || secureOutput === undefined}
-                                            onClick={() => verifyAddress(currentAddressIndex)}>
-                                            {verifyLabel}
-                                        </Button>
-                                    )}
+                                    <VerifyButton
+                                        device={device}
+                                        disabled={verifying || secureOutput === undefined}
+                                        forceVerification={forceVerification}
+                                        onClick={() => verifyAddress(currentAddressIndex)}/>
                                     <ButtonLink
                                         transparent
                                         to={`/account/${code}`}>

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -15,377 +15,312 @@
  * limitations under the License.
  */
 
-import React, { Component} from 'react';
-import { route } from '../../../utils/route';
+import React, { FunctionComponent, useEffect, useRef, useState} from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLoad } from '../../../hooks/api';
 import * as accountApi from '../../../api/account';
 import { TDevices } from '../../../api/devices';
+import { route } from '../../../utils/route';
+import { getScriptName, isEthereumBased } from '../utils';
 import { alertUser } from '../../../components/alert/Alert';
 import { CopyableInput } from '../../../components/copy/Copy';
 import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
 import { Button, ButtonLink, Radio } from '../../../components/forms';
+import { Message } from '../../../components/message/message';
 import { Entry } from '../../../components/guide/entry';
 import { Guide } from '../../../components/guide/guide';
 import { Header } from '../../../components/layout';
 import { QRCode } from '../../../components/qrcode/qrcode';
-import Status from '../../../components/status/status';
-import { load } from '../../../decorators/load';
-import { translate, TranslateProps } from '../../../decorators/translate';
-import { apiGet } from '../../../utils/request';
-import { getScriptName, isEthereumBased } from '../utils';
-import style from './receive.module.css';
+import { PairedWarning } from './components/bb01paired';
 import { ArrowCirlceLeft, ArrowCirlceLeftActive, ArrowCirlceRight, ArrowCirlceRightActive } from '../../../components/icon';
-import { Message } from '../../../components/message/message';
+import style from './receive.module.css';
 
-interface ReceiveProps {
-    code?: string;
+interface Props {
+    code: string;
     devices: TDevices;
     accounts: accountApi.IAccount[];
     deviceIDs: string[];
 }
 
-interface State {
-    verifying: boolean;
-    activeIndex: number;
-    paired: boolean | null;
-    // index into `availableScriptTypes`, or 0 if none are available.
-    addressType: number;
-    addressDialog?: { addressType: number };
-}
-
-interface LoadedReceiveProps {
-    // first array index: address types. second array index: unused addresses of that address type.
-    receiveAddresses: accountApi.ReceiveAddressList[];
-    secureOutput: {
-        hasSecureOutput: boolean;
-        optional: boolean;
-    };
-}
-
-type Props = LoadedReceiveProps & ReceiveProps & TranslateProps;
+type AddressDialog = { addressType: number } | undefined;
 
 // For BTC/LTC: all possible address types we want to offer to the user, ordered by priority (first one is default).
 // Types that are not available in the addresses delivered by the backend should be ignored.
-const scriptTypes: accountApi.ScriptType[] = ['p2wpkh', 'p2tr', 'p2wpkh-p2sh']
+const scriptTypes: accountApi.ScriptType[] = ['p2wpkh', 'p2tr', 'p2wpkh-p2sh'];
 
-class Receive extends Component<Props, State> {
-    // Find index in list of receive addresses that matches the given script type, or -1 if not found.
-    private getIndexOfMatchingScriptType = (scriptType: accountApi.ScriptType): number => {
-        return this.props.receiveAddresses.findIndex(addrs => addrs.scriptType !== null && scriptType === addrs.scriptType);
+// Find index in list of receive addresses that matches the given script type, or -1 if not found.
+const getIndexOfMatchingScriptType = (
+    receiveAddresses: accountApi.ReceiveAddressList[],
+    scriptType: accountApi.ScriptType
+): number => {
+    if (!receiveAddresses) {
+        return -1;
     }
+    return receiveAddresses.findIndex(addrs => addrs.scriptType !== null && scriptType === addrs.scriptType);
+};
 
-    // All script types that are present in the addresses delivered by the backend. Will be empty for if there are no such addresses, e.g. in Ethereum.
-    private availableScriptTypes: accountApi.ScriptType[] = scriptTypes.filter(sc => this.getIndexOfMatchingScriptType(sc) >= 0);
-    public readonly state: State = {
-        verifying: false,
-        activeIndex: 0,
-        paired: null,
-        addressType: 0,
-    }
+export const Receive: FunctionComponent<Props> = ({
+    accounts,
+    code,
+    devices,
+    deviceIDs,
+}) => {
+    const { t } = useTranslation();
+    const [verifying, setVerifying] = useState<boolean>(false);
+    const [activeIndex, setActiveIndex] = useState<number>(0);
+    // index into `availableScriptTypes`, or 0 if none are available.
+    const [addressType, setAddressType] = useState<number>(0);
+    const [addressDialog, setAddressDialog] = useState<AddressDialog>();
+    const [currentAddresses, setCurrentAddresses] = useState<accountApi.IReceiveAddress[]>();
+    const [currentAddressIndex, setCurrentAddressIndex] = useState<number>(0);
 
-    public componentDidMount() {
-        if (this.getDevice() === 'bitbox') {
-            apiGet('devices/' + this.props.deviceIDs[0] + '/has-mobile-channel').then(paired => {
-                this.setState({ paired });
-            });
-        }
-    }
+    const device = deviceIDs.length ? devices[deviceIDs[0]] : undefined;
+    const account = accounts.find(({ code: accountCode }) => accountCode === code);
 
-    public UNSAFE_componentWillMount() {
-        this.registerEvents();
-    }
+    // first array index: address types. second array index: unused addresses of that address type.
+    const receiveAddresses = useLoad(accountApi.getReceiveAddressList(code));
+    const secureOutput = useLoad(accountApi.hasSecureOutput(code));
 
-    public componentWillUnmount() {
-        this.unregisterEvents();
-    }
-
-    private registerEvents = () => {
-        document.addEventListener('keydown', this.handleKeyDown);
-    }
-
-    private unregisterEvents = () => {
-        document.removeEventListener('keydown', this.handleKeyDown);
-    }
-
-    private handleKeyDown = (e: KeyboardEvent) => {
-        if (e.keyCode === 27) {
-            if (!this.state.verifying) {
-                route(`/account/${this.props.code}`);
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.keyCode === 27 && !verifying) {
+                route(`/account/${code}`);
             }
-        }
-    }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [code, verifying]);
 
-    private verifyAddress = (addressesIndex: number) => {
-        const { receiveAddresses, secureOutput, code } = this.props;
-        if (code === undefined) {
-            return;
-        }
-        const { activeIndex } = this.state;
-        if (!secureOutput.hasSecureOutput) {
-            this.unregisterEvents();
-            alertUser(this.props.t('receive.warning.secureOutput'), {
-                callback: this.registerEvents
-            });
-            return;
-        }
-        this.setState({ verifying: true });
-        accountApi.verifyAddress(
-            code,
-            receiveAddresses[addressesIndex].addresses[activeIndex].addressID).then(() => {
-                this.setState({ verifying: false });
-            });
-    }
+    const availableScriptTypes = useRef<accountApi.ScriptType[]>();
 
-    private previous = (e: React.SyntheticEvent) => {
+    useEffect(() => {
+        if (receiveAddresses) {
+            // All script types that are present in the addresses delivered by the backend. Will be empty for if there are no such addresses, e.g. in Ethereum.
+            availableScriptTypes.current = scriptTypes.filter(sc => getIndexOfMatchingScriptType(receiveAddresses, sc) >= 0);
+        }
+    }, [receiveAddresses]);
+
+    useEffect(() => {
+        if (receiveAddresses && availableScriptTypes.current) {
+            let addressIndex = availableScriptTypes.current.length > 0 ? getIndexOfMatchingScriptType(receiveAddresses, availableScriptTypes.current[addressType]) : 0;
+            if (addressIndex === -1) {
+                addressIndex = 0;
+            }
+            setCurrentAddressIndex(addressIndex);
+            setCurrentAddresses(receiveAddresses[addressIndex].addresses);
+        }
+    }, [addressType, availableScriptTypes, receiveAddresses]);
+
+    const verifyAddress = (addressesIndex: number) => {
+        if (receiveAddresses && secureOutput) {
+            if (code === undefined) {
+                return;
+            }
+            if (!secureOutput.hasSecureOutput) {
+                alertUser(t('receive.warning.secureOutput'));
+                return;
+            }
+            setVerifying(true);
+            accountApi.verifyAddress(code, receiveAddresses[addressesIndex].addresses[activeIndex].addressID)
+                .then(() => setVerifying(false));
+        }
+    };
+
+    const previous = (e: React.SyntheticEvent) => {
         e.preventDefault();
-        const activeIndex = this.state.activeIndex;
-        if (!this.state.verifying && activeIndex > 0) {
-            this.setState({
-                activeIndex: activeIndex - 1,
-            });
+        if (verifying && activeIndex > 0) {
+            setActiveIndex(activeIndex - 1);
         }
-    }
+    };
 
-    private next = (e: React.SyntheticEvent, numAddresses: number) => {
+    const next = (e: React.SyntheticEvent, numAddresses: number) => {
         e.preventDefault();
-        const { verifying, activeIndex } = this.state;
         if (!verifying && activeIndex < numAddresses - 1) {
-            this.setState({
-                activeIndex: activeIndex + 1,
-            });
+            setActiveIndex(activeIndex + 1);
         }
+    };
+
+    // enable copying only after verification has been invoked if verification is possible and not optional.
+    const forceVerification = secureOutput === undefined ? true : (secureOutput.hasSecureOutput && !secureOutput.optional);
+    const enableCopy = !forceVerification;
+
+    let verifyLabel = t('receive.verify'); // fallback
+    if (device === 'bitbox') {
+        verifyLabel = t('receive.verifyBitBox01');
+    } else if (device === 'bitbox02') {
+        verifyLabel = t('receive.verifyBitBox02');
     }
 
-    private getAccount = () => {
-        return this.props.accounts.find(({ code }) => code === this.props.code);
-    }
-
-    private getDevice = () => {
-        if (this.props.deviceIDs.length === 0) {
-            return undefined;
-        }
-        return this.props.devices[this.props.deviceIDs[0]];
-    }
-
-    public render() {
-        const {
-             t,
-            code,
-            receiveAddresses,
-            secureOutput
-        } = this.props;
-        const {
-            verifying,
-            activeIndex,
-            paired,
-            addressDialog,
-            addressType,
-        } = this.state;
-        const account = this.getAccount();
-        if (account === undefined) {
-            return null;
-        }
-        let uriPrefix = '';
+    let uriPrefix = '';
+    if (account) {
         if (account.coinCode === 'btc' || account.coinCode === 'tbtc') {
             uriPrefix = 'bitcoin:';
         } else if (account.coinCode === 'ltc' || account.coinCode === 'tltc') {
             uriPrefix = 'litecoin:';
         }
-        // enable copying only after verification has been invoked if verification is possible and not optional.
-        const forceVerification = secureOutput.hasSecureOutput && !secureOutput.optional;
-        const enableCopy = !forceVerification;
+    }
 
-        let currentAddressIndex = this.availableScriptTypes.length > 0 ? this.getIndexOfMatchingScriptType(this.availableScriptTypes[addressType]) : 0;
-        if (currentAddressIndex === -1) {
-            currentAddressIndex = 0;
-        }
-        const currentAddresses = receiveAddresses[currentAddressIndex].addresses;
-        const hasManyScriptTypes = this.availableScriptTypes.length > 1;
-        let address = currentAddresses[activeIndex].address;
+    let address = '';
+    if (currentAddresses) {
+        address = currentAddresses[activeIndex].address;
         if (!enableCopy && !verifying) {
             address = address.substring(0, 8) + '...';
         }
+    }
 
-        let verifyLabel = t('receive.verify'); // fallback
-        const device = this.getDevice();
-        if (device === 'bitbox') {
-            verifyLabel = t('receive.verifyBitBox01');
-        } else if (device === 'bitbox02') {
-            verifyLabel = t('receive.verifyBitBox02');
-        }
-        const content = (
-            <div style={{position: 'relative'}}>
-                <div className={style.qrCodeContainer}>
-                    <QRCode data={enableCopy ? uriPrefix + address : undefined} />
-                </div>
-                <div className={style.labels}>
-                    {
-                        currentAddresses.length > 1 && (
-                            <button
-                                className={style.previous}
-                                onClick={this.previous}>
-                                {(verifying || activeIndex === 0) ? (
-                                    <ArrowCirlceLeft height="24" width="24" />
-                                ) : (
-                                    <ArrowCirlceLeftActive height="24" width="24" title={t('button.previous')} />
-                                )}
-                            </button>
-                        )
-                    }
-                    <p className={style.label}>{t('receive.label')} {currentAddresses.length > 1 ? `(${activeIndex + 1}/${currentAddresses.length})` : ''}</p>
-                    {
-                        currentAddresses.length > 1 && (
-                            <button
-                                className={style.next}
-                                onClick={e => this.next(e, currentAddresses.length)}>
-                                {(verifying || activeIndex >= currentAddresses.length - 1) ? (
-                                    <ArrowCirlceRight height="24" width="24" />
-                                ) : (
-                                    <ArrowCirlceRightActive height="24" width="24" title={t('button.next')} />
-                                )}
-                            </button>
-                        )
-                    }
-                </div>
-                <CopyableInput disabled={!enableCopy} value={address} flexibleHeight />
-                { hasManyScriptTypes && (
-                    <button
-                        className={style.changeType}
-                        onClick={() => this.setState(({ addressType, addressDialog }) => ({
-                            addressDialog: !addressDialog ? { addressType } : undefined
-                        }))}>
-                        {t('receive.changeScriptType')}
-                    </button>
-                )}
-                { hasManyScriptTypes && addressDialog && (
-                    <form onSubmit={e => {
-                        e.preventDefault();
-                        this.setState(() => ({
-                            activeIndex: 0,
-                            addressType: addressDialog.addressType,
-                            addressDialog: undefined,
-                        }));
-                    }}>
-                        <Dialog medium title={t('receive.changeScriptType')} >
-                            {this.availableScriptTypes.map((scriptType, i) => (
-                                <div key={scriptType}>
-                                    <Radio
-                                        checked={addressDialog.addressType === i}
-                                        id={scriptType}
-                                        name="scriptType"
-                                        onChange={() => this.setState({ addressDialog: { addressType: i }})}
-                                        title={getScriptName(scriptType)}>
-                                        {t(`receive.scriptType.${scriptType}`)}
-                                    </Radio>
-                                    {scriptType === 'p2tr' && addressDialog.addressType === i && (
-                                        <Message type="warning">
-                                            {t('receive.taprootWarning')}
-                                        </Message>
+    const hasManyScriptTypes = availableScriptTypes.current && availableScriptTypes.current.length > 1;
+
+    return (
+        <div className="contentWithGuide">
+            <div className="container">
+                {device === 'bitbox' && (<PairedWarning deviceID={deviceIDs[0]} />)}
+                <Header title={<h2>{t('receive.title', { accountName: account?.coinName })}</h2>} />
+                <div className="innerContainer scrollableContainer">
+                    <div className="content narrow isVerticallyCentered">
+                        <div className="box large text-center">
+                        { currentAddresses && (
+                            <div style={{position: 'relative'}}>
+                                <div className={style.qrCodeContainer}>
+                                    <QRCode data={enableCopy ? uriPrefix + address : undefined} />
+                                </div>
+                                <div className={style.labels}>
+                                    { currentAddresses.length > 1 && (
+                                        <button
+                                            className={style.previous}
+                                            onClick={previous}>
+                                            {(verifying || activeIndex === 0) ? (
+                                                <ArrowCirlceLeft height="24" width="24" />
+                                            ) : (
+                                                <ArrowCirlceLeftActive height="24" width="24" title={t('button.previous')} />
+                                            )}
+                                        </button>
+                                    )}
+                                    <p className={style.label}>
+                                        {t('receive.label')} {currentAddresses.length > 1 ? `(${activeIndex + 1}/${currentAddresses.length})` : ''}
+                                    </p>
+                                    { currentAddresses.length > 1 && (
+                                        <button
+                                            className={style.next}
+                                            onClick={e => next(e, currentAddresses.length)}>
+                                            {(verifying || activeIndex >= currentAddresses.length - 1) ? (
+                                                <ArrowCirlceRight height="24" width="24" />
+                                            ) : (
+                                                <ArrowCirlceRightActive height="24" width="24" title={t('button.next')} />
+                                            )}
+                                        </button>
                                     )}
                                 </div>
-                            ))}
-                            <DialogButtons>
-                                <Button primary type="submit">
-                                    {t('button.done')}
-                                </Button>
-                            </DialogButtons>
-                        </Dialog>
-                    </form>
-                )}
-                <div className="buttons">
-                    {
-                        forceVerification && (
-                            <Button
-                                primary
-                                disabled={verifying || secureOutput === undefined}
-                                onClick={() => this.verifyAddress(currentAddressIndex)}>
-                                {t('receive.showFull')}
-                            </Button>
-                        )
-                    }
-                    {
-                        !forceVerification && (
-                            <Button
-                                primary
-                                disabled={verifying || secureOutput === undefined}
-                                onClick={() => this.verifyAddress(currentAddressIndex)}>
-                                {verifyLabel}
-                            </Button>
-                        )
-                    }
-                    <ButtonLink
-                        transparent
-                        to={`/account/${code}`}>
-                        {t('button.back')}
-                    </ButtonLink>
-                </div>
-                {
-                    forceVerification && verifying && (
-                        <div className={style.hide}></div>
-                    )
-                }
-                {
-                    forceVerification && verifying && (
-                        <Dialog
-                            title={verifyLabel}
-                            disableEscape={true}
-                            medium centered>
-                            <div className="text-center">
-                                {
-                                    isEthereumBased(account.coinCode) &&
-                                    <p>
-                                        <strong>
-                                            {t('receive.onlyThisCoin.warning', {
-                                                coinName: account.coinName,
-                                            })}
-                                        </strong><br />
-                                        {t('receive.onlyThisCoin.description')}
-                                    </p>
-                                }
-                                <QRCode data={uriPrefix + address} />
-                                <p>{t('receive.verifyInstruction')}</p>
+                                <CopyableInput disabled={!enableCopy} value={address} flexibleHeight />
+                                { hasManyScriptTypes && (
+                                    <button
+                                        className={style.changeType}
+                                        onClick={() => setAddressDialog(!addressDialog ? { addressType } : undefined)}>
+                                        {t('receive.changeScriptType')}
+                                    </button>
+                                )}
+                                { hasManyScriptTypes && addressDialog && (
+                                    <form onSubmit={e => {
+                                        e.preventDefault();
+                                        setActiveIndex(0);
+                                        setAddressType(addressDialog.addressType);
+                                        setAddressDialog(undefined);
+                                    }}>
+                                        <Dialog medium title={t('receive.changeScriptType')} >
+                                            {availableScriptTypes.current && availableScriptTypes.current.map((scriptType, i) => (
+                                                <div key={scriptType}>
+                                                    <Radio
+                                                        checked={addressDialog.addressType === i}
+                                                        id={scriptType}
+                                                        name="scriptType"
+                                                        onChange={() => setAddressDialog({ addressType: i })}
+                                                        title={getScriptName(scriptType)}>
+                                                        {t(`receive.scriptType.${scriptType}`)}
+                                                    </Radio>
+                                                    {scriptType === 'p2tr' && addressDialog.addressType === i && (
+                                                        <Message type="warning">
+                                                            {t('receive.taprootWarning')}
+                                                        </Message>
+                                                    )}
+                                                </div>
+                                            ))}
+                                            <DialogButtons>
+                                                <Button primary type="submit">
+                                                    {t('button.done')}
+                                                </Button>
+                                            </DialogButtons>
+                                        </Dialog>
+                                    </form>
+                                )}
+                                <div className="buttons">
+                                    { forceVerification && (
+                                        <Button
+                                            primary
+                                            disabled={verifying || secureOutput === undefined}
+                                            onClick={() => verifyAddress(currentAddressIndex)}>
+                                            {t('receive.showFull')}
+                                        </Button>
+                                    )}
+                                    { !forceVerification && (
+                                        <Button
+                                            primary
+                                            disabled={verifying || secureOutput === undefined}
+                                            onClick={() => verifyAddress(currentAddressIndex)}>
+                                            {verifyLabel}
+                                        </Button>
+                                    )}
+                                    <ButtonLink
+                                        transparent
+                                        to={`/account/${code}`}>
+                                        {t('button.back')}
+                                    </ButtonLink>
+                                </div>
+                                { forceVerification && verifying && (
+                                    <div className={style.hide}></div>
+                                )}
+                                { account && forceVerification && verifying && (
+                                    <Dialog
+                                        title={verifyLabel}
+                                        disableEscape={true}
+                                        medium centered>
+                                        <div className="text-center">
+                                            { isEthereumBased(account.coinCode) && (
+                                                <p>
+                                                    <strong>
+                                                        {t('receive.onlyThisCoin.warning', {
+                                                            coinName: account.coinName,
+                                                        })}
+                                                    </strong><br />
+                                                    {t('receive.onlyThisCoin.description')}
+                                                </p>
+                                            )}
+                                            <QRCode data={uriPrefix + address} />
+                                            <p>{t('receive.verifyInstruction')}</p>
+                                        </div>
+                                        <div className="m-bottom-half">
+                                            <CopyableInput value={address} flexibleHeight />
+                                        </div>
+                                    </Dialog>
+                                )}
                             </div>
-                            <div className="m-bottom-half">
-                                <CopyableInput value={address} flexibleHeight />
-                            </div>
-                        </Dialog>
-                    )
-                }
-            </div>
-        );
-
-        return (
-            <div className="contentWithGuide">
-                <div className="container">
-                    <Status type="warning" hidden={paired !== false}>
-                        {t('warning.receivePairing')}
-                    </Status>
-                    <Header title={<h2>{t('receive.title', { accountName: account.coinName })}</h2>} />
-                    <div className="innerContainer scrollableContainer">
-                        <div className="content narrow isVerticallyCentered">
-                            <div className="box large text-center">
-                                {content}
-                            </div>
+                        )}
                         </div>
                     </div>
                 </div>
-                <Guide>
-                    <Entry key="guide.receive.address" entry={t('guide.receive.address')} />
-                    <Entry key="guide.receive.whyVerify" entry={t('guide.receive.whyVerify')} />
-                    <Entry key="guide.receive.howVerify" entry={t('guide.receive.howVerify')} />
-                    <Entry key="guide.receive.plugout" entry={t('guide.receive.plugout')} />
-                    {currentAddresses.length > 1 && <Entry key="guide.receive.whyMany" entry={t('guide.receive.whyMany')} />}
-                    {currentAddresses.length > 1 && <Entry key="guide.receive.why20" entry={t('guide.receive.why20')} />}
-                    {currentAddresses.length > 1 && <Entry key="guide.receive.addressChange" entry={t('guide.receive.addressChange')} />}
-                    {receiveAddresses.length > 1 && currentAddresses.length > 1 && <Entry key="guide.receive.addressFormats" entry={t('guide.receive.addressFormats')} />}
-                </Guide>
             </div>
-        );
-    }
+            <Guide>
+                <Entry key="guide.receive.address" entry={t('guide.receive.address')} />
+                <Entry key="guide.receive.whyVerify" entry={t('guide.receive.whyVerify')} />
+                <Entry key="guide.receive.howVerify" entry={t('guide.receive.howVerify')} />
+                <Entry key="guide.receive.plugout" entry={t('guide.receive.plugout')} />
+                {currentAddresses && (
+                    <>
+                        {currentAddresses.length > 1 && <Entry key="guide.receive.whyMany" entry={t('guide.receive.whyMany')} />}
+                        {currentAddresses.length > 1 && <Entry key="guide.receive.why20" entry={t('guide.receive.why20')} />}
+                        {currentAddresses.length > 1 && <Entry key="guide.receive.addressChange" entry={t('guide.receive.addressChange')} />}
+                        {receiveAddresses && receiveAddresses.length > 1 && currentAddresses.length > 1 && <Entry key="guide.receive.addressFormats" entry={t('guide.receive.addressFormats')} />}
+                    </>
+                )}
+            </Guide>
+        </div>
+    );
 }
-
-const loadHOC = load<LoadedReceiveProps, ReceiveProps & TranslateProps>(({ code }) => ({
-    secureOutput: `account/${code}/has-secure-output`,
-    receiveAddresses: `account/${code}/receive-addresses`,
-}))(Receive);
-const HOC = translate()(loadHOC);
-export { HOC as Receive };

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -423,7 +423,7 @@ class Send extends Component<Props, State> {
     }
 
     private sendToSelf = (event: React.SyntheticEvent) => {
-        accountApi.getReceiveAddressList(this.getAccount()!.code)
+        accountApi.getReceiveAddressList(this.getAccount()!.code)()
             .then(receiveAddresses => {
                 this.setState({ recipientAddress: receiveAddresses[0].addresses[0].address });
                 this.handleFormChange(event);

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -61,6 +61,7 @@ export const AppRouter: FunctionComponent<Props> = ({ devices, deviceIDs, device
 
     const AccReceive = <InjectParams>
         <Receive
+            code={'' /* dummy to satisfy TS */}
             devices={devices}
             deviceIDs={deviceIDs}
             accounts={activeAccounts} />


### PR DESCRIPTION
- removed HOC decorators and typed has-secure-output api
- changed receive-address api to work with useLoad
- moved PairedWarning to sub component to load it conditionally
- before: if warning.secureOutput was shown it removed the keydown
  that is used to esc the receive view, and added again after the
  alert callback. This is not necessary as handleKeyDown only
  escapes if verifying is false.