### PR TITLE
android: add external link queries for Android 11 permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add attestation check on device setting
 - Fix unsufficient gas funds error message on erc20 transactions
 - Display trailing zeroes for BTC/LTC amount formatting
+- Fix broken links on Android 11+
 
 ## 4.34.0
 - Bundle BitBox02 firmware version v9.12.0

--- a/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
+++ b/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
@@ -11,6 +11,20 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
+    <!-- to allow external links and mailto -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="mailto" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/frontends/android/BitBoxApp/build.gradle
+++ b/frontends/android/BitBoxApp/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.4'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
With Android 11 the visibility of the installed packages has been filtered to offer a higher privacy level to the user. This commit add to AndroidManifest.xml the `queries` elements needed to open external links for web pages and `mailto` urls.

Queries support is not granted in all Gradle versions. For this reason, the latter has been updated to v3.5.4.

Refs:
https://developer.android.com/training/package-visibility
https://medium.com/androiddevelopers/package-visibility-in-android-11-cc857f221cd9
https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html