### PR TITLE
frontend: fixed download cert, check, and add buttons

### DIFF
--- a/frontends/web/src/routes/settings/electrum-add-server.tsx
+++ b/frontends/web/src/routes/settings/electrum-add-server.tsx
@@ -73,6 +73,10 @@ export const ElectrumAddServer = ({
     setLoadingCheck(false);
   };
 
+  const downloadCertButtonDisabled: boolean = electrumServer.trim().length === 0 || electrumCert.trim().length > 0 || loadingCert;
+
+  const checkConnectionButtonDisabled: boolean = electrumServer.trim().length === 0 || loadingCheck;
+
   return (
     <div className={style.addServer}>
       <div className="flex flex-row flex-start flex-wrap">
@@ -104,7 +108,7 @@ export const ElectrumAddServer = ({
         placeholder={'-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----'}
       />
       <div className={[style.block, 'flex flex-row flex-end'].join(' ')}>
-        <Button primary disabled={loadingCert || electrumCert !== ''} onClick={downloadCert}>
+        <Button primary disabled={downloadCertButtonDisabled} onClick={downloadCert}>
           {
             loadingCert && (
               <div className={style.miniSpinnerContainer}>
@@ -122,7 +126,7 @@ export const ElectrumAddServer = ({
         </div>
       </div>
       <div className={['flex flex-row flex-end spaced', style.block].join(' ')}>
-        <Button primary disabled={electrumServer === '' || loadingCheck} onClick={check}>
+        <Button primary disabled={checkConnectionButtonDisabled} onClick={check}>
           {
             loadingCheck && (
               <div className={style.miniSpinnerContainer}>

--- a/frontends/web/src/routes/settings/electrum.module.css
+++ b/frontends/web/src/routes/settings/electrum.module.css
@@ -54,7 +54,7 @@
     word-break: normal;
 }
 
-.servers .server > div button[disabled] {
+.servers .server > div button[disabled], textarea[name="electrumCert"] ~ div button[disabled] {
     background-color: var(--color-disabled);
     color: var(--color-secondary);
 }


### PR DESCRIPTION
The ‘download cert’ and ‘check’ buttons were not showing the loading animation when they were  supposed to. The problem
was due to the buttons' incorrect styling. It caused the animation to look invisible.

To fix the issue, their style has been altered to be the same as the buttons at the top of the page (the ‘Check’ and
‘Remove’ buttons). The `disabled` conditions for each button have also  been slightly refactored to increase its robustness
& readability which also fixed an existing bug.

Screen capture of the **now working (visible)** animation:

https://user-images.githubusercontent.com/28676406/199158463-05b41792-6aa4-4716-8fb0-d8fb920f41ab.mov


