### PR TITLE
backend/devices/keystore: don't panic if previous output missing

### DIFF
--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -150,7 +150,8 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 	for index, txIn := range transaction.TxIn {
 		spentOutput, ok := btcProposedTx.PreviousOutputs[txIn.PreviousOutPoint]
 		if !ok {
-			keystore.log.Panic("There needs to be exactly one output being spent per input!")
+			keystore.log.Error("There needs to be exactly one output being spent per input.")
+			return errp.New("There needs to be exactly one output being spent per input.")
 		}
 		address := btcProposedTx.GetAddress(spentOutput.ScriptHashHex())
 		isSegwit, subScript := address.ScriptForHashToSign()

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -303,7 +303,11 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 
 	inputs := make([]*firmware.BTCTxInput, len(tx.TxIn))
 	for inputIndex, txIn := range tx.TxIn {
-		prevOut := btcProposedTx.PreviousOutputs[txIn.PreviousOutPoint]
+		prevOut, ok := btcProposedTx.PreviousOutputs[txIn.PreviousOutPoint]
+		if !ok {
+			keystore.log.Error("There needs to be exactly one output being spent per input.")
+			return errp.New("There needs to be exactly one output being spent per input.")
+		}
 
 		inputAddress := btcProposedTx.GetAddress(prevOut.ScriptHashHex())
 

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -205,7 +205,8 @@ func (keystore *Keystore) SignTransaction(
 	for index, txIn := range transaction.TxIn {
 		spentOutput, ok := btcProposedTx.PreviousOutputs[txIn.PreviousOutPoint]
 		if !ok {
-			keystore.log.Panic("There needs to be exactly one output being spent per input!")
+			keystore.log.Error("There needs to be exactly one output being spent per input.")
+			return errp.New("There needs to be exactly one output being spent per input.")
 		}
 		address := btcProposedTx.GetAddress(spentOutput.ScriptHashHex())
 		isSegwit, subScript := address.ScriptForHashToSign()


### PR DESCRIPTION
Not being able to reference the previous output of an input is a bug,
but at the moment one can run into it when making really fast
consecutive transactions: if a new tx is made before the previous one
is broadcast and received from the Electrum backend, it might reuse
UTXOs, which become spent the moment the previous tx is processed.

This commit simply removes the panic and turns it into an error that
the user sees in the frontend.