### PR TITLE
frontend: remove unused placeholder prop

### DIFF
--- a/frontends/web/src/routes/account/add/components/coin-dropdown.tsx
+++ b/frontends/web/src/routes/account/add/components/coin-dropdown.tsx
@@ -51,7 +51,6 @@ function CoinDropDown({
       onInput={e => onChange(supportedCoins.find(c => {
         return c.coinCode === (e.target as HTMLSelectElement).value;
       }) as backendAPI.ICoin)}
-      placeholder={t('buy.info.selectPlaceholder')}
       value={value}
       id="coinCodeDropDown" />
   );


### PR DESCRIPTION
Select elements do not have placeholder prop. The selectPlaceholder
key is already added to the component via the first option.

TypeScript did not catch this as error because we use
JSX.IntrinsicElements['select'], which extends from HTMLAttributes:
interface SelectHTMLAttributes<T> extends HTMLAttributes<T>
where placeholder is an option.

Removed the placeholder prop.