### PR TITLE
frontend: add missing scripttype translation

### DIFF
--- a/frontends/web/src/routes/account/info/signingconfiguration.tsx
+++ b/frontends/web/src/routes/account/info/signingconfiguration.tsx
@@ -100,7 +100,7 @@ class SigningConfiguration extends Component<Props, State> {
             </p>
             { ('scriptType' in config) ? (
               <p key="scriptName" className={style.entry}>
-                <strong>Type:</strong>
+                <strong>{t('accountInfo.scriptType')}:</strong>
                 <span>{getScriptName(config.scriptType)}</span>
               </p>
             ) : null}


### PR DESCRIPTION
The key accountInfo.scriptType was accidentally removed in:
9019690a0fe26a468e971632f348e775c66f05b5

This change replaces the hardcoded 'Type:' with the scriptType
translation.