### PR TITLE
frontend: converted LanguageSwitch to a functional component and updated its test

### DIFF
--- a/frontends/web/src/components/language/types.ts
+++ b/frontends/web/src/components/language/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type TActiveLanguageCodes = 'bg' | 'de' | 'en' | 'es'
+    | 'fr' | 'hi' | 'it' | 'ja' | 'ms' | 'nl' | 'pt'
+    | 'ru' | 'sl' | 'tr' | 'zh';
+
+type TLanguage = {
+    code: TActiveLanguageCodes;
+    display: string;
+};
+
+export type TLanguagesList = TLanguage[];


### PR DESCRIPTION
As a part of our refactoring efforts and to follow the latest conventions in the frontend, class components need to be converted into functional ones whenever possible. 

Tests are updated so they work with the newly created functional component and its hooks. Also migrated the test away from enzyme to testing-library/react, as we plan to remove and not use enzyme anymore in the future.