### PR TITLE
frontend: improved insufficient gas error for erc20 txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix update balance after transaction sent
 - Fix missing utxos update after new transaction is sent
 - Add attestation check on device setting
+- Fix unsufficient gas funds error message on erc20 transactions
 
 ## 4.34.0
 - Bundle BitBox02 firmware version v9.12.0

--- a/backend/accounts/errors/errors.go
+++ b/backend/accounts/errors/errors.go
@@ -43,4 +43,7 @@ var (
 	// ErrNotAvailable is returned if data required is not available yet. Example: the headers are
 	// not synced yet, which is a prerequisite to making a timeseries of the portfolio.
 	ErrNotAvailable = errpkg.New("notAvailable")
+
+	// ERC20InsufficientGasFunds is returned when there is not enough ETH to pay the erc20 transaction fee.
+	ERC20InsufficientGasFunds = errpkg.New("erc20InsufficientGasFunds")
 )

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/util"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/etherscan"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/config"
@@ -378,7 +379,11 @@ func (handlers *Handlers) postAccountSendTx(r *http.Request) (interface{}, error
 		return map[string]interface{}{"success": false, "aborted": true}, nil
 	}
 	if err != nil {
-		return map[string]interface{}{"success": false, "errorMessage": err.Error()}, nil
+		result := map[string]interface{}{"success": false, "errorMessage": err.Error()}
+		if err.Error() == etherscan.ERC20GasErr {
+			result["errorCode"] = errors.ERC20InsufficientGasFunds.Error()
+		}
+		return result, nil
 	}
 	return map[string]interface{}{"success": true}, nil
 }

--- a/backend/coins/eth/etherscan/etherscan.go
+++ b/backend/coins/eth/etherscan/etherscan.go
@@ -44,6 +44,9 @@ var CallInterval = 260 * time.Millisecond
 
 const apiKey = "X3AFAGQT2QCAFTFPIH9VJY88H9PIQ2UWP7"
 
+// ERC20GasErr is the error message returned from etherscan when there is not enough ETH to pay the transaction fee.
+const ERC20GasErr = "insufficient funds for gas * price + value"
+
 // EtherScan is a rate-limited etherscan api client. See https://etherscan.io/apis.
 type EtherScan struct {
 	url        string

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -232,6 +232,7 @@ export interface ISendTx {
     aborted?: boolean;
     success?: boolean;
     errorMessage?: string;
+    errorCode?: string;
 }
 
 export const sendTx = (code: AccountCode): Promise<ISendTx> => {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1194,6 +1194,7 @@
       "total": "Total"
     },
     "error": {
+      "erc20InsufficientGasFunds": "It seems like you do not have enough Ether to pay for this ERC20 transaction. Please make sure you hold enough Ether in your wallet",
       "feeTooLow": "fee too low",
       "feesNotAvailable": "Could not estimate fees",
       "insufficientFunds": "insufficient funds",

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -257,8 +257,14 @@ class Send extends Component<Props, State> {
         this.setState({ isAborted: true });
         setTimeout(() => this.setState({ isAborted: false }), 5000);
       } else {
-        const { errorMessage } = result;
-        alertUser(this.props.t('unknownError', errorMessage && { errorMessage }));
+        switch (result.errorCode) {
+        case 'erc20InsufficientGasFunds':
+          alertUser(this.props.t(`send.error.${result.errorCode}`));
+          break;
+        default:
+          const { errorMessage } = result;
+          alertUser(this.props.t('unknownError', errorMessage && { errorMessage }));
+        }
       }
     })
       .catch((error) => console.error(error))


### PR DESCRIPTION
If the user tries to send an erc20 transaction without having enough ETH to pay for the fee, etherscan returns a rough error message, which was previously displayed in the frontend as is.
Now the backend returns a dedicated error code and the frontend displays a comprehensible and localized error message.