### PR TITLE
backend: do not allow links to cryptocompare.com anymore

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -67,7 +67,6 @@ var fixedURLWhitelist = []string{
 	"https://shiftcrypto.support/",
 	// Exchange rates.
 	"https://www.coingecko.com/",
-	"https://www.cryptocompare.com/",
 	// Block explorers.
 	"https://blockstream.info/tx/",
 	"https://blockstream.info/testnet/tx/",


### PR DESCRIPTION
BitBoxApp used cryptocompare.com for exchange rates but uses coingecko now.

Removed cryptocompare.com so that links to it cannot be opened anymore.

Updated locize too.