### PR TITLE
frontend/api/account: add conversions to UTXO amount type

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -280,6 +280,7 @@ export interface UTXO {
     amount: {
         amount: string;
         unit: Coin;
+        conversions: Conversions;
     };
     scriptType: ScriptType;
 }


### PR DESCRIPTION
It is delivered by the backend and used in <FiatConversion> to display
the conversions already.