### PR TITLE
Frontend remove links from locize

### DIFF
--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -105,7 +105,7 @@ class Guide extends Component<Props> {
                     <div className={style.content}>
                         {children}
                         <div className={style.entry}>
-                            {t('guide.appendix.text')} <A href={t('guide.appendix.href')}>{t('guide.appendix.link')}</A>
+                            {t('guide.appendix.text')} <A href="https://shiftcrypto.ch/contact">{t('guide.appendix.link')}</A>
                         </div>
                     </div>
                 </div>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -561,10 +561,6 @@
       "title": "How can I move my coins out of the Legacy account?"
     },
     "accountRates": {
-      "link": {
-        "text": "www.coingecko.com",
-        "url": "https://www.coingecko.com/"
-      },
       "text": "We update exchange rates every minute from CoinGecko.",
       "title": "Which exchange rates apply?"
     },
@@ -577,10 +573,6 @@
       "title": "Why can't I send any {{unit}}?"
     },
     "accountSummaryAmount": {
-      "link": {
-        "text": "www.coingecko.com",
-        "url": "https://www.coingecko.com/"
-      },
       "text": "The total amount is the sum of all your crypto accounts. Exchange rates are obtained from coingecko.com.\n\nNote: If you use MyEtherWallet for tokens not supported in the BitBoxApp, they will not be included in the amount displayed.",
       "title": "How is the total amount calculated?"
     },
@@ -635,7 +627,6 @@
       }
     },
     "appendix": {
-      "href": "https://shiftcrypto.ch/contact",
       "link": "Contact us!",
       "text": "Another question?"
     },
@@ -791,8 +782,7 @@
       },
       "instructions": {
         "link": {
-          "text": "Guide to connect your node",
-          "url": "https://guides.shiftcrypto.ch/bitboxapp/full-node/"
+          "text": "Guide to connect your node"
         },
         "text": "For a full tutorial, please visit our guide:",
         "title": "How do I connect my BitBoxApp to my own full node?"
@@ -821,16 +811,14 @@
       },
       "btc-p2sh": {
         "link": {
-          "text": "Segregated witness benefits",
-          "url": "https://bitcoincore.org/en/2016/01/26/segwit-benefits/"
+          "text": "Segregated witness benefits"
         },
         "text": "This is a backwards compatible Segwit account (p2sh-p2wpkh). It uses a new transaction format that saves you network fees. The address format is similar to legacy, and as such can be used with all existing Bitcoin wallets/exchanges/services.",
         "title": "What is the Bitcoin account?"
       },
       "btc-p2wpkh": {
         "link": {
-          "text": "Bech32 adoption",
-          "url": "https://en.bitcoin.it/wiki/Bech32_adoption"
+          "text": "Bech32 adoption"
         },
         "text": "Use the new Bitcoin bech32 address format to reap the full benefits of Segwit's cheaper network fees. Remember that this format is not accepted everywhere yet.",
         "title": "What is Bitcoin bech32?"
@@ -862,8 +850,7 @@
       },
       "getDevice": {
         "link": {
-          "text": "Order a BitBox",
-          "url": "https://shiftcrypto.shop/"
+          "text": "Order a BitBox"
         },
         "text": "You can buy a BitBox in our online shop:",
         "title": "How can I get a device?"
@@ -874,8 +861,7 @@
       },
       "lostDevice": {
         "link": {
-          "text": "Backup center",
-          "url": "https://shiftcrypto.ch/backup"
+          "text": "Backup center"
         },
         "text": "You can recover your accounts on a new BitBox or with our backup center.",
         "title": "I lost my device. Now what?"

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -367,10 +367,24 @@ class Account extends Component<Props, State> {
                         <Entry key="guide.settings.btc-p2pkh" entry={t('guide.settings.btc-p2pkh')} />
                     )}
                     {this.isBTCScriptType('p2wpkh-p2sh', account, accountInfo) && (
-                        <Entry key="guide.settings.btc-p2sh" entry={t('guide.settings.btc-p2sh')} />
+                        <Entry key="guide.settings.btc-p2sh" entry={{
+                            link: {
+                                text: t('guide.settings.btc-p2sh.link.text'),
+                                url: 'https://bitcoincore.org/en/2016/01/26/segwit-benefits/'
+                            },
+                            text: t('guide.settings.btc-p2sh.text'),
+                            title: t('guide.settings.btc-p2sh.title')
+                        }} />
                     )}
                     {this.isBTCScriptType('p2wpkh', account, accountInfo) && (
-                    <Entry key="guide.settings.btc-p2wpkh" entry={t('guide.settings.btc-p2wpkh')} />
+                        <Entry key="guide.settings.btc-p2wpkh" entry={{
+                            link: {
+                                text: t('guide.settings.btc-p2wpkh.link.text'),
+                                url: 'https://en.bitcoin.it/wiki/Bech32_adoption'
+                            },
+                            text: t('guide.settings.btc-p2wpkh.text'),
+                            title: t('guide.settings.btc-p2wpkh.title')
+                        }} />
                     )}
                     {balance && balance.available.amount === '0' && (
                         <Entry key="accountSendDisabled" entry={t('guide.accountSendDisabled', { unit: balance.available.unit })} />
@@ -398,7 +412,14 @@ class Account extends Component<Props, State> {
                     <Entry key="accountFiat" entry={t('guide.accountFiat')} />
 
                     { /* careful, also used in Settings */ }
-                    <Entry key="accountRates" entry={t('guide.accountRates')} />
+                    <Entry key="accountRates" entry={{
+                        link: {
+                            text: 'www.coingecko.com',
+                            url: 'https://www.coingecko.com/'
+                        },
+                        text: t('guide.accountRates.text'),
+                        title: t('guide.accountRates.title')
+                    }} />
 
                     <Entry key="cointracking" entry={{
                         link: {

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -359,7 +359,14 @@ class AccountsSummary extends Component<Props, State> {
                 </div>
                 <Guide>
                     <Entry key="accountSummaryDescription" entry={t('guide.accountSummaryDescription')} />
-                    <Entry key="accountSummaryAmount" entry={t('guide.accountSummaryAmount')} />
+                    <Entry key="accountSummaryAmount" entry={{
+                        link: {
+                            text: 'www.coingecko.com',
+                            url: 'https://www.coingecko.com/'
+                        },
+                        text: t('guide.accountSummaryAmount.text'),
+                        title: t('guide.accountSummaryAmount.title')
+                    }} />
                 </Guide>
             </div>
         );

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -16,6 +16,7 @@
 
 import { FunctionComponent, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import i18n from '../../i18n/i18n';
 import { useLoad } from '../../hooks/api';
 import { getTesting } from '../../api/backend';
 import { Entry } from '../../components/guide/entry';
@@ -64,8 +65,24 @@ export const Waiting: FunctionComponent = () => {
             </div>
             <Guide>
                 <Entry entry={t('guide.waiting.welcome')} shown={true} />
-                <Entry entry={t('guide.waiting.getDevice')} />
-                <Entry entry={t('guide.waiting.lostDevice')} />
+                <Entry entry={{
+                    link: {
+                        text: t('guide.waiting.getDevice.link.text'),
+                        url: 'https://shiftcrypto.shop/',
+                    },
+                    text: t('guide.waiting.getDevice.text'),
+                    title: t('guide.waiting.getDevice.title'),
+                }} />
+                <Entry entry={{
+                    link: {
+                        text: t('guide.waiting.lostDevice.link.text'),
+                        url: (i18n.language === 'de')
+                            ? 'https://shiftcrypto.support/help/de-de/5-backup/8-wie-kann-ich-ein-bitbox02-wallet-in-ein-drittanbieter-wallet-importieren'
+                            : 'https://shiftcrypto.support/help/en-us/5-backup/8-how-do-i-restore-my-wallet-if-my-bitbox02-is-lost',
+                    },
+                    text: t('guide.waiting.lostDevice.text'),
+                    title: t('guide.waiting.lostDevice.title'),
+                }} />
                 <Entry entry={t('guide.waiting.internet')} />
                 <Entry entry={t('guide.waiting.deviceNotRecognized')} />
                 <Entry entry={t('guide.waiting.useWithoutDevice')} />

--- a/frontends/web/src/routes/settings/electrum.jsx
+++ b/frontends/web/src/routes/settings/electrum.jsx
@@ -318,7 +318,7 @@ class ElectrumSettings extends Component {
     }
 
     render() {
-        const { t } = this.props;
+        const { i18n, t } = this.props;
         const { testing, activeTab } = this.state;
         return (
             <div className="contentWithGuide">
@@ -366,7 +366,16 @@ class ElectrumSettings extends Component {
                     <Entry key="guide.settings-electrum.options" entry={t('guide.settings-electrum.options')} />
                     <Entry key="guide.settings-electrum.connection" entry={t('guide.settings-electrum.connection')} />
                     <Entry key="guide.settings-electrum.tor" entry={t('guide.settings-electrum.tor')} />
-                    <Entry key="guide.settings-electrum.instructions" entry={t('guide.settings-electrum.instructions')} />
+                    <Entry key="guide.settings-electrum.instructions" entry={{
+                        link: {
+                            text: t('guide.settings-electrum.instructions.link.text'),
+                            url: (i18n.language === 'de')
+                                ? 'https://shiftcrypto.support/help/de-de/14-privatsphare/29-verbindung-der-bitboxapp-zu-meinem-bitcoin-full-node'
+                                : 'https://shiftcrypto.support/help/en-us/14-privacy/29-how-to-connect-the-bitboxapp-to-my-own-full-node'
+                        },
+                        text: t('guide.settings-electrum.instructions.text'),
+                        title: t('guide.settings-electrum.instructions.title')
+                    }} />
                 </Guide>
             </div>
         );

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -298,7 +298,14 @@ class Settings extends Component<Props, State> {
                 <Guide>
                     <Entry key="guide.settings.servers" entry={t('guide.settings.servers')} />
                     <Entry key="guide.settings-electrum.why" entry={t('guide.settings-electrum.why')} />
-                    <Entry key="guide.accountRates" entry={t('guide.accountRates')} />
+                    <Entry key="guide.accountRates" entry={{
+                        link: {
+                            text: 'www.coingecko.com',
+                            url: 'https://www.coingecko.com/'
+                        },
+                        text: t('guide.accountRates.text'),
+                        title: t('guide.accountRates.title')
+                    }} />
                     <Entry key="guide.settings-electrum.tor" entry={t('guide.settings-electrum.tor')} />
                 </Guide>
             </div>


### PR DESCRIPTION
There is no need to maintain links to the support section and other
resources in the translation. The original idea was to use different
links for each language but it turns out that this was never used.

Moving all remaining links from translation file to the frontend.

tested:

- Waitscreen order and backup center
- Accountsummary coingecko link
- Connect to own node (en and de)
- Guide appendix
- BitBox01 guide in non-unified bech32 accounts