### PR TITLE
frontend: fix coin and unit styling in tx overview

### DIFF
--- a/frontends/web/src/components/rates/rates.module.css
+++ b/frontends/web/src/components/rates/rates.module.css
@@ -1,7 +1,8 @@
 .rates {
     cursor: default;
-    margin: 0;
     line-height: 1;
+    margin: 0;
+    white-space: nowrap;
 }
 
 .unit {
@@ -12,6 +13,7 @@
 .unitAction {
     color: var(--color-secondary);
     font-size: var(--size-default);
+    font-variant: normal;
     position: relative;
 }
 

--- a/frontends/web/src/components/transactions/transaction.module.css
+++ b/frontends/web/src/components/transactions/transaction.module.css
@@ -51,7 +51,19 @@
 }
 
 .fiat {
+    font-variant: tabular-nums;
+}
 
+.amount {
+    font-variant: tabular-nums;
+    max-width: 100%;
+}
+
+.amountOverflow {
+    overflow: hidden;
+    padding-right: 40px;
+    position: relative;
+    text-overflow: ellipsis;
 }
 
 .send {
@@ -63,11 +75,18 @@
 }
 
 .currency {
-
+    font-variant: tabular-nums;
 }
 
 .currencyUnit {
     color: var(--color-secondary);
+    font-variant: normal;
+}
+
+.amountOverflow .currencyUnit {
+    position: absolute;
+    right: 0;
+    top: 0;
 }
 
 .action {
@@ -274,4 +293,12 @@
     .fee {
         min-width: 0;
     }
+}
+
+@media (max-width: 560px) {
+
+    .status {
+        display: none;
+    }
+
 }

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -207,11 +207,10 @@ class Transaction extends Component<Props, State> {
                 <FiatConversion amount={amount} sign={sign} noAction />
               </span>
             </div>
-            <div className={parentStyle.currency}>
-              <span className={`${style.currency} ${typeClassName}`}>
+            <div className={`${parentStyle.currency} ${typeClassName}`}>
+              <span className={`${style.amount} ${style.amountOverflow}`}>
                 {sign}{amount.amount}
-                {' '}
-                <span className={style.currencyUnit}>{amount.unit}</span>
+                <span className={style.currencyUnit}>&nbsp;{amount.unit}</span>
               </span>
             </div>
             <div className={[parentStyle.action, parentStyle.showOnMedium].join(' ')}>
@@ -302,12 +301,10 @@ class Transaction extends Component<Props, State> {
               </div>
               <div className={style.detail}>
                 <label>{t('transaction.details.amount')}</label>
-                <p>
-                  <span className={`${style.currency} ${typeClassName}`}>
-                    {sign}{transactionInfo.amount.amount}
-                    {' '}
-                    <span className={style.currencyUnit}>{transactionInfo.amount.unit}</span>
-                  </span>
+                <p className={typeClassName}>
+                  <span className={style.amount}>{sign}{amount.amount}</span>
+                  {' '}
+                  <span className={style.currencyUnit}>{transactionInfo.amount.unit}</span>
                 </p>
               </div>
               <div className={style.detail}>

--- a/frontends/web/src/components/transactions/transactions.module.css
+++ b/frontends/web/src/components/transactions/transactions.module.css
@@ -56,8 +56,8 @@
 }
 
 .activity {
-  min-width: 362px;
-  width: 362px;
+  min-width: 334px;
+  width: 334px;
   text-align: left;
 }
 
@@ -73,8 +73,8 @@
 }
 
 .currency {
-  min-width: 202px;
-  width: 202px;
+  min-width: 230px;
+  width: 230px;
   justify-content: flex-end;
 }
 
@@ -162,9 +162,29 @@
 }
 
 @media (max-width: 768px) {
+
   .container {
     margin: var(--space-default) 0;
   }
+
+
+  .fiat,
+  .currency {
+    min-width: 0;
+    width: auto;
+  }
+
+  .fiat {
+    flex-grow: 1;
+    flex-shrink: 0;
+    justify-content: flex-end;
+  }
+
+  .currency {
+    flex-grow: 0;
+    flex-shrink: 1;
+  }
+
 }
 
 @media (max-width: 666px) {
@@ -189,7 +209,8 @@
   }
 
   .status {
-    min-width: 100px;
     margin-left: 2px;
+    min-width: 14px;
+    padding-right: 0;
   }
 }


### PR DESCRIPTION
Sometimes the unit breaks onto a separate line, this happens with
large amounts or coins with lots of decimal for example with ETH.

Changed styling so that very large amounts are cut off with "…",
but only visually so that copy/paste contains takes the whole
amount. This should also fix the issue with large amounts on
small screen, in extreme cases the fiat amount should squeeze
the coin amount together.

Also added "font-variant: tabular-nums" definition for the amount
so that all numbers take equal space, without using a monospace
font.

![Screen Shot 2022-10-19 at 13 51 03](https://user-images.githubusercontent.com/546900/196684314-9f7bd3ef-7557-4337-91e6-f5d8a68ee611.png)

and small screen:

![Screen Shot 2022-10-19 at 14 33 16](https://user-images.githubusercontent.com/546900/196691940-b51ddbcc-4a93-4916-a965-d246ea6f3f96.png)
