### PR TITLE
backend/conversions: fix nil conversions when rates not available

### DIFF
--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -33,7 +33,7 @@ func FormatAsCurrency(amount *big.Rat, coinUnit string) string {
 
 // Conversions handles fiat conversions.
 func Conversions(amount Amount, coin Coin, isFee bool, ratesUpdater *rates.RateUpdater) map[string]string {
-	var conversions map[string]string
+	conversions := map[string]string{}
 	rates := ratesUpdater.LatestPrice()
 	if rates != nil {
 		unit := coin.Unit(isFee)
@@ -48,11 +48,10 @@ func Conversions(amount Amount, coin Coin, isFee bool, ratesUpdater *rates.RateU
 
 // ConversionsAtTime handles fiat conversions at a specific time.
 func ConversionsAtTime(amount Amount, coin Coin, isFee bool, ratesUpdater *rates.RateUpdater, timeStamp *time.Time) map[string]string {
-	var conversions map[string]string
+	conversions := map[string]string{}
 	rates := ratesUpdater.LatestPrice()
 	if rates != nil {
 		unit := coin.Unit(isFee)
-		conversions = map[string]string{}
 		for fiat := range rates[unit] {
 			value := ratesUpdater.HistoricalPriceAt(string(coin.Code()), fiat, *timeStamp)
 			if value == 0 {

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -119,7 +119,7 @@ function Conversion({
   let isAvailable = false;
 
   // amount.conversions[active] can be empty in recent transactions.
-  if (amount && amount.conversions[active] !== '') {
+  if (amount && amount.conversions[active] && amount.conversions[active] !== '') {
     isAvailable = true;
     formattedValue = amount.conversions[active];
   }


### PR DESCRIPTION
Unexpected errors from coingecko service were causing the backend to send amounts with nil conversions field, which caused runtime errors on the frontend. With this update, a != nil conversions field should always be available even when coingecko errors accour, allowing the frontend to handle the situation without blocks.