### PR TITLE
frontend: add eslint rule to make semicolons mandatory

### DIFF
--- a/frontends/web/.eslintrc.json
+++ b/frontends/web/.eslintrc.json
@@ -7,7 +7,9 @@
     "jsx-quotes": ["error", "prefer-double"],
     "no-trailing-spaces": "error",
     "object-curly-spacing": ["error", "always"],
-    "quotes": ["error", "single"]
+    "quotes": ["error", "single"],
+    "semi": "error",
+    "no-extra-semi": "error"
   },
   "overrides": [
     {

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -57,7 +57,7 @@ export interface ITotalBalance {
 
 export const getAccountsTotalBalance = (): Promise<ITotalBalance> => {
   return apiGet('accounts/total-balance');
-}
+};
 
 export interface IStatus {
     disabled: boolean;

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -67,7 +67,7 @@ export const getVersion = (
   deviceID: string
 ): Promise<VersionInfo> => {
   return apiGet(`devices/bitbox02/${deviceID}/version`);
-}
+};
 
 export const setMnemonicPassphraseEnabled = (
   deviceID: string,

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -16,7 +16,7 @@
  */
 
 import { Component } from 'react';
-import { AppRouter } from './routes/router'
+import { AppRouter } from './routes/router';
 import { getAccounts, IAccount } from './api/account';
 import { syncAccountsList } from './api/accountsync';
 import { getDeviceList, TDevices } from './api/devices';
@@ -60,7 +60,7 @@ class App extends Component<Props, State> {
     if (panelStore.state.activeSidebar) {
       toggleSidebar();
     }
-  }
+  };
 
   public componentDidMount() {
     this.unsubscribe = apiWebsocket(({ type, data, meta }) => {
@@ -162,17 +162,17 @@ class App extends Component<Props, State> {
       route('/', true);
       return;
     }
-  }
+  };
 
   // Returns a string representation of the current devices, so it can be used in the `key` property of subcomponents.
   // The prefix is used so different subcomponents can have unique keys to not confuse the renderer.
   private devicesKey = (prefix: string): string => {
     return prefix + ':' + JSON.stringify(this.state.devices, Object.keys(this.state.devices).sort());
-  }
+  };
 
   private activeAccounts = (): IAccount[] => {
     return this.state.accounts.filter(acct => acct.active);
-  }
+  };
 
   public render() {
     const { accounts, devices } = this.state;

--- a/frontends/web/src/components/alert/Alert.tsx
+++ b/frontends/web/src/components/alert/Alert.tsx
@@ -60,7 +60,7 @@ class Alert extends Component<WithTranslation, State> {
     this.setState({
       active: false,
     });
-  }
+  };
 
   private alertUser = (
     message: string,
@@ -76,7 +76,7 @@ class Alert extends Component<WithTranslation, State> {
       asDialog,
       message,
     });
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/components/anchor/anchor.tsx
+++ b/frontends/web/src/components/anchor/anchor.tsx
@@ -42,6 +42,6 @@ const A:FunctionComponent<Props> =({ href, icon, children, ...props }) => {
       {children}
     </span>
   );
-}
+};
 
 export default A;

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -88,7 +88,7 @@ class Aopp extends Component<Props, State> {
       aoppAPI.chooseAccount(this.state.accountCode);
     }
     e.preventDefault();
-  }
+  };
 
   public render() {
     const { t, aopp } = this.props;

--- a/frontends/web/src/components/aopp/verifyaddress.tsx
+++ b/frontends/web/src/components/aopp/verifyaddress.tsx
@@ -42,7 +42,7 @@ class VerifyAddress extends Component<Props, State> {
     accountAPI.verifyAddress(this.props.accountCode, this.props.addressID).then(() => {
       this.setState({ verifying: false });
     });
-  }
+  };
 
   public render() {
     const { t, address } = this.props;

--- a/frontends/web/src/components/badge/badge.tsx
+++ b/frontends/web/src/components/badge/badge.tsx
@@ -12,4 +12,4 @@ export const Badge: FunctionComponent<Props> = ({ type, className, children }) =
       {children}
     </span>
   );
-}
+};

--- a/frontends/web/src/components/balance/balance.tsx
+++ b/frontends/web/src/components/balance/balance.tsx
@@ -58,4 +58,4 @@ export const Balance: FunctionComponent<Props> = ({
       }
     </header>
   );
-}
+};

--- a/frontends/web/src/components/centeredcontent/centeredcontent.tsx
+++ b/frontends/web/src/components/centeredcontent/centeredcontent.tsx
@@ -25,4 +25,4 @@ export const CenteredContent: FunctionComponent = ({ children }) => {
       </div>
     </div>
   );
-}
+};

--- a/frontends/web/src/components/confirm/Confirm.tsx
+++ b/frontends/web/src/components/confirm/Confirm.tsx
@@ -39,7 +39,7 @@ interface State {
  * this should be mounted only once in the App
  */
 export const Confirm: FunctionComponent = () => {
-  const [state, setState] = useState<State>({ active: false })
+  const [state, setState] = useState<State>({ active: false });
   const { t } = useTranslation();
   const callback = useRef<TCallback>(() => {});
 
@@ -83,5 +83,5 @@ export const Confirm: FunctionComponent = () => {
       <Button primary onClick={() => respond(true)}>{customButtonText ? customButtonText : t('dialog.confirm')}</Button>
       <Button transparent onClick={() => respond(false)}>{t('dialog.cancel')}</Button>
     </DialogButtons>
-  </Dialog>
+  </Dialog>;
 };

--- a/frontends/web/src/components/copy/Copy.tsx
+++ b/frontends/web/src/components/copy/Copy.tsx
@@ -39,7 +39,7 @@ interface State {
 class CopyableInput extends Component<Props, State> {
   public readonly state: State = {
     success: false,
-  }
+  };
 
   private textArea = createRef<HTMLTextAreaElement>();
 
@@ -64,7 +64,7 @@ class CopyableInput extends Component<Props, State> {
 
   private onFocus = (e: React.SyntheticEvent<HTMLTextAreaElement, FocusEvent>) => {
     e.currentTarget.focus();
-  }
+  };
 
   private copy = () => {
     this.textArea.current?.select();
@@ -73,7 +73,7 @@ class CopyableInput extends Component<Props, State> {
         setTimeout(() => this.setState({ success: false }), 1500);
       });
     }
-  }
+  };
 
   public render() {
     const { alignLeft, alignRight, borderLess, t, value, className, disabled, flexibleHeight } = this.props;

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -94,19 +94,19 @@ class BitBox02Bootloader extends Component<Props, State> {
     apiGet('devices/bitbox02-bootloader/' + this.props.deviceID + '/status').then(status => {
       this.setState({ status });
     });
-  }
+  };
 
   private upgradeFirmware = () => {
     apiPost('devices/bitbox02-bootloader/' + this.props.deviceID + '/upgrade-firmware');
-  }
+  };
 
   private reboot = () => {
     apiPost('devices/bitbox02-bootloader/' + this.props.deviceID + '/reboot');
-  }
+  };
 
   private screenRotate = () => {
     apiPost('devices/bitbox02-bootloader/' + this.props.deviceID + '/screen-rotate');
-  }
+  };
 
   public render() {
     const { t,

--- a/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
@@ -40,8 +40,8 @@ const ToggleFWHash: FunctionComponent<Props> = ({ enabled, deviceID }) => {
       'devices/bitbox02-bootloader/' + deviceID + '/set-firmware-hash-enabled',
       enabled,
     );
-    setEnabledState(enabled)
-  }
+    setEnabledState(enabled);
+  };
 
   return (
     <div className="box slim divide">
@@ -55,7 +55,7 @@ const ToggleFWHash: FunctionComponent<Props> = ({ enabled, deviceID }) => {
       </div>
     </div>
   );
-}
+};
 
 const HOC = load<LoadedProps, ToggleProps>(({ deviceID }) => ({ enabled: 'devices/bitbox02-bootloader/' + deviceID + '/show-firmware-hash-enabled' }))(ToggleFWHash);
 export { HOC as ToggleShowFirmwareHash };

--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -58,7 +58,7 @@ class Dialog extends Component<Props, State> {
     const input = e.target as HTMLElement;
     const index = input.getAttribute('index');
     this.setState({ currentTab: Number(index) });
-  }
+  };
 
   private focusWithin = () => {
     if (this.modalContent.current) {
@@ -71,21 +71,21 @@ class Dialog extends Component<Props, State> {
       }
       document.addEventListener('keydown', this.handleKeyDown);
     }
-  }
+  };
 
   private focusFirst = () => {
     const focusables = this.focusableChildren;
     if (focusables.length && focusables[0].getAttribute('autofocus') !== 'false') {
       focusables[0].focus();
     }
-  }
+  };
 
   private updateIndex = (isNext: boolean) => {
     const target = this.getNextIndex(isNext);
     this.setState({ currentTab: target }, () => {
       this.focusableChildren[target].focus();
     });
-  }
+  };
 
   private getNextIndex(isNext: boolean) {
     const { currentTab } = this.state;
@@ -112,7 +112,7 @@ class Dialog extends Component<Props, State> {
     } else if (isTab) {
       this.updateIndex(true);
     }
-  }
+  };
 
   private deactivate = () => {
     if (!this.modal.current || !this.overlay.current) {
@@ -126,7 +126,7 @@ class Dialog extends Component<Props, State> {
         this.props.onClose();
       }
     });
-  }
+  };
 
   private activate = () => {
     this.setState({ active: true }, () => {
@@ -138,7 +138,7 @@ class Dialog extends Component<Props, State> {
       this.focusWithin();
       this.focusFirst();
     });
-  }
+  };
 
   public render() {
     const {
@@ -211,7 +211,7 @@ class Dialog extends Component<Props, State> {
 
 interface DialogButtonsProps {
     children: React.ReactNode;
-};
+}
 
 function DialogButtons({ children }: DialogButtonsProps) {
   return (

--- a/frontends/web/src/components/forms/button.tsx
+++ b/frontends/web/src/components/forms/button.tsx
@@ -63,7 +63,7 @@ export const ButtonLink: FunctionComponent<Props & LinkProps> = ({
       {children}
     </Link>
   );
-}
+};
 
 export const Button: FunctionComponent<Props & ComponentPropsWithoutRef<'button'>> = ({
   type = 'button',
@@ -92,4 +92,4 @@ export const Button: FunctionComponent<Props & ComponentPropsWithoutRef<'button'
       {children}
     </button>
   );
-}
+};

--- a/frontends/web/src/components/forms/checkbox.tsx
+++ b/frontends/web/src/components/forms/checkbox.tsx
@@ -44,6 +44,6 @@ const Checkbox: FunctionComponent<CheckboxProps> = ({
       <label htmlFor={id}>{label} {children}</label>
     </span>
   );
-}
+};
 
 export default Checkbox;

--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -54,7 +54,7 @@ export class Entry extends Component<Props, State> {
       shown: !state.shown,
       highlighted: false,
     }));
-  }
+  };
 
   public render() {
     const props = this.props;

--- a/frontends/web/src/components/headerssync/headerssync.tsx
+++ b/frontends/web/src/components/headerssync/headerssync.tsx
@@ -69,4 +69,4 @@ export const HeadersSync: FunctionComponent<Props> = ({ coinCode }) => {
       </div>
     </div>
   );
-}
+};

--- a/frontends/web/src/components/inlineMessage/InlineMessage.jsx
+++ b/frontends/web/src/components/inlineMessage/InlineMessage.jsx
@@ -20,7 +20,7 @@ import style from './InlineMessage.module.css';
 export default class InlineMessage extends Component {
   deactivate = () => {
     this.props.onEnd();
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/components/language/language.test.tsx
+++ b/frontends/web/src/components/language/language.test.tsx
@@ -31,13 +31,13 @@ describe('components/language/language', () => {
 
     supportedLangs.forEach((lang, idx) => {
       it(`returns exact match (${lang.code})`, async () => {
-        await i18n.changeLanguage(lang.code)
+        await i18n.changeLanguage(lang.code);
 
         let ctx: any;
         act(() => {
           /* @ts-ignore */
           ctx = mount(<LanguageSwitch i18n={i18n} languages={supportedLangs} />);
-        })
+        });
 
         expect(ctx.childAt(0).state('selectedIndex')).toEqual(idx);
       });

--- a/frontends/web/src/components/language/language.tsx
+++ b/frontends/web/src/components/language/language.tsx
@@ -78,7 +78,7 @@ class LanguageSwitch extends Component<Props, State> {
 
   abort = () => {
     this.setState({ activeDialog: false });
-  }
+  };
 
   getSelectedIndex = (languages: TLanguagesList) => {
     const lang = this.props.i18n.language;
@@ -99,7 +99,7 @@ class LanguageSwitch extends Component<Props, State> {
       return 0;
     }
     return index;
-  }
+  };
 
   changeLanguage = (langCode: TActiveLanguageCodes, index: number) => {
     // const langCode = e.target.dataset.code;
@@ -109,7 +109,7 @@ class LanguageSwitch extends Component<Props, State> {
       activeDialog: false,
     });
     i18n.changeLanguage(langCode);
-  }
+  };
 
   render() {
     const { t } = this.props;

--- a/frontends/web/src/components/layout/grid.tsx
+++ b/frontends/web/src/components/layout/grid.tsx
@@ -25,7 +25,7 @@ export const Grid: FunctionComponent<GridProps> = ({ children }) => {
       {children}
     </section>
   );
-}
+};
 
 type ColumnProps = {
     asCard?: boolean;
@@ -40,7 +40,7 @@ export const Column: FunctionComponent<ColumnProps> = ({
       {children}
     </div>
   );
-}
+};
 
 type ColumnButtonsProps = {}
 
@@ -50,4 +50,4 @@ export const ColumnButtons: FunctionComponent<ColumnButtonsProps> = ({ children 
       {children}
     </div>
   );
-}
+};

--- a/frontends/web/src/components/layout/header.tsx
+++ b/frontends/web/src/components/layout/header.tsx
@@ -35,7 +35,7 @@ class Header extends Component<Props> {
       toggleGuide();
     }
     return false;
-  }
+  };
 
   public render() {
     const { t, title, narrow, children, guideExists, shown, sidebarStatus } = this.props;

--- a/frontends/web/src/components/layout/main.tsx
+++ b/frontends/web/src/components/layout/main.tsx
@@ -25,4 +25,4 @@ export const Main: FunctionComponent<MainProps> = ({ children }) => {
       {children}
     </main>
   );
-}
+};

--- a/frontends/web/src/components/layout/version.tsx
+++ b/frontends/web/src/components/layout/version.tsx
@@ -28,6 +28,6 @@ const Version: FunctionComponent = () => {
     return null;
   }
   return <p>{t('footer.appVersion')} {version}</p>;
-}
+};
 
 export { Version };

--- a/frontends/web/src/components/message/message.test.tsx
+++ b/frontends/web/src/components/message/message.test.tsx
@@ -15,9 +15,9 @@
  */
 
 import 'jest';
-import { render } from '@testing-library/react'
+import { render } from '@testing-library/react';
 import { Message } from './message';
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';
 
 describe('components/message/message', () => {
   it('should have child nodes', () => {

--- a/frontends/web/src/components/mobiledatawarning.tsx
+++ b/frontends/web/src/components/mobiledatawarning.tsx
@@ -35,4 +35,4 @@ export const MobileDataWarning: FunctionComponent = () => {
       {t('mobile.usingMobileDataWarning')}
     </Status>
   );
-}
+};

--- a/frontends/web/src/components/password.jsx
+++ b/frontends/web/src/components/password.jsx
@@ -35,13 +35,13 @@ class PasswordSingleInputClass extends Component {
     password: '',
     seePlaintext: false,
     capsLock: false
-  }
+  };
 
   password = createRef();
 
   idPrefix = () => {
     return this.props.idPrefix || '';
-  }
+  };
 
   UNSAFE_componentWillMount() {
     window.addEventListener('keydown', this.handleCheckCaps);
@@ -67,7 +67,7 @@ class PasswordSingleInputClass extends Component {
         label: this.props.label
       }));
     }
-  }
+  };
 
   clear = () => {
     this.setState({
@@ -75,7 +75,7 @@ class PasswordSingleInputClass extends Component {
       seePlaintext: false,
       capsLock: false
     });
-  }
+  };
 
   validate = () => {
     if (this.regex && this.password.current && !this.password.current.validity.valid) {
@@ -86,7 +86,7 @@ class PasswordSingleInputClass extends Component {
     } else {
       this.props.onValidPassword(null);
     }
-  }
+  };
 
   handleFormChange = event => {
     let value = event.target.value;
@@ -95,14 +95,14 @@ class PasswordSingleInputClass extends Component {
     }
     const stateKey = event.target.id.slice(this.idPrefix().length);
     this.setState({ [stateKey]: value }, this.validate);
-  }
+  };
 
   handleCheckCaps = event => {
     const capsLock = hasCaps(event);
     if (capsLock !== null) {
       this.setState({ capsLock });
     }
-  }
+  };
 
   render() {
     const {
@@ -162,14 +162,14 @@ class PasswordRepeatInputClass extends Component {
     passwordRepeat: '',
     seePlaintext: false,
     capsLock: false
-  }
+  };
 
   password = createRef();
   passwordRepeat = createRef();
 
   idPrefix = () => {
     return this.props.idPrefix || '';
-  }
+  };
 
   UNSAFE_componentWillMount() {
     window.addEventListener('keydown', this.handleCheckCaps);
@@ -195,7 +195,7 @@ class PasswordRepeatInputClass extends Component {
         label: this.props.label
       }));
     }
-  }
+  };
 
   validate = () => {
     if (
@@ -209,7 +209,7 @@ class PasswordRepeatInputClass extends Component {
     } else {
       this.props.onValidPassword(null);
     }
-  }
+  };
 
   handleFormChange = event => {
     let value = event.target.value;
@@ -218,14 +218,14 @@ class PasswordRepeatInputClass extends Component {
     }
     const stateKey = event.target.id.slice(this.idPrefix().length);
     this.setState({ [stateKey]: value }, this.validate);
-  }
+  };
 
   handleCheckCaps = event => {
     const capsLock = hasCaps(event);
         if (capsLock != null) { // eslint-disable-line
       this.setState({ capsLock });
     }
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/components/settingsButton/settingsButton.tsx
+++ b/frontends/web/src/components/settingsButton/settingsButton.tsx
@@ -33,6 +33,6 @@ const SettingsButton: FunctionComponent<SettingsButtonProps> = ({
       </svg>
     </button>
   );
-}
+};
 
 export { SettingsButton };

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -74,7 +74,7 @@ const GetAccountLink: FunctionComponent<IAccount & { handleSidebarItemClick: ((e
       </Link>
     </div>
   );
-}
+};
 
 
 class Sidebar extends Component<Props> {
@@ -92,13 +92,13 @@ class Sidebar extends Component<Props> {
     document.addEventListener('touchstart', this.handleTouchStart);
     document.addEventListener('touchmove', this.handleTouchMove);
     document.addEventListener('touchend', this.handleTouchEnd);
-  }
+  };
 
   private removeTouchEvents = () => {
     document.removeEventListener('touchstart', this.handleTouchStart);
     document.removeEventListener('touchmove', this.handleTouchMove);
     document.removeEventListener('touchend', this.handleTouchEnd);
-  }
+  };
 
   private handleTouchStart = (e: TouchEvent) => {
     const touch = e.touches[0];
@@ -106,7 +106,7 @@ class Sidebar extends Component<Props> {
       x: touch.clientX,
       y: touch.clientY,
     };
-  }
+  };
 
   private handleTouchMove = (e: TouchEvent) => {
     if (this.props.sidebarStatus !== 'forceHidden') {
@@ -114,7 +114,7 @@ class Sidebar extends Component<Props> {
         this.swipe.active = true;
       }
     }
-  }
+  };
 
   private handleTouchEnd = (e: TouchEvent) => {
     if (this.props.sidebarStatus !== 'forceHidden') {
@@ -132,14 +132,14 @@ class Sidebar extends Component<Props> {
         active: false,
       };
     }
-  }
+  };
 
   private handleSidebarItemClick = (e: React.SyntheticEvent) => {
     const el = (e.target as Element).closest('a');
     if (el!.classList.contains('sidebar-active') && window.innerWidth <= 901) {
       toggleSidebar();
     }
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/components/spinner/Spinner.tsx
+++ b/frontends/web/src/components/spinner/Spinner.tsx
@@ -34,7 +34,7 @@ const Spinner: FunctionComponent<Props> = ({ text, guideExists }) => {
   const handleKeyDown = (e: KeyboardEvent) => {
     e.preventDefault();
     (document.activeElement as HTMLInputElement).blur();
-  }
+  };
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);
@@ -87,7 +87,7 @@ const Spinner: FunctionComponent<Props> = ({ text, guideExists }) => {
       <div className={style.overlay}></div>
     </div>
   );
-}
+};
 
 const SharedSpinner = share<SharedProps, SpinnerProps>(store)(Spinner);
 export { SharedSpinner as Spinner };

--- a/frontends/web/src/components/status/status.tsx
+++ b/frontends/web/src/components/status/status.tsx
@@ -81,7 +81,7 @@ export default class Status extends Component<Props, State> {
     this.setState({
       show: false,
     });
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/components/toast/Toast.jsx
+++ b/frontends/web/src/components/toast/Toast.jsx
@@ -20,7 +20,7 @@ import style from './Toast.module.css';
 export default class Toast extends Component {
   state = {
     active: false,
-  }
+  };
 
   componentDidMount() {
     setTimeout(this.show, 5);
@@ -28,14 +28,14 @@ export default class Toast extends Component {
 
   show = () => {
     this.setState({ active: true });
-  }
+  };
 
   hide = () => {
     this.setState({ active: false });
     if (this.props.onHide) {
       this.props.onHide();
     }
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -60,7 +60,7 @@ class Transaction extends Component<Props, State> {
       day: 'numeric',
     } as Intl.DateTimeFormatOptions;
     return new Date(Date.parse(time)).toLocaleString(this.props.i18n.language, options);
-  }
+  };
 
   private showDetails = () => {
     this.setState({
@@ -68,16 +68,16 @@ class Transaction extends Component<Props, State> {
       newNote: this.props.note,
       editMode: !this.props.note,
     });
-  }
+  };
 
   private hideDetails = () => {
     this.setState({ transactionDialog: false });
-  }
+  };
 
   private handleNoteInput = (e: Event) => {
     const target = e.target as HTMLInputElement;
     this.setState({ newNote: target.value });
-  }
+  };
 
   private handleEdit = (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -93,7 +93,7 @@ class Transaction extends Component<Props, State> {
       ({ editMode }) => ({ editMode: !editMode }),
       this.focusEdit,
     );
-  }
+  };
 
   private focusEdit = () => {
     if (this.editButton.current) {
@@ -103,7 +103,7 @@ class Transaction extends Component<Props, State> {
       this.input.current.scrollLeft = this.input.current.scrollWidth;
       this.input.current.focus();
     }
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/components/update/update.tsx
+++ b/frontends/web/src/components/update/update.tsx
@@ -51,7 +51,7 @@ const Update: FunctionComponent<Props> = ({ file }) => {
       {!runningInAndroid() && downloadElement}
     </Status>
   );
-}
+};
 
 const HOC = load<Props>({ file: 'update' })(Update);
 

--- a/frontends/web/src/components/wait-dialog/wait-dialog.tsx
+++ b/frontends/web/src/components/wait-dialog/wait-dialog.tsx
@@ -42,7 +42,7 @@ class WaitDialog extends Component<Props, State> {
 
   public readonly state: State = {
     active: false,
-  }
+  };
 
   public UNSAFE_componentWillMount() {
     document.body.addEventListener('keydown', this.handleKeyDown);
@@ -63,7 +63,7 @@ class WaitDialog extends Component<Props, State> {
     }
     e.preventDefault();
     e.stopPropagation();
-  }
+  };
 
   private activate = () => {
     this.setState({ active: true }, () => {
@@ -73,7 +73,7 @@ class WaitDialog extends Component<Props, State> {
       this.overlay.current.classList.add(style.activeOverlay);
       this.modal.current.classList.add(style.activeModal);
     });
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/decorators/translate.ts
+++ b/frontends/web/src/decorators/translate.ts
@@ -1,4 +1,4 @@
 import { WithTranslation, withTranslation } from 'react-i18next';
 
-export const translate = withTranslation
+export const translate = withTranslation;
 export type TranslateProps = WithTranslation

--- a/frontends/web/src/hooks/api.ts
+++ b/frontends/web/src/hooks/api.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DependencyList, useEffect, useState } from 'react'
+import { DependencyList, useEffect, useState } from 'react';
 import { SubscriptionCallback } from '../api/subscribe';
 import { Unsubscribe } from '../utils/event';
 import { useMountedRef } from './utils';
@@ -40,7 +40,7 @@ export const useSubscribe = <T>(
     [] // eslint-disable-line react-hooks/exhaustive-deps
   );
   return respose;
-}
+};
 
 /**
  * useLoad is a hook to load a promise.
@@ -94,4 +94,4 @@ export const useSync = <T>(
     }, // we pass no dependencies because it's only queried once
     []); // eslint-disable-line react-hooks/exhaustive-deps
   return respose;
-}
+};

--- a/frontends/web/src/hooks/keyboard.ts
+++ b/frontends/web/src/hooks/keyboard.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect } from 'react'
+import { useEffect } from 'react';
 
 /**
  * useEsc handles ESC key.
@@ -28,7 +28,7 @@ export const useEsc = (
       if (e.key === 'Escape') {
         callback();
       }
-    }
+    };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [callback]);

--- a/frontends/web/src/hooks/utils.ts
+++ b/frontends/web/src/hooks/utils.ts
@@ -24,7 +24,7 @@ import { useRef, useEffect } from 'react';
 export const useMountedRef = () => {
   const mounted = useRef(true);
   useEffect(() => (
-    () => {mounted.current = false}
-  ), [])
+    () => {mounted.current = false;}
+  ), []);
   return mounted;
-}
+};

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -216,7 +216,7 @@ class Account extends Component<Props, State> {
         transactions: undefined,
       });
     }
-  }
+  };
 
   private export = () => {
     if (this.state.status === undefined || this.state.status.fatalError) {
@@ -229,7 +229,7 @@ class Account extends Component<Props, State> {
         }
       })
       .catch(console.error);
-  }
+  };
 
   private isBTCScriptType = (
     scriptType: accountApi.ScriptType,
@@ -242,20 +242,20 @@ class Account extends Component<Props, State> {
     const config = accountInfo.signingConfigurations[0].bitcoinSimple;
     return (account.coinCode === 'btc' || account.coinCode === 'tbtc') &&
             config !== undefined && config.scriptType === scriptType;
-  }
+  };
 
   private deviceIDs = (devices: TDevices) => {
     return Object.keys(devices);
-  }
+  };
 
   private dataLoaded = () => {
     return this.state.balance !== undefined && this.state.transactions !== undefined;
-  }
+  };
 
   private supportsBuy = () => {
     // True if at least one external service supports onramp for this account.
     return this.props.moonpayBuySupported;
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -62,7 +62,7 @@ class AddAccount extends Component<Props, State> {
 
   private onlyOneSupportedCoin = (): boolean => {
     return this.state.supportedCoins.length === 1;
-  }
+  };
 
   public componentDidMount() {
     backendAPI.getSupportedCoins()
@@ -95,7 +95,7 @@ class AddAccount extends Component<Props, State> {
       this.setState({ step: 'choose-name' });
       break;
     }
-  }
+  };
 
   private next = (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -143,7 +143,7 @@ class AddAccount extends Component<Props, State> {
       break;
 
     }
-  }
+  };
 
   private isFirstStep = () => {
     switch (this.state.step) {
@@ -154,7 +154,7 @@ class AddAccount extends Component<Props, State> {
     case 'success':
       return false;
     }
-  }
+  };
 
   private renderContent = () => {
     const { t } = this.props;
@@ -187,7 +187,7 @@ class AddAccount extends Component<Props, State> {
         </div>
       );
     }
-  }
+  };
 
   private getTextFor = (step: TStep) => {
     const { t } = this.props;
@@ -208,7 +208,7 @@ class AddAccount extends Component<Props, State> {
         nextButtonText: t('addAccount.success.nextButton'),
       };
     }
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/account/add/components/steps.tsx
+++ b/frontends/web/src/routes/account/add/components/steps.tsx
@@ -26,7 +26,7 @@ export const Steps: FunctionComponent<Props> = ({
   current,
   children
 }) => {
-  let childrens = React.Children.toArray(children).filter(React.isValidElement) as React.ReactElement[]
+  let childrens = React.Children.toArray(children).filter(React.isValidElement) as React.ReactElement[];
   return (
     <div className={style.steps}>
       { childrens
@@ -45,7 +45,7 @@ export const Steps: FunctionComponent<Props> = ({
         }) }
     </div>
   );
-}
+};
 
 interface StepProps {
     line?: boolean;

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -58,7 +58,7 @@ export const Info: FunctionComponent<Props> = ({
     }
     const numberOfXPubs = info.signingConfigurations.length;
     setViewXPub((viewXPub + 1) % numberOfXPubs);
-  }
+  };
 
   return (
     <div className="contentWithGuide">
@@ -105,4 +105,4 @@ export const Info: FunctionComponent<Props> = ({
       ) : null }
     </div>
   );
-}
+};

--- a/frontends/web/src/routes/account/info/signingconfiguration.tsx
+++ b/frontends/web/src/routes/account/info/signingconfiguration.tsx
@@ -42,7 +42,7 @@ class SigningConfiguration extends Component<Props, State> {
 
   public readonly state: State = {
     canVerifyExtendedPublicKey: false,
-  }
+  };
 
   public componentDidMount() {
     this.canVerifyExtendedPublicKeys();
@@ -52,11 +52,11 @@ class SigningConfiguration extends Component<Props, State> {
     getCanVerifyXPub(this.props.code).then(canVerifyExtendedPublicKey => {
       this.setState({ canVerifyExtendedPublicKey });
     });
-  }
+  };
 
   private verifyExtendedPublicKey = (signingConfigIndex: number) => {
     verifyXPub(this.props.code, signingConfigIndex);
-  }
+  };
 
   private getSimpleInfo(): TBitcoinSimple | TEthereumSimple {
     const { info } = this.props;

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -300,4 +300,4 @@ export const Receive: FunctionComponent<Props> = ({
       </Guide>
     </div>
   );
-}
+};

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -89,22 +89,22 @@ class FeeTargets extends Component<Props, State> {
         this.setFeeTarget(defaultFeeTarget);
       })
       .catch(console.error);
-  }
+  };
 
   private handleFeeTargetChange = (event: React.SyntheticEvent) => {
     const target = event.target as HTMLSelectElement;
     this.setFeeTarget(target.options[target.selectedIndex].value as accountApi.FeeTargetCode);
-  }
+  };
 
   private handleCustomFee = (event: Event) => {
     const target = event.target as HTMLInputElement;
     this.props.onCustomFee(target.value);
-  }
+  };
 
   private setFeeTarget = (feeTarget: accountApi.FeeTargetCode) => {
     this.setState({ feeTarget });
     this.props.onFeeTargetChange(feeTarget);
-  }
+  };
 
   private getProposeFeeText = (): string => {
     if (!this.props.proposedFee) {
@@ -113,13 +113,13 @@ class FeeTargets extends Component<Props, State> {
     const { amount, unit, conversions } = this.props.proposedFee;
     const fiatUnit = this.props.fiatUnit;
     return `${amount} ${unit} ${conversions ? ` = ${conversions[fiatUnit]} ${fiatUnit}` : ''}`;
-  }
+  };
 
   private focusInput = () => {
     if (!this.props.disabled && this.input.current && this.input.current.autofocus) {
       this.input.current.focus();
     }
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -131,7 +131,7 @@ class Send extends Component<Props, State> {
       return false;
     }
     return isBitcoinBased(account.coinCode);
-  }
+  };
 
   public componentDidMount() {
     if (this.props.code) {
@@ -196,11 +196,11 @@ class Send extends Component<Props, State> {
 
   private registerEvents = () => {
     document.addEventListener('keydown', this.handleKeyDown);
-  }
+  };
 
   private unregisterEvents = () => {
     document.removeEventListener('keydown', this.handleKeyDown);
-  }
+  };
 
   private handleKeyDown = (e: KeyboardEvent) => {
     if (e.keyCode === 27) {
@@ -210,7 +210,7 @@ class Send extends Component<Props, State> {
         route(`/account/${this.props.code}`);
       }
     }
-  }
+  };
 
   private send = () => {
     if (this.state.noMobileChannelError) {
@@ -253,7 +253,7 @@ class Send extends Component<Props, State> {
         // The following method allows pressing escape again.
         this.setState({ isConfirming: false, signProgress: undefined, signConfirm: false });
       });
-  }
+  };
 
   private txInput = () => ({
     address: this.state.recipientAddress,
@@ -262,12 +262,12 @@ class Send extends Component<Props, State> {
     customFee: this.state.customFee,
     sendAll: this.state.sendAll ? 'yes' : 'no',
     selectedUTXOs: Object.keys(this.selectedUTXOs),
-  })
+  });
 
   private sendDisabled = () => {
     const txInput = this.txInput();
     return !txInput.address || this.state.feeTarget === undefined || (txInput.sendAll === 'no' && !txInput.amount) || (this.state.feeTarget === 'custom' && !this.state.customFee);
-  }
+  };
 
   private validateAndDisplayFee = (updateFiat: boolean = true) => {
     this.setState({
@@ -300,7 +300,7 @@ class Send extends Component<Props, State> {
         });
       this.pendingProposals.push(propose);
     }, 400);
-  }
+  };
 
   private handleNoteInput = (event: Event) => {
     const target = (event.target as HTMLInputElement);
@@ -309,7 +309,7 @@ class Send extends Component<Props, State> {
     }, () => {
       apiPost('account/' + this.getAccount()!.code + '/propose-tx-note', this.state.note);
     });
-  }
+  };
 
   private txProposal = (updateFiat: boolean, result: {
         errorCode?: string;
@@ -360,7 +360,7 @@ class Send extends Component<Props, State> {
       }
       this.setState({ isUpdatingProposal: false });
     }
-  }
+  };
 
   private handleFormChange = (event: React.SyntheticEvent) => {
     const target = (event.target as HTMLInputElement);
@@ -381,13 +381,13 @@ class Send extends Component<Props, State> {
     }), () => {
       this.validateAndDisplayFee(true);
     });
-  }
+  };
 
   private handleFiatInput = (event: Event) => {
     const value = (event.target as HTMLInputElement).value;
     this.setState({ fiatAmount: value });
     this.convertFromFiat(value);
-  }
+  };
 
   private convertToFiat = (value?: string | boolean) => {
     if (value) {
@@ -403,7 +403,7 @@ class Send extends Component<Props, State> {
     } else {
       this.setState({ fiatAmount: '' });
     }
-  }
+  };
 
   private convertFromFiat = (value: string) => {
     if (value) {
@@ -420,7 +420,7 @@ class Send extends Component<Props, State> {
     } else {
       this.setState({ amount: '' });
     }
-  }
+  };
 
   private sendToSelf = (event: React.SyntheticEvent) => {
     accountApi.getReceiveAddressList(this.getAccount()!.code)()
@@ -429,30 +429,30 @@ class Send extends Component<Props, State> {
         this.handleFormChange(event);
       })
       .catch(console.error);
-  }
+  };
 
   private feeTargetChange = (feeTarget: accountApi.FeeTargetCode) => {
     this.setState(
       { feeTarget, customFee: '' },
       () => this.validateAndDisplayFee(this.state.sendAll),
     );
-  }
+  };
 
   private onSelectedUTXOsChange = (selectedUTXOs: SelectedUTXO) => {
     this.selectedUTXOs = selectedUTXOs;
     this.validateAndDisplayFee(true);
-  }
+  };
 
   private hasSelectedUTXOs = (): boolean => {
     return Object.keys(this.selectedUTXOs).length !== 0;
-  }
+  };
 
   private getAccount = (): accountApi.IAccount | undefined => {
     if (!this.props.accounts) {
       return undefined;
     }
     return this.props.accounts.find(({ code }) => code === this.props.code);
-  }
+  };
 
   private toggleCoinControl = () => {
     this.setState(({ activeCoinControl }) => {
@@ -461,7 +461,7 @@ class Send extends Component<Props, State> {
       }
       return { activeCoinControl: !activeCoinControl };
     });
-  }
+  };
 
   private parseQRResult = (uri: string) => {
     let address;
@@ -491,7 +491,7 @@ class Send extends Component<Props, State> {
       this.convertToFiat(this.state.amount);
       this.validateAndDisplayFee(true);
     });
-  }
+  };
 
   private toggleScanQR = () => {
     if (this.state.activeScanQR) {
@@ -524,15 +524,15 @@ class Send extends Component<Props, State> {
           this.setState({ activeScanQR: false });
         });
     });
-  }
+  };
 
   private deactivateCoinControl = () => {
     this.setState({ activeCoinControl: false });
-  }
+  };
 
   private handleVideoLoad = () => {
     this.setState({ videoLoading: false });
-  }
+  };
 
   public render() {
     const { t, code } = this.props;

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -61,7 +61,7 @@ export class UTXOsClass extends Component<Props, State> {
     this.setState({ selectedUTXOs: {} }, () => {
       this.props.onChange(this.state.selectedUTXOs);
     });
-  }
+  };
 
   private handleUTXOChange = (event: React.SyntheticEvent) => {
     const target = event.target as HTMLInputElement;
@@ -75,7 +75,7 @@ export class UTXOsClass extends Component<Props, State> {
     this.setState({ selectedUTXOs }, () => {
       this.props.onChange(selectedUTXOs);
     });
-  }
+  };
 
   private renderUTXOs = (scriptType: accountApi.ScriptType) => {
     const { t, explorerURL } = this.props;
@@ -137,7 +137,7 @@ export class UTXOsClass extends Component<Props, State> {
         </ul>
       </div>
     );
-  }
+  };
 
   public render() {
     const { t, active, onClose } = this.props;

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -111,14 +111,14 @@ class AccountsSummary extends Component<Props, State> {
         this.summaryReqTimerID = window.setTimeout(this.getAccountSummary, delay);
       });
     }).catch(console.error);
-  }
+  };
 
   private async getAccountsTotalBalance() {
     try {
       const totalBalancePerCoin = await accountApi.getAccountsTotalBalance();
       this.setState({ totalBalancePerCoin });
     } catch (err) {
-      console.error(err)
+      console.error(err);
     }
   }
 
@@ -129,7 +129,7 @@ class AccountsSummary extends Component<Props, State> {
         : accountPerCoin[account.coinCode] = [account];
       return accountPerCoin;
     }, {} as TAccountCoinMap);
-  }
+  };
 
   private onEvent = (data: any) => {
     for (const account of this.props.accounts) {
@@ -153,7 +153,7 @@ class AccountsSummary extends Component<Props, State> {
         break;
       }
     }
-  }
+  };
 
   private async onStatusChanged(code: string, initial: boolean = false) {
     const status = await accountApi.getStatus(code);
@@ -180,7 +180,7 @@ class AccountsSummary extends Component<Props, State> {
       this.setState({ exported });
     })
       .catch(console.error);
-  }
+  };
 
   private balanceRow = (
     { code, name, coinCode, coinUnit }: PropsWithChildren<BalanceRowProps>,
@@ -227,7 +227,7 @@ class AccountsSummary extends Component<Props, State> {
         </td>
       </tr>
     );
-  }
+  };
 
   private subTotalRow({ coinCode, coinName, coinUnit, balance }: PropsWithChildren<BalanceRowProps>) {
     const { t } = this.props;

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -60,7 +60,7 @@ class Chart extends Component<Props, State> {
       chartTotal: null,
       chartIsUpToDate: false,
     }
-  }
+  };
 
   public readonly state: State = {
     display: 'all',
@@ -103,7 +103,7 @@ class Chart extends Component<Props, State> {
 
   private hasData = (): boolean => {
     return this.props.data.chartDataDaily && this.props.data.chartDataDaily.length > 0;
-  }
+  };
 
   private createChart = () => {
     const { data: { chartIsUpToDate, chartDataMissing } } = this.props;
@@ -178,7 +178,7 @@ class Chart extends Component<Props, State> {
       window.addEventListener('resize', this.onResize);
       setTimeout(() => this.ref.current?.classList.remove(styles.invisible), 200);
     }
-  }
+  };
 
   private onResize = () => {
     if (this.resizeTimerID) {
@@ -190,7 +190,7 @@ class Chart extends Component<Props, State> {
       }
       this.chart.resize(this.ref.current.offsetWidth, this.height);
     }, 200);
-  }
+  };
 
   private getUTCRange = () => {
     const now = new Date();
@@ -207,7 +207,7 @@ class Chart extends Component<Props, State> {
       to,
       from,
     };
-  }
+  };
 
   private displayWeek = () => {
     if (this.state.source !== 'hourly' && this.lineSeries && this.props.data.chartDataHourly && this.chart) {
@@ -228,7 +228,7 @@ class Chart extends Component<Props, State> {
         });
       }
     );
-  }
+  };
 
   private displayMonth = () => {
     if (this.state.source !== 'daily' && this.lineSeries && this.props.data.chartDataDaily && this.chart) {
@@ -249,7 +249,7 @@ class Chart extends Component<Props, State> {
         });
       }
     );
-  }
+  };
 
   private displayYear = () => {
     if (this.state.source !== 'daily' && this.lineSeries && this.props.data.chartDataDaily && this.chart) {
@@ -270,7 +270,7 @@ class Chart extends Component<Props, State> {
         });
       }
     );
-  }
+  };
 
   private displayAll = () => {
     if (this.state.source !== 'daily' && this.lineSeries && this.props.data.chartDataDaily && this.chart) {
@@ -286,7 +286,7 @@ class Chart extends Component<Props, State> {
         this.chart.timeScale().fitContent();
       }
     );
-  }
+  };
 
   private calculateChange = () => {
     const data = this.props.data[this.state.source === 'daily' ? 'chartDataDaily' : 'chartDataHourly'];
@@ -315,7 +315,7 @@ class Chart extends Component<Props, State> {
       difference: ((valueDiff / valueFrom) * 100),
       diffSince: `${data[rangeFrom].value.toFixed(2)} (${this.renderDate(Number(data[rangeFrom].time) * 1000)})`
     });
-  }
+  };
 
   private handleCrosshair = ({ point, time, seriesPrices }: MouseEventParams) => {
     if (!this.refToolTip.current) {
@@ -347,7 +347,7 @@ class Chart extends Component<Props, State> {
       toolTipLeft,
       toolTipTime: time as number,
     });
-  }
+  };
 
   private renderDate = (date: number) => {
     return new Date(date).toLocaleString(
@@ -362,7 +362,7 @@ class Chart extends Component<Props, State> {
         } : null)
       }
     );
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -57,11 +57,11 @@ class BuyInfo extends Component<Props, State> {
   public readonly state: State = {
     status: this.props.config.frontend.skipBuyDisclaimer ? 'choose' : 'agree',
     selected: this.props.code,
-  }
+  };
 
   componentDidMount = () => {
     this.checkSupportedCoins();
-  }
+  };
 
   private handleProceed = () => {
     const { status, selected } = this.state;
@@ -70,13 +70,13 @@ class BuyInfo extends Component<Props, State> {
     } else {
       this.setState({ status: 'choose' }, this.maybeProceed);
     }
-  }
+  };
 
   private maybeProceed = () => {
     if (this.state.status === 'choose' && this.state.options !== undefined && this.state.options.length === 1) {
       route(`/buy/moonpay/${this.state.options[0].value}`);
     }
-  }
+  };
 
   private checkSupportedCoins = () => {
     Promise.all(
@@ -92,11 +92,11 @@ class BuyInfo extends Component<Props, State> {
         this.setState({ options }, this.maybeProceed);
       })
       .catch(console.error);
-  }
+  };
 
   private handleSkipDisclaimer = (e: ChangeEvent<HTMLInputElement>) => {
     setConfig({ frontend: { skipBuyDisclaimer: e.target.checked } });
-  }
+  };
 
   private getCryptoName = (): string => {
     const { accounts, code, t } = this.props;
@@ -109,7 +109,7 @@ class BuyInfo extends Component<Props, State> {
       return isBitcoinOnly(account.coinCode) ? 'Bitcoin' : t('buy.info.crypto');
     }
     return t('buy.info.crypto');
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -67,14 +67,14 @@ class Moonpay extends Component<Props, State> {
       }
       this.setState({ height: this.ref.current.offsetHeight });
     }, 200);
-  }
+  };
 
   private getAccount = (): IAccount | undefined => {
     if (!this.props.accounts) {
       return undefined;
     }
     return this.props.accounts.find(({ code }) => code === this.props.code);
-  }
+  };
 
   private getCryptoName = (): string => {
     const { t } = this.props;
@@ -83,7 +83,7 @@ class Moonpay extends Component<Props, State> {
       return isBitcoinOnly(account.coinCode) ? 'Bitcoin' : t('buy.info.crypto');
     }
     return t('buy.info.crypto');
-  }
+  };
 
   public render() {
     const { moonpay, t } = this.props;

--- a/frontends/web/src/routes/device/bitbox01/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox01/backups.tsx
@@ -76,11 +76,11 @@ class Backups extends Component<Props, State> {
         alertUser(errorMessage);
       }
     });
-  }
+  };
 
   private handleBackuplistChange = (backupID: string) => {
     this.setState({ selectedBackup: backupID });
-  }
+  };
 
   private scrollIntoView = (event: React.SyntheticEvent) => {
     if(!this.scrollableContainer.current){
@@ -94,7 +94,7 @@ class Backups extends Component<Props, State> {
     }
     const top = Math.max((offsetTop + offsetHeight) - this.scrollableContainer.current.offsetHeight, 0);
     this.scrollableContainer.current.scroll({ top, behavior: 'smooth' });
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/bitbox01.jsx
+++ b/frontends/web/src/routes/device/bitbox01/bitbox01.jsx
@@ -53,7 +53,7 @@ class Device extends Component {
     deviceStatus: '',
     goal: '',
     success: null,
-  }
+  };
 
   componentDidMount() {
     this.onDevicesRegisteredChanged();
@@ -95,7 +95,7 @@ class Device extends Component {
         }
       });
     });
-  }
+  };
 
   onDeviceStatusChanged = () => {
     if (this.state.deviceRegistered) {
@@ -108,7 +108,7 @@ class Device extends Component {
         this.setState({ deviceStatus });
       });
     }
-  }
+  };
 
   getDeviceID() {
     return this.props.deviceID || null;
@@ -116,19 +116,19 @@ class Device extends Component {
 
   handleCreate = () => {
     this.setState({ goal: GOAL.CREATE });
-  }
+  };
 
   handleRestore = () => {
     this.setState({ goal: GOAL.RESTORE });
-  }
+  };
 
   handleBack = () => {
     this.setState({ goal: null });
-  }
+  };
 
   handleSuccess = () => {
     this.setState({ success: true });
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/check.jsx
+++ b/frontends/web/src/routes/device/bitbox01/check.jsx
@@ -28,7 +28,7 @@ class Check extends Component {
     password: null,
     activeDialog: false,
     message: null,
-  }
+  };
 
   abort = () => {
     this.setState({
@@ -36,15 +36,15 @@ class Check extends Component {
       activeDialog: false,
       message: null,
     });
-  }
+  };
 
   handleFormChange = event => {
     this.setState({ [event.target.id]: event.target.value });
-  }
+  };
 
   validate = () => {
     return this.props.selectedBackup && this.state.password;
-  }
+  };
 
   check = event => {
     event.preventDefault();
@@ -67,11 +67,11 @@ class Check extends Component {
       }
       this.setState({ message });
     });
-  }
+  };
 
   setValidPassword = password => {
     this.setState({ password });
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
+++ b/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
@@ -29,7 +29,7 @@ class UpgradeFirmware extends Component {
     newVersion: '',
     isConfirming: false,
     activeDialog: false,
-  }
+  };
 
   upgradeFirmware = () => {
     this.setState({
@@ -56,7 +56,7 @@ class UpgradeFirmware extends Component {
 
   abort = () => {
     this.setState({ activeDialog: false });
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/create.jsx
+++ b/frontends/web/src/routes/device/bitbox01/create.jsx
@@ -30,7 +30,7 @@ class Create extends Component {
     backupName: '',
     recoveryPassword: '',
     activeDialog: false,
-  }
+  };
 
   abort = () => {
     this.setState({
@@ -39,7 +39,7 @@ class Create extends Component {
       recoveryPassword: '',
       activeDialog: false,
     });
-  }
+  };
 
   handleFormChange = event => {
     this.setState({ [event.target.id]: event.target.value });
@@ -47,7 +47,7 @@ class Create extends Component {
 
   validate = () => {
     return !this.state.waiting && this.state.backupName !== '';
-  }
+  };
 
   create = event => {
     event.preventDefault();
@@ -67,7 +67,7 @@ class Create extends Component {
         }
       }
     });
-  }
+  };
 
   render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -61,11 +61,11 @@ class Restore extends Component<Props, State> {
       understand: false,
       password: undefined,
     });
-  }
+  };
 
   private validate = () => {
     return this.props.selectedBackup && this.state.password;
-  }
+  };
 
   private restore = (event: React.SyntheticEvent) => {
     event.preventDefault();
@@ -101,15 +101,15 @@ class Restore extends Component<Props, State> {
         }));
       }
     });
-  }
+  };
 
   private handleUnderstandChange = (e: React.SyntheticEvent) => {
     this.setState({ understand: (e.target as HTMLInputElement).checked });
-  }
+  };
 
   private setValidPassword = (password: string) => {
     this.setState({ password });
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
@@ -32,7 +32,7 @@ class ChangePIN extends Component {
     errorCode: null,
     isConfirming: false,
     activeDialog: false,
-  }
+  };
 
   abort = () => {
     this.setState({
@@ -41,11 +41,11 @@ class ChangePIN extends Component {
       isConfirming: false,
       activeDialog: false,
     });
-  }
+  };
 
   validate = () => {
     return this.state.newPIN && this.state.oldPIN;
-  }
+  };
 
   changePin = event => {
     event.preventDefault();
@@ -65,15 +65,15 @@ class ChangePIN extends Component {
         }));
       }
     });
-  }
+  };
 
   setValidOldPIN = e => {
     this.setState({ oldPIN: e.target.value });
-  }
+  };
 
   setValidNewPIN = newPIN => {
     this.setState({ newPIN });
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
@@ -29,7 +29,7 @@ class DeviceLock extends Component {
   state = {
     isConfirming: false,
     activeDialog: false,
-  }
+  };
 
   resetDevice = () => {
     this.setState({
@@ -48,7 +48,7 @@ class DeviceLock extends Component {
 
   abort = () => {
     this.setState({ activeDialog: false });
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
@@ -32,7 +32,7 @@ class HiddenWallet extends Component {
     pin: null,
     isConfirming: false,
     activeDialog: false,
-  }
+  };
 
   abort = () => {
     this.setState({
@@ -40,15 +40,15 @@ class HiddenWallet extends Component {
       isConfirming: false,
       activeDialog: false,
     });
-  }
+  };
 
   handleFormChange = event => {
     this.setState({ [event.target.id]: event.target.value });
-  }
+  };
 
   validate = () => {
     return this.state.password && this.state.pin;
-  }
+  };
 
   createHiddenWallet = event => {
     event.preventDefault();
@@ -72,15 +72,15 @@ class HiddenWallet extends Component {
         }));
       }
     });
-  }
+  };
 
   setValidPassword = password => {
     this.setState({ password });
-  }
+  };
 
   setValidPIN = pin => {
     this.setState({ pin });
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/settings/components/legacyhiddenwallet.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/legacyhiddenwallet.jsx
@@ -35,7 +35,7 @@ class LegacyHiddenWallet extends Component {
         this.props.onChange(newValue);
       }
     });
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
@@ -100,7 +100,7 @@ class MobilePairing extends Component<Props, State> {
         break;
       }
     }
-  }
+  };
 
   private reconnectUnpaired = () => {
     // If a mobile connection exists, but the device is not marked as paired, then mark it as paired.
@@ -115,7 +115,7 @@ class MobilePairing extends Component<Props, State> {
         alertUser(this.props.t('pairing.success.text'));
       });
     });
-  }
+  };
 
   private startPairing = () => {
     confirmation(this.props.t('pairing.confirm'), response => {
@@ -140,18 +140,18 @@ class MobilePairing extends Component<Props, State> {
         }
       });
     });
-  }
+  };
 
   private abort = () => {
     this.setState({
       showQRCode: false,
       status: false,
     });
-  }
+  };
 
   private toggleQRCode = () => {
     this.setState({ showQRCode: !this.state.showQRCode });
-  }
+  };
 
   public render() {
     const { t, deviceLocked, paired, hasMobileChannel } = this.props;

--- a/frontends/web/src/routes/device/bitbox01/settings/components/randomnumber.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/randomnumber.jsx
@@ -38,14 +38,14 @@ class RandomNumber extends Component {
         number,
       });
     });
-  }
+  };
 
   abort = () => {
     this.setState({
       active: false,
       number: undefined,
     });
-  }
+  };
 
   render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
@@ -33,11 +33,11 @@ class Reset extends Component {
     isConfirming: false,
     activeDialog: false,
     understand: false,
-  }
+  };
 
   handleUnderstandChange = (e) => {
     this.setState({ understand: e.target.checked });
-  }
+  };
 
   resetDevice = () => {
     this.setState({
@@ -60,7 +60,7 @@ class Reset extends Component {
 
   setValidPIN = e => {
     this.setState({ pin: e.target.value });
-  }
+  };
 
   abort = () => {
     this.setState({
@@ -69,7 +69,7 @@ class Reset extends Component {
       isConfirming: false,
       activeDialog: false,
     });
-  }
+  };
 
   render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
@@ -47,7 +47,7 @@ class Settings extends Component {
     mobileChannel: false,
     connected: false,
     newHiddenWallet: true,
-  }
+  };
 
   componentDidMount() {
     apiGet('devices/' + this.props.deviceID + '/info').then(({

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -83,15 +83,15 @@ class Initialize extends Component<Props, State> {
         });
       }
     });
-  }
+  };
 
   private setValidPassword = (password: string) => {
     this.setState({ password });
-  }
+  };
 
   private handleStart = () => {
     this.setState({ showInfo: false });
-  }
+  };
 
   public render() {
     const { t, goBack } = this.props;

--- a/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
@@ -45,7 +45,7 @@ class SecurityInformation extends Component<Props, State> {
 
   private handleStart = () => {
     this.setState({ showInfo: false });
-  }
+  };
 
   public render() {
     const { t, goBack, goal, children } = this.props;

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
@@ -45,7 +45,7 @@ class SeedCreateNew extends Component {
       password_required: false,
       funds_access: false,
     },
-  }
+  };
 
   walletNameInput = createRef();
 
@@ -58,11 +58,11 @@ class SeedCreateNew extends Component {
       return false;
     }
     return this.state.backupPassword && this.state.walletName !== '';
-  }
+  };
 
   handleFormChange = ({ target }) => {
     this.setState({ [target.id]: target.value });
-  }
+  };
 
   handleSubmit = event => {
     event.preventDefault();
@@ -86,24 +86,24 @@ class SeedCreateNew extends Component {
       }
       this.setState({ backupPassword: '' });
     });
-  }
+  };
 
   setValidBackupPassword = backupPassword => {
     this.setState({ backupPassword });
-  }
+  };
 
   validAgreements = () => {
     const { agreements } = this.state;
     const invalid = Object.keys(agreements).map(agr => agreements[agr]).includes(false);
     return !invalid;
-  }
+  };
 
   handleAgreementChange = ({ target }) => {
     this.setState(state => ({ agreements: {
       ...state.agreements,
       [target.id]: target.checked
     } }));
-  }
+  };
 
   checkSDcard = () => {
     apiGet('devices/' + this.props.deviceID + '/info').then(({ sdcard }) => {
@@ -116,12 +116,12 @@ class SeedCreateNew extends Component {
       });
       setTimeout(this.checkSDcard, 2500);
     });
-  }
+  };
 
   handleStart = () => {
     this.setState({ showInfo: false });
     this.checkSDcard();
-  }
+  };
 
   renderSpinner() {
     switch (this.state.status) {

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
@@ -38,7 +38,7 @@ class SeedRestore extends Component {
     showInfo: true,
     status: STATUS.CHECKING,
     error: '',
-  }
+  };
 
   componentDidMount () {
     this.checkSDcard();
@@ -49,7 +49,7 @@ class SeedRestore extends Component {
       status: STATUS.ERROR,
       error,
     });
-  }
+  };
 
   checkSDcard = () => {
     apiGet('devices/' + this.props.deviceID + '/info').then(({ sdcard }) => {
@@ -62,12 +62,12 @@ class SeedRestore extends Component {
       });
       setTimeout(this.checkSDcard, 2500);
     });
-  }
+  };
 
   handleStart = () => {
     this.setState({ showInfo: false });
     this.checkSDcard();
-  }
+  };
 
   renderSpinner() {
     switch (this.state.status) {

--- a/frontends/web/src/routes/device/bitbox01/setup/success.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/success.jsx
@@ -27,7 +27,7 @@ class Success extends Component {
 
   handleGetStarted = () => {
     route('/account-summary', true);
-  }
+  };
 
   render() {
     const {

--- a/frontends/web/src/routes/device/bitbox01/unlock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/unlock.jsx
@@ -41,7 +41,7 @@ class Unlock extends Component {
     remainingAttempts: null,
     needsLongTouch: false,
     password: '',
-  }
+  };
 
   handleFormChange = password => {
     this.setState({ password });
@@ -49,7 +49,7 @@ class Unlock extends Component {
 
   validate = () => {
     return this.state.password !== '';
-  }
+  };
 
   handleSubmit = event => {
     event.preventDefault();

--- a/frontends/web/src/routes/device/bitbox01/upgrade/bootloader.jsx
+++ b/frontends/web/src/routes/device/bitbox01/upgrade/bootloader.jsx
@@ -55,7 +55,7 @@ class Bootloader extends Component {
     default:
       break;
     }
-  }
+  };
 
   onStatusChanged = () => {
     apiGet('devices/' + this.props.deviceID + '/bootloader-status')
@@ -67,11 +67,11 @@ class Bootloader extends Component {
           errMsg,
         });
       });
-  }
+  };
 
   upgradeFirmware = () => {
     apiPost('devices/' + this.props.deviceID + '/bootloader/upgrade-firmware');
-  }
+  };
 
   render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/device/bitbox01/upgrade/require_upgrade.jsx
+++ b/frontends/web/src/routes/device/bitbox01/upgrade/require_upgrade.jsx
@@ -24,7 +24,7 @@ import style from '../bitbox01.module.css';
 class RequireUpgrade extends Component {
   state = {
     firmwareVersion: null
-  }
+  };
 
   componentDidMount() {
     apiGet('devices/' + this.props.deviceID + '/info').then(({ version }) => {

--- a/frontends/web/src/routes/device/bitbox02/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox02/backups.tsx
@@ -84,7 +84,7 @@ class Backups extends Component<Props, State> {
       }
     },
     );
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -154,21 +154,21 @@ class BitBox02 extends Component<Props, State> {
     apiGet(this.apiPrefix() + '/attestation').then(attestationResult => {
       this.setState({ attestationResult });
     });
-  }
+  };
 
   private apiPrefix = () => {
     return 'devices/bitbox02/' + this.props.deviceID;
-  }
+  };
 
   private handleGetStarted = () => {
     route('/account-summary', true);
-  }
+  };
 
   private onChannelHashChanged = () => {
     apiGet(this.apiPrefix() + '/channel-hash').then(({ hash, deviceVerified }) => {
       this.setState({ hash, deviceVerified });
     });
-  }
+  };
 
   private onStatusChanged = () => {
     const { showWizard, unlockOnly, appStatus } = this.state;
@@ -198,7 +198,7 @@ class BitBox02 extends Component<Props, State> {
         route('/', true);
       }
     });
-  }
+  };
 
   public componentWillUnmount() {
     const { sidebarStatus } = panelStore.state;
@@ -210,18 +210,18 @@ class BitBox02 extends Component<Props, State> {
 
   private channelVerify = (ok: boolean) => {
     apiPost(this.apiPrefix() + '/channel-hash-verify', ok);
-  }
+  };
 
   private uninitializedStep = () => {
     this.setState({ appStatus: '' });
-  }
+  };
 
   private createWalletStep = () => {
     this.checkSDCard().then(sdCardInserted => {
       this.setState({ sdCardInserted });
     });
     this.setState({ appStatus: 'createWallet' });
-  }
+  };
 
   private restoreBackupStep = () => {
     this.insertSDCard().then(success => {
@@ -232,13 +232,13 @@ class BitBox02 extends Component<Props, State> {
         });
       }
     });
-  }
+  };
 
   private checkSDCard = () => {
     return apiGet('devices/bitbox02/' + this.props.deviceID + '/check-sdcard').then(sdCardInserted => {
       return sdCardInserted;
     });
-  }
+  };
 
   private insertSDCard = () => {
     return this.checkSDCard().then(sdCardInserted => {
@@ -261,7 +261,7 @@ class BitBox02 extends Component<Props, State> {
         return false;
       });
     });
-  }
+  };
 
   private setPassword = () => {
     this.setState({
@@ -281,28 +281,28 @@ class BitBox02 extends Component<Props, State> {
       }
       this.setState({ settingPassword: false, createWalletStatus: 'createBackup' });
     });
-  }
+  };
 
   private restoreBackup = () => {
     this.insertSDCard();
     this.setState({
       restoreBackupStatus: 'restore',
     });
-  }
+  };
 
   private backupOnBeforeRestore = (backup: Backup) => {
     this.setState({
       restoreBackupStatus: 'setPassword',
       selectedBackup: backup,
     });
-  }
+  };
 
   private backupOnAfterRestore = (success: boolean) => {
     if (!success) {
       this.restoreBackup();
     }
     this.setState({ selectedBackup: undefined });
-  }
+  };
 
   private createBackup = () => {
     this.insertSDCard().then(success1 => {
@@ -322,13 +322,13 @@ class BitBox02 extends Component<Props, State> {
         this.setState({ creatingBackup: false, waitDialog: undefined });
       });
     });
-  }
+  };
 
   private handleDeviceNameInput = (event: Event) => {
     const target = (event.target as HTMLInputElement);
     const value: string = target.value;
     this.setState({ deviceName: value });
-  }
+  };
 
   private setDeviceName = () => {
     this.setState({ waitDialog: { title: this.props.t('bitbox02Interact.confirmName') } });
@@ -341,7 +341,7 @@ class BitBox02 extends Component<Props, State> {
           alertUser(result.message, { asDialog: false });
         }
       });
-  }
+  };
 
   private restoreFromMnemonic = () => {
     this.setState({ waitDialog: {
@@ -360,7 +360,7 @@ class BitBox02 extends Component<Props, State> {
         waitDialog: undefined,
       });
     });
-  }
+  };
 
   private handleDisclaimerCheck = (event: React.SyntheticEvent) => {
         type TAgreements = 'agreement1' | 'agreement2' | 'agreement3' | 'agreement4' | 'agreement5';
@@ -369,7 +369,7 @@ class BitBox02 extends Component<Props, State> {
         this.setState({
           [key as TAgreements]: target.checked
         } as unknown as Pick<State, keyof State>);
-  }
+  };
 
   public render() {
     const { t, deviceID } = this.props;

--- a/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
@@ -68,11 +68,11 @@ class Check extends Component<Props, State> {
       }
       this.setState({ message });
     });
-  }
+  };
 
   private abort = () => {
     this.setState({ activeDialog: false, userVerified: false });
-  }
+  };
 
   public render() {
     const { t, backups } = this.props;

--- a/frontends/web/src/routes/device/bitbox02/createbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/createbackup.tsx
@@ -48,7 +48,7 @@ class Create extends Component<Props, State> {
       }
       this.setState({ creatingBackup: false, disabled: false });
     });
-  }
+  };
 
   private maybeCreateBackup = () => {
     this.setState({ disabled: true });
@@ -67,7 +67,7 @@ class Create extends Component<Props, State> {
       }
       this.createBackup();
     });
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/device/bitbox02/gotostartupsettings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/gotostartupsettings.tsx
@@ -40,7 +40,7 @@ class GotoStartupSettings extends Component<Props, State> {
     apiPost(this.props.apiPrefix + '/goto-startup-settings').then(() => {
       this.setState({ isConfirming: false });
     });
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -59,7 +59,7 @@ class Passphrase extends Component<Props, State> {
     infoStep: 0,
     status: 'info',
     understood: false,
-  }
+  };
 
   public componentDidMount() {
     getDeviceInfo(this.props.deviceID)
@@ -96,9 +96,9 @@ class Passphrase extends Component<Props, State> {
           defaultValue: e.message || t('genericError'),
         }));
       });
-  }
+  };
 
-  private stopInfo = () => route(`/device/${this.props.deviceID}`)
+  private stopInfo = () => route(`/device/${this.props.deviceID}`);
 
   private continueInfo = () => {
     if (this.state.infoStep === 0) {
@@ -106,7 +106,7 @@ class Passphrase extends Component<Props, State> {
       return;
     }
     this.setState(({ infoStep }) => ({ infoStep: infoStep - 1 }));
-  }
+  };
 
   private backInfo = () => {
     if (this.state.infoStep === undefined) {
@@ -121,7 +121,7 @@ class Passphrase extends Component<Props, State> {
       return;
     }
     this.setState(({ infoStep }) => ({ infoStep: infoStep + 1 }));
-  }
+  };
 
   private renderEnableInfo = () => {
     const { infoStep, understood } = this.state;
@@ -291,7 +291,7 @@ class Passphrase extends Component<Props, State> {
       console.error(`invalid infoStep ${infoStep}`);
       return;
     }
-  }
+  };
 
   private renderDisableInfo = () => {
     const { t } = this.props;
@@ -319,7 +319,7 @@ class Passphrase extends Component<Props, State> {
         </ViewButtons>
       </View>
     );
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/device/bitbox02/reset.tsx
+++ b/frontends/web/src/routes/device/bitbox02/reset.tsx
@@ -54,11 +54,11 @@ class Reset extends Component<Props, State> {
         alertUser(this.props.t('reset.notReset'));
       }
     });
-  }
+  };
 
   private handleUnderstandChange = (e: ChangeEvent<HTMLInputElement>) => {
     this.setState({ understand: e.target.checked });
-  }
+  };
 
   private abort = () => {
     this.setState({
@@ -66,7 +66,7 @@ class Reset extends Component<Props, State> {
       isConfirming: false,
       activeDialog: false,
     });
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
+++ b/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
@@ -41,7 +41,7 @@ class SDCardCheck extends Component<Props, State> {
   private check = () => {
     apiGet('devices/bitbox02/' + this.props.deviceID + '/check-sdcard')
       .then(inserted => this.setState({ sdCardInserted: inserted }));
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
@@ -49,7 +49,7 @@ export const SetDeviceName: FunctionComponent<Props> = ({
       const { name: newDeviceName } = await getDeviceInfo(deviceID);
       setCurrentName(newDeviceName);
     } catch (e) {
-      alertUser('Device name could not be set')
+      alertUser('Device name could not be set');
     } finally {
       setActive(false);
       setInProgress(false);

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -130,4 +130,4 @@ export const Settings: FunctionComponent<Props> = ({ deviceID }) => {
       </div>
     </div>
   );
-}
+};

--- a/frontends/web/src/routes/device/bitbox02/showmnemonic.tsx
+++ b/frontends/web/src/routes/device/bitbox02/showmnemonic.tsx
@@ -43,7 +43,7 @@ class ShowMnemonic extends Component<Props, State> {
     apiPost(this.props.apiPrefix + '/show-mnemonic').then(() => {
       this.setState({ inProgress: false });
     });
-  }
+  };
 
   private askShowMnemonic = () => {
     confirmation(this.props.t('backup.showMnemonic.description'), result => {
@@ -52,7 +52,7 @@ class ShowMnemonic extends Component<Props, State> {
       }
     });
 
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
+++ b/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
@@ -50,11 +50,11 @@ class UpgradeButton extends Component<Props, State> {
       this.setState({ confirming: false });
       this.abort();
     });
-  }
+  };
 
   private abort = () => {
     this.setState({ activeDialog: false });
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/routes/device/components/skipfortesting.tsx
+++ b/frontends/web/src/routes/device/components/skipfortesting.tsx
@@ -35,11 +35,11 @@ export class SkipForTesting extends Component<SkipForTestingProps, SkipForTestin
   private registerTestingDevice = (e: React.SyntheticEvent) => {
     apiPost('test/register', { pin: this.state.testPIN });
     e.preventDefault();
-  }
+  };
 
   private handleFormChange = (value: string) => {
     this.setState({ testPIN: value });
-  }
+  };
 
   public render() {
     const { show } = this.props;

--- a/frontends/web/src/routes/device/deviceswitch.tsx
+++ b/frontends/web/src/routes/device/deviceswitch.tsx
@@ -40,6 +40,6 @@ const DeviceSwitch: FunctionComponent<Props> = ({ deviceID, devices }) => {
   default:
     return <Waiting />;
   }
-}
+};
 
 export { DeviceSwitch };

--- a/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
+++ b/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
@@ -28,7 +28,7 @@ import { SDCardCheck } from '../bitbox02/sdcardcheck';
 class ManageBackups extends Component {
   hasDevice = () => {
     return !!this.props.devices[this.props.deviceID];
-  }
+  };
 
   UNSAFE_componentWillMount() {
     if (!this.hasDevice()) {
@@ -44,7 +44,7 @@ class ManageBackups extends Component {
         {this.props.t('button.back')}
       </ButtonLink>
     );
-  }
+  };
 
   listBackups  = () => {
     switch (this.props.devices[this.props.deviceID]) {
@@ -72,7 +72,7 @@ class ManageBackups extends Component {
     default:
       return;
     }
-  }
+  };
 
   renderGuide = t => {
     switch (this.props.devices[this.props.deviceID]) {
@@ -97,7 +97,7 @@ class ManageBackups extends Component {
     default:
       return null;
     }
-  }
+  };
 
   render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/exchanges/exchanges.tsx
+++ b/frontends/web/src/routes/exchanges/exchanges.tsx
@@ -60,11 +60,11 @@ class Exchanges extends Component<Props, State> {
 
   private toggleRegion = (code: Region) => {
     this.setState(({ region }) => ({ region: region !== code ? code : null }));
-  }
+  };
 
   private toggleMethod = (code: Method) => {
     this.setState(({ method }) => ({ method: method !== code ? code : null }));
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -28,36 +28,36 @@ interface Props {
 
 const InjectParams: FunctionComponent = ({ children }) => {
   const params = useParams();
-  return React.cloneElement(children as React.ReactElement, params)
-}
+  return React.cloneElement(children as React.ReactElement, params);
+};
 
 export const AppRouter: FunctionComponent<Props> = ({ devices, deviceIDs, devicesKey, accounts, activeAccounts }) => {
   const Homepage = <DeviceSwitch
     key={devicesKey('device-switch-default')}
     deviceID={null}
     devices={devices}
-  />
+  />;
 
   const Device = <InjectParams>
     <DeviceSwitch
       key={devicesKey('device-switch')}
       deviceID={null}
       devices={devices} />
-  </InjectParams>
+  </InjectParams>;
 
   const Acc = <InjectParams>
     <Account
       code={'' /* dummy to satisfy TS */}
       devices={devices}
       accounts={activeAccounts} />
-  </InjectParams>
+  </InjectParams>;
 
   const AccSend = <InjectParams>
     <Send
       devices={devices}
       deviceIDs={deviceIDs}
       accounts={activeAccounts} />
-  </InjectParams>
+  </InjectParams>;
 
   const AccReceive = <InjectParams>
     <Receive
@@ -65,33 +65,33 @@ export const AppRouter: FunctionComponent<Props> = ({ devices, deviceIDs, device
       devices={devices}
       deviceIDs={deviceIDs}
       accounts={activeAccounts} />
-  </InjectParams>
+  </InjectParams>;
 
   const AccInfo = <InjectParams>
     <Info
       code={''}
       accounts={activeAccounts} />
-  </InjectParams>
+  </InjectParams>;
 
   const BuyInfoEl = <InjectParams>
     <BuyInfo
       devices={devices}
       accounts={activeAccounts} />
-  </InjectParams>
+  </InjectParams>;
 
   const MoonpayEl = <InjectParams>
     <Moonpay
       code={''}
       devices={devices}
       accounts={activeAccounts} />
-  </InjectParams>
+  </InjectParams>;
 
-  const PassphraseEl = <InjectParams><Passphrase deviceID={''} /></InjectParams>
+  const PassphraseEl = <InjectParams><Passphrase deviceID={''} /></InjectParams>;
 
   const ManageBackupsEl = <InjectParams><ManageBackups
     key={devicesKey('manage-backups')}
     devices={devices}
-  /></InjectParams>
+  /></InjectParams>;
 
   return <Routes>
     <Route path="/">
@@ -121,5 +121,5 @@ export const AppRouter: FunctionComponent<Props> = ({ devices, deviceIDs, device
         <Route path="manage-accounts" element={<ManageAccounts key={'manage-accounts'} />} />
       </Route>
     </Route>
-  </Routes>
-}
+  </Routes>;
+};

--- a/frontends/web/src/routes/settings/electrum.jsx
+++ b/frontends/web/src/routes/settings/electrum.jsx
@@ -34,7 +34,7 @@ class ElectrumServerClass extends Component {
     tls: false,
     loadingCheck: false,
     loadingCert: false,
-  }
+  };
 
   componentDidMount() {
     if (this.props.server !== null) {
@@ -52,14 +52,14 @@ class ElectrumServerClass extends Component {
     }
     // in list-mode
     return this.props.server.tls;
-  }
+  };
 
   handleFormChange = event => {
     this.setState({
       [event.target.name]: event.target.value,
       valid: false
     });
-  }
+  };
 
   getServer = () => {
     return {
@@ -67,12 +67,12 @@ class ElectrumServerClass extends Component {
       pemCert: this.state.electrumCert,
       tls: this.isTLS(),
     };
-  }
+  };
 
   add = () => {
     this.props.onAdd(this.getServer());
     this.setState({ electrumServer: '', electrumCert: '' });
-  }
+  };
 
   downloadCert = () => {
     this.setState({
@@ -86,7 +86,7 @@ class ElectrumServerClass extends Component {
       }
       this.setState({ loadingCert: false });
     });
-  }
+  };
 
   check = () => {
     this.setState({ loadingCheck: true });
@@ -101,7 +101,7 @@ class ElectrumServerClass extends Component {
         loadingCheck: false,
       });
     });
-  }
+  };
 
   render() {
     const {
@@ -220,7 +220,7 @@ export const ElectrumServer = withTranslation()(ElectrumServerClass);
 class ElectrumServersClass extends Component {
   state = {
     electrumServers: [],
-  }
+  };
 
   componentDidMount() {
     apiGet('config').then(config => {
@@ -233,21 +233,21 @@ class ElectrumServersClass extends Component {
       config.backend[this.props.coin].electrumServers = this.state.electrumServers;
       apiPost('config', config);
     });
-  }
+  };
 
   onAdd = server => {
     let electrumServers = this.state.electrumServers.slice();
     electrumServers.push(server);
     this.setState({ electrumServers });
     this.save();
-  }
+  };
 
   onRemove = index => {
     let electrumServers = this.state.electrumServers.slice();
     electrumServers.splice(index, 1);
     this.setState({ electrumServers });
     this.save();
-  }
+  };
 
   resetToDefault = () => {
     confirmation(this.props.t('settings.electrum.resetConfirm'), response => {
@@ -260,7 +260,7 @@ class ElectrumServersClass extends Component {
         return;
       }
     });
-  }
+  };
 
   render() {
     const { t } = this.props;
@@ -306,7 +306,7 @@ class ElectrumSettings extends Component {
   state = {
     testing: false,
     activeTab: 'btc',
-  }
+  };
 
   componentDidMount() {
     apiGet('testing').then(testing => this.setState({ testing }));
@@ -315,7 +315,7 @@ class ElectrumSettings extends Component {
   handleTab = e => {
     const target = e.target.dataset.tab;
     this.setState({ activeTab: target });
-  }
+  };
 
   render() {
     const { i18n, t } = this.props;

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -56,7 +56,7 @@ class ManageAccounts extends Component<Props, State> {
 
   private fetchAccounts = () => {
     accountAPI.getAccounts().then(accounts => this.setState({ accounts }));
-  }
+  };
 
   public componentDidMount() {
     this.fetchAccounts();
@@ -107,7 +107,7 @@ class ManageAccounts extends Component<Props, State> {
         </div>
       );
     });
-  }
+  };
 
   private toggleAccount = (accountCode: string, active: boolean) => {
     backendAPI.setAccountActive(accountCode, active).then(({ success, errorMessage }) => {
@@ -117,7 +117,7 @@ class ManageAccounts extends Component<Props, State> {
         alertUser(errorMessage);
       }
     });
-  }
+  };
 
   private toggleShowTokens = (accountCode: string) => {
     this.setState(({ showTokens }) => ({
@@ -126,7 +126,7 @@ class ManageAccounts extends Component<Props, State> {
         [accountCode]: (accountCode in showTokens) ? !showTokens[accountCode] : true,
       }
     }));
-  }
+  };
 
   private erc20TokenCodes = {
     'eth-erc20-usdt': 'Tether USD',
@@ -169,7 +169,7 @@ class ManageAccounts extends Component<Props, State> {
           </div>
         );
       });
-  }
+  };
 
   private toggleToken = (ethAccountCode: string, tokenCode: string, active: boolean) => {
     backendAPI.setTokenActive(ethAccountCode, tokenCode, active).then(({ success, errorMessage }) => {
@@ -179,7 +179,7 @@ class ManageAccounts extends Component<Props, State> {
         alertUser(errorMessage);
       }
     });
-  }
+  };
 
   private updateAccountName = (event: React.SyntheticEvent) => {
     event.preventDefault();
@@ -202,7 +202,7 @@ class ManageAccounts extends Component<Props, State> {
           editErrorMessage: undefined,
         });
       });
-  }
+  };
 
   public render() {
     const { t } = this.props;

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -80,7 +80,7 @@ class Settings extends Component<Props, State> {
       },
     })
       .then(config => this.setState({ config }));
-  }
+  };
 
   private handleFormChange = (event: React.SyntheticEvent) => {
     const target = (event.target as HTMLInputElement);
@@ -91,7 +91,7 @@ class Settings extends Component<Props, State> {
       [target.name]: target.value,
       restart: false,
     });
-  }
+  };
 
   private setProxyConfig = (proxyConfig: any) => {
     setConfig({
@@ -103,7 +103,7 @@ class Settings extends Component<Props, State> {
         restart: true,
       });
     });
-  }
+  };
 
   private handleToggleProxy = (event: React.SyntheticEvent) => {
     const config = this.state.config;
@@ -114,7 +114,7 @@ class Settings extends Component<Props, State> {
     const proxy = config.backend.proxy;
     proxy.useProxy = target.checked;
     this.setProxyConfig(proxy);
-  }
+  };
 
   private setProxyAddress = () => {
     const config = this.state.config;
@@ -130,19 +130,19 @@ class Settings extends Component<Props, State> {
         alertUser(errorMessage);
       }
     });
-  }
+  };
 
   private showProxyDialog = () => {
     this.setState({ activeProxyDialog: true });
-  }
+  };
 
   private hideProxyDialog = () => {
     this.setState({ activeProxyDialog: false });
-  }
+  };
 
   private handleRestartDismissMessage = () => {
     this.setState({ restart: false });
-  }
+  };
 
   public render() {
     const {

--- a/frontends/web/src/setupTests.js
+++ b/frontends/web/src/setupTests.js
@@ -2,7 +2,7 @@
 // this adds jest-dom's custom assertions
 import '@testing-library/jest-dom';
 
-import { configure } from 'enzyme'
+import { configure } from 'enzyme';
 
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 

--- a/frontends/web/src/utils/route.tsx
+++ b/frontends/web/src/utils/route.tsx
@@ -17,21 +17,21 @@
 import { FunctionComponent, useEffect } from 'react';
 import { NavigateFunction, useLocation, useNavigate } from 'react-router';
 
-let navigate: NavigateFunction | undefined
+let navigate: NavigateFunction | undefined;
 
 /**
  * @deprecated preact-router like. Use `useNavigate` hook if possible
  */
 export const route = (route: string, replace?: boolean) => {
   navigate?.(route, { replace });
-}
+};
 
 // This component makes route fn work, and triggers an onChange function
 export const RouterWatcher: FunctionComponent<{onChange: (() => void)}> = ({ onChange }) => {
-  navigate = useNavigate()
-  const { pathname } = useLocation()
+  navigate = useNavigate();
+  const { pathname } = useLocation();
   useEffect(() => {
     onChange();
   }, [onChange, pathname]);
   return null;
-}
+};


### PR DESCRIPTION
We do not use ASI (automatic semicolon insertion).

Added an eslint rule to enforce semicolons and antoher to disallow
unnecessary semicolons after TypeScript interfaces or function
declarations.

This commit's changes were autogenerated with eslint fix, the
command run was `make webfix`.