### PR TITLE
frontend: use generic continue button translation

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -215,7 +215,6 @@
     "insertSDCard": "<strong>Please make sure you have a microSD card inserted in your BitBox02.</strong>",
     "noPasswordMatch": "Passwords did not match, please try again.",
     "pairing": {
-      "confirmButton": "Continue",
       "failed": "Unconfirmed pairing. Please replug your BitBox02.",
       "paired": "You have confirmed on your device that the code matches. If this is correct, you can continue by clicking the button below.",
       "title": "Verify pairing code",
@@ -237,7 +236,6 @@
     },
     "stepCreate": {
       "buttonBack": "Go back",
-      "buttonContinue": "Continue",
       "description": "This name is used as the device name and for the backup.",
       "nameLabel": "BitBox02 name",
       "namePlaceholder": "My BitBox02",
@@ -868,7 +866,6 @@
       "e102": "The device password must consist of at least 4 characters."
     },
     "info": {
-      "button": "Continue",
       "description1": "Choose your device password. This will be used to unlock your BitBox.",
       "description2": "You can use numbers, letters & symbols. Longer passwords offer higher security.",
       "description3": "If you lose the device password you will have to reset your device and restore your wallet backup.",
@@ -1076,7 +1073,6 @@
   },
   "securityInformation": {
     "create": {
-      "button": "Continue",
       "description1": "We recommend you set up your device in a safe environment, meaning you are away from other people that could see what password you choose.",
       "description2": "You will be asked to create two passwords.",
       "description3": "The first is the <strong>device password</strong> which unlocks your BitBox device and can be changed later.",
@@ -1085,7 +1081,6 @@
       "title": "Security information"
     },
     "restore": {
-      "button": "Continue",
       "description1": "You will be asked to insert the microSD card you used to store you backup.",
       "description2": "To restore your device you will need your recovery password. ",
       "description3": "Please take care when entering the recovery password. Any password you enter will create a valid wallet. If you enter the wrong password you may be shown a wallet balance that you do not expect.",
@@ -1126,7 +1121,6 @@
       "e200": "Restoring a wallet from a backup requires the microSD card."
     },
     "info": {
-      "button": "Continue",
       "description1": "Insert the microSD card into the BitBox and click “Continue”",
       "description2": "Choose a backup and click “Restore”",
       "description3": "Enter the recovery password",

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -123,7 +123,7 @@ class Initialize extends Component<Props, State> {
         <p>{t('initialize.info.description3')}</p>
         <div className="buttons">
           <Button primary onClick={this.handleStart}>
-            {t('initialize.info.button')}
+            {t('button.continue')}
           </Button>
           <Button
             transparent

--- a/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
@@ -74,7 +74,7 @@ class SecurityInformation extends Component<Props, State> {
                     <SimpleMarkup tagName="p" markup={t('securityInformation.create.description5')} />
                     <div className="buttons">
                       <Button primary onClick={this.handleStart}>
-                        {t('securityInformation.create.button')}
+                        {t('button.continue')}
                       </Button>
                       <Button
                         transparent
@@ -96,7 +96,7 @@ class SecurityInformation extends Component<Props, State> {
                     </Message>
                     <div className="buttons">
                       <Button primary onClick={this.handleStart}>
-                        {t('securityInformation.restore.button')}
+                        {t('button.continue')}
                       </Button>
                       <Button
                         transparent

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
@@ -118,7 +118,7 @@ class SeedRestore extends Component {
                         primary
                         onClick={this.handleStart}
                         disabled={status !== STATUS.DEFAULT}>
-                        {t('seedRestore.info.button')}
+                        {t('button.continue')}
                       </Button>
                       <Button
                         transparent

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -521,7 +521,7 @@ class BitBox02 extends Component<Props, State> {
                 onClick={() => this.channelVerify(true)}
                 disabled={!deviceVerified}
                 hidden={status === 'pairingFailed'}>
-                {t('bitbox02Wizard.pairing.confirmButton')}
+                {t('button.continue')}
               </Button>
             </ViewButtons>
           </View>
@@ -608,7 +608,7 @@ class BitBox02 extends Component<Props, State> {
                   disabled={!deviceName}
                   primary
                   type="submit">
-                  {t('bitbox02Wizard.stepCreate.buttonContinue')}
+                  {t('button.continue')}
                 </Button>
                 <Button
                   onClick={() => this.setState({ appStatus: '' })}
@@ -691,7 +691,7 @@ class BitBox02 extends Component<Props, State> {
                   primary
                   onClick={this.createBackup}
                   disabled={creatingBackup || !readDisclaimers}>
-                  {t('securityInformation.create.button')}
+                  {t('button.continue')}
                 </Button>
               </ViewButtons>
             </View>


### PR DESCRIPTION
The same translation for 'Continue' is used in various components,
changed to use the same generic text everywhere instead of custom
translation key.

Note: I kept different commits so that it is easier to review, but I'll squash
into 1 commit once approved. 