### PR TITLE
Windows: improve Visual Studio installation detection

### DIFF
--- a/frontends/qt/compile_windows.bat
+++ b/frontends/qt/compile_windows.bat
@@ -1,6 +1,22 @@
 :: Compiles the Qt5 app. Part of `make windows`, which also compiles/bundles the deps
 
-call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+setlocal
+set varsbat="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+if exist %varsbat% (goto :CALL_VC_VARS_BAT)
+echo Trying to figure out Visual Studio 2019 location...
+for /f "tokens=2* eol=," %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Classes\CLSID\{2E1517DA-87BF-4443-984A-D2BF18F5A908}\DefaultIcon" ^|findstr /rc:"REG_SZ *"') do set varsbat=%%~b
+If Defined varsbat (
+  set varsbat="%varsbat:common7\ide\devenv.exe,1200=VC\Auxiliary\Build\vcvars64.bat%"
+)
+if exist %varsbat% (goto :CALL_VC_VARS_BAT)
+echo Trying to figure out Visual Studio 2022 location...
+for /f "tokens=2* eol=," %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Classes\CLSID\{33ABD590-0400-4FEF-AF98-5F5A8A99CFC3}\DefaultIcon" ^|findstr /rc:"REG_SZ *"') do set varsbat=%%~b
+If Defined varsbat (
+  set varsbat="%varsbat:common7\ide\devenv.exe,1200=VC\Auxiliary\Build\vcvars64.bat%"
+)
+:CALL_VC_VARS_BAT
+call %varsbat%
+
 cd build
 qmake ..\BitBox.pro
 nmake
@@ -12,3 +28,4 @@ COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\msvcp140_codecvt_ids.dll" windo
 COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\vccorlib140.dll" windows\
 COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\vcruntime140.dll" windows\
 COPY "%VCToolsRedistDir%\x64\Microsoft.VC142.CRT\vcruntime140_1.dll" windows\
+endlocal


### PR DESCRIPTION
Change compile_windows.bat to detect other Visual Studio installations when the VS 2019 Community Edition is not found.

It uses the registry to detect the visual studio installation path.
It assumes the default icon registry value always ends in "ide\devenv.exe,1200". There is no built-in batch file (or shell) command to extract regular expressions, so I had to resort to a non-flexible string replace. Ideally this should use another shell (e.g.: Powershell) or third-party utility to extract the path from the registry.
