### PR TITLE
frontend/bitbox02/settings: handle attestation==null

### DIFF
--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -93,6 +93,6 @@ export const setMnemonicPassphraseEnabled = (
 
 export const verifyAttestation = (
   deviceID: string,
-): Promise<boolean> => {
+): Promise<boolean | null> => {
   return apiGet(`devices/bitbox02/${deviceID}/attestation`);
 };

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -40,8 +40,7 @@ type Props = {
 export const Settings: FunctionComponent<Props> = ({ deviceID }) => {
   const { t } = useTranslation();
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo>();
-  const [attestation, setAttestation] = useState<boolean>();
-
+  const [attestation, setAttestation] = useState<boolean | null>(null);
   useEffect(() => {
     getDeviceInfo(deviceID).then(setDeviceInfo).catch(error => {
       console.error(error);
@@ -89,7 +88,7 @@ export const Settings: FunctionComponent<Props> = ({ deviceID }) => {
                         {t('deviceSettings.hardware.securechip')}
                       </SettingsItem>
                     ) }
-                    {attestation !== undefined && (
+                    {attestation !== null && (
                       <SettingsItem
                         optionalText={t(`deviceSettings.hardware.attestation.${attestation}`)}
                         optionalIcon={attestation ? <Checked/> : <Warning/>}>


### PR DESCRIPTION
The backend can in theory return nil/null in the attestation endpoint, if the endpoint is called before the device.Init() function has finished, where the attesation check is performed.

The bb02 init is a bit messy, in the above state probably most/all other bb02 calls would be broken too. For now, we simply adjust the return type of `verifyAttestation()` to match the backend.