### PR TITLE
frontend/account: call onAccountChanged after init/onStatusChanged

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -114,8 +114,6 @@ export function Account({
       .catch(console.error);
   }, [onAccountChanged, code]);
 
-  useEffect(onStatusChanged, [onStatusChanged, code]);
-
   const subscriptions = useRef<UnsubscribeList>([]);
   useEffect(() => {
     unsubscribe(subscriptions.current);

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -66,7 +66,7 @@ export function Account({
 
   const hasCard = useSDCard(devices, [code]);
 
-  const onAccountChanged = useCallback(() => {
+  const onAccountChanged = useCallback((code: string, status: accountApi.IStatus | undefined) => {
     if (!code || status === undefined || status.fatalError) {
       return;
     }
@@ -93,29 +93,27 @@ export function Account({
       setBalance(undefined);
       setTransactions(undefined);
     }
-  }, [code, status]);
+  }, []);
 
   const onStatusChanged = useCallback(() => {
     const currentCode = code;
     if (!currentCode) {
       return;
     }
-    accountApi.getStatus(currentCode).then(status => {
+    accountApi.getStatus(currentCode).then(async status => {
       if (currentCode !== code) {
         // Results came in after the account was switched. Ignore.
         return;
       }
-      if (!status.disabled) {
-        if (!status.synced) {
-          accountApi.init(currentCode).catch(console.error);
-        }
-      }
       setStatus(status);
+      if (!status.disabled && !status.synced) {
+        await accountApi.init(currentCode).catch(console.error);
+      }
+      onAccountChanged(code, status);
     })
       .catch(console.error);
-  }, [code]);
+  }, [onAccountChanged, code]);
 
-  useEffect(onAccountChanged, [onAccountChanged, status]);
   useEffect(onStatusChanged, [onStatusChanged, code]);
 
   const subscriptions = useRef<UnsubscribeList>([]);
@@ -128,7 +126,7 @@ export function Account({
         }
       }),
       statusChanged(code, () => onStatusChanged()),
-      syncdone(code, () => onAccountChanged()),
+      syncdone(code, () => onAccountChanged(code, status)),
     );
     const unsubscribeList = subscriptions.current;
     return () => unsubscribe(unsubscribeList);


### PR DESCRIPTION
Before this change, onAccountChanged was called immediately when the
account was switched and the code changed, as it depended on the code,
which changed the callback, which led to it being called due to this line:

`useEffect(onAccountChanged, [onAccountChanged, status]);`

Calling this callback before `accountApi.init()` is incorrect and
leads to an error.

Instead of depending on the code and status, we pass it as params
instead.

We also await the result of `init()`, as technically it is also async
and could finis after `onAccountChanged()` was called.