### PR TITLE
android: fix timezone so the BitBox02 shows the correct time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Render number of blocks scanned and percentage progress using fixed-width digits for a more stable UI
 - Transaction details: show fiat value at time of transaction
 - Android: more modern look by changing the status bar color to white while the app is running
+- Android: fix time shown on BitBox02 when restoring a backup (it was shown in UTC instead of local time)
 - Fix update balance after transaction sent
 - Fix missing utxos update after new transaction is sent
 - Add attestation check on device setting


### PR DESCRIPTION
On Android, due to a bug in
Go (https://github.com/golang/go/issues/20455), the local timezone is not correct. It is always UTC.

As a result, when restoring a backup on the BitBox02, the BitBox02 displays the current time in UTC instead of the local time.

This commit contains a workaround to fix the timezone on Android.

Alternative considered: getting the timezone offset in native Android code and sending it to Go-land via backend.Environment. I did not pursue this as a quick search didn't turn up an easy way to get the timezone offset on Android which takes into account daylight-savings etc.