### PR TITLE
frontend: refactor fiat default

### DIFF
--- a/frontends/web/src/components/icon/assets/icons/star-inactive.svg
+++ b/frontends/web/src/components/icon/assets/icons/star-inactive.svg
@@ -1,0 +1,12 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#999999"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round">
+  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+</svg>

--- a/frontends/web/src/components/icon/assets/icons/star.svg
+++ b/frontends/web/src/components/icon/assets/icons/star.svg
@@ -3,7 +3,7 @@
   width="24"
   height="24"
   viewBox="0 0 24 24"
-  fill="none"
+  fill="#F5A04C"
   stroke="#F5A04C"
   stroke-width="2"
   stroke-linecap="round"

--- a/frontends/web/src/components/icon/assets/icons/star.svg
+++ b/frontends/web/src/components/icon/assets/icons/star.svg
@@ -1,0 +1,12 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#F5A04C"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round">
+  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+</svg>

--- a/frontends/web/src/components/icon/icon.tsx
+++ b/frontends/web/src/components/icon/icon.tsx
@@ -33,6 +33,8 @@ import closeXDarkSVG from './assets/icons/close-x-dark.svg';
 import guideSVG from './assets/icons/guide.svg';
 import menuSVG from './assets/icons/menu.svg';
 import warningPNG from './assets/icons/warning.png';
+import starSVG from './assets/icons/star.svg';
+import starInactiveSVG from './assets/icons/star-inactive.svg';
 import style from './icon.module.css';
 
 export const ExpandOpen = (): JSX.Element => (
@@ -118,6 +120,8 @@ export const CloseXDark = (props: ImgProps) => (<img src={closeXDarkSVG} draggab
 export const GuideActive = (props: ImgProps) => (<img src={guideSVG} draggable={false} {...props} />);
 export const Menu = (props: ImgProps) => (<img src={menuSVG} draggable={false} {...props} />);
 export const Warning = (props: ImgProps) => (<img src={warningPNG} draggable={false} {...props} />);
+export const Star = (props: ImgProps) => (<img src={starSVG} draggable={false} {...props} />);
+export const StarInactive = (props: ImgProps) => (<img src={starInactiveSVG} draggable={false} {...props} />);
 /**
  * @deprecated Alert is only used for BitBox01 use `Warning` icon instead
  */

--- a/frontends/web/src/routes/settings/components/fiat/fiat.module.css
+++ b/frontends/web/src/routes/settings/components/fiat/fiat.module.css
@@ -1,110 +1,20 @@
-.button {
-    color: var(--color-secondary);
-    font-size: var(--size-small);
-    font-weight: bold;
-    text-transform: uppercase;
-    top: -.5rem;
-    position: relative;
-    margin-bottom: calc(var(--spacing-half) / 2);
-    cursor: pointer;
-    user-select: none;
-}
-
-.fiatList label {
-    width: 100%;
-}
-
-.fiatList label span {
-    color: var(--color-blue);
-    background-color: transparent;
-    font-size: var(--size-label);
-    font-weight: 400;
-    margin-left: var(--spacing-half);
-    padding: 1px 0;
-    position: absolute;
-    top: 50%;
-    right: 0;
-    transform: translateY(-50%);
-    transition: background-color .2s ease-out;
-    display: inline-block;
-    border-radius: 2px;
-    line-height: 16px;
-    cursor: pointer;
-}
-
-.fiatList label:focus span,
-.fiatList label:hover span,
-.fiatList label span:focus,
-.fiatList label span:hover {
-    outline: none;
-    display: inline-block;
-}
-
-.fiatList label span.show {
-    display: inline-block;
-    padding: 1px var(--spacing-half);
-    background-color: var(--color-blue);
-    color: var(--color-white);
-    cursor: default;
-}
-
-.container {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-}
-
-.left,
-.right {
-    width: calc((100% - var(--space-default)) / 2);
-}
-
-.content {
-    background-color: var(--color-white);
-    padding: var(--space-half);
-}
-
-.content > span > label {
-    display: block;
-}
-
-.content > span:not(:first-child) > label {
-    margin-top: var(--space-quarter);
+.defaultFiat {
+    color: var(--color-gray);
 }
 
 .star {
-    margin-left: auto;
-    margin-right: var(--space-half);
+    background: none;
+    border: none;
     display: flex;
     flex-direction: column;
     justify-content: center;
+    margin-left: auto;
+    margin-right: var(--space-half);
+    padding: 3px;
 }
 
-.star svg {
-    width: 18px;
-    height: 18px;
+.star img {
     color: var(--color-gray-alt);
-}
-
-.star.active svg {
-    color: var(--color-orange);
-}
-
-.currency:not(:first-child) {
-    border-top: solid 1px var(--color-lightgray);
-}
-
-@media (max-width: 768px) {
-    .container {
-        flex-direction: column;
-    }
-
-    .left,
-    .right {
-        width: 100%;
-    }
-
-    .right {
-        margin-top: var(--space-half);
-    }
+    height: 18px;
+    width: 18px;
 }

--- a/frontends/web/src/routes/settings/components/fiat/fiat.tsx
+++ b/frontends/web/src/routes/settings/components/fiat/fiat.tsx
@@ -16,6 +16,7 @@
 
 import React, { PropsWithChildren } from 'react';
 import { Fiat } from '../../../../api/account';
+import { Star, StarInactive } from '../../../../components/icon';
 import {
   currencies,
   selectFiat,
@@ -71,18 +72,7 @@ function Selection({
                       title={t(main ? 'fiat.default' : 'fiat.setDefault', { code: currency })}
                       data-code={currency}
                       onClick={setDefault}>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="24"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round">
-                        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
-                      </svg>
+                      { main ? <Star /> : <StarInactive /> }
                     </a>
                   )
                 }

--- a/frontends/web/src/routes/settings/components/fiat/fiat.tsx
+++ b/frontends/web/src/routes/settings/components/fiat/fiat.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2022 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,17 +64,24 @@ function Selection({
             const toggled = selected.includes(currency);
             return (
               <div key={currency} className={parentStyle.setting}>
-                <p className="m-none">{currency}</p>
+                <p className="m-none">
+                  {currency}
+                  {' '}
+                  {main && (
+                    <small className={style.defaultFiat}>
+                      {t('fiat.default')}
+                    </small>
+                  )}
+                </p>
                 {
                   toggled && (
-                    <a
-                      className={[style.star, main ? style.active : ''].join(' ')}
-                      href="#"
+                    <button
+                      className={style.star}
                       title={t(main ? 'fiat.default' : 'fiat.setDefault', { code: currency })}
                       data-code={currency}
                       onClick={setDefault}>
                       { main ? <Star /> : <StarInactive /> }
-                    </a>
+                    </button>
                   )
                 }
                 <Toggle


### PR DESCRIPTION
This is not about fixing the financial system but only about which
legacy currency should be set as the default unit of account. lol.

The current styling of the default fiat is star becomes orange
(outlined icon) and the toggle becomes inactive as it is disabled
so that the default cannot be turned off. The styling looks
confusing as it is not clear that this is the default.

To improve the visual styling this commit:

- added small '(default)' text after the currency
- made active star more prominent, changed from outline to filled

Also (additional commit)
- move inline svg to image to reduce the bundle size, JavaScript parse time and React dom diffing.
