### PR TITLE
frontend: adding trailing zeroes to BTC and LTC formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix missing utxos update after new transaction is sent
 - Add attestation check on device setting
 - Fix unsufficient gas funds error message on erc20 transactions
+- Display trailing zeroes for BTC/LTC amount formatting
 
 ## 4.34.0
 - Bundle BitBox02 firmware version v9.12.0

--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -20,7 +20,6 @@ import (
 	"math/big"
 	"os"
 	"path"
-	"strings"
 	"sync"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -158,8 +157,7 @@ func (coin *Coin) Decimals(isFee bool) uint {
 
 // FormatAmount implements coinpkg.Coin.
 func (coin *Coin) FormatAmount(amount coinpkg.Amount, isFee bool) string {
-	s := new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(unitSatoshi)).FloatString(8)
-	return strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	return new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(unitSatoshi)).FloatString(8)
 }
 
 // ToUnit implements coinpkg.Coin.

--- a/backend/coins/btc/coin_test.go
+++ b/backend/coins/btc/coin_test.go
@@ -93,9 +93,9 @@ func (s *testSuite) TestCoin() {
 
 func (s *testSuite) TestFormatAmount() {
 	for _, isFee := range []bool{false, true} {
-		require.Equal(s.T(), "12.3456891", s.coin.FormatAmount(
+		require.Equal(s.T(), "12.34568910", s.coin.FormatAmount(
 			coin.NewAmountFromInt64(1234568910), isFee))
-		require.Equal(s.T(), "0", s.coin.FormatAmount(
+		require.Equal(s.T(), "0.00000000", s.coin.FormatAmount(
 			coin.NewAmountFromInt64(0), isFee))
 		require.Equal(s.T(), "0.00000001", s.coin.FormatAmount(
 			coin.NewAmountFromInt64(1), isFee))

--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -13,7 +13,7 @@ import (
 func FormatAsPlainCurrency(amount *big.Rat, coinUnit string) string {
 	var formatted string
 	if coinUnit == rates.BTC.String() {
-		formatted = strings.TrimRight(strings.TrimRight(amount.FloatString(8), "0"), ".")
+		formatted = amount.FloatString(8)
 	} else {
 		formatted = amount.FloatString(2)
 	}

--- a/frontends/web/src/components/balance/balance.tsx
+++ b/frontends/web/src/components/balance/balance.tsx
@@ -19,6 +19,7 @@ import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IBalance } from '../../api/account';
 import { FiatConversion } from '../../components/rates/rates';
+import { bitcoinRemoveTrailingZeroes } from '../../utils/trailing-zeroes';
 import style from './balance.module.css';
 
 interface Props {
@@ -36,24 +37,29 @@ export const Balance: FunctionComponent<Props> = ({
       <header className={style.balance}></header>
     );
   }
+
+  // remove trailing zeroes from Bitcoin balance
+  const availableBalance = bitcoinRemoveTrailingZeroes(balance.available.amount, balance.available.unit);
+  const incomingBalance = bitcoinRemoveTrailingZeroes(balance.incoming.amount, balance.incoming.unit);
+
   return (
     <header className={style.balance}>
       <table className={style.balanceTable}>
         <tbody>
           <tr>
-            <td className={style.availableAmount}>{balance.available.amount}</td>
+            <td className={style.availableAmount}>{availableBalance}</td>
             <td className={style.availableUnit}>{balance.available.unit}</td>
           </tr>
-          <FiatConversion amount={balance.available} tableRow noAction={noRotateFiat}/>
+          <FiatConversion amount={balance.available} tableRow noAction={noRotateFiat} noBtcZeroes/>
         </tbody>
       </table>
       {
         balance.hasIncoming && (
           <p className={style.pendingBalance}>
-            {t('account.incoming')} +{balance.incoming.amount} {balance.incoming.unit} /
+            {t('account.incoming')} +{incomingBalance} {balance.incoming.unit} /
             <span className={style.incomingConversion}>
               {' '}
-              <FiatConversion amount={balance.incoming} />
+              <FiatConversion amount={balance.incoming} noBtcZeroes/>
             </span>
           </p>
         )

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -20,6 +20,7 @@ import { Fiat, IAmount } from '../../api/account';
 import { share } from '../../decorators/share';
 import { Store } from '../../decorators/store';
 import { setConfig } from '../../utils/config';
+import { bitcoinRemoveTrailingZeroes } from '../../utils/trailing-zeroes';
 import { equal } from '../../utils/equal';
 import { apiGet, apiPost } from '../../utils/request';
 import style from './rates.module.css';
@@ -100,7 +101,7 @@ interface ProvidedProps {
     skipUnit?: boolean;
     noAction?: boolean;
     sign?: string;
-
+    noBtcZeroes?: boolean;
 }
 
 type Props = ProvidedProps & SharedProps;
@@ -113,6 +114,7 @@ function Conversion({
   active,
   noAction,
   sign,
+  noBtcZeroes,
 }: PropsWithChildren<Props>): JSX.Element | null {
 
   let formattedValue = '---';
@@ -122,6 +124,9 @@ function Conversion({
   if (amount && amount.conversions[active] && amount.conversions[active] !== '') {
     isAvailable = true;
     formattedValue = amount.conversions[active];
+    if (noBtcZeroes) {
+      formattedValue = bitcoinRemoveTrailingZeroes(formattedValue, active);
+    }
   }
 
   if (tableRow) {

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -20,6 +20,7 @@ import { ISummary } from '../../../api/account';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { Skeleton } from '../../../components/skeleton/skeleton';
 import { formatNumber } from '../../../components/rates/rates';
+import { bitcoinRemoveTrailingZeroes } from '../../../utils/trailing-zeroes';
 import styles from './chart.module.css';
 
 export interface FormattedLineData extends LineData {
@@ -423,8 +424,9 @@ class Chart extends Component<Props, State> {
         <header>
           <div className={styles.summary}>
             <div className={styles.totalValue}>
-              {chartTotal !== null ? (
-                formattedChartTotal
+              {formattedChartTotal !== null ? (
+                // remove trailing zeroes for BTC fiat total
+                bitcoinRemoveTrailingZeroes(formattedChartTotal, chartFiat)
               ) : (
                 <Skeleton minWidth="220px" />
               )}

--- a/frontends/web/src/utils/trailing-zeroes.test.tsx
+++ b/frontends/web/src/utils/trailing-zeroes.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { bitcoinRemoveTrailingZeroes } from '../../src/utils/trailing-zeroes';
+
+describe('removeTrailingZeroes', () => {
+  let coins;
+
+  describe('coins that need to remove trailing zeroes', () => {
+    coins = ['BTC', 'TBTC', 'LTC', 'TLTC'];
+    coins.forEach(coin => {
+      it('10.00000000 ' + coin + ' becomes 10', () => {
+        expect(bitcoinRemoveTrailingZeroes('10.00000000', coin)).toBe('10');
+      });
+      it('10.12300000 ' + coin + ' becomes 10.123', () => {
+        expect(bitcoinRemoveTrailingZeroes('10.12300000', coin)).toBe('10.123');
+      });
+      it('42 ' + coin + ' stays 42', () => {
+        expect(bitcoinRemoveTrailingZeroes('42', coin)).toBe('42');
+      });
+    });
+  });
+
+  describe('coins that don\'t need to remove trailing zeroes', () => {
+    coins = ['ETH', 'TETH', 'RETH', 'GOETH'];
+    coins.forEach(coin => {
+      it('10.00000000 ' + coin + ' stays 10.00000000', () => {
+        expect(bitcoinRemoveTrailingZeroes('10.00000000', coin)).toBe('10.00000000');
+      });
+      it('10.12300000 ' + coin + ' stays 10.12300000', () => {
+        expect(bitcoinRemoveTrailingZeroes('10.12300000', coin)).toBe('10.12300000');
+      });
+      it('42 ' + coin + ' stays 42', () => {
+        expect(bitcoinRemoveTrailingZeroes('42', coin)).toBe('42');
+      });
+    });
+  });
+
+});
+

--- a/frontends/web/src/utils/trailing-zeroes.ts
+++ b/frontends/web/src/utils/trailing-zeroes.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function bitcoinRemoveTrailingZeroes(amount: string, unit: string): string {
+  if (amount.includes('.')) {
+    switch (unit) {
+    case 'BTC':
+    case 'TBTC':
+    case 'LTC':
+    case 'TLTC':
+      return amount.replace(/\.?0+$/,'');
+    default:
+    }
+  }
+  return amount;
+}
+
+


### PR DESCRIPTION
Added trailing zeroes when displaying BTC/LTC amounts in the frontend, with the exception of the balances displayed in the header of account and accountsummary views.