### PR TITLE
frontend: add guide entry about change output

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -763,6 +763,10 @@
       }
     },
     "send": {
+      "change": {
+        "text": "The change will be returned to a Taproot address if you have at least one Taproot UTXO. If you use coin control, the change will be returned to a Taproot address if there is at least one Taproot UTXO among the selected UTXOS. In all other cases, the change is returned to a Native Segwit address.",
+        "title": "How is the change output determined?"
+      },
       "fee": {
         "text": "The fee is based on the transaction data size and not its amount. The fee targets are calculated by Bitcoin Core's fee estimation algorithm for each network priority you chose. They are shown if they have a different value from the target below.\nEconomy: 24 blocks (around 4 hours for Bitcoin, 1 hour for Litecoin)\nLow: 12 blocks (around 2 hours for Bitcoin, 30 minutes for Litecoin)\nNormal: 6 blocks (around 1 hour for Bitcoin, 15 minutes for Litecoin)\nHigh: 2 blocks (around 20 minutes for Bitcoin, 5 minutes for Litecoin)\n(A block takes on average ten minutes for Bitcoin (2.5 minutes in Litecoin) to mine and the network load may vary considerably in the above periods.)",
         "title": "How is the fee determined?"

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -37,7 +37,7 @@ import { translate, TranslateProps } from '../../../decorators/translate';
 import { debug } from '../../../utils/env';
 import { apiGet, apiPost } from '../../../utils/request';
 import { apiWebsocket } from '../../../utils/websocket';
-import { isBitcoinBased, customFeeUnit } from '../utils';
+import { isBitcoinBased, customFeeUnit, isBitcoinOnly } from '../utils';
 import { FeeTargets } from './feetargets';
 import style from './send.module.css';
 import { SelectedUTXO, UTXOs, UTXOsClass } from './utxos';
@@ -848,16 +848,15 @@ class Send extends Component<Props, State> {
                 </div>
                 <Guide>
                     <Entry key="guide.send.whyFee" entry={t('guide.send.whyFee')} />
-                    {
-                        isBitcoinBased(account.coinCode) && (
-                            <Entry key="guide.send.priority" entry={t('guide.send.priority')} />
-                        )
-                    }
-                    {
-                        isBitcoinBased(account.coinCode) && (
-                            <Entry key="guide.send.fee" entry={t('guide.send.fee')} />
-                        )
-                    }
+                    { isBitcoinBased(account.coinCode) && (
+                        <Entry key="guide.send.priority" entry={t('guide.send.priority')} />
+                    )}
+                    { isBitcoinBased(account.coinCode) && (
+                        <Entry key="guide.send.fee" entry={t('guide.send.fee')} />
+                    )}
+                    { isBitcoinOnly(account.coinCode) && (
+                        <Entry key="guide.send.change" entry={t('guide.send.change')} />
+                    )}
                     <Entry key="guide.send.revert" entry={t('guide.send.revert')} />
                     <Entry key="guide.send.plugout" entry={t('guide.send.plugout')} />
                 </Guide>


### PR DESCRIPTION
Added guide entry to explain when the change output is a Taproot,
only shown in the guide of bitcoin accounts.

The rest was updated in locize and will need a locize-pull