### PR TITLE
frontend: show point-to-device graphic on pairing step

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -516,13 +516,17 @@ class BitBox02 extends Component<Props, State> {
               )}
             </ViewContent>
             <ViewButtons>
-              <Button
-                primary
-                onClick={() => this.channelVerify(true)}
-                disabled={!deviceVerified}
-                hidden={status === 'pairingFailed'}>
-                {t('button.continue')}
-              </Button>
+              {status !== 'pairingFailed' ? (
+                deviceVerified ? (
+                  <Button
+                    primary
+                    onClick={() => this.channelVerify(true)}>
+                    {t('button.continue')}
+                  </Button>
+                ) : (
+                  <PointToBitBox02 />
+                )
+              ) : null}
             </ViewButtons>
           </View>
         )}


### PR DESCRIPTION
Before there was a disabled grayed out continue button on the pairing step when the user should focus on the device and confirm the code.

Changed so that the is a point-to-device graphic without a disabled button. Once the pairing is confirmed it changes to a continue button.