### PR TITLE
frontend: fix receive view with software keystore

### DIFF
--- a/frontends/web/src/routes/account/receive/index.tsx
+++ b/frontends/web/src/routes/account/receive/index.tsx
@@ -34,15 +34,14 @@ export const Receive: FunctionComponent<Props> = props => {
   } = props;
   const device = deviceIDs.length ? devices[deviceIDs[0]] : undefined;
   switch (device) {
-  case 'bitbox02':
-    return (
-      <ReceiveBB02 {...props} />
-    );
   case 'bitbox':
     return (
       <ReceiveBB01 {...props} />
     );
-  default:
-    return null;
+  case 'bitbox02':
+  default: // software keystore
+    return (
+      <ReceiveBB02 {...props} />
+    );
   }
 };

--- a/frontends/web/src/routes/account/receive/index.tsx
+++ b/frontends/web/src/routes/account/receive/index.tsx
@@ -32,16 +32,21 @@ export const Receive: FunctionComponent<Props> = props => {
     devices,
     deviceIDs,
   } = props;
-  const device = deviceIDs.length ? devices[deviceIDs[0]] : undefined;
+  const deviceID = deviceIDs[0];
+  const device = deviceIDs.length ? devices[deviceID] : undefined;
   switch (device) {
   case 'bitbox':
     return (
-      <ReceiveBB01 {...props} />
+      <ReceiveBB01
+        deviceID={deviceID}
+        {...props} />
     );
   case 'bitbox02':
   default: // software keystore
     return (
-      <ReceiveBB02 {...props} />
+      <ReceiveBB02
+        deviceID={deviceID}
+        {...props} />
     );
   }
 };

--- a/frontends/web/src/routes/account/receive/receive-bb01.tsx
+++ b/frontends/web/src/routes/account/receive/receive-bb01.tsx
@@ -38,7 +38,7 @@ import style from './receive.module.css';
 type Props = {
   accounts: accountApi.IAccount[];
   code: string;
-  deviceIDs: string[];
+  deviceID: string;
 };
 
 type AddressDialog = { addressType: number } | undefined;
@@ -61,7 +61,7 @@ const getIndexOfMatchingScriptType = (
 export const Receive: FunctionComponent<Props> = ({
   accounts,
   code,
-  deviceIDs,
+  deviceID,
 }) => {
   const { t } = useTranslation();
   const [verifying, setVerifying] = useState<boolean>(false);
@@ -156,7 +156,7 @@ export const Receive: FunctionComponent<Props> = ({
   return (
     <div className="contentWithGuide">
       <div className="container">
-        <PairedWarning deviceID={deviceIDs[0]} />
+        <PairedWarning deviceID={deviceID} />
         <Header title={<h2>{t('receive.title', { accountName: account?.coinName })}</h2>} />
         <div className="innerContainer scrollableContainer">
           <div className="content narrow isVerticallyCentered">


### PR DESCRIPTION
In e4f0d4e7 the receive view was split into BitBox01 and BitBox02
components so that the BitBox01 legacy version could remain as is.

This introduced an issue that no receive view is shown with the
software keystore used in webdev (dev mode).

Fixed receive view for software keystore and render the BitBox02
receive component.