### PR TITLE
frontend: update bootloader error styling

### DIFF
--- a/frontends/web/src/components/centeredcontent/style.module.css
+++ b/frontends/web/src/components/centeredcontent/style.module.css
@@ -1,5 +1,5 @@
 .container {
-    align-items: center;
+    align-items: stretch;
     background-position: center bottom;
     background-size: cover;
     display: flex;

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -22,6 +22,7 @@ import { apiWebsocket } from '../../../utils/websocket';
 import { CenteredContent } from '../../centeredcontent/centeredcontent';
 import { Button } from '../../forms';
 import { BitBox02 } from '../../icon/logo';
+import Status from '../../status/status';
 import { ToggleShowFirmwareHash } from './toggleshowfirmwarehash';
 
 interface BitBox02BootloaderProps {
@@ -189,8 +190,10 @@ class BitBox02Bootloader extends Component<Props, State> {
     return (
       <CenteredContent>
         <BitBox02 />
+        {status.errMsg && (
+          <Status type="warning">{status.errMsg}</Status>
+        )}
         {contents}
-        <p className="text-center">{status.errMsg}</p>
       </CenteredContent>
     );
   }


### PR DESCRIPTION
Currently the error is styled as plain text below the bootloader
dialog.

Changed styling to use status component as already used in various
other places and position before the bootloader dialog.

Before:
![Screen Shot 2022-06-20 at 7 47 08 AM](https://user-images.githubusercontent.com/546900/174536825-37ceb072-e726-441d-b2da-342bb532647c.png)

With this PR:
![Screen Shot 2022-06-20 at 8 12 25 AM](https://user-images.githubusercontent.com/546900/174536848-62e3f7b2-5a37-4f1a-b2b3-b4e64a206f67.png)
