### PR TITLE
frontend/bitbox02/checkbackup: fix async bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add 'sat' unit for Bitcoin accounts, available in Settings view
 - Add version number and available updates check in settings
 - Add translation feedback link in the guide
+- Fix a UI bug when checking a backup where the confirmation dialog is sometimes empty
 
 ## 4.34.0
 - Bundle BitBox02 firmware version v9.12.0

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -97,11 +97,15 @@ export const verifyAttestation = (
   return apiGet(`devices/bitbox02/${deviceID}/attestation`);
 };
 
-type CheckBackupResponse = FailResponse | (SuccessResponse & { backupID: string; });
-
 export const checkBackup = (
   deviceID: string,
   silent: boolean,
-): Promise<CheckBackupResponse> => {
-  return apiPost(`devices/bitbox02/${deviceID}/backups/check`, { silent });
+): Promise<string> => {
+  return apiPost(`devices/bitbox02/${deviceID}/backups/check`, { silent })
+    .then((response: FailResponse | (SuccessResponse & { backupID: string; })) => {
+      if (response.success) {
+        return response.backupID;
+      }
+      throw response;
+    });
 };

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -96,3 +96,12 @@ export const verifyAttestation = (
 ): Promise<boolean | null> => {
   return apiGet(`devices/bitbox02/${deviceID}/attestation`);
 };
+
+type CheckBackupResponse = FailResponse | (SuccessResponse & { backupID: string; });
+
+export const checkBackup = (
+  deviceID: string,
+  silent: boolean,
+): Promise<CheckBackupResponse> => {
+  return apiPost(`devices/bitbox02/${deviceID}/backups/check`, { silent });
+};

--- a/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
@@ -15,8 +15,8 @@
  */
 
 import { Component } from 'react';
+import * as bitbox02API from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
-import { apiPost } from '../../../utils/request';
 import { Backup, BackupsListItem } from '../components/backup';
 import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
 import { Button } from '../../../components/forms';
@@ -45,9 +45,7 @@ class Check extends Component<Props, State> {
   };
 
   private checkBackup = (silent: boolean, backups: Backup[]) => {
-    apiPost('devices/bitbox02/' + this.props.deviceID + '/backups/check', {
-      silent,
-    }).then( response => {
+    bitbox02API.checkBackup(this.props.deviceID, silent).then(response => {
       let message;
       // "silent" call gets the backup id from device without blocking to display in dialogue
       if (silent && response.success && response.backupID) {


### PR DESCRIPTION
If the first checkBackup() call has a delay in the backend and the
second checkBackup() call starts before the first handles the
response, the dialog will be empty. I encountered this bug in the wild
recently.

Awaiting the first response before requesting the second fixes this.