### PR TITLE
backend/usb/hid: prepend 0 byte to packet

### DIFF
--- a/backend/devices/bitbox/communication.go
+++ b/backend/devices/bitbox/communication.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"runtime"
 	"unicode"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -232,13 +231,6 @@ func (communication *Communication) SendBootloader(msg []byte) ([]byte, error) {
 	for written < sendLen {
 		chunk := paddedMsg.Next(usbWriteReportSize)
 		chunkLen := len(chunk)
-		if runtime.GOOS != "windows" {
-			// packets have a 0 byte report ID in front. The karalabe hid library adds it
-			// automatically for windows, and not for unix, as there, it is stripped by the signal11
-			// hid library.  Since we are padding with zeroes, we have to add it (to be stripped by
-			// signal11), as otherwise, it would strip our 0 byte that is just padding.
-			chunk = append([]byte{0}, chunk...)
-		}
 		_, err := communication.communication.Write(chunk)
 		if err != nil {
 			return nil, errp.WithStack(err)

--- a/backend/devices/usb/hid.go
+++ b/backend/devices/usb/hid.go
@@ -17,6 +17,7 @@ package usb
 import (
 	"encoding/hex"
 	"io"
+	"runtime"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
 	hid "github.com/karalabe/usb"
@@ -66,13 +67,44 @@ func (info hidDeviceInfo) Identifier() string {
 	return hex.EncodeToString([]byte(info.DeviceInfo.Path))
 }
 
+// karalabeUsbReportIDFix wraps the karalabe/hid device ReadWriteCloser to prepend the zero-byte
+// report ID for platforms other than Windows as a workaround to the karalabe/usb package, which
+// only prepends it on Windows. See the Write() method for more details.
+type karalabeUsbReportIDFix struct {
+	device io.ReadWriteCloser
+}
+
+func (k *karalabeUsbReportIDFix) Read(p []byte) (int, error) {
+	return k.device.Read(p)
+}
+
+func (k *karalabeUsbReportIDFix) Write(p []byte) (int, error) {
+	if runtime.GOOS != "windows" {
+		// packets have a 0 byte report ID in front. The karalabe usb library adds it
+		// automatically for windows, and not for unix, as there, it is stripped by the signal11
+		// hid library. We have to add it (to be stripped by signal11), otherwise a zero that is
+		// actually part of the packet would be stripped, leading to a corrupt packet. Our
+		// packets could start with a zero if e.g. the 4-bytes CID starts with a zero byte
+		//
+		// See
+		// - https://github.com/karalabe/usb/blob/87927bb2c8544d009d8ac7350b1ac892b60c8115/hid_enabled.go#L126-L128.
+		// - https://github.com/karalabe/usb/blob/87927bb2c8544d009d8ac7350b1ac892b60c8115/hidapi/libusb/hid.c#L1003-L1007
+		p = append([]byte{0}, p...)
+	}
+	return k.device.Write(p)
+}
+
+func (k *karalabeUsbReportIDFix) Close() error {
+	return k.device.Close()
+}
+
 // Open implements DeviceInfo.
 func (info hidDeviceInfo) Open() (io.ReadWriteCloser, error) {
 	device, err := info.DeviceInfo.Open()
 	if err != nil {
 		return nil, err
 	}
-	return device, nil
+	return &karalabeUsbReportIDFix{device}, nil
 }
 
 // DeviceInfos returns a slice of all recognized devices.


### PR DESCRIPTION
If a USB packet starts with a zero byte, that byte will be stripped by the C USB library (i.e. signal11 on Linux), leading to a broken package.

We only need to add it if not on Windows, as karalabel/usb prepends this zero byte already for Windows (I think this is a bug in karalabe/usb and karalabe/hid, which didn't consider that a packet could start with a zero byte right after the report ID).

Currently we don't observe a bug because the first byte in each packet is the `cid` (channel identifier), which is currnetly harddcoded to `0xff000000` in bitbox02-api-go. If we start using a random CID, and it starts with a zero byte, the packet will be corrupted and the BitBox02 will not be able to parse it.

The same fix was also added to the bitbox01 in the BitBoxApp (https://github.com/digitalbitbox/bitbox-wallet-app/blob/bd70f6c400268355cee94891397447796f02fbde/backend/devices/bitbox/communication.go#L235-L241), where it was crucial because packets in the bitbox01 are padded with zero bytes to the left. We can remove the fix there, as it uses the same hid functions as the BitBox02.