### PR TITLE
frontend: better l10n of numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Localize numbers using the user's chosen language and system region
 - Render number of blocks scanned and percentage progress using fixed-width digits for a more stable UI
 - Transaction Details: show fiat value at time of transaction
 

--- a/frontends/web/src/components/headerssync/headerssync.tsx
+++ b/frontends/web/src/components/headerssync/headerssync.tsx
@@ -29,7 +29,7 @@ interface Props {
 }
 
 export const HeadersSync: FunctionComponent<Props> = ({ coinCode }) => {
-  const { t } = useTranslation();
+  const { i18n, t } = useTranslation();
   const status = useSubscribe(subscribeCoinHeaders(coinCode));
   const [hidden, setHidden] = useState<boolean>(false);
   const mounted = useMountedRef();
@@ -47,12 +47,7 @@ export const HeadersSync: FunctionComponent<Props> = ({ coinCode }) => {
   const total = status.targetHeight - status.tipAtInitTime;
   const value = 100 * (status.tip - status.tipAtInitTime) / total;
   const loaded = !total || value >= 100;
-  let formatted = status.tip.toString();
-  let position = formatted.length - 3;
-  while (position > 0) {
-    formatted = formatted.slice(0, position) + '\'' + formatted.slice(position);
-    position = position - 3;
-  }
+  const formatted = new Intl.NumberFormat(i18n.language).format(status.tip);
 
   return (
     <div className={style.syncContainer}>

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -285,7 +285,7 @@ class AccountsSummary extends Component<Props, State> {
   }
 
   public render() {
-    const { t, accounts } = this.props;
+    const { i18n, t, accounts } = this.props;
     const { exported, data, balances } = this.state;
     return (
       <div className="contentWithGuide">
@@ -353,7 +353,7 @@ class AccountsSummary extends Component<Props, State> {
                         {(data && data.chartTotal !== null) ? (
                           <>
                             <strong>
-                              {formatCurrency(data.chartTotal, data.chartFiat)}
+                              {formatCurrency(i18n.language, data.chartTotal, data.chartFiat)}
                             </strong>
                             {' '}
                             <span className={style.coinUnit}>

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -366,6 +366,7 @@ class Chart extends Component<Props, State> {
 
   public render() {
     const {
+      i18n,
       t,
       data: {
         chartDataDaily,
@@ -394,7 +395,7 @@ class Chart extends Component<Props, State> {
         <header>
           <div className={styles.summary}>
             <div className={styles.totalValue}>
-              {chartTotal !== null ? formatCurrency(chartTotal, chartFiat) : (
+              {chartTotal !== null ? formatCurrency(i18n.language, chartTotal, chartFiat) : (
                 <Skeleton minWidth="220px" />
               )}
               <span className={styles.totalUnit}>
@@ -410,7 +411,7 @@ class Chart extends Component<Props, State> {
                     {(difference < 0) ? (<ArrowUp />) : (<ArrowDown />)}
                   </span>
                   <span className={styles.diffValue}>
-                    {formatNumber(difference, 2)}
+                    {formatNumber(i18n.language, difference, 2)}
                     <span className={styles.diffUnit}>%</span>
                   </span>
                 </>
@@ -461,7 +462,7 @@ class Chart extends Component<Props, State> {
             {toolTipValue !== undefined ? (
               <span>
                 <h2 className={styles.toolTipValue}>
-                  {formatCurrency(toolTipValue, chartFiat)}
+                  {formatCurrency(i18n.language, toolTipValue, chartFiat)}
                   <span className={styles.toolTipUnit}>{chartFiat}</span>
                 </h2>
                 <span className={styles.toolTipTime}>


### PR DESCRIPTION
Use the locale-specific formatting for currency numbers instead of always using `'` as the thousandths separator. This is done using `Intl.NumberFormatter` with the user's chosen language. Note: this uses plain number formatting instead of Intl's currency formatting because Intl's currency formatting attaches a currency symbol ($, €), while the current UI doesn't show the symbol.

Currency rendering in portfolio using the Testnet testing data:
German:
<img width="251" alt="de" src="https://user-images.githubusercontent.com/379606/179708809-cf0e5111-ee72-4899-8e7f-d662b2e6880c.png">

English:
<img width="235" alt="en" src="https://user-images.githubusercontent.com/379606/179708820-66775a13-42f0-450e-9beb-4eeec60199e9.png">

However, some strings in the account summary are still not localized because they come from the API:

<img width="716" alt="account summary" src="https://user-images.githubusercontent.com/379606/179709149-87659973-eef1-40d3-bc64-1a9e423c4b59.png">

