### PR TITLE
qt: setRequestInterceptor is obsolete

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -324,7 +324,7 @@ int main(int argc, char *argv[])
         });
 
     RequestInterceptor interceptor;
-    view->page()->profile()->setRequestInterceptor(&interceptor);
+    view->page()->profile()->setUrlRequestInterceptor(&interceptor);
     QObject::connect(
         view->page(),
         &QWebEnginePage::featurePermissionRequested,


### PR DESCRIPTION
The obsolete setRequestInterceptor causes the follwing warning:
'Use of deprecated not thread-safe setter, use setUrlRequestInterceptor instead.'

Use setUrlRequestInterceptor instead, see
https://doc.qt.io/qt-5/qwebengineprofile-obsolete.html#setRequestInterceptor