### PR TITLE
backend: add a BtcUnit type and use it everywhere to format sats

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,8 +58,6 @@ linters-settings:
       - underef
       - unlambda
       - unslice
-  gocyclo:
-    min-complexity: 28
   maligned:
     # print struct with more effective memory layout or not, false by default
     suggest-new: true
@@ -132,6 +130,7 @@ linters:
     - forbidigo
     - makezero
     - nolintlint
+    - gocyclo
   disable-all: false
 
 issues:
@@ -150,7 +149,6 @@ issues:
     - path: _test\.go
       linters:
         - errcheck
-        - gocyclo
         - godot
         - gosec
         - testpackage

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -60,7 +60,7 @@ type AccountConfig struct {
 	// Opens a file in a default application. The filename is not checked.
 	UnsafeSystemOpen func(filename string) error
 	// BtcCurrencyUnit is the unit which should be used to format fiat amounts values expressed in BTC..
-	BtcCurrencyUnit string
+	BtcCurrencyUnit coin.BtcUnit
 }
 
 // BaseAccount is an account struct with common functionality to all coin accounts.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -343,27 +343,26 @@ func (backend *Backend) Coin(code coinpkg.Code) (coinpkg.Coin, error) {
 	dbFolder := backend.arguments.CacheDirectoryPath()
 
 	erc20Token := erc20TokenByCode(code)
+	btcFormatUnit := backend.config.AppConfig().Backend.BtcUnit
 	switch {
 	case code == coinpkg.CodeRBTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeRBTC, "Bitcoin Regtest", "RBTC", &chaincfg.RegressionNetParams, dbFolder, servers, "", backend.socksProxy)
+		coin = btc.NewCoin(coinpkg.CodeRBTC, "Bitcoin Regtest", "RBTC", coinpkg.BtcUnitDefault, &chaincfg.RegressionNetParams, dbFolder, servers, "", backend.socksProxy)
 	case code == coinpkg.CodeTBTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeTBTC, "Bitcoin Testnet", "TBTC", &chaincfg.TestNet3Params, dbFolder, servers,
+		coin = btc.NewCoin(coinpkg.CodeTBTC, "Bitcoin Testnet", "TBTC", btcFormatUnit, &chaincfg.TestNet3Params, dbFolder, servers,
 			"https://blockstream.info/testnet/tx/", backend.socksProxy)
-		coin.SetFormatUnit(backend.config.AppConfig().Backend.BtcUnit)
 	case code == coinpkg.CodeBTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeBTC, "Bitcoin", "BTC", &chaincfg.MainNetParams, dbFolder, servers,
+		coin = btc.NewCoin(coinpkg.CodeBTC, "Bitcoin", "BTC", btcFormatUnit, &chaincfg.MainNetParams, dbFolder, servers,
 			"https://blockstream.info/tx/", backend.socksProxy)
-		coin.SetFormatUnit(backend.config.AppConfig().Backend.BtcUnit)
 	case code == coinpkg.CodeTLTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeTLTC, "Litecoin Testnet", "TLTC", &ltc.TestNet4Params, dbFolder, servers,
+		coin = btc.NewCoin(coinpkg.CodeTLTC, "Litecoin Testnet", "TLTC", coinpkg.BtcUnitDefault, &ltc.TestNet4Params, dbFolder, servers,
 			"http://explorer.litecointools.com/tx/", backend.socksProxy)
 	case code == coinpkg.CodeLTC:
 		servers := backend.defaultElectrumXServers(code)
-		coin = btc.NewCoin(coinpkg.CodeLTC, "Litecoin", "LTC", &ltc.MainNetParams, dbFolder, servers,
+		coin = btc.NewCoin(coinpkg.CodeLTC, "Litecoin", "LTC", coinpkg.BtcUnitDefault, &ltc.MainNetParams, dbFolder, servers,
 			"https://insight.litecore.io/tx/", backend.socksProxy)
 	case code == coinpkg.CodeETH:
 		etherScan := etherscan.NewEtherScan("https://api.etherscan.io/api", backend.etherScanHTTPClient)

--- a/backend/chart.go
+++ b/backend/chart.go
@@ -297,8 +297,8 @@ func (backend *Backend) ChartData() (*Chart, error) {
 	}
 
 	chartFiat := fiat
-	if fiat == rates.BTC.String() {
-		chartFiat = backend.Config().AppConfig().Backend.BtcUnit
+	if fiat == rates.BTC.String() && backend.Config().AppConfig().Backend.BtcUnit == coin.BtcUnitSats {
+		chartFiat = "sat"
 	}
 
 	var chartTotal *float64

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -43,7 +43,7 @@ func TestAccount(t *testing.T) {
 	defer func() { _ = os.RemoveAll(dbFolder) }()
 
 	coin := btc.NewCoin(
-		code, "Bitcoin Testnet", unit, net, dbFolder, nil, explorer, socksproxy.NewSocksProxy(false, ""))
+		code, "Bitcoin Testnet", unit, coin.BtcUnitDefault, net, dbFolder, nil, explorer, socksproxy.NewSocksProxy(false, ""))
 
 	blockchainMock := &blockchainMock.BlockchainMock{}
 	blockchainMock.MockRegisterOnConnectionErrorChangedEvent = func(f func(error)) {}

--- a/backend/coins/btc/coin_test.go
+++ b/backend/coins/btc/coin_test.go
@@ -57,7 +57,7 @@ type testSuite struct {
 func (s *testSuite) SetupTest() {
 	s.dbFolder = test.TstTempDir("btc-dbfolder")
 
-	s.coin = btc.NewCoin(s.code, "Some coin", s.unit, s.net, s.dbFolder, nil,
+	s.coin = btc.NewCoin(s.code, "Some coin", s.unit, coin.BtcUnitDefault, s.net, s.dbFolder, nil,
 		explorer, socksproxy.NewSocksProxy(false, ""))
 	blockchainMock := &blockchainMock.BlockchainMock{}
 	blockchainMock.MockHeadersSubscribe = func(

--- a/backend/coins/btc/maketx/maketx_test.go
+++ b/backend/coins/btc/maketx/maketx_test.go
@@ -41,8 +41,8 @@ import (
 
 var noDust = btcutil.Amount(0)
 
-var tltc = btc.NewCoin(coin.CodeTLTC, "TLTC", "Litecoin Testnet", &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "", socksproxy.NewSocksProxy(false, ""))
-var tbtc = btc.NewCoin(coin.CodeTBTC, "TBTC", "Bitcoin Testnet", &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "https://blockstream.info/testnet/tx/", socksproxy.NewSocksProxy(false, ""))
+var tltc = btc.NewCoin(coin.CodeTLTC, "Litecoin Testnet", "TBTC", coin.BtcUnitDefault, &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "", socksproxy.NewSocksProxy(false, ""))
+var tbtc = btc.NewCoin(coin.CodeTBTC, "Bitcoin Testnet", "TBTC", coin.BtcUnitDefault, &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "https://blockstream.info/testnet/tx/", socksproxy.NewSocksProxy(false, ""))
 
 // For reference, tx vsizes assuming two outputs (normal + change), for N inputs:
 // 1 inputs: 226

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -161,7 +161,7 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (
 		allowZero := false
 
 		unit := int64(unitSatoshi)
-		if account.coin.formatUnit == coin.UnitSats {
+		if account.coin.formatUnit == coin.BtcUnitSats {
 			unit = 1
 		}
 		parsedAmount, err := args.Amount.Amount(big.NewInt(unit), allowZero)

--- a/backend/coins/btc/util/util.go
+++ b/backend/coins/btc/util/util.go
@@ -71,6 +71,6 @@ func AddressFromPkScript(pkScript []byte, net *chaincfg.Params) (btcutil.Address
 }
 
 // FormatBtcAsSat returns true if the btcUnit param is `[t]sat`.
-func FormatBtcAsSat(btcUnit string) bool {
-	return btcUnit == coin.UnitSats || btcUnit == "t"+coin.UnitSats
+func FormatBtcAsSat(btcUnit coin.BtcUnit) bool {
+	return btcUnit == coin.BtcUnitSats
 }

--- a/backend/coins/coin/codes.go
+++ b/backend/coins/coin/codes.go
@@ -42,11 +42,15 @@ const (
 	// There are some more coin codes for the supported erc20 tokens in erc20.go.
 )
 
+// BtcUnit defines how BTC values are formatted.
+type BtcUnit string
+
 const (
-	// UnitBtc represents Bitcoin unit.
-	UnitBtc string = "BTC"
-	// UnitSats represents Satoshi unit.
-	UnitSats string = "sat"
+	// BtcUnitDefault formats the value in the default unit, e.g. "BTC" for Bitcoin, "TBTC" for
+	// Bitcoin testnet.
+	BtcUnitDefault BtcUnit = "default"
+	// BtcUnitSats formats the value as satoshis. Applies to both Bitcoin mainnet and testnet.
+	BtcUnitSats BtcUnit = "sat"
 )
 
 // TestnetCoins is the subset of all coins which are available in testnet mode.

--- a/backend/coins/coin/coin.go
+++ b/backend/coins/coin/coin.go
@@ -41,9 +41,6 @@ type Coin interface {
 	// The fee unit is usually the same as the main unit, but can differ.
 	Unit(isFee bool) string
 
-	// SetFormatUnit sets the unit used to format the amount, e.g. "BTC" or "sat".
-	SetFormatUnit(unit string)
-
 	// GetFormatUnit sets the unit used to format the amount, e.g. "BTC" or "sat".
 	GetFormatUnit() string
 

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -119,11 +119,6 @@ func (coin *Coin) Unit(isFee bool) string {
 	return coin.unit
 }
 
-// SetFormatUnit implements coin.Coin.
-func (coin *Coin) SetFormatUnit(string) {
-	// No need for format unit on ETH coins.
-}
-
 // GetFormatUnit implements coin.Coin.
 func (coin *Coin) GetFormatUnit() string {
 	return coin.unit

--- a/backend/coins/eth/coin_test.go
+++ b/backend/coins/eth/coin_test.go
@@ -124,8 +124,6 @@ func (s *testSuite) TestParseAmount() {
 	require.Equal(s.T(), err, nil)
 	require.Equal(s.T(), intWeiAmount, intAmount)
 
-	// SetFormatUnit implementation is empty for eth
-	s.coin.SetFormatUnit("useless-string")
 	coinAmount, err = s.coin.ParseAmount(ethAmount)
 	require.Equal(s.T(), err, nil)
 	intAmount, err = coinAmount.Int64()

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -89,8 +89,8 @@ type Backend struct {
 	// as reported by the OS.
 	UserLanguage string `json:"userLanguage"`
 
-	// BtcUnit is the unit used to represents Bitcoin amounts, e.g. `BTC` or `sat`.
-	BtcUnit string `json:"btcUnit"`
+	// BtcUnit is the unit used to represent Bitcoin amounts. See `coin.BtcUnit` for details.
+	BtcUnit coin.BtcUnit `json:"btcUnit"`
 }
 
 // DeprecatedCoinActive returns the Active setting for a coin by code.  This call is should not be
@@ -220,7 +220,7 @@ func NewDefaultAppConfig() AppConfig {
 			// Copied from frontend/web/src/components/rates/rates.tsx.
 			FiatList: []string{rates.USD.String(), rates.EUR.String(), rates.CHF.String()},
 			MainFiat: rates.USD.String(),
-			BtcUnit:  "BTC",
+			BtcUnit:  coin.BtcUnitDefault,
 		},
 	}
 }

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -499,7 +499,7 @@ func (handlers *Handlers) postBtcFormatUnit(r *http.Request) (interface{}, error
 	}
 
 	var request struct {
-		Unit string `json:"unit"`
+		Unit coinpkg.BtcUnit `json:"unit"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
@@ -513,13 +513,13 @@ func (handlers *Handlers) postBtcFormatUnit(r *http.Request) (interface{}, error
 	if err != nil {
 		return response{Success: false}, nil
 	}
-	btcCoin.SetFormatUnit(unit)
+	btcCoin.(*btc.Coin).SetFormatUnit(unit)
 
 	btcCoin, err = handlers.backend.Coin(coinpkg.CodeTBTC)
 	if err != nil {
 		return response{Success: false}, nil
 	}
-	btcCoin.SetFormatUnit(unit)
+	btcCoin.(*btc.Coin).SetFormatUnit(unit)
 
 	// update BTC format unit for fiat conversions
 	for _, account := range handlers.backend.Accounts() {
@@ -745,7 +745,7 @@ func (handlers *Handlers) getConvertFromFiatHandler(r *http.Request) (interface{
 		unit = unit[2:]
 	}
 
-	if from == rates.BTC.String() && handlers.backend.Config().AppConfig().Backend.BtcUnit == coinpkg.UnitSats {
+	if from == rates.BTC.String() && handlers.backend.Config().AppConfig().Backend.BtcUnit == coinpkg.BtcUnitSats {
 		fiatRat = coinpkg.Sat2Btc(fiatRat)
 	}
 

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -16,8 +16,6 @@
 
 import { apiGet, apiPost } from '../utils/request';
 import { ChartData } from '../routes/account/summary/chart';
-import { BtcUnit } from './coins';
-
 
 export type CoinCode = 'btc' | 'tbtc' | 'ltc' | 'tltc' | 'eth' | 'teth' | 'reth';
 
@@ -25,7 +23,7 @@ export type AccountCode = string;
 
 export type Fiat = 'AUD' | 'BRL' | 'BTC' | 'CAD' | 'CHF' | 'CNY' | 'EUR' | 'GBP' | 'HKD' | 'ILS' | 'JPY' | 'KRW' | 'NOK' | 'RUB' | 'SEK' | 'SGD' | 'USD';
 
-export type ConversionUnit = Fiat | BtcUnit
+export type ConversionUnit = Fiat | 'sat'
 
 export type MainnetCoin = 'BTC' | 'LTC' | 'ETH';
 

--- a/frontends/web/src/api/coins.ts
+++ b/frontends/web/src/api/coins.ts
@@ -19,7 +19,7 @@ import { CoinCode } from './account';
 import { ISuccess } from './backend';
 import { apiPost } from '../utils/request';
 
-export type BtcUnit = 'BTC' | 'sat';
+export type BtcUnit = 'default' | 'sat';
 
 interface Status {
     targetHeight: number;

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -38,7 +38,7 @@ export const currencies: Fiat[] = ['AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'EUR', 'GB
 export const store = new Store<SharedProps>({
   active: 'USD',
   selected: ['USD', 'EUR', 'CHF'],
-  btcUnit: 'BTC',
+  btcUnit: 'default',
 });
 
 // TODO: should not invoking apiGet imediatelly, see the apiGet() function for more details

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -120,7 +120,7 @@ class Send extends Component<Props, State> {
     noMobileChannelError: false,
     fiatUnit: fiat.state.active,
     coinControl: false,
-    btcUnit : 'BTC',
+    btcUnit : 'default',
     activeCoinControl: false,
     hasCamera: false,
     activeScanQR: false,
@@ -608,7 +608,7 @@ class Send extends Component<Props, State> {
         {t('send.signprogress.label')}: {signProgress.step}/{signProgress.steps}
       </span>
     ) : undefined;
-    const baseCurrencyUnit = fiatUnit === 'BTC' ? btcUnit : fiatUnit;
+    const baseCurrencyUnit: accountApi.ConversionUnit = fiatUnit === 'BTC' && btcUnit === 'sat' ? 'sat' : fiatUnit;
     return (
       <div className="contentWithGuide">
         <div className="container">

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -135,7 +135,7 @@ class Settings extends Component<Props, State> {
       return;
     }
     const target = (event.target as HTMLInputElement);
-    var unit: BtcUnit = 'BTC';
+    var unit: BtcUnit = 'default';
     if (target.checked) {
       unit = 'sat';
     }


### PR DESCRIPTION
Instead of 'BTC' | 'sat', we use 'default' | 'sat', to avoid confusion with BTC coin units which also include 'TBTC' for testnet.

This helps with readability of the code, as the type and possible values are clear at every step.