### PR TITLE
go: update Go to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   # https://docs.github.com/en/packages/guides/pushing-and-pulling-docker-images
   #
   # Keep this in sync with default in scripts/travis-ci.sh.
-  CI_IMAGE: ghcr.io/digitalbitbox/bitbox-wallet-app-ci:11
+  CI_IMAGE: ghcr.io/digitalbitbox/bitbox-wallet-app-ci:14
   TRAVIS_BUILD_DIR: ${{github.workspace}}
 
 jobs:
@@ -115,7 +115,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.18.x
       - name: Build macOS app
         run: >
           ./scripts/travis-ci.sh qt-osx;

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,8 @@
 
 # options for analysis running
 run:
+  go: 1.18
+
   # default concurrency is a available CPU number
   concurrency: 4
 
@@ -84,6 +86,9 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - golint
+    - scopelint
+    - interfacer
     - gosec
     - bodyclose
     - dogsled
@@ -102,6 +107,31 @@ linters:
     - stylecheck
     - whitespace
     - wsl
+    - execinquery
+    - ireturn
+    - wrapcheck
+    - varnamelen
+    - tagliatelle
+    - paralleltest
+    - nonamedreturns
+    - noctx
+    - nlreturn
+    - cyclop
+    - ifshort
+    - exhaustive
+    - nilnil
+    - nilerr
+    - forcetypeassert
+    - exhaustivestruct
+    - exhaustruct
+    - maintidx
+    - errorlint
+    - gofumpt
+    - gci
+    - errname
+    - forbidigo
+    - makezero
+    - nolintlint
   disable-all: false
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -21,21 +21,22 @@ catch:
 	@echo "Choose a make target."
 envinit:
 	# Keep golangci-lint version in sync with what's in .github/workflows/ci.yml.
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.43.0
-	GO111MODULE=off go get -u github.com/stretchr/testify # needed for mockery
-	GO111MODULE=on go get -u github.com/vektra/mockery/...
-	GO111MODULE=off go get -u github.com/matryer/moq
-	GO111MODULE=off go get golang.org/x/tools/cmd/goimports
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.46.1
+	go install github.com/vektra/mockery/v2@latest
+	go install github.com/matryer/moq@latest
+	go install golang.org/x/tools/cmd/goimports@latest
 	go install golang.org/x/mobile/cmd/gomobile@latest
+	# The gomobile/gobind libs are also needed when using `gomobile bind`, but it's not compatible with vendoring:
+	# https://github.com/golang/go/issues/50994#issuecomment-1032754206
+	GO111MODULE=off go get -u golang.org/x/mobile/cmd/gomobile
 	gomobile init
 # Initializiation on MacOS
 #  - run make from $GOPATH/src/github.com/digitalbitbox/bitbox-wallet-app
 #  - additional dependencies: Qt 5.15 & Xcode command line tools
-#  - add to $PATH: /usr/local/opt/go@1.16/bin
+#  - add to $PATH: /usr/local/opt/go@1.18/bin
 osx-init:
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-	brew install go@1.16
-	brew install qt@5
+	brew install go@1.18	brew install qt@5
 	$(MAKE) envinit
 servewallet:
 	go run -mod=vendor ./cmd/servewallet

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The below instructions assume a unix environment.
 
 To build the app or run the development workflow, the following dependencies need to be installed:
 
-- [Go](https://golang.org/doc/install) version 1.16
+- [Go](https://golang.org/doc/install) version 1.18
 - [Node.js](https://nodejs.org/) version 14.x
 - [NPM](https://docs.npmjs.com/about-npm-versions) version 7.x or newer
 - [Qt5](https://www.qt.io) version 5.15.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,14 @@ environment:
   nodejs_version: "16"
   matrix:
     - QT: C:\Qt\5.15.2\msvc2019_64
-      GOROOT: C:\go116
+      GOROOT: C:\go118
       GOPATH: C:\gopath\
       PLATFORM: amd64
       COMPILER: msvc
 
 # https://www.appveyor.com/docs/windows-images-software/#golang
 # If you change this, also change the GOROOT variable above to point to the right installation folder.
-stack: go 1.16
+stack: go 1.18
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/backend/accounts/feetarget.go
+++ b/backend/accounts/feetarget.go
@@ -62,6 +62,6 @@ const (
 	// estimated automatically.
 	FeeTargetCodeCustom FeeTargetCode = "custom"
 
-	// DefaultFeeTarget is the default fee target
+	// DefaultFeeTarget is the default fee target.
 	DefaultFeeTarget = FeeTargetCodeNormal
 )

--- a/backend/accounts/transaction.go
+++ b/backend/accounts/transaction.go
@@ -47,7 +47,8 @@ const (
 	// TxStatusComplete means the tx is complete, depending on the number of confirmations needed
 	// for the respective coin.
 	TxStatusComplete TxStatus = "complete"
-	// TxStatusFailed means the tx is confirmed but considered failed, e.g. a ETH transaction which
+	// TxStatusFailed means the tx is confirmed but considered failed, e.g. a ETH transaction with a
+	// too low gas limit.
 	TxStatusFailed TxStatus = "failed"
 )
 

--- a/backend/coins/btc/maketx/txsize_internal_test.go
+++ b/backend/coins/btc/maketx/txsize_internal_test.go
@@ -39,6 +39,7 @@ var scriptTypes = []signing.ScriptType{
 
 func testEstimateTxSize(
 	t *testing.T, useSegwit bool, outputScriptType, changeScriptType signing.ScriptType) {
+	t.Helper()
 	// A signature can be 70 or 71 bytes (excluding sighash op).
 	// We take one that has 71 bytes, as the size function returns the maximum possible size.
 	sigBytes, err := hex.DecodeString(

--- a/backend/coins/coin/codes.go
+++ b/backend/coins/coin/codes.go
@@ -32,7 +32,7 @@ const (
 	CodeETH Code = "eth"
 	// CodeTETH is Ethereum Ropsten.
 	CodeTETH Code = "teth"
-	// CodeRETH is Ethereum Rinkeby
+	// CodeRETH is Ethereum Rinkeby.
 	CodeRETH Code = "reth"
 	// CodeERC20TEST is an arbitrarily picked test ERC20 token on Ropsten.
 	CodeERC20TEST Code = "erc20Test"

--- a/backend/devices/bitbox/error.go
+++ b/backend/devices/bitbox/error.go
@@ -37,7 +37,7 @@ const (
 	// listing the backups.
 	errSDOpenDir = 403
 
-	// ========= Below are error codes defined locally, not by the BitBox firmware. ========
+	// ========= Below are error codes defined locally, not by the BitBox firmware.
 
 	errPINIncorrect     = 10000
 	errReplacePINFailed = 10001

--- a/backend/rates/history_test.go
+++ b/backend/rates/history_test.go
@@ -249,7 +249,6 @@ func BenchmarkLoadHistoryBucket(b *testing.B) {
 	updater := NewRateUpdater(nil, dbdir)
 	updater.dumpHistoryBucket("btcUSD", rates)
 	updater.Stop()
-	updater = nil // make sure unused in the rest of the test
 
 	updater2 := NewRateUpdater(nil, dbdir)
 	defer updater2.Stop()

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -30,11 +30,11 @@ Build artifacts:
 
 ## MacOS
 
-Make sure you have `qt@5/bin`, `go@1.16/bin` and `go/bin` in your PATH, i.e. add to your `.zshrc`
+Make sure you have `qt@5/bin`, `go@1.18/bin` and `go/bin` in your PATH, i.e. add to your `.zshrc`
 
 ```bash
 export PATH="$PATH:/usr/local/opt/qt@5/bin"
-export PATH="$PATH:/usr/local/opt/go@1.16/bin"
+export PATH="$PATH:/usr/local/opt/go@1.18/bin"
 export PATH="$PATH:$HOME/go/bin"
 ```
 
@@ -65,7 +65,7 @@ $  xcrun altool --notarization-info NOTARIZATION_ID --username "APPLE_ID" --pass
 ## Windows
 
 The build requires `mingw-w64`, `bash` (e.g. `git-bash`), `make`, `Microsoft Visual Studio 2019`,
-`go 1.16`, `node@14`, `QT 5.15.2` with `qtwebengine`, `nsis` and possibly other tools.
+`go 1.18`, `node@14`, `QT 5.15.2` with `qtwebengine`, `nsis` and possibly other tools.
 
 Some of the tools are easy to install with `choco`:
 

--- a/scripts/docker_install.sh
+++ b/scripts/docker_install.sh
@@ -46,7 +46,7 @@ npm install -g npm@8.3.0
 npm install -g locize-cli
 
 mkdir -p /opt/go_dist
-curl https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz | tar -xz -C /opt/go_dist
+curl https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz | tar -xz -C /opt/go_dist
 
 # Needed for qt5. fuse is needed to run the linuxdeployqt appimage.
 apt-get install -y --no-install-recommends fuse

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -14,16 +14,19 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     # Which docker image to use to run the CI. Defaults to Docker Hub.
     # Overwrite with CI_IMAGE=docker/image/path environment variable.
     # Keep this in sync with .github/workflows/ci.yml.
-    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:13}"
+    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:14}"
     # Time image pull to compare in the future.
     time docker pull "$CI_IMAGE"
 
     # .gradle dir is mapped to preserve cache.
+    #
+    # safe.directory is added due to "unsafe repository (REPO is owned by someone else)" in GitHub
+    # CI (https://github.com/actions/checkout/issues/760)
     docker run --privileged \
            -v $HOME/.gradle:/root/.gradle \
            -v ${TRAVIS_BUILD_DIR}:/opt/go/${GO_SRC_DIR}/ \
            -i "${CI_IMAGE}" \
-           bash -c "make -C \$GOPATH/${GO_SRC_DIR} ${WHAT}"
+           bash -c "git config --global --add safe.directory \$GOPATH/${GO_SRC_DIR} && make -C \$GOPATH/${GO_SRC_DIR} ${WHAT}"
 fi
 
 # The following is executed only on macOS machines.

--- a/util/errp/errp.go
+++ b/util/errp/errp.go
@@ -21,17 +21,17 @@ import (
 )
 
 var (
-	// New wraps errors.New
+	// New wraps errors.New.
 	New = errors.New
-	// Newf wraps errors.Newf
+	// Newf wraps errors.Newf.
 	Newf = errors.Errorf
-	// WithStack wraps errors.WithStack
+	// WithStack wraps errors.WithStack.
 	WithStack = errors.WithStack
-	// Cause wraps errors.Cause
+	// Cause wraps errors.Cause.
 	Cause = errors.Cause
-	// Wrap wraps errors.Wrap
+	// Wrap wraps errors.Wrap.
 	Wrap = errors.Wrap
-	// WithMessage wraps errors.WithMessage
+	// WithMessage wraps errors.WithMessage.
 	WithMessage = errors.WithMessage
 )
 


### PR DESCRIPTION
Go 1.18 by default enables adding VCS info to the binary by querying
`git`. See https://tip.golang.org/doc/go1.18 ("VCS"). This fails in
the GitHub CI with the following error:

```
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

It turns out that `git status` etc. on Github CI fails with:

```
fatal: unsafe repository ('/opt/go/src/github.com/digitalbitbox/bitbox-wallet-app' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /opt/go/src/github.com/digitalbitbox/bitbox-wallet-app
```

The issue is fixed by following this instruction.

See also: https://github.com/actions/checkout/issues/760#issuecomment-1097501613

golangci: remove newly added linters

Updated golangci-lint at the same time, so we only have to rebuild the
Docker image once instead of twice.

We updated from v1.43.0 to v1.46.1, which enabled a lot of new
linters.

In the future we should disable all linters by default and whitelist
the linters we want, instead of doing the opposite.

The linters disabled in this commit should be checked individually to
decide which to enable.
