### PR TITLE
frontend: add fitContent option to the view component

### DIFF
--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -208,7 +208,7 @@ class Aopp extends Component<Props, State> {
       );
     case 'success':
       return (
-        <View fullscreen textCenter>
+        <View fitContent fullscreen textCenter>
           <ViewContent withIcon="success">
             <p className={styles.successText}>{t('aopp.success.title')}</p>
             <p className={styles.proceed}>

--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -34,16 +34,22 @@
 .inner {
     display: flex;
     flex-direction: column;
-
-    margin: 0 auto;
+    margin: auto;
     max-width: 100%;
     padding-bottom: var(--space-half);
     padding-top: var(--space-half);
     width: 480px;
 }
-.center {
-    margin-bottom: auto;
-    margin-top: auto;
+.inner.fit {
+    flex-shrink: 0;
+    max-height: 100%;
+    padding-bottom: 0;
+    padding-top: 0;
+}
+.fit .content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 .textCenter,
 .text-center {
@@ -51,14 +57,6 @@
 }
 .text-left {
     text-align: left;
-}
-.inner:not(.center) {
-    display: flex;
-    flex-direction: column;
-    max-height: 100%;
-    flex-shrink: 0;
-    padding-bottom: var(--space-large);
-    padding-top: 17vh;
 }
 @media (max-width: 768px) {
     .inner {
@@ -68,7 +66,7 @@
         margin: 0 auto;
         min-height: auto !important;
     }
-    .inner:not(.center) {
+    .inner.fit {
         padding-bottom: var(--space-half);
         padding-top: 2vh;
     }
@@ -153,6 +151,9 @@
     min-height: 80px;
     word-break: break-word;
 }
+.fit .content {
+    flex-shrink: 1;
+}
 @media (max-width: 768px) {
     .content {
         flex-grow: 1;
@@ -180,6 +181,7 @@
 
 .content .largeIcon {
     margin: 0 0 var(--space-default) 0;
+    max-height: 100%;
     width: 50%;
 }
 @media (max-width: 768px) {

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -23,9 +23,9 @@ import style from './view.module.css';
 
 type ViewProps = {
     dialog?: boolean;
+    fitContent?: boolean;
     fullscreen?: boolean;
     minHeight?: string;
-    top?: boolean;
     onClose?: () => void;
     position?: 'fill' | '';
     textCenter?: boolean;
@@ -33,10 +33,21 @@ type ViewProps = {
     withBottomBar?: boolean;
 }
 
+/**
+ * View component is used as a container component to wrap ViewHeader, ViewContent and ViewButtons
+ * @param dialog wether to render the view as a dialog
+ * @param fitContent tries to squeeze the whole view into the visible area, if true the icon specified through ViewContent withIcon will shrink if the visible area is bigger than the window height
+ * @param fullscreen wether the View container should cover the whole window
+ * @param minHeight optional minimum height, useful for keeping content area same size through multiple views
+ * @param onClose if a callback is provided it will render a close button that triggers the callback
+ * @param textCenter centers all text content in the view
+ * @param width can be used to overwrite the default width of the inner area
+ * @param withBottomBar enables a footer with some logo and language switch
+ */
 export function View({
   dialog = false,
+  fitContent = false,
   fullscreen,
-  top = false,
   children,
   minHeight,
   onClose,
@@ -50,8 +61,8 @@ export function View({
     dialog ? style.dialog : ''
   }`;
   let classNames = style.inner;
-  if (!top) {
-    classNames += ` ${style.center}`;
+  if (fitContent) {
+    classNames += ` ${style.fit}`;
   }
   if (textCenter) {
     classNames += ` ${style.textCenter}`;
@@ -90,6 +101,13 @@ type ViewContentProps = {
     withIcon?: 'success';
 }
 
+/**
+ * ViewContent useful for all sorts of content, text, images, grids and forms
+ * @param fullWidth useful to present content on small screen on the full width of the screen
+ * @param minHeight can be used to set a minimum content height to keep the same height over multiple views
+ * @param textAlign allows overwriting text alignment in the content area
+ * @param withIcon supports success icon currently, but could support other icons in the future
+ */
 export function ViewContent({
   children,
   fullWidth,
@@ -120,6 +138,12 @@ type HeaderProps = {
     withAppLogo?: boolean;
 }
 
+/**
+ * ViewHeader component to render the view's title and a byline
+ * @param small option to reduce the size of the header
+ * @param title the title of the view
+ * @param withAppLogo if true includes the BitBoxApp logo before the title
+ */
 export function ViewHeader({
   children,
   small,
@@ -138,6 +162,9 @@ export function ViewHeader({
 
 type ViewButtonsProps = {}
 
+/**
+ * ViewButtons component use as container for buttons
+ */
 export function ViewButtons({ children }: PropsWithChildren<ViewButtonsProps>) {
   return (
     <div className={style.buttons}>

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -737,6 +737,7 @@ class BitBox02 extends Component<Props, State> {
         { (appStatus === 'createWallet' && status === 'initialized') && (
           <View
             key="success"
+            fitContent
             fullscreen
             textCenter
             withBottomBar>


### PR DESCRIPTION
If a View has a success icon by `<ViewContent withIcon="success"`
but not a lot of other content sometimes the ViewButtons are not
in the visible area on smaller screens.

Refactored the unused `top` option into `fitContent` to indicate
that the View should try to fit all content into the visible area.
With `fitContent` the big success icon will shrink if there is not
enough available space.

Note the footer could still be outside of the visible area and only
visible when scrolling down.

Also added some docstrings to the View component.