### PR TITLE
frontend: fix incorrect errorcode type

### DIFF
--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -106,12 +106,12 @@ class AddAccount extends Component<Props, State> {
       this.setState({ step: 'choose-name' });
       break;
     case 'choose-name':
-                interface ResponseData {
-                    success: boolean;
-                    accountCode?: string;
-                    errorCode?: 'alreadyExists' | 'limitReached';
-                    errorMessage?: string;
-                }
+      type ResponseData = {
+        success: boolean;
+        accountCode?: string;
+        errorCode?: 'accountAlreadyExists' | 'accountLimitReached';
+        errorMessage?: string;
+      };
       this.setState({ adding: true });
       apiPost('account-add', {
         coinCode,


### PR DESCRIPTION
The ResponseData type in the frontend incorrectly assumed that
the errorCodes are 'alreadyExists' and 'limitReached', but the
codes are prefixed with 'account'. See the ErrorCode in errors.go.

Changed to accountAlreadyExists and accountLimitReached.

Also changed interface to type to not accidentally extend an
existin interface, should always use type.