### PR TITLE
frontend/api: implement typed function to verify attestation on bb02

### DIFF
--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -81,3 +81,9 @@ export const setMnemonicPassphraseEnabled = (
       return Promise.resolve();
     });
 };
+
+export const verifyAttestation = (
+  deviceID: string,
+): Promise<boolean> => {
+  return apiGet(`devices/bitbox02/${deviceID}/attestation`);
+};

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -17,7 +17,7 @@
 
 import React, { Component, FormEvent } from 'react';
 import { Backup } from '../components/backup';
-import { getVersion, setDeviceName, VersionInfo } from '../../../api/bitbox02';
+import { getVersion, setDeviceName, VersionInfo, verifyAttestation } from '../../../api/bitbox02';
 import { multilineMarkup } from '../../../utils/markup';
 import { convertDateToLocaleString } from '../../../utils/date';
 import { route } from '../../../utils/route';
@@ -151,7 +151,7 @@ class BitBox02 extends Component<Props, State> {
   }
 
   private updateAttestationCheck = () => {
-    apiGet(this.apiPrefix() + '/attestation').then(attestationResult => {
+    verifyAttestation(this.props.deviceID).then(attestationResult => {
       this.setState({ attestationResult });
     });
   };


### PR DESCRIPTION
Before this, `/attestation` endpoint was called in an untyped way from `bitbox02.tsx`. Now there is a dedicated typed funcion in `api/bitbox02.ts`.