### PR TITLE
backend/rates: add supported fiat enum

### DIFF
--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -12,7 +12,7 @@ import (
 // This should be used when `FormatAsCurrency` can't be used because a simpler formatting is needed (e.g. to populate forms in the frontend).
 func FormatAsPlainCurrency(amount *big.Rat, coinUnit string) string {
 	var formatted string
-	if coinUnit == "BTC" {
+	if coinUnit == rates.BTC.String() {
 		formatted = strings.TrimRight(strings.TrimRight(amount.FloatString(8), "0"), ".")
 	} else {
 		formatted = amount.FloatString(2)

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/rates"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
 )
@@ -214,8 +215,8 @@ func NewDefaultAppConfig() AppConfig {
 				DeprecatedActiveERC20Tokens: []string{},
 			},
 			// Copied from frontend/web/src/components/rates/rates.tsx.
-			FiatList: []string{"USD", "EUR", "CHF"},
-			MainFiat: "USD",
+			FiatList: []string{rates.USD.String(), rates.EUR.String(), rates.CHF.String()},
+			MainFiat: rates.USD.String(),
 		},
 	}
 }

--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -50,6 +50,35 @@ type exchangeRate struct {
 	timestamp time.Time
 }
 
+// Fiat type represents currency strings.
+type Fiat string
+
+// String return a string representing the Fiat.
+func (f Fiat) String() string {
+	return string(f)
+}
+
+// supported Fiat.
+const (
+	AUD Fiat = "AUD"
+	BRL Fiat = "BRL"
+	CAD Fiat = "CAD"
+	CHF Fiat = "CHF"
+	CNY Fiat = "CNY"
+	EUR Fiat = "EUR"
+	GBP Fiat = "GBP"
+	HKD Fiat = "HKD"
+	ILS Fiat = "ILS"
+	JPY Fiat = "JPY"
+	KRW Fiat = "KRW"
+	NOK Fiat = "NOK"
+	RUB Fiat = "RUB"
+	SEK Fiat = "SEK"
+	SGD Fiat = "SGD"
+	USD Fiat = "USD"
+	BTC Fiat = "BTC"
+)
+
 // RateUpdater provides cryptocurrency-to-fiat conversion rates.
 type RateUpdater struct {
 	observable.Implementation


### PR DESCRIPTION
Added an enum with all the supported fiats and removed fiat strings
from around the code