### PR TITLE
frontend: refactor account to functional component

### DIFF
--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -59,3 +59,9 @@ export const getQRCode = (data: string) => {
     return apiGet(`qr?data=${encodeURIComponent(data)}`);
   };
 };
+
+export const isMoonpayBuySupported = (code: string) => {
+  return (): Promise<boolean> => {
+    return apiGet(`exchange/moonpay/buy-supported/${code}`);
+  };
+};

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -41,6 +41,12 @@ export const getDeviceInfo = (
     });
 };
 
+export const checkSDCard = (
+  deviceID: string,
+): Promise<boolean> => {
+  return apiGet(`devices/bitbox02/${deviceID}/check-sdcard`);
+};
+
 export const setDeviceName = (
   deviceID: string,
   newDeviceName: string,

--- a/frontends/web/src/hooks/sdcard.ts
+++ b/frontends/web/src/hooks/sdcard.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DependencyList, useEffect, useState } from 'react';
+import { TDevices } from '../api/devices';
+import { checkSDCard } from '../api/bitbox02';
+import { getDeviceInfo as getBitBox01DeviceInfo } from '../api/bitbox01';
+import { useMountedRef } from './utils';
+
+/**
+ * useSDCard hook to check if one of the devices has a SDCard plugged in
+ * @param devices which to check
+ * @param dependencies optional array to re-run the check if any of the dependency change, devices is automatically added to the dependencies list
+ */
+export const useSDCard = (
+  devices: TDevices,
+  dependencies?: DependencyList,
+) => {
+  const [sdcard, setSDCard] = useState<boolean>(false);
+  const mounted = useMountedRef();
+  useEffect(() => {
+    const deviceIDs = Object.keys(devices);
+    Promise.all(deviceIDs.map(deviceID => {
+      switch (devices[deviceID]) {
+      case 'bitbox':
+        return getBitBox01DeviceInfo(deviceID)
+          .then(({ sdcard }) => sdcard);
+      case 'bitbox02':
+        return checkSDCard(deviceID);
+      default:
+        return false;
+      }
+    }))
+      .then(sdcards => sdcards.some(sdcard => sdcard))
+      .then(result => {
+        if (mounted.current) {
+          setSDCard(result);
+        }
+      })
+      .catch(console.error);
+    // disable warning about mounted not in the dependency list
+  }, [devices, ...(dependencies || [])] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return sdcard;
+};

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -5,14 +5,6 @@
     "exportTransactions": "Export transactions to downloads folder as CSV file",
     "fatalError": "There was an unexpected error.",
     "incoming": "Incoming",
-    "info": {
-      "btc-p2pkh": "This is a legacy Bitcoin account. It is recommended that you use the Segwit Bitcoin account instead, as it incurs lower network fees.",
-      "btc-p2wpkh": "This Native Segwit Bitcoin account incurs even lower network fees through the bech32 address format. It's bleeding edge technology but not yet widely supported.",
-      "btc-p2wpkh-p2sh": "This is a Segwit Bitcoin account, and is recommended for lower network fees. If you have just upgraded from the previous app, you can find your funds in the Bitcoin Legacy account, which you can enable in the settings. If you want to try cutting edge technology and save even more network fees, go to Settings and enable a Native Segwit Bitcoin account, which uses the Bech32 address format.",
-      "tbtc-p2pkh": "$t(account.info.btc-p2pkh)",
-      "tbtc-p2wpkh": "$t(account.info.btc-p2wpkh)",
-      "tbtc-p2wpkh-p2sh": "$t(account.info.btc-p2wpkh-p2sh)"
-    },
     "initializing": "Getting information from the blockchain…",
     "maybeProxyError": "Tor proxy enabled. Ensure that your Tor proxy is running properly, or disable the proxy setting.",
     "reconnecting": "Lost connection, trying to reconnect…",

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -40,16 +40,6 @@ import { BuyCTA } from './info/buyCTA';
 import style from './account.module.css';
 import { isBitcoinBased } from './utils';
 
-// Show some additional info for the following coin types, if legacy split acocunts is enabled.
-const WithCoinTypeInfo = [
-  'btc-p2pkh',
-  'btc-p2wpkh',
-  'btc-p2wpkh-p2sh',
-  'tbtc-p2pkh',
-  'tbtc-p2wpkh',
-  'tbtc-p2wpkh-p2sh',
-];
-
 type Props = {
   accounts: accountApi.IAccount[];
   code: string;
@@ -228,13 +218,6 @@ export function Account({
                 code={code}
                 unit={balance.available.unit} />
             )}
-            <Status
-              className="m-bottom-default"
-              hidden={!WithCoinTypeInfo.includes(code)}
-              dismissable={`info-${code}`}
-              type="info">
-              {t(`account.info.${code}`)}
-            </Status>
             <div className="flex flex-row flex-between flex-items-center flex-column-mobile flex-reverse-mobile">
               <label className="labelXLarge flex-self-start-mobile">
                 {t('accountSummary.availableBalance')}

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -15,11 +15,15 @@
  * limitations under the License.
  */
 
-import { Component } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { useLoad } from '../../hooks/api';
 import * as accountApi from '../../api/account';
 import { syncAddressesCount } from '../../api/accountsync';
 import { TDevices } from '../../api/devices';
-import { getDeviceInfo } from '../../api/bitbox01';
+import { isMoonpayBuySupported } from '../../api/backend';
+import { useSDCard } from '../../hooks/sdcard';
 import { unsubscribe, UnsubscribeList } from '../../utils/subscriptions';
 import { statusChanged, syncdone } from '../../api/subscribe-legacy';
 import { alertUser } from '../../components/alert/Alert';
@@ -31,13 +35,10 @@ import { Info } from '../../components/icon';
 import { Spinner } from '../../components/spinner/Spinner';
 import Status from '../../components/status/status';
 import { Transactions } from '../../components/transactions/transactions';
-import { load } from '../../decorators/load';
-import { translate, TranslateProps } from '../../decorators/translate';
 import { apiGet } from '../../utils/request';
 import { BuyCTA } from './info/buyCTA';
 import style from './account.module.css';
 import { isBitcoinBased } from './utils';
-import { Link } from 'react-router-dom';
 
 // Show some additional info for the following coin types, if legacy split acocunts is enabled.
 const WithCoinTypeInfo = [
@@ -49,324 +50,245 @@ const WithCoinTypeInfo = [
   'tbtc-p2wpkh-p2sh',
 ];
 
-interface AccountProps {
-    code: string;
-    devices: TDevices;
-    accounts: accountApi.IAccount[];
-}
+type Props = {
+  accounts: accountApi.IAccount[];
+  code: string;
+  devices: TDevices;
+};
 
-interface LoadedAccountProps {
-    moonpayBuySupported: boolean;
-    config: any;
-}
+export function Account({
+  accounts,
+  code,
+  devices,
+}: Props) {
+  const { t } = useTranslation();
 
-interface State {
-    status?: accountApi.IStatus;
-    transactions?: accountApi.ITransaction[];
-    balance?: accountApi.IBalance;
-    hasCard: boolean;
-    accountInfo?: accountApi.ISigningConfigurationList;
-    syncedAddressesCount?: number;
-}
+  const [balance, setBalance] = useState<accountApi.IBalance>();
+  const [status, setStatus] = useState<accountApi.IStatus>();
+  const [syncedAddressesCount, setSyncedAddressesCount] = useState<number>();
+  const [transactions, setTransactions] = useState<accountApi.ITransaction[]>();
+  const [usesProxy, setUsesProxy] = useState<boolean>();
+  const [stateCode, setStateCode] = useState<string>();
 
-type Props = LoadedAccountProps & AccountProps & TranslateProps;
+  useEffect(() => {
+    apiGet('config').then(({ backend }) => setUsesProxy(backend.proxy.useProxy));
+  }, []);
 
-class Account extends Component<Props, State> {
-  public readonly state: State = {
-    status: undefined,
-    transactions: undefined,
-    balance: undefined,
-    hasCard: false,
-    accountInfo: undefined,
-    syncedAddressesCount: undefined,
-  };
+  const hasCard = useSDCard(devices, [code]);
 
-  private subscriptions: UnsubscribeList = [];
-
-  public componentDidMount() {
-    this.checkSDCards();
-    if (!this.props.code) {
+  const onAccountChanged = useCallback(() => {
+    if (!code || status === undefined || status.fatalError) {
       return;
     }
-    this.subscribe();
-    this.onStatusChanged();
-  }
-
-  public componentWillUnmount() {
-    unsubscribe(this.subscriptions);
-  }
-
-  public UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.code && nextProps.code !== this.props.code) {
-      this.setState({
-        status: undefined,
-        balance: undefined,
-        syncedAddressesCount: 0,
-        transactions: undefined,
-      });
+    if (status.synced && status.offlineError === null) {
+      const currentCode = code;
+      Promise.all([
+        accountApi.getBalance(currentCode).then(newBalance => {
+          if (currentCode !== code) {
+            // Results came in after the account was switched. Ignore.
+            return;
+          }
+          setBalance(newBalance);
+        }),
+        accountApi.getTransactionList(code).then(newTransactions => {
+          if (currentCode !== code) {
+            // Results came in after the account was switched. Ignore.
+            return;
+          }
+          setTransactions(newTransactions);
+        })
+      ])
+        .catch(console.error);
+    } else {
+      setBalance(undefined);
+      setTransactions(undefined);
     }
-  }
+  }, [code, status]);
 
-  public componentDidUpdate(prevProps: Props) {
-    if (!this.props.code) {
+  const onStatusChanged = useCallback(() => {
+    const currentCode = code;
+    if (!currentCode) {
       return;
     }
-    if (this.props.code !== prevProps.code) {
-      this.onStatusChanged();
-      this.checkSDCards();
-      unsubscribe(this.subscriptions);
-      this.subscribe();
-    }
-    if (this.deviceIDs(this.props.devices).length !== this.deviceIDs(prevProps.devices).length) {
-      this.checkSDCards();
-    }
-  }
-
-  private subscribe() {
-    this.subscriptions.push(
-      syncAddressesCount(this.props.code, (code, syncedAddressesCount) => {
-        if (code === this.props.code) {
-          this.setState({ syncedAddressesCount });
-        }
-      }),
-      statusChanged(this.props.code, () => this.onStatusChanged()),
-      syncdone(this.props.code, () => this.onAccountChanged()),
-    );
-  }
-
-  private checkSDCards() {
-    Promise.all(this.deviceIDs(this.props.devices).map(deviceID => {
-      switch (this.props.devices[deviceID]) {
-      case 'bitbox':
-        return getDeviceInfo(deviceID)
-          .then(({ sdcard }) => sdcard);
-      case 'bitbox02':
-        return apiGet(`devices/bitbox02/${deviceID}/check-sdcard`)
-          .then(sdcard => sdcard);
-      default:
-        return [];
-      }
-    }))
-      .then(sdcards => sdcards.some(sdcard => sdcard))
-      .then(hasCard => this.setState({ hasCard }))
-      .catch(console.error);
-  }
-
-  private onStatusChanged() {
-    const code = this.props.code;
-    if (!code) {
-      return;
-    }
-    accountApi.getStatus(code).then(status => {
-      if (this.props.code !== code) {
+    accountApi.getStatus(currentCode).then(status => {
+      if (currentCode !== code) {
         // Results came in after the account was switched. Ignore.
         return;
       }
       if (!status.disabled) {
         if (!status.synced) {
-          accountApi.init(code).catch(console.error);
-        } else {
-          accountApi.getInfo(code)().then(accountInfo => {
-            if (this.props.code !== code) {
-              // Results came in after the account was switched. Ignore.
-              return;
-            }
-            this.setState({ accountInfo });
-          })
-            .catch(console.error);
+          accountApi.init(currentCode).catch(console.error);
         }
       }
-      this.setState({ status }, this.onAccountChanged);
+      setStatus(status);
     })
       .catch(console.error);
-  }
+  }, [code]);
 
-  private onAccountChanged = () => {
-    const status = this.state.status;
-    if (!this.props.code || status === undefined || status.fatalError) {
+  useEffect(onAccountChanged, [onAccountChanged, status]);
+  useEffect(onStatusChanged, [onStatusChanged, code]);
+
+  const subscriptions = useRef<UnsubscribeList>([]);
+  useEffect(() => {
+    unsubscribe(subscriptions.current);
+    subscriptions.current.push(
+      syncAddressesCount(code, (givenCode, addressesSynced) => {
+        if (givenCode === code) {
+          setSyncedAddressesCount(addressesSynced);
+        }
+      }),
+      statusChanged(code, () => onStatusChanged()),
+      syncdone(code, () => onAccountChanged()),
+    );
+    const unsubscribeList = subscriptions.current;
+    return () => unsubscribe(unsubscribeList);
+  }, [code, onAccountChanged, onStatusChanged, status]);
+
+  const moonpayBuySupported = useLoad(isMoonpayBuySupported(code));
+
+  function exportAccount() {
+    if (status === undefined || status.fatalError) {
       return;
     }
-    if (status.synced && status.offlineError === null) {
-      const expectedCode = this.props.code;
-      Promise.all([
-        accountApi.getBalance(this.props.code).then(balance => {
-          if (this.props.code !== expectedCode) {
-            // Results came in after the account was switched. Ignore.
-            return;
-          }
-          this.setState({ balance });
-        }),
-        accountApi.getTransactionList(this.props.code).then(transactions => {
-          if (this.props.code !== expectedCode) {
-            // Results came in after the account was switched. Ignore.
-            return;
-          }
-          this.setState({ transactions });
-        })
-      ])
-        .catch(console.error);
-    } else {
-      this.setState({
-        balance: undefined,
-        transactions: undefined,
-      });
-    }
-  };
-
-  private export = () => {
-    if (this.state.status === undefined || this.state.status.fatalError) {
-      return;
-    }
-    accountApi.exportAccount(this.props.code)
+    accountApi.exportAccount(code)
       .then(result => {
         if (result !== null && !result.success) {
           alertUser(result.errorMessage);
         }
       })
       .catch(console.error);
-  };
+  }
 
-  private deviceIDs = (devices: TDevices) => {
-    return Object.keys(devices);
-  };
+  useEffect(() => {
+    setStateCode(code);
+    setBalance(undefined);
+    setStatus(undefined);
+    setSyncedAddressesCount(0);
+    setTransactions(undefined);
+    onStatusChanged();
+  }, [code, onStatusChanged]);
 
-  private dataLoaded = () => {
-    return this.state.balance !== undefined && this.state.transactions !== undefined;
-  };
+  const hasDataLoaded = balance !== undefined && transactions !== undefined;
 
-  private supportsBuy = () => {
-    // True if at least one external service supports onramp for this account.
-    return this.props.moonpayBuySupported;
-  };
+  const account = accounts && accounts.find(acct => acct.code === code);
+  if (stateCode !== code) {
+    // Sync code property with stateCode to work around a re-render that
+    // happens briefly before `setStatus(undefined)` stops rendering again below.
+    return null;
+  }
+  if (!account || status === undefined) {
+    return null;
+  }
 
-  public render() {
-    const {
-      t,
-      code,
-      accounts,
-      config,
-    } = this.props;
-    const {
-      status,
-      transactions,
-      balance,
-      hasCard,
-      syncedAddressesCount,
-    } = this.state;
-    const account = accounts &&
-                        accounts.find(acct => acct.code === code);
-    if (!account || status === undefined) {
-      return null;
+  const canSend = balance && balance.available.amount !== '0';
+
+  const initializingSpinnerText =
+    (syncedAddressesCount !== undefined && syncedAddressesCount > 1) ? (
+      '\n' + t('account.syncedAddressesCount', {
+        count: syncedAddressesCount.toString(),
+        defaultValue: 0,
+      } as any)
+    ) : '';
+
+  const offlineErrorTextLines: string[] = [];
+  if (status.offlineError !== null) {
+    offlineErrorTextLines.push(t('account.reconnecting'));
+    offlineErrorTextLines.push(status.offlineError);
+    if (usesProxy) {
+      offlineErrorTextLines.push(t('account.maybeProxyError'));
     }
+  }
 
-    const canSend = balance && balance.available.amount !== '0';
+  const showBuyButton = moonpayBuySupported
+    && balance
+    && balance.available.amount === '0'
+    && !balance.hasIncoming
+    && transactions && transactions.length === 0;
 
-    const initializingSpinnerText =
-            (syncedAddressesCount !== undefined && syncedAddressesCount > 1) ? (
-              '\n' + t('account.syncedAddressesCount', {
-                count: syncedAddressesCount.toString(),
-                defaultValue: 0,
-              } as any)
-            ) : '';
-
-    const offlineErrorTextLines: string[] = [];
-    if (status.offlineError !== null) {
-      offlineErrorTextLines.push(t('account.reconnecting'));
-      offlineErrorTextLines.push(status.offlineError);
-      if (config.backend.proxy.useProxy) {
-        offlineErrorTextLines.push(t('account.maybeProxyError'));
-      }
-    }
-
-    const showBuyButton = this.supportsBuy()
-            && balance
-            && balance.available.amount === '0'
-            && !balance.hasIncoming
-            && transactions && transactions.length === 0;
-
-    return (
-      <div className="contentWithGuide">
-        <div className="container">
-          <Status hidden={!hasCard} type="warning">
-            {t('warning.sdcard')}
-          </Status>
-          <Header
-            title={<h2><span>{account.name}</span></h2>}>
-            <Link to={`/account/${code}/info`} title={t('accountInfo.title')} className="flex flex-row flex-items-center">
-              <Info className={style.accountIcon} />
-              <span>{t('accountInfo.label')}</span>
-            </Link>
-          </Header>
-          {status.synced && this.dataLoaded() && isBitcoinBased(account.coinCode) && <HeadersSync coinCode={account.coinCode} />}
-          <div className="innerContainer scrollableContainer">
-            <div className="content padded">
-              { showBuyButton && (
-                <BuyCTA
-                  code={code}
-                  unit={balance.available.unit} />
-              )}
-              <Status
-                className="m-bottom-default"
-                hidden={!WithCoinTypeInfo.includes(code)}
-                dismissable={`info-${code}`}
-                type="info">
-                {t(`account.info.${code}`)}
-              </Status>
-              <div className="flex flex-row flex-between flex-items-center flex-column-mobile flex-reverse-mobile">
-                <label className="labelXLarge flex-self-start-mobile">{t('accountSummary.availableBalance')}</label>
-                <div className={style.actionsContainer}>
-                  {canSend ? (
-                    <Link key="sendLink" to={`/account/${code}/send`} className={style.send}><span>{t('button.send')}</span></Link>
-                  ) : (
-                    <span key="sendDisabled" className={`${style.send} ${style.disabled}`}>{t('button.send')}</span>
-                  )}
-                  <Link key="receive" to={`/account/${code}/receive`} className={style.receive}><span>{t('button.receive')}</span></Link>
-                  { this.supportsBuy() && (
-                    <Link key="buy" to={`/buy/info/${code}`} className={style.buy}><span>{t('button.buy')}</span></Link>
-                  )}
-                </div>
-              </div>
-              <div className="box large">
-                <Balance balance={balance} />
-              </div>
-              {
-                !status.synced || offlineErrorTextLines.length || !this.dataLoaded() || status.fatalError ? (
-                  <Spinner text={
-                    (status.fatalError && t('account.fatalError'))
-                                        || offlineErrorTextLines.join('\n')
-                                        || (!status.synced &&
-                                            t('account.initializing')
-                                            + initializingSpinnerText
-                                        )
-                                        || ''
-                  } />
+  return (
+    <div className="contentWithGuide">
+      <div className="container">
+        <Status hidden={!hasCard} type="warning">
+          {t('warning.sdcard')}
+        </Status>
+        <Header
+          title={<h2><span>{account.name}</span></h2>}>
+          <Link to={`/account/${code}/info`} title={t('accountInfo.title')} className="flex flex-row flex-items-center">
+            <Info className={style.accountIcon} />
+            <span>{t('accountInfo.label')}</span>
+          </Link>
+        </Header>
+        {status.synced && hasDataLoaded && isBitcoinBased(account.coinCode) && (
+          <HeadersSync coinCode={account.coinCode} />
+        )}
+        <div className="innerContainer scrollableContainer">
+          <div className="content padded">
+            { showBuyButton && (
+              <BuyCTA
+                code={code}
+                unit={balance.available.unit} />
+            )}
+            <Status
+              className="m-bottom-default"
+              hidden={!WithCoinTypeInfo.includes(code)}
+              dismissable={`info-${code}`}
+              type="info">
+              {t(`account.info.${code}`)}
+            </Status>
+            <div className="flex flex-row flex-between flex-items-center flex-column-mobile flex-reverse-mobile">
+              <label className="labelXLarge flex-self-start-mobile">
+                {t('accountSummary.availableBalance')}
+              </label>
+              <div className={style.actionsContainer}>
+                {canSend ? (
+                  <Link key="sendLink" to={`/account/${code}/send`} className={style.send}>
+                    <span>{t('button.send')}</span>
+                  </Link>
                 ) : (
-                  <Transactions
-                    accountCode={code}
-                    handleExport={this.export}
-                    explorerURL={account.blockExplorerTxPrefix}
-                    transactions={transactions}
-                  />
-                )
-              }
+                  <span key="sendDisabled" className={`${style.send} ${style.disabled}`}>
+                    {t('button.send')}
+                  </span>
+                )}
+                <Link key="receive" to={`/account/${code}/receive`} className={style.receive}>
+                  <span>{t('button.receive')}</span>
+                </Link>
+                { moonpayBuySupported && (
+                  <Link key="buy" to={`/buy/info/${code}`} className={style.buy}>
+                    <span>{t('button.buy')}</span>
+                  </Link>
+                )}
+              </div>
             </div>
+            <div className="box large">
+              <Balance balance={balance} />
+            </div>
+            { !status.synced || offlineErrorTextLines.length || !hasDataLoaded || status.fatalError ? (
+              <Spinner text={
+                (status.fatalError && t('account.fatalError'))
+                  || offlineErrorTextLines.join('\n')
+                  || (!status.synced &&
+                      t('account.initializing')
+                      + initializingSpinnerText
+                  )
+                  || ''
+              } />
+            ) : (
+              <Transactions
+                accountCode={code}
+                handleExport={exportAccount}
+                explorerURL={account.blockExplorerTxPrefix}
+                transactions={transactions}
+              />
+            ) }
           </div>
         </div>
-        <AccountGuide
-          account={account}
-          unit={balance?.available.unit}
-          hasIncomingBalance={balance && balance.hasIncoming}
-          hasTransactions={transactions !== undefined && transactions.length > 0}
-          hasNoBalance={balance && balance.available.amount === '0'} />
       </div>
-    );
-  }
+      <AccountGuide
+        account={account}
+        unit={balance?.available.unit}
+        hasIncomingBalance={balance && balance.hasIncoming}
+        hasTransactions={transactions !== undefined && transactions.length > 0}
+        hasNoBalance={balance && balance.available.amount === '0'} />
+    </div>
+  );
 }
-
-const loadHOC = load<LoadedAccountProps, AccountProps & TranslateProps>(({ code }) => ({
-  moonpayBuySupported: `exchange/moonpay/buy-supported/${code}`,
-  config: 'config',
-}))(Account);
-
-const HOC = translate()(loadHOC);
-export { HOC as Account };

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -17,7 +17,7 @@
 
 import React, { Component, FormEvent } from 'react';
 import { Backup } from '../components/backup';
-import { getVersion, setDeviceName, VersionInfo, verifyAttestation } from '../../../api/bitbox02';
+import { checkSDCard, getVersion, setDeviceName, VersionInfo, verifyAttestation } from '../../../api/bitbox02';
 import { multilineMarkup } from '../../../utils/markup';
 import { convertDateToLocaleString } from '../../../utils/date';
 import { route } from '../../../utils/route';
@@ -238,9 +238,7 @@ class BitBox02 extends Component<Props, State> {
   };
 
   private checkSDCard = () => {
-    return apiGet('devices/bitbox02/' + this.props.deviceID + '/check-sdcard').then(sdCardInserted => {
-      return sdCardInserted;
-    });
+    return checkSDCard(this.props.deviceID);
   };
 
   private insertSDCard = () => {


### PR DESCRIPTION
Ongoing effort to rewrite all class based components to functional components so we can use hooks.
    
- typed check-sdcard api
- typed buy-supported api
- remove load decorator and load config directly

also: remove old account type information
    
This was used before unified accounts were introduced. Removing.