### PR TITLE
frontend/send: disable fiat selection for send view

### DIFF
--- a/frontends/web/src/components/balance/balance.tsx
+++ b/frontends/web/src/components/balance/balance.tsx
@@ -23,10 +23,12 @@ import style from './balance.module.css';
 
 interface Props {
     balance?: IBalance;
+    noRotateFiat?: boolean;
 }
 
 export const Balance: FunctionComponent<Props> = ({
   balance,
+  noRotateFiat,
 }) => {
   const { t } = useTranslation();
   if (!balance) {
@@ -42,7 +44,7 @@ export const Balance: FunctionComponent<Props> = ({
             <td className={style.availableAmount}>{balance.available.amount}</td>
             <td className={style.availableUnit}>{balance.available.unit}</td>
           </tr>
-          <FiatConversion amount={balance.available} tableRow />
+          <FiatConversion amount={balance.available} tableRow noAction={noRotateFiat}/>
         </tbody>
       </table>
       {

--- a/frontends/web/src/components/rates/rates.module.css
+++ b/frontends/web/src/components/rates/rates.module.css
@@ -24,6 +24,7 @@
     text-align: right;
 }
 
+.availableFiatUnitNoAction,
 .availableFiatUnit {
     color: var(--color-secondary);
     cursor: default;

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -123,7 +123,16 @@ function Conversion({
     return (
       <tr className={unstyled ? '' : style.fiatRow}>
         <td className={unstyled ? '' : style.availableFiatAmount}>{formattedValue}</td>
-        <td className={unstyled ? '' : style.availableFiatUnit} onClick={rotateFiat}>{active}</td>
+        {
+          !noAction && (
+            <td className={unstyled ? '' : style.availableFiatUnit} onClick={rotateFiat}>{active}</td>
+          )
+        }
+        {
+          noAction && (
+            <td className={unstyled ? '' : style.availableFiatUnitNoAction}>{active}</td>
+          )
+        }
       </tr>
     );
   }

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -597,7 +597,7 @@ class Send extends Component<Props, State> {
                 <label className="labelXLarge">{t('send.availableBalance')}</label>
               </div>
               <div className="box large">
-                <Balance balance={balance} />
+                <Balance balance={balance} noRotateFiat/>
               </div>
               {
                 coinControl && (

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -105,7 +105,7 @@ export class UTXOsClass extends Component<Props, State> {
                           {utxo.amount.unit}
                         </span>
                       </span>
-                      <FiatConversion amount={utxo.amount} unstyled />
+                      <FiatConversion amount={utxo.amount} unstyled noAction/>
                     </div>
                     <div className={style.address}>
                       <span className={style.label}>


### PR DESCRIPTION
The use of fiat selection in send view was affecting only the balance,
but not the other parts of the page (i.e. the fiat amount to be transfered).
Since it is not easy to decide which should be the correct behavior if
the user change the fiat while compiling the form, we thought it was
better to disable the feature in this view.