### PR TITLE
frontend: fix alert user ui text overflow

### DIFF
--- a/frontends/web/src/components/alert/Alert.tsx
+++ b/frontends/web/src/components/alert/Alert.tsx
@@ -89,7 +89,7 @@ class Alert extends Component<WithTranslation, State> {
                     textCenter={!asDialog}
                     fullscreen>
                     <ViewHeader title={multilineMarkup({
-                        tagName: 'div',
+                        tagName: 'span',
                         markup: message,
                     })} />
                     <ViewButtons>

--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -88,6 +88,7 @@
     color: var(--color-secondary);
     font-size: var(--size-default);
     margin-bottom: var(--space-default);
+    word-break: break-word;
 }
 .dialog .header {
     padding-left: var(--space-default);
@@ -126,6 +127,9 @@
     font-weight: 400;
     margin-bottom: var(--space-half);
 }
+.title span {
+    display: block;
+}
 
 .header p {
     margin-top: var(--space-quarter);
@@ -147,6 +151,7 @@
     flex-grow: 1;
     flex-shrink: 0;
     min-height: 80px;
+    word-break: break-word;
 }
 @media (max-width: 768px) {
     .content {


### PR DESCRIPTION
The alertUser component recently changed to use view component
internally, this didn't handle long text well, long text was
displayed overflowing the width of the dialog.

Changed styling of the view header and content to break-words
which fixes this issue.

Also changed, that multiline messages do not use div elements
as that is not allowed as child of H1 elements, which is what
ViewHeader uses.

Tested:
- long invalid addresses in electrum settings
- normal stupid simple message signing
- enable passphrase