### PR TITLE
frontend: fix simple message signing success view

### DIFF
--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -47,9 +47,9 @@
     padding-top: 0;
 }
 .fit .content {
+    align-items: stretch;
     display: flex;
     flex-direction: column;
-    align-items: center;
 }
 .textCenter,
 .text-center {
@@ -180,7 +180,7 @@
 }
 
 .content .largeIcon {
-    margin: 0 0 var(--space-default) 0;
+    margin: var(--space-half) auto;
     max-height: 100%;
     width: 50%;
 }


### PR DESCRIPTION
The contents of the success view was not aligned with the content width, this is a regression introduced in:
- 6fae0143e9e23dc3b3df8b4058fc45668a7341f9