### PR TITLE
frontend/guide/entry: convert to FunctionalComponent

### DIFF
--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component } from 'react';
+import { FunctionComponent, useState } from 'react';
 import A from '../anchor/anchor';
 import style from './guide.module.css';
 
@@ -28,68 +28,39 @@ export interface EntryProp {
 }
 
 interface EntryProps {
-    entry: EntryProp | string; // string could be the entry translation key in cimode, e.g. 'guide.waiting.1'.
+    entry: EntryProp;
     shown?: boolean;
 }
 
 type Props = EntryProps;
 
-interface State {
-    shown: boolean;
-}
+export const Entry: FunctionComponent<Props> = props => {
+  const [shown, setShown] = useState<boolean>(props.shown || false);
 
-export class Entry extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      shown: props.shown || false,
-    };
-  }
-
-  private toggle = () => {
-    this.setState(state => ({
-      shown: !state.shown,
-    }));
+  const toggle = () => {
+    setShown(shown => !shown);
   };
 
-  public render() {
-    const props = this.props;
-    const {
-      shown,
-    } = this.state;
-    let entry: EntryProp;
-    if (typeof props.entry === 'string') {
-      entry = {
-        title: props.entry + '.title',
-        text: props.entry + '.text',
-        link: {
-          url: props.entry + '.link.url',
-          text: props.entry + '.link.text',
-        },
-      };
-    } else {
-      entry = props.entry;
-    }
-    return (
-      <div className={style.entry}>
-        <div className={style.entryTitle} onClick={this.toggle}>
-          <div className={style.entryToggle}>{shown ? '–' : '+'}</div>
-          <div className={style.entryTitleText}>
-            <h2>{entry.title}</h2>
-          </div>
-        </div>
-        <div className={[style.entryContent, shown ? style.expanded : ''].join(' ')}>
-          {shown ? (
-            <div className="flex-1">
-              {entry.text.trim().split('\n').map(p => <p key={p}>{p}</p>)}
-              {entry.link && (
-                <p><A href={entry.link.url}>{entry.link.text}</A></p>
-              )}
-              {props.children}
-            </div>
-          ) : null}
+  const entry = props.entry;
+  return (
+    <div className={style.entry}>
+      <div className={style.entryTitle} onClick={toggle}>
+        <div className={style.entryToggle}>{shown ? '–' : '+'}</div>
+        <div className={style.entryTitleText}>
+          <h2>{entry.title}</h2>
         </div>
       </div>
-    );
-  }
-}
+      <div className={[style.entryContent, shown ? style.expanded : ''].join(' ')}>
+        {shown ? (
+          <div className="flex-1">
+            {entry.text.trim().split('\n').map(p => <p key={p}>{p}</p>)}
+            {entry.link && (
+              <p><A href={entry.link.url}>{entry.link.text}</A></p>
+            )}
+            {props.children}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -30,29 +30,25 @@ export interface EntryProp {
 interface EntryProps {
     entry: EntryProp | string; // string could be the entry translation key in cimode, e.g. 'guide.waiting.1'.
     shown?: boolean;
-    highlighted?: boolean;
 }
 
 type Props = EntryProps;
 
 interface State {
     shown: boolean;
-    highlighted: boolean;
 }
 
 export class Entry extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      shown: props.shown || props.highlighted || false,
-      highlighted: props.highlighted || false,
+      shown: props.shown || false,
     };
   }
 
   private toggle = () => {
     this.setState(state => ({
       shown: !state.shown,
-      highlighted: false,
     }));
   };
 
@@ -60,7 +56,6 @@ export class Entry extends Component<Props, State> {
     const props = this.props;
     const {
       shown,
-      highlighted,
     } = this.state;
     let entry: EntryProp;
     if (typeof props.entry === 'string') {
@@ -76,7 +71,7 @@ export class Entry extends Component<Props, State> {
       entry = props.entry;
     }
     return (
-      <div className={highlighted ? style.highlighted : style.entry}>
+      <div className={style.entry}>
         <div className={style.entryTitle} onClick={this.toggle}>
           <div className={style.entryToggle}>{shown ? '–' : '+'}</div>
           <div className={style.entryTitleText}>

--- a/frontends/web/src/components/guide/guide.module.css
+++ b/frontends/web/src/components/guide/guide.module.css
@@ -88,12 +88,6 @@
     margin-top: var(--space-default);
 }
 
-.highlighted {
-    margin: 1.1em -1em;
-    padding: 0.5em 1em;
-    background-color: var(--color-darkblue);
-}
-
 .entryTitle {
     display: flex;
     flex-direction: row;
@@ -151,7 +145,7 @@
         transform: translateX(100%);
         transition-delay: 0.2s;
     }
-    
+
     .show {
         opacity: 1;
         z-index: 4002;


### PR DESCRIPTION
The entry property was also changed from `EntryProp | string` to
`EntryProp`, as the locize in-app editor (`cimode`) does not exist
anymore (removed in 29a0764e).

