### PR TITLE
frontend: add manage-device guide

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -689,6 +689,26 @@
       "text": "Click the \"Export\" button and open the downloads folder where you will find the CSV export. Then click the link below, upload your BitBox CSV file and import the data in order to use it for your CoinTracking portfolio manager and to create your tax reports.",
       "title": "How to import my transactions into CoinTracking?"
     },
+    "device": {
+      "attestation": {
+        "link": {
+          "text": "Read more about the authenticity check"
+        },
+        "text": "The BitBoxApp performs an attestation check on the BitBox02 to verify if the device is genuine. The check is done locally and does not connect to any servers.",
+        "title": "How does the authenticity check work?"
+      },
+      "name": {
+        "text": "This is the name of your wallet and backup. The name is used for future backups and can be used to help distinguish between different wallets. It can be changed at any time but note that backups made before the change will still use the previous name.",
+        "title": "What is the BitBox02 name used for?"
+      },
+      "secure-chip": {
+        "link": {
+          "text": "Read more about the secure chip"
+        },
+        "text": "This information shows the model number of the secure chip, the most up to date chip is ATECC608B with improved security features compared to older models.",
+        "title": "Why show the secure chip model?"
+      }
+    },
     "exchanges": {
       "commission": {
         "text": "This page uses affiliate links where available. However, not all listed exchanges have an affiliate program. Whether an exchange offers one does not influence our decision to list them.",

--- a/frontends/web/src/routes/device/bitbox02/settings-guide.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings-guide.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import i18n from '../../../i18n/i18n';
+import { Entry } from '../../../components/guide/entry';
+import { Guide } from '../../../components/guide/guide';
+
+export const ManageDeviceGuide = () => {
+  const { t } = useTranslation();
+  return (
+    <Guide>
+      <Entry key="whatAreAccounts" entry={t('guide.device.name')} />
+      <Entry key="guide.device.secure-chip" entry={{
+        link: {
+          text: t('guide.device.secure-chip.link.text'),
+          url: 'https://shiftcrypto.ch/blog/bitbox-05-2021-masnee-update/#check-your-secure-chip-variant'
+        },
+        text: t('guide.device.secure-chip.text'),
+        title: t('guide.device.secure-chip.title')
+      }} />
+      <Entry key="guide.device.attestation" entry={{
+        link: {
+          text: t('guide.device.attestation.link.text'),
+          url: (i18n.language === 'de')
+            ? 'https://shiftcrypto.ch/de/bitbox02/sicherheit/#device-authenticity-check'
+            : 'https://shiftcrypto.ch/bitbox02/security-features/#device-authenticity-check'
+        },
+        text: t('guide.device.attestation.text'),
+        title: t('guide.device.attestation.title')
+      }} />
+    </Guide>
+  );
+};

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -32,6 +32,7 @@ import { SetDeviceName } from './setdevicename';
 import { ShowMnemonic } from './showmnemonic';
 import { UpgradeButton } from './upgradebutton';
 import { alertUser } from '../../../components/alert/Alert';
+import { ManageDeviceGuide } from './settings-guide';
 
 type Props = {
     deviceID: string;
@@ -137,6 +138,7 @@ export const Settings: FunctionComponent<Props> = ({ deviceID }) => {
           </Footer>
         </div>
       </div>
+      <ManageDeviceGuide />
     </div>
   );
 };


### PR DESCRIPTION
Added a guide to manage device with entries about:

- BitBox02 name
- Secure chip
- Attestation / authenticity check

![Screen Shot 2022-11-01 at 11 44 09](https://user-images.githubusercontent.com/546900/199216693-50880400-b4a1-44bf-a71a-fa904b36754b.png)
