### PR TITLE
frontend: only show buy button if there is no tx and no incoming tx

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -297,6 +297,12 @@ class Account extends Component<Props, State> {
             }
         }
 
+        const showBuyButton = this.supportsBuy()
+            && balance
+            && balance.available.amount === '0'
+            && !balance.hasIncoming
+            && transactions && transactions.length === 0;
+
         return (
             <div className="contentWithGuide">
                 <div className="container">
@@ -313,7 +319,11 @@ class Account extends Component<Props, State> {
                     {status.synced && this.dataLoaded() && isBitcoinBased(account.coinCode) && <HeadersSync coinCode={account.coinCode} />}
                     <div className="innerContainer scrollableContainer">
                         <div className="content padded">
-                            { this.supportsBuy() && balance && (balance.available.amount === '0') && <BuyCTA code={code} unit={balance.available.unit} /> }
+                            { showBuyButton && (
+                                <BuyCTA
+                                    code={code}
+                                    unit={balance.available.unit} />
+                            )}
                             <Status
                                 className="m-bottom-default"
                                 hidden={!WithCoinTypeInfo.includes(code)}


### PR DESCRIPTION
The buy button is currently shown if the balance is zero, but
didn't take into consideration if there is an incoming tx or
if there was transactions in the past.

Changed the conditions on when to show the buy button on the
account overview, taking incoming and old transactions into
account.