### PR TITLE
qt: remove unused QT_BITBOX_ALLOW_EXTERNAL_URLS

### DIFF
--- a/frontends/qt/BitBox.pro
+++ b/frontends/qt/BitBox.pro
@@ -44,12 +44,6 @@ win32 {
     QMAKE_CXXFLAGS += $$CMISC
 }
 
-# Pass on env var as a define.
-QT_BITBOX_ALLOW_EXTERNAL_URLS = $$(QT_BITBOX_ALLOW_EXTERNAL_URLS)
-equals(QT_BITBOX_ALLOW_EXTERNAL_URLS, 1) {
-    DEFINES += QT_BITBOX_ALLOW_EXTERNAL_URLS
-}
-
 # https://stackoverflow.com/questions/18462420/how-to-specify-mac-platform-in-qmake-qtcreator
 unix:!macx {
     QMAKE_LFLAGS_RPATH=

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -104,10 +104,6 @@ class RequestInterceptor : public QWebEngineUrlRequestInterceptor {
 public:
     explicit RequestInterceptor() : QWebEngineUrlRequestInterceptor() { }
     void interceptRequest(QWebEngineUrlRequestInfo& info) override {
-#ifdef QT_BITBOX_ALLOW_EXTERNAL_URLS
-        // Do not block anything.
-        return;
-#endif
         // Do not block qrc:/ local pages or js blobs
         if (info.requestUrl().scheme() == "qrc" || info.requestUrl().scheme() == "blob") {
             return;


### PR DESCRIPTION
Introduced in 8a27bfe72793a86fdbdbc1384700861bdc84eb4c to enable the in-app lociz editor, which was removed again in 29a0764ea4a5d4f412ec928055439a083c47d99d.