### PR TITLE
backend: for pending tx, set fiatAtTime to null, not an empty struct

### DIFF
--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -102,8 +102,8 @@ func (handlers *Handlers) formatAmountAsJSON(amount coin.Amount, isFee bool) For
 	}
 }
 
-func (handlers *Handlers) formatAmountAtTimeAsJSON(amount coin.Amount, timeStamp *time.Time) FormattedAmount {
-	return FormattedAmount{
+func (handlers *Handlers) formatAmountAtTimeAsJSON(amount coin.Amount, timeStamp *time.Time) *FormattedAmount {
+	return &FormattedAmount{
 		Amount: handlers.account.Coin().FormatAmount(amount, false),
 		Unit:   handlers.account.Coin().Unit(false),
 		Conversions: coin.ConversionsAtTime(
@@ -129,7 +129,7 @@ type Transaction struct {
 	Type                     string            `json:"type"`
 	Status                   accounts.TxStatus `json:"status"`
 	Amount                   FormattedAmount   `json:"amount"`
-	AmountAtTime             FormattedAmount   `json:"amountAtTime"`
+	AmountAtTime             *FormattedAmount  `json:"amountAtTime"`
 	Fee                      FormattedAmount   `json:"fee"`
 	Time                     *string           `json:"time"`
 	Addresses                []string          `json:"addresses"`
@@ -163,7 +163,7 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 		feeString = handlers.formatAmountAsJSON(*txInfo.Fee, true)
 	}
 	var formattedTime *string
-	var amountAtTime FormattedAmount
+	var amountAtTime *FormattedAmount
 	if txInfo.Timestamp != nil {
 		t := txInfo.Timestamp.Format(time.RFC3339)
 		formattedTime = &t

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -151,7 +151,7 @@ export const getBalance = (code: AccountCode): Promise<IBalance> => {
 export interface ITransaction {
     addresses: string[];
     amount: IAmount;
-    amountAtTime: IAmount;
+    amountAtTime: IAmount | null;
     fee: IAmount;
     feeRatePerKb: IAmount;
     gas: number;

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -140,7 +140,7 @@ function Conversion({
 }: PropsWithChildren<Props>): JSX.Element | null {
 
   const coin = amount.unit;
-  let formattedValue = '---';
+  let formattedValue = '';
 
   if (amount.conversions) {
     if (amount.conversions[active] !== '')

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -292,7 +292,10 @@ class Transaction extends Component<Props, State> {
                 <label>{t('transaction.details.fiatAtTime')}</label>
                 <p>
                   <span className={`${style.fiat} ${typeClassName}`}>
-                    <FiatConversion amount={transactionInfo.amountAtTime} noAction>{sign}</FiatConversion>
+                    { transactionInfo.amountAtTime ?
+                      <FiatConversion amount={transactionInfo.amountAtTime} noAction>{sign}</FiatConversion>
+                      : '---'
+                    }
                   </span>
                 </p>
               </div>


### PR DESCRIPTION
This indicates clearly to the frontend that the value does not
exist. FiatConversion then is not invoked with garbage data, which
allows FiatConversion to be simplified by not taking into
consideration `null` conversions.