### PR TITLE
frontend/backend: modify transaction loading flow and add fiat value at time of transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Transaction Details: show fiat value at time of transaction
 
 ## 4.34.0
 - Bundle BitBox02 firmware version v9.12.0

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -53,6 +53,7 @@ func NewHandlers(
 	handleFunc("/init", handlers.postInit).Methods("POST")
 	handleFunc("/status", handlers.getAccountStatus).Methods("GET")
 	handleFunc("/transactions", handlers.ensureAccountInitialized(handlers.getAccountTransactions)).Methods("GET")
+	handleFunc("/transaction", handlers.ensureAccountInitialized(handlers.getAccountTransaction)).Methods("GET")
 	handleFunc("/export", handlers.ensureAccountInitialized(handlers.postExportTransactions)).Methods("POST")
 	handleFunc("/info", handlers.ensureAccountInitialized(handlers.getAccountInfo)).Methods("GET")
 	handleFunc("/utxos", handlers.ensureAccountInitialized(handlers.getUTXOs)).Methods("GET")
@@ -101,11 +102,25 @@ func (handlers *Handlers) formatAmountAsJSON(amount coin.Amount, isFee bool) For
 	}
 }
 
+func (handlers *Handlers) formatAmountAtTimeAsJSON(amount coin.Amount, timeStamp *time.Time) FormattedAmount {
+	return FormattedAmount{
+		Amount: handlers.account.Coin().FormatAmount(amount, false),
+		Unit:   handlers.account.Coin().Unit(false),
+		Conversions: coin.ConversionsAtTime(
+			amount,
+			handlers.account.Coin(),
+			false,
+			handlers.account.Config().RateUpdater,
+			timeStamp,
+		),
+	}
+}
+
 func (handlers *Handlers) formatBTCAmountAsJSON(amount btcutil.Amount, isFee bool) FormattedAmount {
 	return handlers.formatAmountAsJSON(coin.NewAmountFromInt64(int64(amount)), isFee)
 }
 
-// Transaction is the info returned per transaction by the /transactions endpoint.
+// Transaction is the info returned per transaction by the /transactions and /transaction endpoint.
 type Transaction struct {
 	TxID                     string            `json:"txID"`
 	InternalID               string            `json:"internalID"`
@@ -114,6 +129,7 @@ type Transaction struct {
 	Type                     string            `json:"type"`
 	Status                   accounts.TxStatus `json:"status"`
 	Amount                   FormattedAmount   `json:"amount"`
+	AmountAtTime             FormattedAmount   `json:"amountAtTime"`
 	Fee                      FormattedAmount   `json:"fee"`
 	Time                     *string           `json:"time"`
 	Addresses                []string          `json:"addresses"`
@@ -139,43 +155,48 @@ func (handlers *Handlers) ensureAccountInitialized(h func(*http.Request) (interf
 	}
 }
 
-func (handlers *Handlers) getAccountTransactions(_ *http.Request) (interface{}, error) {
-	result := []Transaction{}
-	txs, err := handlers.account.Transactions()
-	if err != nil {
-		return nil, err
+// getTxInfoJSON encodes a given transaction in JSON.
+// If `detail` is false, Coin related details, fees and historical fiat amount won't be included.
+func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail bool) Transaction {
+	var feeString FormattedAmount
+	if txInfo.Fee != nil {
+		feeString = handlers.formatAmountAsJSON(*txInfo.Fee, true)
 	}
-	for _, txInfo := range txs {
-		var feeString FormattedAmount
-		if txInfo.Fee != nil {
-			feeString = handlers.formatAmountAsJSON(*txInfo.Fee, true)
-		}
-		var formattedTime *string
-		if txInfo.Timestamp != nil {
-			t := txInfo.Timestamp.Format(time.RFC3339)
-			formattedTime = &t
-		}
-		addresses := []string{}
-		for _, addressAndAmount := range txInfo.Addresses {
-			addresses = append(addresses, addressAndAmount.Address)
-		}
-		txInfoJSON := Transaction{
-			TxID:                     txInfo.TxID,
-			InternalID:               txInfo.InternalID,
-			NumConfirmations:         txInfo.NumConfirmations,
-			NumConfirmationsComplete: txInfo.NumConfirmationsComplete,
-			Type: map[accounts.TxType]string{
-				accounts.TxTypeReceive:  "receive",
-				accounts.TxTypeSend:     "send",
-				accounts.TxTypeSendSelf: "send_to_self",
-			}[txInfo.Type],
-			Status:    txInfo.Status,
-			Amount:    handlers.formatAmountAsJSON(txInfo.Amount, false),
-			Fee:       feeString,
-			Time:      formattedTime,
-			Addresses: addresses,
-			Note:      handlers.account.TxNote(txInfo.InternalID),
-		}
+	var formattedTime *string
+	var amountAtTime FormattedAmount
+	if txInfo.Timestamp != nil {
+		t := txInfo.Timestamp.Format(time.RFC3339)
+		formattedTime = &t
+		amountAtTime = handlers.formatAmountAtTimeAsJSON(txInfo.Amount, txInfo.Timestamp)
+	} else if txInfo.CreatedTimestamp != nil {
+		t := txInfo.CreatedTimestamp.Format(time.RFC3339)
+		formattedTime = &t
+	}
+
+	addresses := []string{}
+	for _, addressAndAmount := range txInfo.Addresses {
+		addresses = append(addresses, addressAndAmount.Address)
+	}
+	txInfoJSON := Transaction{
+		TxID:                     txInfo.TxID,
+		InternalID:               txInfo.InternalID,
+		NumConfirmations:         txInfo.NumConfirmations,
+		NumConfirmationsComplete: txInfo.NumConfirmationsComplete,
+		Type: map[accounts.TxType]string{
+			accounts.TxTypeReceive:  "receive",
+			accounts.TxTypeSend:     "send",
+			accounts.TxTypeSendSelf: "send_to_self",
+		}[txInfo.Type],
+		Status:    txInfo.Status,
+		Amount:    handlers.formatAmountAsJSON(txInfo.Amount, false),
+		Time:      formattedTime,
+		Addresses: addresses,
+		Note:      handlers.account.TxNote(txInfo.InternalID),
+	}
+
+	if detail {
+		txInfoJSON.Fee = feeString
+		txInfoJSON.AmountAtTime = amountAtTime
 		switch handlers.account.Coin().(type) {
 		case *btc.Coin:
 			txInfoJSON.VSize = txInfo.VSize
@@ -189,9 +210,36 @@ func (handlers *Handlers) getAccountTransactions(_ *http.Request) (interface{}, 
 			txInfoJSON.Gas = txInfo.Gas
 			txInfoJSON.Nonce = txInfo.Nonce
 		}
-		result = append(result, txInfoJSON)
+	}
+	return txInfoJSON
+}
+
+func (handlers *Handlers) getAccountTransactions(_ *http.Request) (interface{}, error) {
+	result := []Transaction{}
+	txs, err := handlers.account.Transactions()
+	if err != nil {
+		return nil, err
+	}
+	for _, txInfo := range txs {
+		result = append(result, handlers.getTxInfoJSON(txInfo, false))
 	}
 	return result, nil
+}
+
+func (handlers *Handlers) getAccountTransaction(r *http.Request) (interface{}, error) {
+	internalID := r.URL.Query().Get("id")
+	txs, err := handlers.account.Transactions()
+	if err != nil {
+		return nil, err
+	}
+	for _, txInfo := range txs {
+		if txInfo.InternalID != internalID {
+			continue
+		}
+
+		return handlers.getTxInfoJSON(txInfo, true), nil
+	}
+	return nil, nil
 }
 
 func (handlers *Handlers) postExportTransactions(_ *http.Request) (interface{}, error) {

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -134,7 +134,7 @@ export type Conversions = null | {
 
 export interface IAmount {
     amount: string;
-    conversions: Conversions;
+    conversions?: Conversions;
     unit: Coin;
 }
 
@@ -151,6 +151,7 @@ export const getBalance = (code: AccountCode): Promise<IBalance> => {
 export interface ITransaction {
     addresses: string[];
     amount: IAmount;
+    amountAtTime: IAmount;
     fee: IAmount;
     feeRatePerKb: IAmount;
     gas: number;
@@ -184,6 +185,9 @@ export const getTransactionList = (code: AccountCode): Promise<ITransaction[]> =
   return apiGet(`account/${code}/transactions`);
 };
 
+export const getTransaction = (code: AccountCode, id: ITransaction['internalID']): Promise<ITransaction | null> => {
+  return apiGet(`account/${code}/transaction?id=${id}`);
+};
 
 export interface IExport {
     success: boolean;

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -16,7 +16,7 @@
  */
 
 import { PropsWithChildren } from 'react';
-import { Coin, Fiat } from '../../api/account';
+import { Coin, Fiat, IAmount } from '../../api/account';
 import { share } from '../../decorators/share';
 import { Store } from '../../decorators/store';
 import { setConfig } from '../../utils/config';
@@ -118,13 +118,8 @@ export function formatCurrency(amount: number, fiat: Fiat): string {
 
 }
 
-export interface AmountInterface {
-    amount: string;
-    unit: Coin;
-}
-
 interface ProvidedProps {
-    amount: AmountInterface;
+    amount: IAmount;
     tableRow?: boolean;
     unstyled?: boolean;
     skipUnit?: boolean;
@@ -143,13 +138,17 @@ function Conversion({
   noAction,
   children,
 }: PropsWithChildren<Props>): JSX.Element | null {
-  if (!rates) {
-    return null;
-  }
+
   const coin = amount.unit;
-  let formattedValue = '';
-  if (rates[coin]) {
-    formattedValue = formatCurrency(rates[coin][active] * Number(amount.amount), active);
+  let formattedValue = '---';
+
+  if (amount.conversions) {
+    if (amount.conversions[active] !== '')
+      formattedValue = amount.conversions[active];
+  } else {
+    if (rates && rates[coin]) {
+      formattedValue = formatCurrency(rates[coin][active] * Number(amount.amount), active);
+    }
   }
   if (tableRow) {
     return (

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1321,6 +1321,7 @@
       "date": "Date",
       "fiat": "Fiat",
       "fiatAmount": "Fiat amount",
+      "fiatAtTime": "Fiat at time of transaction",
       "status": "Status",
       "type": "Type"
     },


### PR DESCRIPTION
/transactions endpoint modified to load only data displayed in transaction frontend list

A new /transaction endpoint created to load all available data for specific transaction in order to populate the detailed transaction view in frontend

FiatConversion component modified to use backend-calculated fiat amount conversions when available

Added code to show fiat value at time of transaction in detailed transaction view