### PR TITLE
frontend: increase minimum height of passphrase intro content

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -38,7 +38,7 @@ const INFO_STEPS_ENABLE = 5;
 // disabling passphrase shows only 1 info dialog
 const INFO_STEPS_DISABLE = 0;
 
-const CONTENT_MIN_HEIGHT = '34em';
+const CONTENT_MIN_HEIGHT = '38em';
 const CONTENT_WIDTH = '740px';
 
 interface MnemonicPassphraseButtonProps {


### PR DESCRIPTION
The passphrase introduction explains what a passphrase is through
multiple steps. The second step is getting another line in a
different commit as that is pulled form locize.

This change increased the minimum height of the content area so
that all steps use the same height.