### PR TITLE
frontend/account: fix CanSend and Buy call to action

### DIFF
--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -326,9 +326,10 @@ func (handlers *Handlers) getAccountBalance(_ *http.Request) (interface{}, error
 		return nil, err
 	}
 	return map[string]interface{}{
-		"available":   handlers.formatAmountAsJSON(balance.Available(), false),
-		"incoming":    handlers.formatAmountAsJSON(balance.Incoming(), false),
-		"hasIncoming": balance.Incoming().BigInt().Sign() > 0,
+		"hasAvailable": balance.Available().BigInt().Sign() > 0,
+		"available":    handlers.formatAmountAsJSON(balance.Available(), false),
+		"hasIncoming":  balance.Incoming().BigInt().Sign() > 0,
+		"incoming":     handlers.formatAmountAsJSON(balance.Incoming(), false),
 	}, nil
 }
 

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -142,6 +142,7 @@ export interface IAmount {
 }
 
 export interface IBalance {
+    hasAvailable: boolean;
     available: IAmount;
     hasIncoming: boolean;
     incoming: IAmount;

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -170,7 +170,7 @@ export function Account({
     return null;
   }
 
-  const canSend = balance && balance.available.amount !== '0';
+  const canSend = balance && balance.hasAvailable;
 
   const initializingSpinnerText =
     (syncedAddressesCount !== undefined && syncedAddressesCount > 1) ? (
@@ -191,7 +191,7 @@ export function Account({
 
   const showBuyButton = moonpayBuySupported
     && balance
-    && balance.available.amount === '0'
+    && !balance.hasAvailable
     && !balance.hasIncoming
     && transactions && transactions.length === 0;
 

--- a/frontends/web/src/routes/account/info/buyCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyCTA.tsx
@@ -34,7 +34,7 @@ export const AddBuyOnEmptyBalances: FunctionComponent<{balances?: Balances}> = (
     return null;
   }
   const balanceList = Object.entries(balances);
-  if (balanceList.some(entry => entry[1].available.amount !== '0')) {
+  if (balanceList.some(entry => entry[1].hasAvailable)) {
     return null;
   }
   if (balanceList.map(entry => entry[1].available.unit).every(isBitcoinCoin)) {


### PR DESCRIPTION
Since recently, BTC amounts are returned with trailing zeroes, so the `'0'` string comparison stopped working to check if there is a balance.

Similar to `hasAvailable`, the backend should deliver the information.