### PR TITLE
backend: remove sensitive data from the log file

### DIFF
--- a/backend/coins/btc/transactions/verification.go
+++ b/backend/coins/btc/transactions/verification.go
@@ -15,8 +15,6 @@
 package transactions
 
 import (
-	"fmt"
-
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/blockchain"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers"
@@ -96,11 +94,10 @@ func (transactions *Transactions) verifyTransaction(txHash chainhash.Hash, heigh
 		func(merkle []blockchain.TXHash, pos int) {
 			expectedMerkleRoot := hashMerkleRoot(merkle, txHash, pos)
 			if expectedMerkleRoot != header.MerkleRoot {
-				transactions.log.Warning(
-					fmt.Sprintf("Merkle root verification failed for %s", txHash))
+				transactions.log.Warning("Merkle root verification failed")
 				return
 			}
-			transactions.log.Debugf("Merkle root verification succeeded for %s", txHash)
+			transactions.log.Debugf("Merkle root verification succeeded")
 
 			defer transactions.Lock()()
 			dbTx, err := transactions.db.Begin()

--- a/backend/signing/configuration.go
+++ b/backend/signing/configuration.go
@@ -36,7 +36,7 @@ type KeyInfo struct {
 }
 
 func (ki KeyInfo) String() string {
-	return fmt.Sprintf("keypath=%s,xpub=%s", ki.AbsoluteKeypath.Encode(), ki.ExtendedPublicKey)
+	return fmt.Sprintf("keypath=%s", ki.AbsoluteKeypath.Encode())
 }
 
 type keyInfoEncoding struct {


### PR DESCRIPTION
xpubs and transaction hashes are sensitive informations and their logging
doesn't seem to be really useful. This update removes it.

