### PR TITLE
android: set the FLAG_SECURE flag preventing screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Android: prevent app window from appearing in screenshots or from being viewed on non-secure displays
 
 ## 4.32.0 [2022-03-16]
 - Bundle BitBox02 firmware version v9.10.0

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -23,6 +23,7 @@ import androidx.lifecycle.ViewModelProviders;
 import android.os.Handler;
 import android.os.Message;
 import android.os.Bundle;
+import android.view.WindowManager;
 import android.webkit.CookieManager;
 import android.webkit.JavascriptInterface;
 import android.webkit.MimeTypeMap;
@@ -102,7 +103,10 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         Util.log("lifecycle: onCreate");
 
-        getSupportActionBar().hide(); // hide title bar with app name.
+        // Hide title bar with app name.
+        getSupportActionBar().hide();
+        // Treat the content of the window as secure, preventing it from appearing in screenshots or from being viewed on non-secure displays.
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
         setContentView(R.layout.activity_main);
         final WebView vw = (WebView)findViewById(R.id.vw);
         // For onramp iframe'd widgets like MoonPay.


### PR DESCRIPTION
And preventing display of the app window e.g. in the app switcher.