### PR TITLE
frontend: more eslint spacing rules

### DIFF
--- a/frontends/web/.eslintrc.json
+++ b/frontends/web/.eslintrc.json
@@ -13,7 +13,10 @@
     "quotes": ["error", "single"],
     "semi": "error",
     "space-before-blocks": ["error", "always"],
-    "no-extra-semi": "error"
+    "no-extra-semi": "error",
+    "@typescript-eslint/type-annotation-spacing": "error",
+    "arrow-spacing": "error",
+    "space-infix-ops": "error"
   },
   "overrides": [
     {

--- a/frontends/web/src/components/anchor/anchor.tsx
+++ b/frontends/web/src/components/anchor/anchor.tsx
@@ -26,7 +26,7 @@ interface Props {
     [property: string]: any;
 }
 
-const A:FunctionComponent<Props> =({ href, icon, children, ...props }) => {
+const A: FunctionComponent<Props> = ({ href, icon, children, ...props }) => {
   return (
     <span className={style.link} onClick={(e: SyntheticEvent) => {
       e.preventDefault();

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -468,7 +468,7 @@ class Chart extends Component<Props, State> {
                   {this.renderDate(toolTipTime * 1000)}
                 </span>
               </span>
-            ): null}
+            ) : null}
           </span>
         </div>
       </section>


### PR DESCRIPTION
No space before type colon, space after type colon. Spaces around type arrows.

Spaces around funcion arrows.

Spaces around operators, e.g. `let a = b` instead of `let a=b`.