### PR TITLE
android: make status bar color the same white as the app background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 - Render number of blocks scanned and percentage progress using fixed-width digits for a more stable UI
-- Transaction Details: show fiat value at time of transaction
+- Transaction details: show fiat value at time of transaction
+- Android: more modern look by changing the status bar color to white while the app is running
 
 ## 4.34.0
 - Bundle BitBox02 firmware version v9.12.0

--- a/frontends/android/BitBoxApp/app/src/main/res/values-v23/styles.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/values-v23/styles.xml
@@ -1,0 +1,7 @@
+<resources>
+    <!-- extend the base theme to add styles available only with API level 23+ -->
+    <style name="AppTheme" parent="BaseAppTheme">
+        <item name="android:statusBarColor">@color/colorPrimary</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+</resources>

--- a/frontends/android/BitBoxApp/app/src/main/res/values/colors.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#008577</color>
-    <color name="colorPrimaryDark">#00574B</color>
+    <color name="colorPrimary">#FFFFFF</color>
+    <color name="colorPrimaryDark">#E5E5E5</color>
     <color name="colorAccent">#D81B60</color>
 </resources>

--- a/frontends/android/BitBoxApp/app/src/main/res/values/styles.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/values/styles.xml
@@ -1,11 +1,12 @@
 <resources>
-
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+  <!-- Base application theme. -->
+    <style name="BaseAppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <!-- declare the theme name that's actually applied in the manifest file -->
+    <style name="AppTheme" parent="BaseAppTheme" />
 </resources>


### PR DESCRIPTION
Before it was a dark green from Android project template that we never
changed.

```
<item name="android:windowLightStatusBar">true</item>
```

is added so that the text in the status bar turns black, otherwise it
would become invisible (white on white).

windowLightStatusBar is available only from API level 23 (even though
statusBarColor is available already from API level 21), so we enable
it for 23+.