### PR TITLE
frontend: improve visual loading of the account summary view

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -39,7 +39,7 @@ interface SidebarProps {
 }
 
 interface SubscribedProps {
-    keystores: Array<{ type: 'hardware' | 'software' }>;
+    keystores?: Array<{ type: 'hardware' | 'software' }>;
 }
 
 type Props = SubscribedProps & SharedPanelProps & SidebarProps & TranslateProps;
@@ -164,7 +164,7 @@ class Sidebar extends Component<Props> {
                         </div>
                     </Link>
                     <div className="sidebarHeaderContainer">
-                        <span className="sidebarHeader" hidden={!keystores.length}>
+                        <span className="sidebarHeader" hidden={!keystores?.length}>
                             {t('sidebar.accounts')}
                         </span>
                     </div>
@@ -253,7 +253,7 @@ class Sidebar extends Component<Props> {
                             <span className="sidebar_label">{t('sidebar.settings')}</span>
                         </NavLink>
                     </div>
-                    {(debug && keystores.some(({ type }) => type === 'software') && deviceIDs.length === 0) && (
+                    {(debug && keystores?.some(({ type }) => type === 'software') && deviceIDs.length === 0) && (
                         <div key="eject" className="sidebarItem">
                             <a href="#" onClick={eject}>
                                 <div className="single">
@@ -279,7 +279,7 @@ function eject(e: React.SyntheticEvent): void {
 
 const subscribeHOC = subscribe<SubscribedProps, SharedPanelProps & SidebarProps & TranslateProps>(
     { keystores: 'keystores' },
-    true,
+    false,
     false,
 )(Sidebar);
 

--- a/frontends/web/src/components/skeleton/skeleton.module.css
+++ b/frontends/web/src/components/skeleton/skeleton.module.css
@@ -1,0 +1,21 @@
+.skeleton {
+    animation: skeleton-loading 1.4s ease infinite;
+    background: linear-gradient(90deg, rgba(190, 190, 190, .2) 25%, rgba(129, 129, 129, .24) 37%, rgba(190, 190, 190, .2) 63%);
+    background-size: 400% 100%;
+    display: inline-block;
+    max-width: 100%;
+    overflow: clip;
+}
+.skeleton::before {
+    /* Add an invisible underscore _ character to inherit the parents font-size and force the correct height */
+    color: transparent;
+    content: "_";
+    display: block;
+    line-height: 1;
+    min-width: 1em;
+}
+
+@keyframes skeleton-loading {
+    0% { background-position: 100% 50%; }
+    to { background-position: 0 50%; }
+}

--- a/frontends/web/src/components/skeleton/skeleton.tsx
+++ b/frontends/web/src/components/skeleton/skeleton.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FunctionComponent } from 'react';
+import style from './skeleton.module.css';
+
+type Props = {
+    fontSize?: string;
+    minWidth?: string;
+};
+
+export const Skeleton: FunctionComponent<Props> = ({
+    fontSize,
+    minWidth = '100%',
+}) => {
+    return (
+        <span className={style.skeleton} style={{ fontSize, minWidth }} />
+    );
+};

--- a/frontends/web/src/routes/account/info/buyCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyCTA.tsx
@@ -17,9 +17,9 @@ const BuyCTAComponent: FunctionComponent<Props> = ({code, unit, t}) => {
     const onCTA = () => route(code ? `/buy/info/${code}` : '/buy/info');
     return (
     <div className={`${styles.main} columns-container`}>
-        <h3 className="column">{t('accountInfo.buyCTA.information.looksEmpty')}</h3>
-        <h3 className="column">{t('accountInfo.buyCTA.information.start')}</h3>
-        <div className="column">
+        <h3 className="subTitle">{t('accountInfo.buyCTA.information.looksEmpty')}</h3>
+        <h3>{t('accountInfo.buyCTA.information.start')}</h3>
+        <div>
             <Button primary onClick={onCTA}>{unit ? t('accountInfo.buyCTA.buy', {unit}) : t('accountInfo.buyCTA.buyCrypto')}</Button>
         </div>
     </div>);

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -42,6 +42,10 @@
     font-weight: 400;
 }
 
+.table tr td.noAccount {
+    text-align: center;
+}
+
 .table tr > td:not(:first-child),
 .table tr > th:not(:first-child) {
     text-align: right;

--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -9,6 +9,10 @@
 }
 
 .chartUpdatingMessage {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
   text-align: center;
 }
 
@@ -16,6 +20,7 @@
   display: flex;
   flex-wrap: wrap;
   margin-bottom: var(--spacing-half);
+  min-height: 68px;
 }
 
 .summary {}
@@ -49,6 +54,12 @@
 .filters button.filterActive {
   background: var(--color-blue);
   border-color: var(--color-blue);
+  color: var(--color-white);
+}
+
+.filters button[disabled] {
+  background: var(--color-mediumgray);
+  border-color: var(--color-mediumgray);
   color: var(--color-white);
 }
 

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -15,22 +15,19 @@
  */
 
 import { createChart, IChartApi, BarsInfo, LineData, LineStyle, LogicalRange, ISeriesApi, UTCTimestamp, MouseEventHandler, MouseEventParams, BarPrice } from 'lightweight-charts';
-import { Component, createRef} from 'react';
-import { Fiat } from '../../../api/account';
+import { Component, createRef, ReactChild} from 'react';
+import { ISummary } from '../../../api/account';
 import { translate, TranslateProps } from '../../../decorators/translate';
+import { Skeleton } from '../../../components/skeleton/skeleton';
 import { formatCurrency, formatNumber } from '../../../components/rates/rates';
 import styles from './chart.module.css';
 
 export type ChartData = LineData[];
 
-interface ChartProps {
-    // If undefined, data is missing.
-    dataDaily?: ChartData;
-    dataHourly?: ChartData;
-    fiatUnit: Fiat;
-    total: number | null;
-    isUpToDate: boolean;
-}
+type ChartProps = {
+    data: ISummary;
+    noDataPlaceholder?: ReactChild;
+};
 
 interface State {
     display: 'week' | 'month' | 'year' | 'all';
@@ -53,6 +50,17 @@ class Chart extends Component<Props, State> {
     private lineSeries?: ISeriesApi<'Area'>;
     private resizeTimerID?: any;
     private height: number = 300;
+
+    static readonly defaultProps: ChartProps = {
+        data: {
+            chartDataMissing: true,
+            chartDataDaily: [],
+            chartDataHourly: [],
+            chartFiat: 'USD',
+            chartTotal: null,
+            chartIsUpToDate: false,
+        }
+    }
 
     public readonly state: State = {
         display: 'all',
@@ -77,28 +85,29 @@ class Chart extends Component<Props, State> {
     }
 
     public componentDidUpdate(prev: Props) {
-        const { dataDaily, dataHourly } = this.props;
+        const { chartDataDaily, chartDataHourly } = this.props.data;
         if (!this.chart) {
             this.createChart();
         }
         if (
-            (this.lineSeries && prev.dataDaily && prev.dataHourly && dataDaily && dataHourly)
+            (this.lineSeries && prev.data.chartDataDaily && prev.data.chartDataHourly && chartDataDaily && chartDataHourly)
             && (
-                prev.dataDaily.length !== dataDaily.length
-                || prev.dataHourly.length !== dataHourly.length
+                prev.data.chartDataDaily.length !== chartDataDaily.length
+                || prev.data.chartDataHourly.length !== chartDataHourly.length
             )
         ) {
-            const data = this.state.source === 'hourly' ? dataHourly : dataDaily;
+            const data = this.state.source === 'hourly' ? chartDataHourly : chartDataDaily;
             this.lineSeries.setData(data);
         }
     }
 
     private hasData = () => {
-        return this.props.dataDaily && this.props.dataDaily.length;
+        return this.props.data.chartDataDaily && this.props.data.chartDataDaily.length;
     }
 
     private createChart = () => {
-        if (this.ref.current && this.hasData()) {
+        const { data: { chartIsUpToDate, chartDataMissing } } = this.props;
+        if (this.ref.current && this.hasData() && (chartIsUpToDate && !chartDataMissing)) {
             if (!this.chart) {
                 this.chart = createChart(this.ref.current, {
                     width: this.ref.current.offsetWidth,
@@ -162,7 +171,7 @@ class Chart extends Component<Props, State> {
                 lineColor: 'rgba(94, 148, 192, 1)',
                 crosshairMarkerRadius: 6,
             });
-            this.lineSeries.setData(this.props.dataDaily as ChartData);
+            this.lineSeries.setData(this.props.data.chartDataDaily as ChartData);
             this.chart.timeScale().subscribeVisibleLogicalRangeChange(this.calculateChange);
             this.chart.subscribeCrosshairMove(this.handleCrosshair as MouseEventHandler);
             this.chart.timeScale().fitContent();
@@ -201,8 +210,8 @@ class Chart extends Component<Props, State> {
     }
 
     private displayWeek = () => {
-        if (this.state.source !== 'hourly' && this.lineSeries && this.props.dataHourly && this.chart) {
-            this.lineSeries.setData(this.props.dataHourly);
+        if (this.state.source !== 'hourly' && this.lineSeries && this.props.data.chartDataHourly && this.chart) {
+            this.lineSeries.setData(this.props.data.chartDataHourly || []);
             this.chart.applyOptions({ timeScale: { timeVisible: true } });
         }
         this.setState(
@@ -222,8 +231,8 @@ class Chart extends Component<Props, State> {
     }
 
     private displayMonth = () => {
-        if (this.state.source !== 'daily' && this.lineSeries && this.props.dataDaily && this.chart) {
-            this.lineSeries.setData(this.props.dataDaily);
+        if (this.state.source !== 'daily' && this.lineSeries && this.props.data.chartDataDaily && this.chart) {
+            this.lineSeries.setData(this.props.data.chartDataDaily || []);
             this.chart.applyOptions({ timeScale: { timeVisible: false } });
         }
         this.setState(
@@ -243,8 +252,8 @@ class Chart extends Component<Props, State> {
     }
 
     private displayYear = () => {
-        if (this.state.source !== 'daily' && this.lineSeries && this.props.dataDaily && this.chart) {
-            this.lineSeries.setData(this.props.dataDaily);
+        if (this.state.source !== 'daily' && this.lineSeries && this.props.data.chartDataDaily && this.chart) {
+            this.lineSeries.setData(this.props.data.chartDataDaily);
             this.chart.applyOptions({ timeScale: { timeVisible: false } });
         }
         this.setState(
@@ -264,8 +273,8 @@ class Chart extends Component<Props, State> {
     }
 
     private displayAll = () => {
-        if (this.state.source !== 'daily' && this.lineSeries && this.props.dataDaily && this.chart) {
-            this.lineSeries.setData(this.props.dataDaily);
+        if (this.state.source !== 'daily' && this.lineSeries && this.props.data.chartDataDaily && this.chart) {
+            this.lineSeries.setData(this.props.data.chartDataDaily);
             this.chart.applyOptions({ timeScale: { timeVisible: false } });
         }
         this.setState(
@@ -280,7 +289,7 @@ class Chart extends Component<Props, State> {
     }
 
     private calculateChange = () => {
-        const data = this.props[this.state.source === 'daily' ? 'dataDaily' : 'dataHourly'];
+        const data = this.props.data[this.state.source === 'daily' ? 'chartDataDaily' : 'chartDataHourly'];
         if (!data || !this.chart || !this.lineSeries) {
             return;
         }
@@ -300,7 +309,7 @@ class Chart extends Component<Props, State> {
             return;
         }
         const valueFrom = data[rangeFrom].value;
-        const valueTo = this.props.total;
+        const valueTo = this.props.data.chartTotal;
         const valueDiff = valueTo ? valueTo - valueFrom : 0;
         this.setState({
             difference: ((valueDiff / valueFrom) * 100),
@@ -356,7 +365,17 @@ class Chart extends Component<Props, State> {
     }
 
     public render() {
-        const { t, dataDaily, fiatUnit, isUpToDate, total } = this.props;
+        const {
+            t,
+            data: {
+                chartDataDaily,
+                chartDataMissing,
+                chartFiat,
+                chartIsUpToDate,
+                chartTotal,
+            },
+            noDataPlaceholder,
+        } = this.props;
         const {
             difference,
             diffSince,
@@ -367,58 +386,71 @@ class Chart extends Component<Props, State> {
             toolTipLeft,
             toolTipTime,
         } = this.state;
-        if (dataDaily === undefined) {
-            return (
-                <p className={styles.chartUpdatingMessage}>
-                    {t('chart.dataMissing')}
-                </p>
-            );
-        }
-        const diff = difference && Number.isFinite(difference) ? (
-            <span className={styles[difference < 0 ? 'down' : 'up']} title={diffSince}>
-                <span className={styles.arrow}>
-                    {difference < 0 ? (<ArrowUp />) : (<ArrowDown />)}
-                </span>
-                <span className={styles.diffValue}>
-                    {formatNumber(difference, 2)}
-                    <span className={styles.diffUnit}>%</span>
-                </span>
-            </span>
-        ) : null;
-
+        const hasDifferenece = difference && Number.isFinite(difference);
+        const hasData = this.hasData();
         return (
             <section className={styles.chart}>
                 <header>
                     <div className={styles.summary}>
-                        {total ? (
-                            <div className={styles.totalValue}>
-                                {formatCurrency(total, fiatUnit)}
-                                <span className={styles.totalUnit}>{fiatUnit}</span>
-                            </div>
-                        ) : null}
-                        {diff}
-                    </div>
-                    { this.hasData() ? (
-                        <div className={styles.filters}>
-                            <button className={display === 'week' ? styles.filterActive : undefined} onClick={this.displayWeek}>
-                                {t('chart.filter.week')}
-                            </button>
-                            <button className={display === 'month' ? styles.filterActive : undefined} onClick={this.displayMonth}>
-                                {t('chart.filter.month')}
-                            </button>
-                            <button className={display === 'year' ? styles.filterActive : undefined} onClick={this.displayYear}>
-                                {t('chart.filter.year')}
-                            </button>
-                            <button className={display === 'all' ? styles.filterActive : undefined} onClick={this.displayAll}>
-                                {t('chart.filter.all')}
-                            </button>
+                        <div className={styles.totalValue}>
+                            {chartTotal !== null ? formatCurrency(chartTotal, chartFiat) : (
+                                <Skeleton minWidth="220px" />
+                            )}
+                            <span className={styles.totalUnit}>
+                                {chartTotal !== null && chartFiat}
+                            </span>
                         </div>
-                    ) : null }
-                </header>
-                <div className={styles.chartCanvas}>
-                    <div className={styles.chartUpdatingMessage}>
-                        {!isUpToDate ? t('chart.dataUpdating') : null}
+                        <span className={!hasDifferenece ? '' : (
+                            styles[difference < 0 ? 'down' : 'up']
+                        )} title={diffSince}>
+                            {hasDifferenece ? (
+                            <>
+                                <span className={styles.arrow}>
+                                    {(difference < 0) ? (<ArrowUp />) : (<ArrowDown />)}
+                                </span>
+                                <span className={styles.diffValue}>
+                                    {formatNumber(difference, 2)}
+                                    <span className={styles.diffUnit}>%</span>
+                                </span>
+                            </>
+                            ) : chartTotal === 0 ? null : (<Skeleton fontSize="1.125rem" minWidth="125px" />)}
+                        </span>
                     </div>
+                    <div className={styles.filters}>
+                        <button
+                            className={display === 'week' ? styles.filterActive : undefined}
+                            disabled={!hasData || chartTotal === 0}
+                            onClick={this.displayWeek}>
+                            {t('chart.filter.week')}
+                        </button>
+                        <button
+                            className={display === 'month' ? styles.filterActive : undefined}
+                            disabled={!hasData || chartTotal === 0}
+                            onClick={this.displayMonth}>
+                            {t('chart.filter.month')}
+                        </button>
+                        <button
+                            className={display === 'year' ? styles.filterActive : undefined}
+                            disabled={!hasData || chartTotal === 0}
+                            onClick={this.displayYear}>
+                            {t('chart.filter.year')}
+                        </button>
+                        <button
+                            className={display === 'all' ? styles.filterActive : undefined}
+                            disabled={!hasData || chartTotal === 0}
+                            onClick={this.displayAll}>
+                            {t('chart.filter.all')}
+                        </button>
+                    </div>
+                </header>
+                <div className={styles.chartCanvas} style={{minHeight: `${this.height}px`}}>
+                    {(!chartIsUpToDate || chartDataMissing) ? (
+                        <div className={styles.chartUpdatingMessage} style={{height: `${this.height}px`}}>
+                            {chartDataDaily === undefined
+                                ? t('chart.dataMissing')
+                                : t('chart.dataUpdating')}
+                        </div>
+                    ) : hasData ? null : noDataPlaceholder}
                     <div ref={this.ref} className={styles.invisible}></div>
                     <span
                         ref={this.refToolTip}
@@ -428,8 +460,8 @@ class Chart extends Component<Props, State> {
                         {toolTipValue !== undefined ? (
                             <span>
                                 <h2 className={styles.toolTipValue}>
-                                    {formatCurrency(toolTipValue, fiatUnit)}
-                                    <span className={styles.toolTipUnit}>{fiatUnit}</span>
+                                    {formatCurrency(toolTipValue, chartFiat)}
+                                    <span className={styles.toolTipUnit}>{chartFiat}</span>
                                 </h2>
                                 <span className={styles.toolTipTime}>
                                     {this.renderDate(toolTipTime * 1000)}


### PR DESCRIPTION
Showing a placeholder (Skeleton) during loading improves the
user experience as there is less layout shifting and clear
indicators where content can be expected.

The skeleton component adds an invisible character so that the
CSS automatically inherits font-size from the parent in most
cases this sets the height correctly, if not there is a fontSize
prop to set the height. The component also has a minWidth prop
to indicate the desired width.

Changes:
- use skeleton for account summary view
- change chart on summary to always take a fixed height
- disable chart buttons until chart is loaded
- render sidebar asap even if subscribed keystores HOC is still
  loading
- just pass data to chart component and let it handle it
- changed from setting accountsPerCoin once onmount to creating the
  map on the fly
- conditionally show buy button only in empty charts

Test:
- rm cache, cache/exchangerates, cache/headers-* or cache/account-*
- start the app and observe loading
- alternative generate a performance report in webdev with the
  lighthouse tool (devtools, select desktop) to see a recording
  of the whole loading from first-paint to fully loaded app

If the wallet is empty it shows a buy button, but if the wallet
ever had data showing a buy button on the summary next to the
chart clutters the layout. Removing the buy on the summary when
there is a chart looks more clean. The buy button is still visible
on the empty accounts.