### PR TITLE
frontend/send: enable QR code scanner for ETH-based accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Bundle BitBox02 firmware version v9.10.0
 - Add support for BIP-86 taproot receive addresses
 - Show coin subtotals in 'My portfolio'
+- Add QR-code scanner to Ethereum
 - Transaction details: make transaction ID copyable without opening the block explorer
 - Improve account loading speed when there are many transactions in the account
 - Desktop: add a configuration option using the environment variable `BITBOXAPP_RENDER` to enable


### PR DESCRIPTION
It implements a subset of
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-681.md, not
looking at any parameters.

Same as in BTC/LTC, the QR code scanner result parser is forgiving and
accepts anything. The send form validation will catch it if the parsed
result is not a valid recipient address.