### PR TITLE
Formatting refactor

### DIFF
--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -168,6 +168,13 @@ func (coin *Coin) ToUnit(amount coinpkg.Amount, isFee bool) float64 {
 	return result
 }
 
+// SetAmount implements coinpkg.Coin.
+func (coin *Coin) SetAmount(amount *big.Rat, isFee bool) coinpkg.Amount {
+	satsAmount := new(big.Rat).Mul(amount, new(big.Rat).SetFloat64(unitSatoshi))
+	intSatsAmount, _ := new(big.Int).SetString(satsAmount.FloatString(0), 0)
+	return coinpkg.NewAmount(intSatsAmount)
+}
+
 // Blockchain connects to a blockchain backend.
 func (coin *Coin) Blockchain() blockchain.Interface {
 	return coin.blockchain

--- a/backend/coins/btc/coin_test.go
+++ b/backend/coins/btc/coin_test.go
@@ -16,6 +16,7 @@
 package btc_test
 
 import (
+	"math/big"
 	"os"
 	"testing"
 
@@ -109,6 +110,21 @@ func (s *testSuite) TestToUnit() {
 			coin.NewAmountFromInt64(0), isFee))
 		require.Equal(s.T(), float64(0.00000001), s.coin.ToUnit(
 			coin.NewAmountFromInt64(1), isFee))
+	}
+}
+
+func (s *testSuite) TestSetAmount() {
+	ratAmount1, _ := new(big.Rat).SetString("123.12345678")
+	ratAmount2, _ := new(big.Rat).SetString("0")
+	ratAmount3, _ := new(big.Rat).SetString("123")
+
+	for _, isFee := range []bool{false, true} {
+		require.Equal(s.T(), "12312345678",
+			s.coin.SetAmount(ratAmount1, isFee).BigInt().String())
+		require.Equal(s.T(), "0",
+			s.coin.SetAmount(ratAmount2, isFee).BigInt().String())
+		require.Equal(s.T(), "12300000000",
+			s.coin.SetAmount(ratAmount3, isFee).BigInt().String())
 	}
 }
 

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -102,8 +102,8 @@ func (handlers *Handlers) formatAmountAsJSON(amount coin.Amount, isFee bool) For
 	}
 }
 
-func (handlers *Handlers) formatAmountAtTimeAsJSON(amount coin.Amount, timeStamp *time.Time) FormattedAmount {
-	return FormattedAmount{
+func (handlers *Handlers) formatAmountAtTimeAsJSON(amount coin.Amount, timeStamp *time.Time) *FormattedAmount {
+	return &FormattedAmount{
 		Amount: handlers.account.Coin().FormatAmount(amount, false),
 		Unit:   handlers.account.Coin().Unit(false),
 		Conversions: coin.ConversionsAtTime(
@@ -129,7 +129,7 @@ type Transaction struct {
 	Type                     string            `json:"type"`
 	Status                   accounts.TxStatus `json:"status"`
 	Amount                   FormattedAmount   `json:"amount"`
-	AmountAtTime             FormattedAmount   `json:"amountAtTime"`
+	AmountAtTime             *FormattedAmount  `json:"amountAtTime"`
 	Fee                      FormattedAmount   `json:"fee"`
 	Time                     *string           `json:"time"`
 	Addresses                []string          `json:"addresses"`
@@ -163,7 +163,7 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 		feeString = handlers.formatAmountAsJSON(*txInfo.Fee, true)
 	}
 	var formattedTime *string
-	var amountAtTime FormattedAmount
+	var amountAtTime *FormattedAmount
 	if txInfo.Timestamp != nil {
 		t := txInfo.Timestamp.Format(time.RFC3339)
 		formattedTime = &t

--- a/backend/coins/coin/coin.go
+++ b/backend/coins/coin/coin.go
@@ -16,6 +16,8 @@
 package coin
 
 import (
+	"math/big"
+
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
 )
 
@@ -48,6 +50,10 @@ type Coin interface {
 
 	// ToUnit returns the given amount in the unit as returned above.
 	ToUnit(amount Amount, isFee bool) float64
+
+	// SetAmount return an Amount object representing the *big.Rat given amount
+	// e.g. BTC 1/2 => 50000000
+	SetAmount(amount *big.Rat, isFee bool) Amount
 
 	// // Server returns the host and port of the full node used for blockchain synchronization.
 	// Server() string

--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -8,8 +8,13 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/rates"
 )
 
-func formatAsCurrency(amount float64) string {
-	formatted := strconv.FormatFloat(amount, 'f', 2, 64)
+func formatAsCurrency(amount float64, currency string) string {
+	var formatted string
+	if currency == "BTC" {
+		formatted = strings.TrimRight(strconv.FormatFloat(amount, 'f', 8, 64), "0")
+	} else {
+		formatted = strconv.FormatFloat(amount, 'f', 2, 64)
+	}
 	position := strings.Index(formatted, ".") - 3
 	for position > 0 {
 		formatted = formatted[:position] + "'" + formatted[position:]
@@ -27,7 +32,7 @@ func Conversions(amount Amount, coin Coin, isFee bool, ratesUpdater *rates.RateU
 		float := coin.ToUnit(amount, isFee)
 		conversions = map[string]string{}
 		for key, value := range rates[unit] {
-			conversions[key] = formatAsCurrency(float * value)
+			conversions[key] = formatAsCurrency(float*value, key)
 		}
 	}
 	return conversions
@@ -46,7 +51,7 @@ func ConversionsAtTime(amount Amount, coin Coin, isFee bool, ratesUpdater *rates
 			if value == 0 {
 				conversions[fiat] = ""
 			} else {
-				conversions[fiat] = formatAsCurrency(float * value)
+				conversions[fiat] = formatAsCurrency(float*value, fiat)
 			}
 		}
 	}

--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -8,14 +8,21 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/rates"
 )
 
-// FormatAsCurrency handles formatting for currencies.
-func FormatAsCurrency(amount *big.Rat, coinUnit string) string {
+// FormatAsPlainCurrency handles formatting for currencies in a simplified way.
+// This should be used when `FormatAsCurrency` can't be used because a simpler formatting is needed (e.g. to populate forms in the frontend).
+func FormatAsPlainCurrency(amount *big.Rat, coinUnit string) string {
 	var formatted string
 	if coinUnit == "BTC" {
 		formatted = strings.TrimRight(strings.TrimRight(amount.FloatString(8), "0"), ".")
 	} else {
 		formatted = amount.FloatString(2)
 	}
+	return formatted
+}
+
+// FormatAsCurrency handles formatting for currencies.
+func FormatAsCurrency(amount *big.Rat, coinUnit string) string {
+	formatted := FormatAsPlainCurrency(amount, coinUnit)
 	position := strings.Index(formatted, ".") - 3
 	for position > 0 {
 		formatted = formatted[:position] + "'" + formatted[position:]

--- a/backend/coins/coin/mocks/coin.go
+++ b/backend/coins/coin/mocks/coin.go
@@ -6,21 +6,8 @@ package mocks
 import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
+	"math/big"
 	"sync"
-)
-
-var (
-	lockCoinMockBlockExplorerTransactionURLPrefix sync.RWMutex
-	lockCoinMockClose                             sync.RWMutex
-	lockCoinMockCode                              sync.RWMutex
-	lockCoinMockDecimals                          sync.RWMutex
-	lockCoinMockFormatAmount                      sync.RWMutex
-	lockCoinMockInitialize                        sync.RWMutex
-	lockCoinMockName                              sync.RWMutex
-	lockCoinMockObserve                           sync.RWMutex
-	lockCoinMockSmallestUnit                      sync.RWMutex
-	lockCoinMockToUnit                            sync.RWMutex
-	lockCoinMockUnit                              sync.RWMutex
 )
 
 // Ensure, that CoinMock does implement coin.Coin.
@@ -29,49 +16,52 @@ var _ coin.Coin = &CoinMock{}
 
 // CoinMock is a mock implementation of coin.Coin.
 //
-//     func TestSomethingThatUsesCoin(t *testing.T) {
+// 	func TestSomethingThatUsesCoin(t *testing.T) {
 //
-//         // make and configure a mocked coin.Coin
-//         mockedCoin := &CoinMock{
-//             BlockExplorerTransactionURLPrefixFunc: func() string {
-// 	               panic("mock out the BlockExplorerTransactionURLPrefix method")
-//             },
-//             CloseFunc: func() error {
-// 	               panic("mock out the Close method")
-//             },
-//             CodeFunc: func() coin.Code {
-// 	               panic("mock out the Code method")
-//             },
-//             DecimalsFunc: func(isFee bool) uint {
-// 	               panic("mock out the Decimals method")
-//             },
-//             FormatAmountFunc: func(amount coin.Amount, isFee bool) string {
-// 	               panic("mock out the FormatAmount method")
-//             },
-//             InitializeFunc: func()  {
-// 	               panic("mock out the Initialize method")
-//             },
-//             NameFunc: func() string {
-// 	               panic("mock out the Name method")
-//             },
-//             ObserveFunc: func(in1 func(observable.Event)) func() {
-// 	               panic("mock out the Observe method")
-//             },
-//             SmallestUnitFunc: func() string {
-// 	               panic("mock out the SmallestUnit method")
-//             },
-//             ToUnitFunc: func(amount coin.Amount, isFee bool) float64 {
-// 	               panic("mock out the ToUnit method")
-//             },
-//             UnitFunc: func(isFee bool) string {
-// 	               panic("mock out the Unit method")
-//             },
-//         }
+// 		// make and configure a mocked coin.Coin
+// 		mockedCoin := &CoinMock{
+// 			BlockExplorerTransactionURLPrefixFunc: func() string {
+// 				panic("mock out the BlockExplorerTransactionURLPrefix method")
+// 			},
+// 			CloseFunc: func() error {
+// 				panic("mock out the Close method")
+// 			},
+// 			CodeFunc: func() coin.Code {
+// 				panic("mock out the Code method")
+// 			},
+// 			DecimalsFunc: func(isFee bool) uint {
+// 				panic("mock out the Decimals method")
+// 			},
+// 			FormatAmountFunc: func(amount coin.Amount, isFee bool) string {
+// 				panic("mock out the FormatAmount method")
+// 			},
+// 			InitializeFunc: func()  {
+// 				panic("mock out the Initialize method")
+// 			},
+// 			NameFunc: func() string {
+// 				panic("mock out the Name method")
+// 			},
+// 			ObserveFunc: func(fn func(observable.Event)) func() {
+// 				panic("mock out the Observe method")
+// 			},
+// 			SetAmountFunc: func(amount *big.Rat, isFee bool) coin.Amount {
+// 				panic("mock out the SetAmount method")
+// 			},
+// 			SmallestUnitFunc: func() string {
+// 				panic("mock out the SmallestUnit method")
+// 			},
+// 			ToUnitFunc: func(amount coin.Amount, isFee bool) float64 {
+// 				panic("mock out the ToUnit method")
+// 			},
+// 			UnitFunc: func(isFee bool) string {
+// 				panic("mock out the Unit method")
+// 			},
+// 		}
 //
-//         // use mockedCoin in code that requires coin.Coin
-//         // and then make assertions.
+// 		// use mockedCoin in code that requires coin.Coin
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type CoinMock struct {
 	// BlockExplorerTransactionURLPrefixFunc mocks the BlockExplorerTransactionURLPrefix method.
 	BlockExplorerTransactionURLPrefixFunc func() string
@@ -95,7 +85,10 @@ type CoinMock struct {
 	NameFunc func() string
 
 	// ObserveFunc mocks the Observe method.
-	ObserveFunc func(in1 func(observable.Event)) func()
+	ObserveFunc func(fn func(observable.Event)) func()
+
+	// SetAmountFunc mocks the SetAmount method.
+	SetAmountFunc func(amount *big.Rat, isFee bool) coin.Amount
 
 	// SmallestUnitFunc mocks the SmallestUnit method.
 	SmallestUnitFunc func() string
@@ -137,8 +130,15 @@ type CoinMock struct {
 		}
 		// Observe holds details about calls to the Observe method.
 		Observe []struct {
-			// In1 is the in1 argument value.
-			In1 func(observable.Event)
+			// Fn is the fn argument value.
+			Fn func(observable.Event)
+		}
+		// SetAmount holds details about calls to the SetAmount method.
+		SetAmount []struct {
+			// Amount is the amount argument value.
+			Amount *big.Rat
+			// IsFee is the isFee argument value.
+			IsFee bool
 		}
 		// SmallestUnit holds details about calls to the SmallestUnit method.
 		SmallestUnit []struct {
@@ -156,6 +156,18 @@ type CoinMock struct {
 			IsFee bool
 		}
 	}
+	lockBlockExplorerTransactionURLPrefix sync.RWMutex
+	lockClose                             sync.RWMutex
+	lockCode                              sync.RWMutex
+	lockDecimals                          sync.RWMutex
+	lockFormatAmount                      sync.RWMutex
+	lockInitialize                        sync.RWMutex
+	lockName                              sync.RWMutex
+	lockObserve                           sync.RWMutex
+	lockSetAmount                         sync.RWMutex
+	lockSmallestUnit                      sync.RWMutex
+	lockToUnit                            sync.RWMutex
+	lockUnit                              sync.RWMutex
 }
 
 // BlockExplorerTransactionURLPrefix calls BlockExplorerTransactionURLPrefixFunc.
@@ -165,9 +177,9 @@ func (mock *CoinMock) BlockExplorerTransactionURLPrefix() string {
 	}
 	callInfo := struct {
 	}{}
-	lockCoinMockBlockExplorerTransactionURLPrefix.Lock()
+	mock.lockBlockExplorerTransactionURLPrefix.Lock()
 	mock.calls.BlockExplorerTransactionURLPrefix = append(mock.calls.BlockExplorerTransactionURLPrefix, callInfo)
-	lockCoinMockBlockExplorerTransactionURLPrefix.Unlock()
+	mock.lockBlockExplorerTransactionURLPrefix.Unlock()
 	return mock.BlockExplorerTransactionURLPrefixFunc()
 }
 
@@ -178,9 +190,9 @@ func (mock *CoinMock) BlockExplorerTransactionURLPrefixCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockCoinMockBlockExplorerTransactionURLPrefix.RLock()
+	mock.lockBlockExplorerTransactionURLPrefix.RLock()
 	calls = mock.calls.BlockExplorerTransactionURLPrefix
-	lockCoinMockBlockExplorerTransactionURLPrefix.RUnlock()
+	mock.lockBlockExplorerTransactionURLPrefix.RUnlock()
 	return calls
 }
 
@@ -191,9 +203,9 @@ func (mock *CoinMock) Close() error {
 	}
 	callInfo := struct {
 	}{}
-	lockCoinMockClose.Lock()
+	mock.lockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	lockCoinMockClose.Unlock()
+	mock.lockClose.Unlock()
 	return mock.CloseFunc()
 }
 
@@ -204,9 +216,9 @@ func (mock *CoinMock) CloseCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockCoinMockClose.RLock()
+	mock.lockClose.RLock()
 	calls = mock.calls.Close
-	lockCoinMockClose.RUnlock()
+	mock.lockClose.RUnlock()
 	return calls
 }
 
@@ -217,9 +229,9 @@ func (mock *CoinMock) Code() coin.Code {
 	}
 	callInfo := struct {
 	}{}
-	lockCoinMockCode.Lock()
+	mock.lockCode.Lock()
 	mock.calls.Code = append(mock.calls.Code, callInfo)
-	lockCoinMockCode.Unlock()
+	mock.lockCode.Unlock()
 	return mock.CodeFunc()
 }
 
@@ -230,9 +242,9 @@ func (mock *CoinMock) CodeCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockCoinMockCode.RLock()
+	mock.lockCode.RLock()
 	calls = mock.calls.Code
-	lockCoinMockCode.RUnlock()
+	mock.lockCode.RUnlock()
 	return calls
 }
 
@@ -246,9 +258,9 @@ func (mock *CoinMock) Decimals(isFee bool) uint {
 	}{
 		IsFee: isFee,
 	}
-	lockCoinMockDecimals.Lock()
+	mock.lockDecimals.Lock()
 	mock.calls.Decimals = append(mock.calls.Decimals, callInfo)
-	lockCoinMockDecimals.Unlock()
+	mock.lockDecimals.Unlock()
 	return mock.DecimalsFunc(isFee)
 }
 
@@ -261,9 +273,9 @@ func (mock *CoinMock) DecimalsCalls() []struct {
 	var calls []struct {
 		IsFee bool
 	}
-	lockCoinMockDecimals.RLock()
+	mock.lockDecimals.RLock()
 	calls = mock.calls.Decimals
-	lockCoinMockDecimals.RUnlock()
+	mock.lockDecimals.RUnlock()
 	return calls
 }
 
@@ -279,9 +291,9 @@ func (mock *CoinMock) FormatAmount(amount coin.Amount, isFee bool) string {
 		Amount: amount,
 		IsFee:  isFee,
 	}
-	lockCoinMockFormatAmount.Lock()
+	mock.lockFormatAmount.Lock()
 	mock.calls.FormatAmount = append(mock.calls.FormatAmount, callInfo)
-	lockCoinMockFormatAmount.Unlock()
+	mock.lockFormatAmount.Unlock()
 	return mock.FormatAmountFunc(amount, isFee)
 }
 
@@ -296,9 +308,9 @@ func (mock *CoinMock) FormatAmountCalls() []struct {
 		Amount coin.Amount
 		IsFee  bool
 	}
-	lockCoinMockFormatAmount.RLock()
+	mock.lockFormatAmount.RLock()
 	calls = mock.calls.FormatAmount
-	lockCoinMockFormatAmount.RUnlock()
+	mock.lockFormatAmount.RUnlock()
 	return calls
 }
 
@@ -309,9 +321,9 @@ func (mock *CoinMock) Initialize() {
 	}
 	callInfo := struct {
 	}{}
-	lockCoinMockInitialize.Lock()
+	mock.lockInitialize.Lock()
 	mock.calls.Initialize = append(mock.calls.Initialize, callInfo)
-	lockCoinMockInitialize.Unlock()
+	mock.lockInitialize.Unlock()
 	mock.InitializeFunc()
 }
 
@@ -322,9 +334,9 @@ func (mock *CoinMock) InitializeCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockCoinMockInitialize.RLock()
+	mock.lockInitialize.RLock()
 	calls = mock.calls.Initialize
-	lockCoinMockInitialize.RUnlock()
+	mock.lockInitialize.RUnlock()
 	return calls
 }
 
@@ -335,9 +347,9 @@ func (mock *CoinMock) Name() string {
 	}
 	callInfo := struct {
 	}{}
-	lockCoinMockName.Lock()
+	mock.lockName.Lock()
 	mock.calls.Name = append(mock.calls.Name, callInfo)
-	lockCoinMockName.Unlock()
+	mock.lockName.Unlock()
 	return mock.NameFunc()
 }
 
@@ -348,40 +360,75 @@ func (mock *CoinMock) NameCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockCoinMockName.RLock()
+	mock.lockName.RLock()
 	calls = mock.calls.Name
-	lockCoinMockName.RUnlock()
+	mock.lockName.RUnlock()
 	return calls
 }
 
 // Observe calls ObserveFunc.
-func (mock *CoinMock) Observe(in1 func(observable.Event)) func() {
+func (mock *CoinMock) Observe(fn func(observable.Event)) func() {
 	if mock.ObserveFunc == nil {
 		panic("CoinMock.ObserveFunc: method is nil but Coin.Observe was just called")
 	}
 	callInfo := struct {
-		In1 func(observable.Event)
+		Fn func(observable.Event)
 	}{
-		In1: in1,
+		Fn: fn,
 	}
-	lockCoinMockObserve.Lock()
+	mock.lockObserve.Lock()
 	mock.calls.Observe = append(mock.calls.Observe, callInfo)
-	lockCoinMockObserve.Unlock()
-	return mock.ObserveFunc(in1)
+	mock.lockObserve.Unlock()
+	return mock.ObserveFunc(fn)
 }
 
 // ObserveCalls gets all the calls that were made to Observe.
 // Check the length with:
 //     len(mockedCoin.ObserveCalls())
 func (mock *CoinMock) ObserveCalls() []struct {
-	In1 func(observable.Event)
+	Fn func(observable.Event)
 } {
 	var calls []struct {
-		In1 func(observable.Event)
+		Fn func(observable.Event)
 	}
-	lockCoinMockObserve.RLock()
+	mock.lockObserve.RLock()
 	calls = mock.calls.Observe
-	lockCoinMockObserve.RUnlock()
+	mock.lockObserve.RUnlock()
+	return calls
+}
+
+// SetAmount calls SetAmountFunc.
+func (mock *CoinMock) SetAmount(amount *big.Rat, isFee bool) coin.Amount {
+	if mock.SetAmountFunc == nil {
+		panic("CoinMock.SetAmountFunc: method is nil but Coin.SetAmount was just called")
+	}
+	callInfo := struct {
+		Amount *big.Rat
+		IsFee  bool
+	}{
+		Amount: amount,
+		IsFee:  isFee,
+	}
+	mock.lockSetAmount.Lock()
+	mock.calls.SetAmount = append(mock.calls.SetAmount, callInfo)
+	mock.lockSetAmount.Unlock()
+	return mock.SetAmountFunc(amount, isFee)
+}
+
+// SetAmountCalls gets all the calls that were made to SetAmount.
+// Check the length with:
+//     len(mockedCoin.SetAmountCalls())
+func (mock *CoinMock) SetAmountCalls() []struct {
+	Amount *big.Rat
+	IsFee  bool
+} {
+	var calls []struct {
+		Amount *big.Rat
+		IsFee  bool
+	}
+	mock.lockSetAmount.RLock()
+	calls = mock.calls.SetAmount
+	mock.lockSetAmount.RUnlock()
 	return calls
 }
 
@@ -392,9 +439,9 @@ func (mock *CoinMock) SmallestUnit() string {
 	}
 	callInfo := struct {
 	}{}
-	lockCoinMockSmallestUnit.Lock()
+	mock.lockSmallestUnit.Lock()
 	mock.calls.SmallestUnit = append(mock.calls.SmallestUnit, callInfo)
-	lockCoinMockSmallestUnit.Unlock()
+	mock.lockSmallestUnit.Unlock()
 	return mock.SmallestUnitFunc()
 }
 
@@ -405,9 +452,9 @@ func (mock *CoinMock) SmallestUnitCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockCoinMockSmallestUnit.RLock()
+	mock.lockSmallestUnit.RLock()
 	calls = mock.calls.SmallestUnit
-	lockCoinMockSmallestUnit.RUnlock()
+	mock.lockSmallestUnit.RUnlock()
 	return calls
 }
 
@@ -423,9 +470,9 @@ func (mock *CoinMock) ToUnit(amount coin.Amount, isFee bool) float64 {
 		Amount: amount,
 		IsFee:  isFee,
 	}
-	lockCoinMockToUnit.Lock()
+	mock.lockToUnit.Lock()
 	mock.calls.ToUnit = append(mock.calls.ToUnit, callInfo)
-	lockCoinMockToUnit.Unlock()
+	mock.lockToUnit.Unlock()
 	return mock.ToUnitFunc(amount, isFee)
 }
 
@@ -440,9 +487,9 @@ func (mock *CoinMock) ToUnitCalls() []struct {
 		Amount coin.Amount
 		IsFee  bool
 	}
-	lockCoinMockToUnit.RLock()
+	mock.lockToUnit.RLock()
 	calls = mock.calls.ToUnit
-	lockCoinMockToUnit.RUnlock()
+	mock.lockToUnit.RUnlock()
 	return calls
 }
 
@@ -456,9 +503,9 @@ func (mock *CoinMock) Unit(isFee bool) string {
 	}{
 		IsFee: isFee,
 	}
-	lockCoinMockUnit.Lock()
+	mock.lockUnit.Lock()
 	mock.calls.Unit = append(mock.calls.Unit, callInfo)
-	lockCoinMockUnit.Unlock()
+	mock.lockUnit.Unlock()
 	return mock.UnitFunc(isFee)
 }
 
@@ -471,8 +518,8 @@ func (mock *CoinMock) UnitCalls() []struct {
 	var calls []struct {
 		IsFee bool
 	}
-	lockCoinMockUnit.RLock()
+	mock.lockUnit.RLock()
 	calls = mock.calls.Unit
-	lockCoinMockUnit.RUnlock()
+	mock.lockUnit.RUnlock()
 	return calls
 }

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/erc20"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/rpcclient"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
@@ -145,6 +146,14 @@ func (coin *Coin) ToUnit(amount coin.Amount, isFee bool) float64 {
 	factor := coin.unitFactor(isFee)
 	result, _ := new(big.Rat).SetFrac(amount.BigInt(), factor).Float64()
 	return result
+}
+
+// SetAmount implements coin.Coin.
+func (coin *Coin) SetAmount(amount *big.Rat, isFee bool) coin.Amount {
+	factor := coin.unitFactor(isFee)
+	weiAmount := new(big.Rat).Mul(amount, new(big.Rat).SetInt(factor))
+	intWeiAmount, _ := new(big.Int).SetString(weiAmount.FloatString(0), 0)
+	return coinpkg.NewAmount(intWeiAmount)
 }
 
 // BlockExplorerTransactionURLPrefix implements coin.Coin.

--- a/backend/coins/eth/coin_test.go
+++ b/backend/coins/eth/coin_test.go
@@ -56,4 +56,17 @@ func TestCoin(t *testing.T) {
 		"1.234",
 		c.FormatAmount(coin.NewAmountFromInt64(1.234e18), false),
 	)
+
+	ratAmount1, _ := new(big.Rat).SetString("123.123456789012345678")
+	ratAmount2, _ := new(big.Rat).SetString("0")
+	ratAmount3, _ := new(big.Rat).SetString("123")
+
+	for _, isFee := range []bool{false, true} {
+		require.Equal(t, "123123456789012345678",
+			c.SetAmount(ratAmount1, isFee).BigInt().String())
+		require.Equal(t, "0",
+			c.SetAmount(ratAmount2, isFee).BigInt().String())
+		require.Equal(t, "123000000000000000000",
+			c.SetAmount(ratAmount3, isFee).BigInt().String())
+	}
 }

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -191,7 +191,7 @@ func NewHandlers(
 	getAPIRouter(apiRouter)("/test/register", handlers.postRegisterTestKeystoreHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/test/deregister", handlers.postDeregisterTestKeystoreHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/rates", handlers.getRatesHandler).Methods("GET")
-	getAPIRouter(apiRouter)("/coins/convertToFiat", handlers.getConvertToFiatHandler).Methods("GET")
+	getAPIRouter(apiRouter)("/coins/convertToPlainFiat", handlers.getConvertToPlainFiatHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/coins/convertFromFiat", handlers.getConvertFromFiatHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/coins/tltc/headers/status", handlers.getHeadersStatus(coinpkg.CodeTLTC)).Methods("GET")
 	getAPIRouter(apiRouter)("/coins/tbtc/headers/status", handlers.getHeadersStatus(coinpkg.CodeTBTC)).Methods("GET")
@@ -635,7 +635,7 @@ func (handlers *Handlers) getRatesHandler(_ *http.Request) (interface{}, error) 
 	return handlers.backend.RatesUpdater().LatestPrice(), nil
 }
 
-func (handlers *Handlers) getConvertToFiatHandler(r *http.Request) (interface{}, error) {
+func (handlers *Handlers) getConvertToPlainFiatHandler(r *http.Request) (interface{}, error) {
 	from := r.URL.Query().Get("from")
 	to := r.URL.Query().Get("to")
 	amount := r.URL.Query().Get("amount")
@@ -652,7 +652,7 @@ func (handlers *Handlers) getConvertToFiatHandler(r *http.Request) (interface{},
 
 	return map[string]interface{}{
 		"success":    true,
-		"fiatAmount": coinpkg.FormatAsCurrency(convertedAmount, to),
+		"fiatAmount": coinpkg.FormatAsPlainCurrency(convertedAmount, to),
 	}, nil
 }
 

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"time"
 
@@ -493,6 +492,10 @@ func (handlers *Handlers) getAccountsHandler(_ *http.Request) (interface{}, erro
 
 func (handlers *Handlers) getAccountsTotalBalanceHandler(_ *http.Request) (interface{}, error) {
 	totalPerCoin := make(map[coin.Code]*big.Int)
+	conversionsPerCoin := make(map[coin.Code]map[string]string)
+
+	totalAmount := make(map[coin.Code]accountHandlers.FormattedAmount)
+
 	for _, account := range handlers.backend.Accounts() {
 		if !account.Config().Active {
 			continue
@@ -515,17 +518,21 @@ func (handlers *Handlers) getAccountsTotalBalanceHandler(_ *http.Request) (inter
 		} else {
 			totalPerCoin[coinCode] = new(big.Int).Add(totalPerCoin[coinCode], amount.BigInt())
 		}
+		conversionsPerCoin[coinCode] = coin.Conversions(coin.NewAmount(totalPerCoin[coinCode]), account.Coin(), false, account.Config().RateUpdater)
 	}
 
-	formattedTotalPerCoint := make(map[coin.Code]string)
 	for k, v := range totalPerCoin {
 		currentCoin, err := handlers.backend.Coin(k)
 		if err != nil {
 			return nil, err
 		}
-		formattedTotalPerCoint[k] = currentCoin.FormatAmount(coin.NewAmount(v), false)
+
+		totalAmount[k] = accountHandlers.FormattedAmount{
+			Amount:      currentCoin.FormatAmount(coin.NewAmount(v), false),
+			Conversions: conversionsPerCoin[k],
+		}
 	}
-	return formattedTotalPerCoint, nil
+	return totalAmount, nil
 }
 
 func (handlers *Handlers) postSetAccountActiveHandler(r *http.Request) (interface{}, error) {
@@ -632,17 +639,20 @@ func (handlers *Handlers) getConvertToFiatHandler(r *http.Request) (interface{},
 	from := r.URL.Query().Get("from")
 	to := r.URL.Query().Get("to")
 	amount := r.URL.Query().Get("amount")
-	amountAsFloat, err := strconv.ParseFloat(amount, 64)
-	if err != nil {
+	amountRat, valid := new(big.Rat).SetString(amount)
+	if !valid {
 		return map[string]interface{}{
 			"success": false,
 			"errMsg":  "invalid amount",
 		}, nil
 	}
+
 	rate := handlers.backend.RatesUpdater().LatestPrice()[from][to]
+	convertedAmount := new(big.Rat).Mul(amountRat, new(big.Rat).SetFloat64(rate))
+
 	return map[string]interface{}{
 		"success":    true,
-		"fiatAmount": strconv.FormatFloat(amountAsFloat*rate, 'f', 2, 64),
+		"fiatAmount": coinpkg.FormatAsCurrency(convertedAmount, to),
 	}, nil
 }
 
@@ -650,7 +660,7 @@ func (handlers *Handlers) getConvertFromFiatHandler(r *http.Request) (interface{
 	isFee := false
 	from := r.URL.Query().Get("from")
 	to := r.URL.Query().Get("to")
-	coin, err := handlers.backend.Coin(coinpkg.Code(to))
+	currentCoin, err := handlers.backend.Coin(coinpkg.Code(to))
 	if err != nil {
 		return map[string]interface{}{
 			"success": false,
@@ -658,27 +668,30 @@ func (handlers *Handlers) getConvertFromFiatHandler(r *http.Request) (interface{
 		}, nil
 	}
 
-	amount := r.URL.Query().Get("amount")
-	amountAsFloat, err := strconv.ParseFloat(amount, 64)
-	if err != nil {
+	fiatStr := r.URL.Query().Get("amount")
+	fiatRat, valid := new(big.Rat).SetString(fiatStr)
+	if !valid {
 		return map[string]interface{}{
 			"success": false,
 			"errMsg":  "invalid amount",
 		}, nil
 	}
-	unit := coin.Unit(isFee)
+
+	unit := currentCoin.Unit(isFee)
 	switch unit { // HACK: fake rates for testnet coins
 	case "TBTC", "TLTC", "TETH", "RETH":
 		unit = unit[1:]
 	}
+
 	rate := handlers.backend.RatesUpdater().LatestPrice()[unit][from]
-	result := 0.0
+	result := coin.NewAmountFromInt64(0)
 	if rate != 0.0 {
-		result = amountAsFloat / rate
+		amountRat := new(big.Rat).Quo(fiatRat, new(big.Rat).SetFloat64(rate))
+		result = currentCoin.SetAmount(amountRat, false)
 	}
 	return map[string]interface{}{
 		"success": true,
-		"amount":  strconv.FormatFloat(result, 'f', int(coin.Decimals(isFee)), 64),
+		"amount":  currentCoin.FormatAmount(result, false),
 	}, nil
 }
 

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -52,7 +52,8 @@ export const getAccounts = (): Promise<IAccount[]> => {
 };
 
 export interface ITotalBalance {
-    [key: string]: string;
+    [key: string]: IAmount;
+
 }
 
 export const getAccountsTotalBalance = (): Promise<ITotalBalance> => {
@@ -117,6 +118,7 @@ export interface ISummary {
     chartDataHourly: ChartData;
     chartFiat: Fiat;
     chartTotal: number | null;
+    formattedChartTotal: string | null;
     chartIsUpToDate: boolean; // only valid if chartDataMissing is false
 }
 

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -130,13 +130,13 @@ export const exportSummary = (): Promise<string> => {
   return apiPost('export-account-summary');
 };
 
-export type Conversions = null | {
+export type Conversions = {
     [key in Fiat]: string;
 }
 
 export interface IAmount {
     amount: string;
-    conversions?: Conversions;
+    conversions: Conversions;
     unit: Coin;
 }
 
@@ -153,7 +153,7 @@ export const getBalance = (code: AccountCode): Promise<IBalance> => {
 export interface ITransaction {
     addresses: string[];
     amount: IAmount;
-    amountAtTime: IAmount;
+    amountAtTime: IAmount | null;
     fee: IAmount;
     feeRatePerKb: IAmount;
     gas: number;
@@ -279,10 +279,7 @@ export interface UTXO {
     txId: string;
     txOutput: number;
     address: string;
-    amount: {
-        amount: string;
-        unit: Coin;
-    };
+    amount: IAmount;
     scriptType: ScriptType;
 }
 

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -93,7 +93,7 @@ export function formatNumber(amount: number, maxDigits: number): string {
 }
 
 interface ProvidedProps {
-    amount: IAmount;
+    amount?: IAmount;
     tableRow?: boolean;
     unstyled?: boolean;
     skipUnit?: boolean;
@@ -118,7 +118,7 @@ function Conversion({
   if (amount && amount.conversions[active] !== '') {
     formattedValue = amount.conversions[active];
   }
-  
+
   if (tableRow) {
     return (
       <tr className={unstyled ? '' : style.fiatRow}>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -292,7 +292,11 @@ class Transaction extends Component<Props, State> {
                 <label>{t('transaction.details.fiatAtTime')}</label>
                 <p>
                   <span className={`${style.fiat} ${typeClassName}`}>
-                    <FiatConversion amount={transactionInfo.amountAtTime} noAction>{sign}</FiatConversion>
+                    { transactionInfo.amountAtTime ?
+                      <FiatConversion amount={transactionInfo.amountAtTime} noAction>{sign}</FiatConversion>
+                      :
+                      <FiatConversion noAction>{sign}</FiatConversion>
+                    }
                   </span>
                 </p>
               </div>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -677,7 +677,7 @@ class Send extends Component<Props, State> {
                         onInput={this.handleFiatInput}
                         disabled={sendAll}
                         error={amountError}
-                        value={fiatAmount}
+                        value={fiatAmount.replace('\'','')} /* input with type=number doesn't like some formatting chars like [']. */
                         placeholder={t('send.amount.placeholder')} />
                     </div>
                   </div>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -394,7 +394,7 @@ class Send extends Component<Props, State> {
   private convertToFiat = (value?: string | boolean) => {
     if (value) {
       const coinUnit = this.getAccount()!.coinUnit;
-      apiGet(`coins/convertToFiat?from=${coinUnit}&to=${this.state.fiatUnit}&amount=${value}`)
+      apiGet(`coins/convertToPlainFiat?from=${coinUnit}&to=${this.state.fiatUnit}&amount=${value}`)
         .then(data => {
           if (data.success) {
             this.setState({ fiatAmount: data.fiatAmount });
@@ -677,7 +677,7 @@ class Send extends Component<Props, State> {
                         onInput={this.handleFiatInput}
                         disabled={sendAll}
                         error={amountError}
-                        value={fiatAmount.replace('\'','')} /* input with type=number doesn't like some formatting chars like [']. */
+                        value={fiatAmount}
                         placeholder={t('send.amount.placeholder')} />
                     </div>
                   </div>

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -22,7 +22,7 @@ import A from '../../../components/anchor/anchor';
 import { Header } from '../../../components/layout';
 import { Entry } from '../../../components/guide/entry';
 import { Guide } from '../../../components/guide/guide';
-import { FiatConversion, formatCurrency } from '../../../components/rates/rates';
+import { FiatConversion } from '../../../components/rates/rates';
 import { Check } from '../../../components/icon/icon';
 import Logo from '../../../components/icon/logo';
 import Spinner from '../../../components/spinner/ascii';
@@ -60,7 +60,7 @@ type Props = WithTranslation & AccountSummaryProps;
 interface BalanceRowProps {
     code: accountApi.AccountCode;
     name: string;
-    balance?: string;
+    balance?: accountApi.IAmount;
     coinUnit: string;
     coinCode: accountApi.CoinCode;
     coinName: string;
@@ -254,14 +254,14 @@ class AccountsSummary extends Component<Props, State> {
         { nameCol }
         <td data-label={t('accountSummary.balance')}>
           <span className={style.summaryTableBalance}>
-            <strong>{balance}</strong>
+            <strong>{balance.amount}</strong>
             {' '}
             <span className={style.coinUnit}>{coinUnit}</span>
           </span>
         </td>
         <td data-label={t('accountSummary.fiatBalance')}>
           <strong>
-            <FiatConversion amount={{ amount: balance, unit: coinUnit as accountApi.Coin }} noAction={true} />
+            <FiatConversion amount={balance} noAction={true} />
           </strong>
         </td>
       </tr>
@@ -352,10 +352,10 @@ class AccountsSummary extends Component<Props, State> {
                         <strong>{t('accountSummary.total')}</strong>
                       </th>
                       <td colSpan={2}>
-                        {(data && data.chartTotal !== null) ? (
+                        {(data && data.formattedChartTotal !== null) ? (
                           <>
                             <strong>
-                              {formatCurrency(data.chartTotal, data.chartFiat)}
+                              {data.formattedChartTotal}
                             </strong>
                             {' '}
                             <span className={style.coinUnit}>

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -47,6 +47,10 @@ interface State {
 
 type Props = ChartProps & TranslateProps;
 
+interface FormattedData {
+  [key: number]: string;
+}
+
 class Chart extends Component<Props, State> {
   private ref = createRef<HTMLDivElement>();
   private refToolTip = createRef<HTMLSpanElement>();
@@ -54,7 +58,7 @@ class Chart extends Component<Props, State> {
   private lineSeries?: ISeriesApi<'Area'>;
   private resizeTimerID?: any;
   private height: number = 300;
-  private formattedData?: Map<number, string>;
+  private formattedData?: FormattedData;
 
   static readonly defaultProps: ChartProps = {
     data: {
@@ -113,17 +117,14 @@ class Chart extends Component<Props, State> {
     return this.props.data.chartDataDaily && this.props.data.chartDataDaily.length > 0;
   };
 
-  private setFormattedData(data : ChartData) {
-    if (!this.formattedData)
-      this.formattedData = new Map<number,string>();
-    // TODO BEERO -> change with a map() function?
+  private setFormattedData(data: ChartData) {
+    this.formattedData = {} as FormattedData;
+
     data.forEach( entry => {
       if (this.formattedData) {
-        this.formattedData.set(entry.time as number, entry.formattedValue);
-        //console.log('added: ' + this.formattedData.get(entry.time as number));
+        this.formattedData[entry.time as number] = entry.formattedValue;
       }
     });
-    //console.log('data: ' +  [...(this.formattedData? this.formattedData.entries(): [])]);
   }
 
   private createChart = () => {
@@ -369,7 +370,7 @@ class Chart extends Component<Props, State> {
     const toolTipLeft =  Math.max(40, Math.min(parent.clientWidth - 140, point.x + 40 - 70));
     this.setState({
       toolTipVisible: true,
-      toolTipValue: this.formattedData? this.formattedData.get(time as number) : '',
+      toolTipValue: this.formattedData ? this.formattedData[time as number] : '',
       toolTipTop,
       toolTipLeft,
       toolTipTime: time as number,

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -19,10 +19,14 @@ import { Component, createRef, ReactChild } from 'react';
 import { ISummary } from '../../../api/account';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { Skeleton } from '../../../components/skeleton/skeleton';
-import { formatCurrency, formatNumber } from '../../../components/rates/rates';
+import { formatNumber } from '../../../components/rates/rates';
 import styles from './chart.module.css';
 
-export type ChartData = LineData[];
+export interface FormattedLineData extends LineData {
+  formattedValue: string;
+}
+
+export type ChartData = FormattedLineData[];
 
 type ChartProps = {
     data: ISummary;
@@ -35,7 +39,7 @@ interface State {
     difference?: number;
     diffSince?: string;
     toolTipVisible: boolean;
-    toolTipValue?: number;
+    toolTipValue?: string;
     toolTipTop: number;
     toolTipLeft: number;
     toolTipTime: number;
@@ -50,6 +54,7 @@ class Chart extends Component<Props, State> {
   private lineSeries?: ISeriesApi<'Area'>;
   private resizeTimerID?: any;
   private height: number = 300;
+  private formattedData?: Map<number, string>;
 
   static readonly defaultProps: ChartProps = {
     data: {
@@ -58,6 +63,7 @@ class Chart extends Component<Props, State> {
       chartDataHourly: [],
       chartFiat: 'USD',
       chartTotal: null,
+      formattedChartTotal: null,
       chartIsUpToDate: false,
     }
   };
@@ -70,6 +76,7 @@ class Chart extends Component<Props, State> {
     toolTipTop: 0,
     toolTipLeft: 0,
     toolTipTime: 0,
+
   };
 
   public componentDidMount() {
@@ -98,12 +105,26 @@ class Chart extends Component<Props, State> {
     ) {
       const data = this.state.source === 'hourly' ? chartDataHourly : chartDataDaily;
       this.lineSeries.setData(data);
+      this.setFormattedData(data);
     }
   }
 
   private hasData = (): boolean => {
     return this.props.data.chartDataDaily && this.props.data.chartDataDaily.length > 0;
   };
+
+  private setFormattedData(data : ChartData) {
+    if (!this.formattedData)
+      this.formattedData = new Map<number,string>();
+    // TODO BEERO -> change with a map() function?
+    data.forEach( entry => {
+      if (this.formattedData) {
+        this.formattedData.set(entry.time as number, entry.formattedValue);
+        //console.log('added: ' + this.formattedData.get(entry.time as number));
+      }
+    });
+    //console.log('data: ' +  [...(this.formattedData? this.formattedData.entries(): [])]);
+  }
 
   private createChart = () => {
     const { data: { chartIsUpToDate, chartDataMissing } } = this.props;
@@ -172,11 +193,13 @@ class Chart extends Component<Props, State> {
         crosshairMarkerRadius: 6,
       });
       this.lineSeries.setData(this.props.data.chartDataDaily as ChartData);
+      this.setFormattedData(this.props.data.chartDataDaily as ChartData);
       this.chart.timeScale().subscribeVisibleLogicalRangeChange(this.calculateChange);
       this.chart.subscribeCrosshairMove(this.handleCrosshair as MouseEventHandler);
       this.chart.timeScale().fitContent();
       window.addEventListener('resize', this.onResize);
       setTimeout(() => this.ref.current?.classList.remove(styles.invisible), 200);
+
     }
   };
 
@@ -212,6 +235,7 @@ class Chart extends Component<Props, State> {
   private displayWeek = () => {
     if (this.state.source !== 'hourly' && this.lineSeries && this.props.data.chartDataHourly && this.chart) {
       this.lineSeries.setData(this.props.data.chartDataHourly || []);
+      this.setFormattedData(this.props.data.chartDataHourly || []);
       this.chart.applyOptions({ timeScale: { timeVisible: true } });
     }
     this.setState(
@@ -233,6 +257,7 @@ class Chart extends Component<Props, State> {
   private displayMonth = () => {
     if (this.state.source !== 'daily' && this.lineSeries && this.props.data.chartDataDaily && this.chart) {
       this.lineSeries.setData(this.props.data.chartDataDaily || []);
+      this.setFormattedData(this.props.data.chartDataDaily || []);
       this.chart.applyOptions({ timeScale: { timeVisible: false } });
     }
     this.setState(
@@ -254,6 +279,7 @@ class Chart extends Component<Props, State> {
   private displayYear = () => {
     if (this.state.source !== 'daily' && this.lineSeries && this.props.data.chartDataDaily && this.chart) {
       this.lineSeries.setData(this.props.data.chartDataDaily);
+      this.setFormattedData(this.props.data.chartDataDaily);
       this.chart.applyOptions({ timeScale: { timeVisible: false } });
     }
     this.setState(
@@ -275,6 +301,7 @@ class Chart extends Component<Props, State> {
   private displayAll = () => {
     if (this.state.source !== 'daily' && this.lineSeries && this.props.data.chartDataDaily && this.chart) {
       this.lineSeries.setData(this.props.data.chartDataDaily);
+      this.setFormattedData(this.props.data.chartDataDaily);
       this.chart.applyOptions({ timeScale: { timeVisible: false } });
     }
     this.setState(
@@ -313,7 +340,7 @@ class Chart extends Component<Props, State> {
     const valueDiff = valueTo ? valueTo - valueFrom : 0;
     this.setState({
       difference: ((valueDiff / valueFrom) * 100),
-      diffSince: `${data[rangeFrom].value.toFixed(2)} (${this.renderDate(Number(data[rangeFrom].time) * 1000)})`
+      diffSince: `${data[rangeFrom].formattedValue} (${this.renderDate(Number(data[rangeFrom].time) * 1000)})`
     });
   };
 
@@ -342,7 +369,7 @@ class Chart extends Component<Props, State> {
     const toolTipLeft =  Math.max(40, Math.min(parent.clientWidth - 140, point.x + 40 - 70));
     this.setState({
       toolTipVisible: true,
-      toolTipValue: price,
+      toolTipValue: this.formattedData? this.formattedData.get(time as number) : '',
       toolTipTop,
       toolTipLeft,
       toolTipTime: time as number,
@@ -373,6 +400,7 @@ class Chart extends Component<Props, State> {
         chartFiat,
         chartIsUpToDate,
         chartTotal,
+        formattedChartTotal,
       },
       noDataPlaceholder,
     } = this.props;
@@ -394,7 +422,9 @@ class Chart extends Component<Props, State> {
         <header>
           <div className={styles.summary}>
             <div className={styles.totalValue}>
-              {chartTotal !== null ? formatCurrency(chartTotal, chartFiat) : (
+              {chartTotal !== null ? (
+                formattedChartTotal
+              ) : (
                 <Skeleton minWidth="220px" />
               )}
               <span className={styles.totalUnit}>
@@ -461,7 +491,7 @@ class Chart extends Component<Props, State> {
             {toolTipValue !== undefined ? (
               <span>
                 <h2 className={styles.toolTipValue}>
-                  {formatCurrency(toolTipValue, chartFiat)}
+                  {toolTipValue}
                   <span className={styles.toolTipUnit}>{chartFiat}</span>
                 </h2>
                 <span className={styles.toolTipTime}>


### PR DESCRIPTION
This PR (WIP):
- Fixes the BTC 2 digits backend formatting bug
- Proposes a draft solution to centralize formatting handling in the backend, exploiting higher precision when available

I still see room for some improvements in FromUnit implementation precision.

See commit messages for details.

Once agreed on this first draft, the next step is to refactor the frontend part, moving all the occasional formatting done there into the backend.