### PR TITLE
frontend: add guide entry for sats

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -793,6 +793,10 @@
       }
     },
     "settings": {
+      "sats": {
+        "text": "A Satoshi ('sat' for short) is the smallest unit of Bitcoin. One Satoshi is a hundred millionth of a bitcoin (0.00000001 BTC). It is named after the creator of Bitcoin, Satoshi Nakamoto.",
+        "title": "What is a Satoshi?"
+      },
       "servers": {
         "text": "This app communicates with the Shift Crypto servers to check for updates, load transactions, and send information to paired mobile apps.\nThe app also retrieves the latest exchange rates from CoinGecko. All conversions are calculated locally which means no data about the amount of your transaction is ever transmitted.\nNote: For Ethereum and ERC20 Tokens, we use Etherscan.io APIs.",
         "title": "Which servers does this app talk to?"
@@ -1241,7 +1245,7 @@
       "setProxyAddress": "Set proxy address",
       "title": "Expert settings",
       "useProxy": "Enable tor proxy",
-      "useSats": "Display BTC values in sat"
+      "useSats": "Display BTC values in Satoshis"
     },
     "header": {
       "home": "Home"

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -374,8 +374,7 @@ class Settings extends Component<Props, State> {
           </div>
         </div>
         <Guide>
-          <Entry key="guide.settings.servers" entry={t('guide.settings.servers')} />
-          <Entry key="guide.settings-electrum.why" entry={t('guide.settings-electrum.why')} />
+          <Entry key="guide.settings.sats" entry={t('guide.settings.sats')} />
           <Entry key="guide.accountRates" entry={{
             link: {
               text: 'www.coingecko.com',
@@ -384,6 +383,8 @@ class Settings extends Component<Props, State> {
             text: t('guide.accountRates.text'),
             title: t('guide.accountRates.title')
           }} />
+          <Entry key="guide.settings.servers" entry={t('guide.settings.servers')} />
+          <Entry key="guide.settings-electrum.why" entry={t('guide.settings-electrum.why')} />
           <Entry key="guide.settings-electrum.tor" entry={t('guide.settings-electrum.tor')} />
         </Guide>
       </div>


### PR DESCRIPTION
Added 'What is a Satoshi' guide entry on the settings page, as not all users might know what it is.

Also reordered settings entry and moved which exchange rates up as second entry.


![Screen Shot 2022-10-26 at 14 47 57](https://user-images.githubusercontent.com/546900/198029912-a89ec35e-ebe3-40bc-b32f-5098e9a325d1.png)
