### PR TITLE
Frontend blocking firmware upgrade

### DIFF
--- a/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
+++ b/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
@@ -91,9 +91,7 @@ class UpgradeFirmware extends Component {
         }
         {
           activeDialog && (
-            <Dialog
-              title={t('upgradeFirmware.title')}
-              onClose={this.abort}>
+            <Dialog title={t('upgradeFirmware.title')}>
               <p className="m-top-none">{t('upgradeFirmware.description', {
                 currentVersion, newVersion
               })}</p>

--- a/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
+++ b/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
@@ -84,9 +84,7 @@ class UpgradeButton extends Component<Props, State> {
         }
         {
           activeDialog && (
-            <Dialog
-              title={t('upgradeFirmware.title')}
-              onClose={this.abort}>
+            <Dialog title={t('upgradeFirmware.title')}>
               {confirming ? t('confirmOnDevice') : (
                 <p>{t('upgradeFirmware.description', {
                   currentVersion: versionInfo.currentVersion,

--- a/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
+++ b/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
@@ -19,9 +19,7 @@ import { Component } from 'react';
 import { VersionInfo } from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiPost } from '../../../utils/request';
-import { Dialog } from '../../../components/dialog/dialog';
-// TODO: use DialogButtons
-import dialogStyle from '../../../components/dialog/dialog.module.css';
+import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
 import { Button } from '../../../components/forms';
 import { SettingsButton } from '../../../components/settingsButton/settingsButton';
 
@@ -92,7 +90,7 @@ class UpgradeButton extends Component<Props, State> {
                 })}</p>
               )}
               { !confirming && (
-                <div className={dialogStyle.actions}>
+                <DialogButtons>
                   <Button
                     primary
                     onClick={this.upgradeFirmware}>
@@ -101,7 +99,7 @@ class UpgradeButton extends Component<Props, State> {
                   <Button transparent onClick={this.abort}>
                     {t('button.back')}
                   </Button>
-                </div>
+                </DialogButtons>
               )}
             </Dialog>
           )


### PR DESCRIPTION
Once the user is prompted to confirm upgrading the firmware on the
device, the dialog in the app should be blocking.

Changed to use DialogButtons to have nice alignment and do
not need to import the CSS file from another component.