### PR TITLE
frontend: kerning of progress numbers using tabular-nums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Render number of blocks scanned and percentage progress using fixed-width digits for a more stable UI
 - Transaction Details: show fiat value at time of transaction
 
 ## 4.34.0

--- a/frontends/web/src/components/headerssync/headerssync.module.css
+++ b/frontends/web/src/components/headerssync/headerssync.module.css
@@ -33,6 +33,7 @@
 .syncText {
     display: inline-block;
     height: 100%;
+    font-variant: tabular-nums;
 }
 
 .spinnerContainer {

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -110,6 +110,10 @@
   color: var(--color-secondary);
 }
 
+.syncText {
+    font-variant: tabular-nums;
+}
+
 .table progress {
     appearance: none;
 }

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -218,7 +218,7 @@ class AccountsSummary extends Component<Props, State> {
     return (
       <tr key={`${code}_syncing`}>
         { nameCol }
-        <td colSpan={2}>
+        <td colSpan={2} className={style.syncText}>
           { t('account.syncedAddressesCount', {
             count: syncStatus?.toString(),
             defaultValue: 0,


### PR DESCRIPTION
When showing rapidly changing numbers like the number of blocks scanned, tabular numbers make the UI more stable. For example, a number like "11" is narrow while "12" is wider. By using tabular numbers, the width of the UI stays stable when it goes from rendering "11" to "12".

I added `font-variant: tabular-nums` to a few progress indicators. There is one indicator in account.tsx (`initializingSpinnerText`) that I didn't modify since it would require bigger changes to the Spinner component, such as allowing a parent to pass in JSX children instead of supporting only the `text` prop.

Block syncing progress:

https://user-images.githubusercontent.com/379606/179463028-19867286-09da-43d5-9b5e-39cacaec644c.mp4

Account summary scanning progress:

<img width="391" alt="accountsummary" src="https://user-images.githubusercontent.com/379606/179462985-9c2534a0-412d-4b91-9378-69c5f69d4c05.png">
