### PR TITLE
frontend: disable chart filter buttons if chartdatamissing

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -101,8 +101,8 @@ class Chart extends Component<Props, State> {
         }
     }
 
-    private hasData = () => {
-        return this.props.data.chartDataDaily && this.props.data.chartDataDaily.length;
+    private hasData = (): boolean => {
+        return this.props.data.chartDataDaily && this.props.data.chartDataDaily.length > 0;
     }
 
     private createChart = () => {
@@ -388,6 +388,7 @@ class Chart extends Component<Props, State> {
         } = this.state;
         const hasDifferenece = difference && Number.isFinite(difference);
         const hasData = this.hasData();
+        const disableFilters = !hasData || chartTotal === 0 || chartDataMissing;
         return (
             <section className={styles.chart}>
                 <header>
@@ -419,25 +420,25 @@ class Chart extends Component<Props, State> {
                     <div className={styles.filters}>
                         <button
                             className={display === 'week' ? styles.filterActive : undefined}
-                            disabled={!hasData || chartTotal === 0}
+                            disabled={disableFilters}
                             onClick={this.displayWeek}>
                             {t('chart.filter.week')}
                         </button>
                         <button
                             className={display === 'month' ? styles.filterActive : undefined}
-                            disabled={!hasData || chartTotal === 0}
+                            disabled={disableFilters}
                             onClick={this.displayMonth}>
                             {t('chart.filter.month')}
                         </button>
                         <button
                             className={display === 'year' ? styles.filterActive : undefined}
-                            disabled={!hasData || chartTotal === 0}
+                            disabled={disableFilters}
                             onClick={this.displayYear}>
                             {t('chart.filter.year')}
                         </button>
                         <button
                             className={display === 'all' ? styles.filterActive : undefined}
-                            disabled={!hasData || chartTotal === 0}
+                            disabled={disableFilters}
                             onClick={this.displayAll}>
                             {t('chart.filter.all')}
                         </button>


### PR DESCRIPTION
The chart filter buttons to change the chart to display
week, month, year and all is currently only checking
if the chart contains any data and the total is not 0.

But if the chart is updating the buttons are already active
even though the chart has not loaded and is displaying
updating data.

Changed to check for chartDataMissing and keep the buttons
disabled until everything is up to date.