### PR TITLE
android: target api level 31, enforced by Google Play

### DIFF
--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -6,7 +6,7 @@ android {
     defaultConfig {
         applicationId "ch.shiftcrypto.bitboxapp"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 38
         versionName "android-4.34.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
+++ b/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
             android:name=".MainActivity"
             android:launchMode="singleTop"
             android:taskAffinity=""
-            android:configChanges="orientation|screenSize|keyboardHidden|keyboard">
+            android:configChanges="orientation|screenSize|keyboardHidden|keyboard"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
According to
https://support.google.com/googleplay/android-developer/answer/11926878, the requirements as of now is that updating an app requires API level 31 (Android 12) by November 1st 2022.

The exported attribute is set according to
https://developer.android.com/about/versions/12/behavior-changes-12#exported:

> If your app targets Android 12 or higher and contains activities,
services, or broadcast receivers that use intent filters, you must explicitly declare the android:exported attribute for these app components.