### PR TITLE
frontend/send: allow more than 2 decimal places in the fiat field

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -670,7 +670,7 @@ class Send extends Component<Props, State> {
                     <div className="column column-1-2">
                       <Input
                         type="number"
-                        step=".01"
+                        step="any"
                         min="0"
                         label={fiatUnit}
                         id="fiatAmount"


### PR DESCRIPTION
When BTC is the selected "fiat" currency, entering more than two
decimal places results in a red error border even though it is a legal
BTC amount.

The two decimal places where not correct before either e.g. for JPY,
where there are no decimals at all.