### PR TITLE
frontend: change address type should change to first address

### DIFF
--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -260,6 +260,7 @@ class Receive extends Component<Props, State> {
                     <form onSubmit={e => {
                         e.preventDefault();
                         this.setState(() => ({
+                            activeIndex: 0,
                             addressType: addressDialog.addressType,
                             addressDialog: undefined,
                         }));


### PR DESCRIPTION
This is a regression, the address index was set to the first
address when changing address type, introduced in:
- https://github.com/digitalbitbox/bitbox-wallet-app/commit/6622cfa8680d12ecd778075b61b8bb7f9650b9cb

Alternatively this is also fixed in https://github.com/digitalbitbox/bitbox-wallet-app/pull/1668