### PR TITLE
frontend: fix react/no-unused-prop-types

### DIFF
--- a/frontends/web/.eslintrc.json
+++ b/frontends/web/.eslintrc.json
@@ -16,7 +16,8 @@
     "no-extra-semi": "error",
     "@typescript-eslint/type-annotation-spacing": "error",
     "arrow-spacing": "error",
-    "space-infix-ops": "error"
+    "space-infix-ops": "error",
+    "react/no-unused-prop-types": "error"
   },
   "overrides": [
     {

--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -34,6 +34,7 @@ interface LoadedProps {
 }
 
 interface BannerProps {
+    // eslint-disable-next-line react/no-unused-prop-types
     msgKey: 'bitbox01';
 }
 

--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -26,8 +26,11 @@ import style from './guide.module.css';
 
 export interface SharedProps {
     shown: boolean;
+    // eslint-disable-next-line react/no-unused-prop-types
     activeSidebar: boolean;
+    // eslint-disable-next-line react/no-unused-prop-types
     sidebarStatus: string;
+    // eslint-disable-next-line react/no-unused-prop-types
     guideExists: boolean;
 }
 

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -26,6 +26,7 @@ import style from './rates.module.css';
 
 export interface SharedProps {
     active: Fiat;
+    // eslint-disable-next-line react/no-unused-prop-types
     selected: Fiat[];
 }
 

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -27,11 +27,10 @@ type ViewProps = {
     fullscreen?: boolean;
     minHeight?: string;
     onClose?: () => void;
-    position?: 'fill' | '';
     textCenter?: boolean;
     width?: string;
     withBottomBar?: boolean;
-}
+};
 
 /**
  * View component is used as a container component to wrap ViewHeader, ViewContent and ViewButtons

--- a/frontends/web/src/routes/account/add/components/steps.tsx
+++ b/frontends/web/src/routes/account/add/components/steps.tsx
@@ -52,7 +52,6 @@ export const Steps: FunctionComponent<Props> = ({
 interface StepProps {
     line?: boolean;
     status?: 'process' | 'finish' | 'wait';
-    step?: number;
     hidden?: boolean;
 }
 

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -33,6 +33,7 @@ interface UTXOsProps {
     explorerURL: string;
     onChange: (selectedUTXO: SelectedUTXO) => void;
     onClose: () => void;
+    // eslint-disable-next-line react/no-unused-prop-types
     ref?: React.RefObject<any> // WithTranslation doesn't add ref prop correctly
 }
 

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -17,7 +17,6 @@
 import React, { ChangeEvent, Component } from 'react';
 import { route } from '../../utils/route';
 import { AccountCode, IAccount } from '../../api/account';
-import { TDevices } from '../../api/devices';
 import Guide from './guide';
 import A from '../../components/anchor/anchor';
 import { Header } from '../../components/layout';
@@ -33,7 +32,6 @@ import style from './info.module.css';
 interface BuyInfoProps {
     accounts: IAccount[];
     code?: string;
-    devices: TDevices;
 }
 
 interface LoadedBuyInfoProps {

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -17,7 +17,6 @@
 
 import { Component, createRef } from 'react';
 import { IAccount } from '../../api/account';
-import { TDevices } from '../../api/devices';
 import Guide from './guide';
 import { Header } from '../../components/layout';
 import { load } from '../../decorators/load';
@@ -29,7 +28,6 @@ import style from './moonpay.module.css';
 interface BuyProps {
     accounts: IAccount[];
     code: string;
-    devices: TDevices;
 }
 
 interface LoadedBuyProps {

--- a/frontends/web/src/routes/device/bitbox01/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox01/backups.tsx
@@ -33,7 +33,6 @@ interface BackupsProps {
     showCreate?: boolean;
     showRestore?: boolean;
     requireConfirmation?: boolean;
-    fillSpace?: boolean;
     displayError?: () => void;
     onRestore?: () => void;
 }

--- a/frontends/web/src/routes/device/bitbox01/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox01/backups.tsx
@@ -33,7 +33,6 @@ interface BackupsProps {
     showCreate?: boolean;
     showRestore?: boolean;
     requireConfirmation?: boolean;
-    displayError?: () => void;
     onRestore?: () => void;
 }
 

--- a/frontends/web/src/routes/device/bitbox01/bitbox01.jsx
+++ b/frontends/web/src/routes/device/bitbox01/bitbox01.jsx
@@ -161,7 +161,7 @@ class Device extends Component {
       }
       return (
         <SecurityInformation goal={goal} goBack={this.handleBack}>
-          <Initialize goal={goal} goBack={this.handleBack} deviceID={deviceID} />
+          <Initialize goBack={this.handleBack} deviceID={deviceID} />
         </SecurityInformation>
       );
     case DeviceStatus.LOGGED_IN:

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -33,7 +33,6 @@ const stateEnum = Object.freeze({
 });
 
 interface InitializeProps {
-    goal: string;
     goBack: () => void;
     deviceID: string;
 }

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
@@ -140,8 +140,7 @@ class SeedRestore extends Component {
                     displayError={this.displayError}
                     deviceID={deviceID}
                     requireConfirmation={false}
-                    onRestore={onSuccess}
-                    fillSpace>
+                    onRestore={onSuccess}>
                     <Button
                       transparent
                       onClick={goBack}>

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
@@ -45,13 +45,6 @@ class SeedRestore extends Component {
     this.checkSDcard();
   }
 
-  displayError = error => {
-    this.setState({
-      status: STATUS.ERROR,
-      error,
-    });
-  };
-
   checkSDcard = () => {
     getDeviceInfo(this.props.deviceID)
       .then(({ sdcard }) => {
@@ -137,7 +130,6 @@ class SeedRestore extends Component {
                 ) : (
                   <Backups
                     showCreate={false}
-                    displayError={this.displayError}
                     deviceID={deviceID}
                     requireConfirmation={false}
                     onRestore={onSuccess}>

--- a/frontends/web/src/routes/device/components/backups.module.css
+++ b/frontends/web/src/routes/device/components/backups.module.css
@@ -38,10 +38,6 @@
     margin-bottom: 1rem;
 }
 
-.fillSpace {
-    margin-top: calc(var(--spacing-default) * -1) !important;
-}
-
 .emptyText {
     text-align: center;
     color: var(--color-secondary);

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -75,14 +75,12 @@ export const AppRouter: FunctionComponent<Props> = ({ devices, deviceIDs, device
 
   const BuyInfoEl = <InjectParams>
     <BuyInfo
-      devices={devices}
       accounts={activeAccounts} />
   </InjectParams>;
 
   const MoonpayEl = <InjectParams>
     <Moonpay
       code={''}
-      devices={devices}
       accounts={activeAccounts} />
   </InjectParams>;
 


### PR DESCRIPTION
Eslint rule react/no-unused-prop-types found a few issues, but also
false positives related to load decorator or custom store.

This change removes unused props, but does not permanently add the
rule to eslint.