### PR TITLE
scripts/run_regtest: make regtest testing work again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ servewallet:
 servewallet-mainnet:
 	go run -mod=vendor ./cmd/servewallet -mainnet
 servewallet-regtest:
-	go run -mod=vendor ./cmd/servewallet -regtest
+	rm -f appfolder.dev/cache/headers-rbtc.bin && go run -mod=vendor ./cmd/servewallet -regtest
 servewallet-prodservers:
 	go run -mod=vendor ./cmd/servewallet -devservers=false
 buildweb:

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -86,10 +86,12 @@ func (backend *Backend) filterAccounts(accountsConfig *config.AccountsConfig, fi
 	var accounts []*config.Account
 	for idx := range accountsConfig.Accounts {
 		account := &accountsConfig.Accounts[idx]
-		if _, isTestnet := coinpkg.TestnetCoins[account.CoinCode]; isTestnet != backend.Testing() {
-			// Don't load testnet accounts when running normally, nor mainnet accounts when running
-			// in testing mode
-			continue
+		if !backend.arguments.Regtest() {
+			if _, isTestnet := coinpkg.TestnetCoins[account.CoinCode]; isTestnet != backend.Testing() {
+				// Don't load testnet accounts when running normally, nor mainnet accounts when running
+				// in testing mode
+				continue
+			}
 		}
 		if isRegtest := account.CoinCode == coinpkg.CodeRBTC; isRegtest != backend.arguments.Regtest() {
 			// Don't load regtest accounts when running normally, nor mainnet accounts when running

--- a/scripts/run_regtest.sh
+++ b/scripts/run_regtest.sh
@@ -47,8 +47,10 @@ docker run -v $BITCOIN_DATADIR:/bitcoin --name=bitcoind-regtest \
        -e RPCUSER=dbb \
        -e RPCPASSWORD=dbb \
        -p 10332:10332 \
+       -p 12340:12340 \
        kylemanna/bitcoind \
        -regtest \
+       -fallbackfee=0.00001 \
        -port=12340 \
        -rpcport=10332 \
        -rpcbind=0.0.0.0 \
@@ -60,12 +62,14 @@ docker run \
        -v $BITCOIN_DATADIR/.bitcoin:/bitcoin \
        -v $ELECTRS_DATADIR:/data \
        --name=electrs-regtest \
-       benma2/electrs \
-       /electrs/electrs -vvvv --cookie-file=/data/rpccreds --timestamp --network=regtest --daemon-rpc-addr=${DOCKER_IP}:10332 --electrum-rpc-addr=127.0.0.1:52001 --daemon-dir=/bitcoin --db-dir=/data &
+       benma2/electrs:v0.9.9 \
+        --cookie-file=/data/rpccreds --log-filters INFO --timestamp --network=regtest --daemon-rpc-addr=${DOCKER_IP}:10332 --daemon-p2p-addr=${DOCKER_IP}:12340 --electrum-rpc-addr=127.0.0.1:52001 --daemon-dir=/bitcoin --db-dir=/data &
 
 echo "Interact with the regtest chain (e.g. generate 101 blocks and send coins):"
+echo "    bitcoin-cli -regtest -datadir=${BITCOIN_DATADIR} -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 createwallet"
 echo "    bitcoin-cli -regtest -datadir=${BITCOIN_DATADIR} -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 getnewaddress"
 echo "    bitcoin-cli -regtest -datadir=${BITCOIN_DATADIR} -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 generatetoaddress 101 <newaddress>"
 echo "    bitcoin-cli -regtest -datadir=${BITCOIN_DATADIR} -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 sendtoaddress <address> <amount>"
+echo "Delete headers-rbtc.bin in the app cache folder before running the BitBoxApp, otherwise it can conflict the fresh regtest chain."
 
 while true; do sleep 1; done


### PR DESCRIPTION
- Checkpoints not defined for regtest, make them optional
- Delete the headers-rbtc.bin file before running, otherwise an existing headers DB can conflict with a new regtest chain
- Fix loading regtest accounts
- Update benma2/electrs with a new image. Dockerfile inlined below:

```
FROM rust:1.64.0 as rust

RUN apt-get update
RUN apt-get install -y clang cmake

RUN git clone --depth 1 --branch v0.9.9 https://github.com/romanz/electrs.git /electrs-src

RUN cd /electrs-src && cargo build --release

WORKDIR /electrs

RUN cp /electrs-src/target/release/electrs /electrs/

STOPSIGNAL SIGKILL

ENTRYPOINT ["/electrs/electrs"]
```