### PR TITLE
backend: add Goerli ETH testnet network

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,5 @@ Get Litecoin Testnet coins here: https://tltc.bitaps.com/
 Get Ethereum Rinkeby coins here: http://rinkeby-faucet.com/
 
 Get Ethereum Ropsten coins here: https://faucet.ropsten.be/
+
+Get Ethereum Goerli coins here: https://goerlifaucet.com/

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -45,13 +45,14 @@ const accountsHardLimit = 5
 func sortAccounts(accounts []*config.Account) {
 	compareCoin := func(coin1, coin2 coinpkg.Code) int {
 		order := map[coinpkg.Code]int{
-			coinpkg.CodeBTC:  0,
-			coinpkg.CodeTBTC: 1,
-			coinpkg.CodeLTC:  2,
-			coinpkg.CodeTLTC: 3,
-			coinpkg.CodeETH:  4,
-			coinpkg.CodeTETH: 5,
-			coinpkg.CodeRETH: 6,
+			coinpkg.CodeBTC:   0,
+			coinpkg.CodeTBTC:  1,
+			coinpkg.CodeLTC:   2,
+			coinpkg.CodeTLTC:  3,
+			coinpkg.CodeETH:   4,
+			coinpkg.CodeTETH:  5,
+			coinpkg.CodeRETH:  6,
+			coinpkg.CodeGOETH: 7,
 		}
 		order1, ok1 := order[coin1]
 		order2, ok2 := order[coin2]
@@ -116,7 +117,7 @@ func (backend *Backend) SupportedCoins(keystore keystore.Keystore) []coinpkg.Cod
 	allCoins := []coinpkg.Code{
 		coinpkg.CodeBTC, coinpkg.CodeTBTC, coinpkg.CodeRBTC,
 		coinpkg.CodeLTC, coinpkg.CodeTLTC,
-		coinpkg.CodeETH, coinpkg.CodeTETH, coinpkg.CodeRETH,
+		coinpkg.CodeETH, coinpkg.CodeTETH, coinpkg.CodeRETH, coinpkg.CodeGOETH,
 	}
 	var availableCoins []coinpkg.Code
 	for _, coinCode := range allCoins {
@@ -221,7 +222,7 @@ func (backend *Backend) createAndPersistAccountConfig(
 			},
 			accountsConfig,
 		)
-	case coinpkg.CodeETH, coinpkg.CodeRETH, coinpkg.CodeTETH:
+	case coinpkg.CodeETH, coinpkg.CodeRETH, coinpkg.CodeTETH, coinpkg.CodeGOETH:
 		bip44Coin := "1'"
 		if coinCode == coinpkg.CodeETH {
 			bip44Coin = "60'"
@@ -672,7 +673,7 @@ func (backend *Backend) persistDefaultAccountConfigs(keystore keystore.Keystore,
 				}
 			}
 		} else {
-			for _, coinCode := range []coinpkg.Code{coinpkg.CodeTBTC, coinpkg.CodeTLTC, coinpkg.CodeTETH, coinpkg.CodeRETH} {
+			for _, coinCode := range []coinpkg.Code{coinpkg.CodeTBTC, coinpkg.CodeTLTC, coinpkg.CodeTETH, coinpkg.CodeRETH, coinpkg.CodeGOETH} {
 				if backend.config.AppConfig().Backend.DeprecatedCoinActive(coinCode) {
 					if _, err := backend.createAndPersistAccountConfig(coinCode, 0, "", keystore, nil, accountsConfig); err != nil {
 						return err

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -260,7 +260,7 @@ func TestSupportedCoins(t *testing.T) {
 		b := newBackend(t, testnetEnabled, regtestDisabled)
 		defer b.Close()
 		require.Equal(t,
-			[]coinpkg.Code{coinpkg.CodeTBTC, coinpkg.CodeTLTC, coinpkg.CodeTETH, coinpkg.CodeRETH},
+			[]coinpkg.Code{coinpkg.CodeTBTC, coinpkg.CodeTLTC, coinpkg.CodeTETH, coinpkg.CodeRETH, coinpkg.CodeGOETH},
 			b.SupportedCoins(&keystoremock.KeystoreMock{
 				SupportsCoinFunc: func(coin coinpkg.Coin) bool {
 					return true

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -76,6 +76,7 @@ var fixedURLWhitelist = []string{
 	"https://etherscan.io/tx/",
 	"https://rinkeby.etherscan.io/tx/",
 	"https://ropsten.etherscan.io/tx/",
+	"https://goerli.etherscan.io/tx/",
 	// Moonpay onramp
 	"https://www.moonpay.com/",
 	"https://support.moonpay.com/",
@@ -378,6 +379,12 @@ func (backend *Backend) Coin(code coinpkg.Code) (coinpkg.Coin, error) {
 		etherScan := etherscan.NewEtherScan("https://api-ropsten.etherscan.io/api", backend.etherScanHTTPClient)
 		coin = eth.NewCoin(etherScan, code, "Ethereum Ropsten", "TETH", "TETH", params.RopstenChainConfig,
 			"https://ropsten.etherscan.io/tx/",
+			etherScan,
+			nil)
+	case code == coinpkg.CodeGOETH:
+		etherScan := etherscan.NewEtherScan("https://api-goerli.etherscan.io/api", backend.etherScanHTTPClient)
+		coin = eth.NewCoin(etherScan, code, "Ethereum Goerli", "GOETH", "GOETH", params.GoerliChainConfig,
+			"https://goerli.etherscan.io/tx/",
 			etherScan,
 			nil)
 	case code == coinpkg.CodeERC20TEST:

--- a/backend/coins/coin/codes.go
+++ b/backend/coins/coin/codes.go
@@ -34,6 +34,8 @@ const (
 	CodeTETH Code = "teth"
 	// CodeRETH is Ethereum Rinkeby.
 	CodeRETH Code = "reth"
+	// CodeGOETH is Ethereum Goerli.
+	CodeGOETH Code = "goeth"
 	// CodeERC20TEST is an arbitrarily picked test ERC20 token on Ropsten.
 	CodeERC20TEST Code = "erc20Test"
 	// If you add coins, don't forget to update `testnetCoins` below.
@@ -46,5 +48,6 @@ var TestnetCoins = map[Code]struct{}{
 	CodeTLTC:      {},
 	CodeTETH:      {},
 	CodeRETH:      {},
+	CodeGOETH:     {},
 	CodeERC20TEST: {},
 }

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -99,7 +99,7 @@ func (backend Backend) DeprecatedCoinActive(code coin.Code) bool {
 		return backend.DeprecatedBitcoinActive
 	case coin.CodeLTC, coin.CodeTLTC:
 		return backend.DeprecatedLitecoinActive
-	case coin.CodeETH, coin.CodeTETH, coin.CodeRETH, coin.CodeERC20TEST:
+	case coin.CodeETH, coin.CodeTETH, coin.CodeRETH, coin.CodeGOETH, coin.CodeERC20TEST:
 		return backend.DeprecatedEthereumActive
 	default:
 		panic(fmt.Sprintf("unknown code %s", code))

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -681,6 +681,8 @@ func (handlers *Handlers) getConvertFromFiatHandler(r *http.Request) (interface{
 	switch unit { // HACK: fake rates for testnet coins
 	case "TBTC", "TLTC", "TETH", "RETH":
 		unit = unit[1:]
+	case "GOETH":
+		unit = unit[2:]
 	}
 
 	rate := handlers.backend.RatesUpdater().LatestPrice()[unit][from]

--- a/backend/rates/gecko.go
+++ b/backend/rates/gecko.go
@@ -42,11 +42,12 @@ var (
 		"ltc": "litecoin",
 		"eth": "ethereum",
 		// Useful for testing with testnets.
-		"tbtc": "bitcoin",
-		"rbtc": "bitcoin",
-		"tltc": "litecoin",
-		"teth": "ethereum",
-		"reth": "ethereum",
+		"tbtc":  "bitcoin",
+		"rbtc":  "bitcoin",
+		"tltc":  "litecoin",
+		"teth":  "ethereum",
+		"reth":  "ethereum",
+		"goeth": "ethereum",
 		// ERC20 tokens as used in the backend.
 		// Frontend and app config use unprefixed name, without "eth-erc20-".
 		"eth-erc20-bat":       "basic-attention-token",

--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -317,8 +317,12 @@ func (updater *RateUpdater) updateLast(ctx context.Context) {
 	}
 
 	// Provide conversion rates for testnets as well, useful for testing.
-	for _, testnetUnit := range []string{"TBTC", "RBTC", "TLTC", "TETH", "RETH"} {
-		rates[testnetUnit] = rates[testnetUnit[1:]]
+	for _, testnetUnit := range []string{"TBTC", "RBTC", "TLTC", "TETH", "RETH", "GOETH"} {
+		if testnetUnit == "GOETH" {
+			rates[testnetUnit] = rates[testnetUnit[2:]]
+		} else {
+			rates[testnetUnit] = rates[testnetUnit[1:]]
+		}
 	}
 
 	if reflect.DeepEqual(rates, updater.last) {

--- a/frontends/web/src/components/icon/logo.tsx
+++ b/frontends/web/src/components/icon/logo.tsx
@@ -81,6 +81,7 @@ const logoMap: LogoMap = {
   'eth': [ETH, ETH_GREY],
   'teth': [ETH, ETH_GREY],
   'reth': [ETH, ETH_GREY],
+  'goeth': [ETH, ETH_GREY],
   'erc20Test': [ETH, ETH_GREY],
 
   'eth-erc20-usdt': [USDT, USDT_GREY],

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.2
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/cespare/cp v1.1.1 // indirect
-	github.com/digitalbitbox/bitbox02-api-go v0.0.0-20220817141646-e9258db31750
+	github.com/digitalbitbox/bitbox02-api-go v0.0.0-20221003094719-2c29561c5a4c
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/flynn/noise v1.0.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/deepmap/oapi-codegen v1.8.2/go.mod h1:YLgSKSDv/bZQB7N4ws6luhozi3cEdRk
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8/go.mod h1:VMaSuZ+SZcx/wljOQKvp5srsbCiKDEb6K2wC4+PiBmQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalbitbox/bitbox02-api-go v0.0.0-20220817141646-e9258db31750 h1:b6udIFaGfW4rldSgbch1eA4l+JHuZ3Ij2Pi2VdE7Iz4=
-github.com/digitalbitbox/bitbox02-api-go v0.0.0-20220817141646-e9258db31750/go.mod h1:4HNNrzUZC3ew0iuD40MoGp6wAhcDw1UtGYBRjJkJF/k=
+github.com/digitalbitbox/bitbox02-api-go v0.0.0-20221003094719-2c29561c5a4c h1:mJl1SA+NVUZGd+LwgRpmLpNyv+kuAhKnEzE+kvIrK+0=
+github.com/digitalbitbox/bitbox02-api-go v0.0.0-20221003094719-2c29561c5a4c/go.mod h1:4HNNrzUZC3ew0iuD40MoGp6wAhcDw1UtGYBRjJkJF/k=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=

--- a/vendor/github.com/digitalbitbox/bitbox02-api-go/api/firmware/device.go
+++ b/vendor/github.com/digitalbitbox/bitbox02-api-go/api/firmware/device.go
@@ -332,10 +332,12 @@ func (device *Device) Product() common.Product {
 }
 
 // SupportsETH returns true if ETH is supported by the device api.
-// coinCode is eth/teth/reth or eth-erc20-xyz, ...
 func (device *Device) SupportsETH(chainID uint64) bool {
 	if *device.product != common.ProductBitBox02Multi {
 		return false
+	}
+	if device.version.AtLeast(semver.NewSemVer(9, 10, 0)) {
+		return true
 	}
 	if device.version.AtLeast(semver.NewSemVer(4, 0, 0)) {
 		switch chainID {

--- a/vendor/github.com/digitalbitbox/bitbox02-api-go/api/firmware/mnemonic.go
+++ b/vendor/github.com/digitalbitbox/bitbox02-api-go/api/firmware/mnemonic.go
@@ -15,6 +15,7 @@
 package firmware
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/digitalbitbox/bitbox02-api-go/api/firmware/messages"
@@ -81,5 +82,6 @@ func (device *Device) SetMnemonicPassphraseEnabled(enabled bool) error {
 	if !ok {
 		return errp.New("unexpected response")
 	}
+	device.log.Info(fmt.Sprintf("SetMnemonicPassphraseEnabled=%v successfully finished", enabled))
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,7 +44,7 @@ github.com/decred/dcrd/crypto/blake256
 github.com/decred/dcrd/dcrec/secp256k1/v4
 github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa
 github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr
-# github.com/digitalbitbox/bitbox02-api-go v0.0.0-20220817141646-e9258db31750
+# github.com/digitalbitbox/bitbox02-api-go v0.0.0-20221003094719-2c29561c5a4c
 ## explicit
 github.com/digitalbitbox/bitbox02-api-go/api/bootloader
 github.com/digitalbitbox/bitbox02-api-go/api/common


### PR DESCRIPTION
ETH merge happened recently, and Ropsten and Rinkeby testnets will soon be deprecated from Etherscan. This add support for the new Goerli testnet.