### PR TITLE
frontend refactor account guide

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -554,10 +554,6 @@
         "title": "What is an extended public key?"
       }
     },
-    "accountLegacyConvert": {
-      "text": "Go to the Bitcoin account, select receive and copy the address. Go back to your legacy account, click send, paste the copied address and tick send all. Then sign and send to move all your coins in a single transaction.",
-      "title": "How can I move my coins out of the Legacy account?"
-    },
     "accountRates": {
       "text": "We update exchange rates every minute from CoinGecko.",
       "title": "Which exchange rates apply?"
@@ -807,24 +803,6 @@
       }
     },
     "settings": {
-      "btc-p2pkh": {
-        "text": "An account that uses an old transaction format, now superseded by the Segwit address and transaction formats. If you used the BitBox with the old desktop app then this account will contain your coins. We recommend transferring your coins to a Bitcoin or Bitcoin bech32 account to save transaction fees.",
-        "title": "What is Bitcoin Legacy?"
-      },
-      "btc-p2sh": {
-        "link": {
-          "text": "Segregated witness benefits"
-        },
-        "text": "This is a backwards compatible Segwit account (p2sh-p2wpkh). It uses a new transaction format that saves you network fees. The address format is similar to legacy, and as such can be used with all existing Bitcoin wallets/exchanges/services.",
-        "title": "What is the Bitcoin account?"
-      },
-      "btc-p2wpkh": {
-        "link": {
-          "text": "Bech32 adoption"
-        },
-        "text": "Use the new Bitcoin bech32 address format to reap the full benefits of Segwit's cheaper network fees. Remember that this format is not accepted everywhere yet.",
-        "title": "What is Bitcoin bech32?"
-      },
       "servers": {
         "text": "This app communicates with the Shift Crypto servers to check for updates, load transactions, and send information to paired mobile apps.\nThe app also retrieves the latest exchange rates from CoinGecko. All conversions are calculated locally which means no data about the amount of your transaction is ever transmitted.\nNote: For Ethereum and ERC20 Tokens, we use Etherscan.io APIs.",
         "title": "Which servers does this app talk to?"

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -24,8 +24,7 @@ import { unsubscribe, UnsubscribeList } from '../../utils/subscriptions';
 import { statusChanged, syncdone } from '../../api/subscribe-legacy';
 import { alertUser } from '../../components/alert/Alert';
 import { Balance } from '../../components/balance/balance';
-import { Entry } from '../../components/guide/entry';
-import { Guide } from '../../components/guide/guide';
+import { AccountGuide } from './guide';
 import { HeadersSync } from '../../components/headerssync/headerssync';
 import { Header } from '../../components/layout';
 import { Info } from '../../components/icon';
@@ -227,19 +226,6 @@ class Account extends Component<Props, State> {
       .catch(console.error);
   };
 
-  private isBTCScriptType = (
-    scriptType: accountApi.ScriptType,
-    account: accountApi.IAccount,
-    accountInfo?: accountApi.ISigningConfigurationList,
-  ): boolean => {
-    if (!accountInfo || accountInfo.signingConfigurations.length !== 1) {
-      return false;
-    }
-    const config = accountInfo.signingConfigurations[0].bitcoinSimple;
-    return (account.coinCode === 'btc' || account.coinCode === 'tbtc') &&
-            config !== undefined && config.scriptType === scriptType;
-  };
-
   private deviceIDs = (devices: TDevices) => {
     return Object.keys(devices);
   };
@@ -367,75 +353,13 @@ class Account extends Component<Props, State> {
             </div>
           </div>
         </div>
-        <Guide>
-          <Entry key="accountDescription" entry={t('guide.accountDescription')} />
-          {this.isBTCScriptType('p2pkh', account, accountInfo) && (
-            <Entry key="guide.settings.btc-p2pkh" entry={t('guide.settings.btc-p2pkh')} />
-          )}
-          {this.isBTCScriptType('p2wpkh-p2sh', account, accountInfo) && (
-            <Entry key="guide.settings.btc-p2sh" entry={{
-              link: {
-                text: t('guide.settings.btc-p2sh.link.text'),
-                url: 'https://bitcoincore.org/en/2016/01/26/segwit-benefits/'
-              },
-              text: t('guide.settings.btc-p2sh.text'),
-              title: t('guide.settings.btc-p2sh.title')
-            }} />
-          )}
-          {this.isBTCScriptType('p2wpkh', account, accountInfo) && (
-            <Entry key="guide.settings.btc-p2wpkh" entry={{
-              link: {
-                text: t('guide.settings.btc-p2wpkh.link.text'),
-                url: 'https://en.bitcoin.it/wiki/Bech32_adoption'
-              },
-              text: t('guide.settings.btc-p2wpkh.text'),
-              title: t('guide.settings.btc-p2wpkh.title')
-            }} />
-          )}
-          {balance && balance.available.amount === '0' && (
-            <Entry key="accountSendDisabled" entry={t('guide.accountSendDisabled', { unit: balance.available.unit })} />
-          )}
-          <Entry key="accountReload" entry={t('guide.accountReload')} />
-          {transactions !== undefined && transactions.length > 0 && (
-            <Entry key="accountTransactionLabel" entry={t('guide.accountTransactionLabel')} />
-          )}
-          {transactions !== undefined && transactions.length > 0 && (
-            <Entry key="accountTransactionTime" entry={t('guide.accountTransactionTime')} />
-          )}
-          {this.isBTCScriptType('p2pkh', account, accountInfo) && (
-            <Entry key="accountLegacyConvert" entry={t('guide.accountLegacyConvert')} />
-          )}
-          {transactions !== undefined &&  transactions.length > 0 && (
-            <Entry key="accountTransactionAttributesGeneric" entry={t('guide.accountTransactionAttributesGeneric')} />
-          )}
-          {transactions !== undefined && transactions.length > 0 && isBitcoinBased(account.coinCode) && (
-            <Entry key="accountTransactionAttributesBTC" entry={t('guide.accountTransactionAttributesBTC')} />
-          )}
-          {balance && balance.hasIncoming && (
-            <Entry key="accountIncomingBalance" entry={t('guide.accountIncomingBalance')} />
-          )}
-          <Entry key="accountTransactionConfirmation" entry={t('guide.accountTransactionConfirmation')} />
-          <Entry key="accountFiat" entry={t('guide.accountFiat')} />
-
-          { /* careful, also used in Settings */ }
-          <Entry key="accountRates" entry={{
-            link: {
-              text: 'www.coingecko.com',
-              url: 'https://www.coingecko.com/'
-            },
-            text: t('guide.accountRates.text'),
-            title: t('guide.accountRates.title')
-          }} />
-
-          <Entry key="cointracking" entry={{
-            link: {
-              text: 'CoinTracking',
-              url: 'https://cointracking.info/import/bitbox/?ref=BITBOX',
-            },
-            text: t('guide.cointracking.text'),
-            title: t('guide.cointracking.title')
-          }} />
-        </Guide>
+        <AccountGuide
+          account={account}
+          accountInfo={accountInfo}
+          unit={balance?.available.unit}
+          hasIncomingBalance={balance && balance.hasIncoming}
+          hasTransactions={transactions !== undefined && transactions.length > 0}
+          hasNoBalance={balance && balance.available.amount === '0'} />
       </div>
     );
   }

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -251,7 +251,6 @@ class Account extends Component<Props, State> {
       transactions,
       balance,
       hasCard,
-      accountInfo,
       syncedAddressesCount,
     } = this.state;
     const account = accounts &&
@@ -355,7 +354,6 @@ class Account extends Component<Props, State> {
         </div>
         <AccountGuide
           account={account}
-          accountInfo={accountInfo}
           unit={balance?.available.unit}
           hasIncomingBalance={balance && balance.hasIncoming}
           hasTransactions={transactions !== undefined && transactions.length > 0}

--- a/frontends/web/src/routes/account/guide.tsx
+++ b/frontends/web/src/routes/account/guide.tsx
@@ -15,14 +15,13 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { IAccount, ISigningConfigurationList } from '../../api/account';
+import { IAccount } from '../../api/account';
 import { Entry } from '../../components/guide/entry';
 import { Guide } from '../../components/guide/guide';
-import { isBitcoinBased, isBTCScriptType } from './utils';
+import { isBitcoinBased } from './utils';
 
 type Props = {
   account: IAccount;
-  accountInfo?: ISigningConfigurationList;
   unit?: string;
   hasNoBalance?: boolean;
   hasIncomingBalance?: boolean;
@@ -31,7 +30,6 @@ type Props = {
 
 export function AccountGuide({
   account,
-  accountInfo,
   unit,
   hasNoBalance,
   hasIncomingBalance,
@@ -41,29 +39,6 @@ export function AccountGuide({
   return (
     <Guide>
       <Entry key="accountDescription" entry={t('guide.accountDescription')} />
-      {isBTCScriptType('p2pkh', account, accountInfo) && (
-        <Entry key="guide.settings.btc-p2pkh" entry={t('guide.settings.btc-p2pkh')} />
-      )}
-      {isBTCScriptType('p2wpkh-p2sh', account, accountInfo) && (
-        <Entry key="guide.settings.btc-p2sh" entry={{
-          link: {
-            text: t('guide.settings.btc-p2sh.link.text'),
-            url: 'https://bitcoincore.org/en/2016/01/26/segwit-benefits/'
-          },
-          text: t('guide.settings.btc-p2sh.text'),
-          title: t('guide.settings.btc-p2sh.title')
-        }} />
-      )}
-      {isBTCScriptType('p2wpkh', account, accountInfo) && (
-        <Entry key="guide.settings.btc-p2wpkh" entry={{
-          link: {
-            text: t('guide.settings.btc-p2wpkh.link.text'),
-            url: 'https://en.bitcoin.it/wiki/Bech32_adoption'
-          },
-          text: t('guide.settings.btc-p2wpkh.text'),
-          title: t('guide.settings.btc-p2wpkh.title')
-        }} />
-      )}
       {hasNoBalance && (
         <Entry key="accountSendDisabled" entry={t('guide.accountSendDisabled', {
           unit
@@ -75,9 +50,6 @@ export function AccountGuide({
       )}
       {hasTransactions && (
         <Entry key="accountTransactionTime" entry={t('guide.accountTransactionTime')} />
-      )}
-      {isBTCScriptType('p2pkh', account, accountInfo) && (
-        <Entry key="accountLegacyConvert" entry={t('guide.accountLegacyConvert')} />
       )}
       {hasTransactions && (
         <Entry key="accountTransactionAttributesGeneric" entry={t('guide.accountTransactionAttributesGeneric')} />

--- a/frontends/web/src/routes/account/guide.tsx
+++ b/frontends/web/src/routes/account/guide.tsx
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { IAccount, ISigningConfigurationList } from '../../api/account';
+import { Entry } from '../../components/guide/entry';
+import { Guide } from '../../components/guide/guide';
+import { isBitcoinBased, isBTCScriptType } from './utils';
+
+type Props = {
+  account: IAccount;
+  accountInfo?: ISigningConfigurationList;
+  unit?: string;
+  hasNoBalance?: boolean;
+  hasIncomingBalance?: boolean;
+  hasTransactions?: boolean;
+};
+
+export function AccountGuide({
+  account,
+  accountInfo,
+  unit,
+  hasNoBalance,
+  hasIncomingBalance,
+  hasTransactions,
+}: Props) {
+  const { t } = useTranslation();
+  return (
+    <Guide>
+      <Entry key="accountDescription" entry={t('guide.accountDescription')} />
+      {isBTCScriptType('p2pkh', account, accountInfo) && (
+        <Entry key="guide.settings.btc-p2pkh" entry={t('guide.settings.btc-p2pkh')} />
+      )}
+      {isBTCScriptType('p2wpkh-p2sh', account, accountInfo) && (
+        <Entry key="guide.settings.btc-p2sh" entry={{
+          link: {
+            text: t('guide.settings.btc-p2sh.link.text'),
+            url: 'https://bitcoincore.org/en/2016/01/26/segwit-benefits/'
+          },
+          text: t('guide.settings.btc-p2sh.text'),
+          title: t('guide.settings.btc-p2sh.title')
+        }} />
+      )}
+      {isBTCScriptType('p2wpkh', account, accountInfo) && (
+        <Entry key="guide.settings.btc-p2wpkh" entry={{
+          link: {
+            text: t('guide.settings.btc-p2wpkh.link.text'),
+            url: 'https://en.bitcoin.it/wiki/Bech32_adoption'
+          },
+          text: t('guide.settings.btc-p2wpkh.text'),
+          title: t('guide.settings.btc-p2wpkh.title')
+        }} />
+      )}
+      {hasNoBalance && (
+        <Entry key="accountSendDisabled" entry={t('guide.accountSendDisabled', {
+          unit
+        })} />
+      )}
+      <Entry key="accountReload" entry={t('guide.accountReload')} />
+      {hasTransactions && (
+        <Entry key="accountTransactionLabel" entry={t('guide.accountTransactionLabel')} />
+      )}
+      {hasTransactions && (
+        <Entry key="accountTransactionTime" entry={t('guide.accountTransactionTime')} />
+      )}
+      {isBTCScriptType('p2pkh', account, accountInfo) && (
+        <Entry key="accountLegacyConvert" entry={t('guide.accountLegacyConvert')} />
+      )}
+      {hasTransactions && (
+        <Entry key="accountTransactionAttributesGeneric" entry={t('guide.accountTransactionAttributesGeneric')} />
+      )}
+      {hasTransactions && isBitcoinBased(account.coinCode) && (
+        <Entry key="accountTransactionAttributesBTC" entry={t('guide.accountTransactionAttributesBTC')} />
+      )}
+      {hasIncomingBalance && (
+        <Entry key="accountIncomingBalance" entry={t('guide.accountIncomingBalance')} />
+      )}
+      <Entry key="accountTransactionConfirmation" entry={t('guide.accountTransactionConfirmation')} />
+      <Entry key="accountFiat" entry={t('guide.accountFiat')} />
+
+      { /* careful, also used in Settings */ }
+      <Entry key="accountRates" entry={{
+        link: {
+          text: 'www.coingecko.com',
+          url: 'https://www.coingecko.com/'
+        },
+        text: t('guide.accountRates.text'),
+        title: t('guide.accountRates.title')
+      }} />
+
+      <Entry key="cointracking" entry={{
+        link: {
+          text: 'CoinTracking',
+          url: 'https://cointracking.info/import/bitbox/?ref=BITBOX',
+        },
+        text: t('guide.cointracking.text'),
+        title: t('guide.cointracking.title')
+      }} />
+    </Guide>
+  );
+}

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { CoinCode, IAccount, ISigningConfigurationList, ScriptType } from '../../api/account';
+import { CoinCode, ScriptType } from '../../api/account';
 
 export function isBitcoinOnly(coinCode: CoinCode): boolean {
   switch (coinCode) {
@@ -80,17 +80,4 @@ export function customFeeUnit(coinCode: CoinCode): string {
     return 'Gwei';
   }
   return '';
-}
-
-export function isBTCScriptType(
-  scriptType: ScriptType,
-  account: IAccount,
-  accountInfo?: ISigningConfigurationList,
-): boolean {
-  if (!accountInfo || accountInfo.signingConfigurations.length !== 1) {
-    return false;
-  }
-  const config = accountInfo.signingConfigurations[0].bitcoinSimple;
-  return (account.coinCode === 'btc' || account.coinCode === 'tbtc')
-    && config !== undefined && config.scriptType === scriptType;
 }

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { CoinCode, ScriptType } from '../../api/account';
+import { CoinCode, IAccount, ISigningConfigurationList, ScriptType } from '../../api/account';
 
 export function isBitcoinOnly(coinCode: CoinCode): boolean {
   switch (coinCode) {
@@ -80,4 +80,17 @@ export function customFeeUnit(coinCode: CoinCode): string {
     return 'Gwei';
   }
   return '';
+}
+
+export function isBTCScriptType(
+  scriptType: ScriptType,
+  account: IAccount,
+  accountInfo?: ISigningConfigurationList,
+): boolean {
+  if (!accountInfo || accountInfo.signingConfigurations.length !== 1) {
+    return false;
+  }
+  const config = accountInfo.signingConfigurations[0].bitcoinSimple;
+  return (account.coinCode === 'btc' || account.coinCode === 'tbtc')
+    && config !== undefined && config.scriptType === scriptType;
 }


### PR DESCRIPTION
- move account guide to its own component
- remove old split account specific guide entries 


Moved isBTCScriptType to utils and the account guide to its own
component so that account.tsx is slightly simpler and easier to
refactor.

These were used in the settings page when we used to have separate
accounts per script type, with toggles for each one. this is also
all gone now with unified accounts and the multi-accounts feature.

Also: there is now a script type guide in the receive screen.