### PR TITLE
backend/btc: make ScriptHashGetHistory synchronous

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -573,6 +573,11 @@ func (account *Account) onAddressStatus(address *addresses.AccountAddress, statu
 // `gapLimit` unused addresses in the tail. It is also called whenever the status (tx history) of
 // changes, to keep the gapLimit tail.
 func (account *Account) ensureAddresses() {
+	if account.isClosed() {
+		account.log.Debug("Stopping ensureAddresses as the account was closed")
+		return
+	}
+
 	defer account.Synchronizer.IncRequestsCounter()()
 
 	dbTx, err := account.db.Begin()

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -537,9 +537,10 @@ func (account *Account) incAndEmitSyncCounter() {
 // there was indeed change, the tx history is downloaded and processed.
 func (account *Account) onAddressStatus(address *addresses.AccountAddress, status string) {
 	if account.isClosed() {
-		account.log.Debug("Ignoring result of ScriptHashGetHistory after the account was closed")
+		account.log.Debug("Ignoring result of ScriptHashSubscribe after the account was closed")
 		return
 	}
+	defer account.Lock()()
 	if status == address.HistoryStatus {
 		account.incAndEmitSyncCounter()
 		// Address didn't change.
@@ -548,34 +549,23 @@ func (account *Account) onAddressStatus(address *addresses.AccountAddress, statu
 
 	account.log.Debug("Address status changed, fetching history.")
 
-	done := account.Synchronizer.IncRequestsCounter()
-	account.coin.Blockchain().ScriptHashGetHistory(
-		address.PubkeyScriptHashHex(),
-		func(history blockchain.TxHistory) {
-			if account.isClosed() {
-				account.log.Debug("Ignoring result of ScriptHashGetHistory after the account was closed")
-				return
-			}
+	defer account.Synchronizer.IncRequestsCounter()()
+	history, err := account.coin.Blockchain().ScriptHashGetHistory(address.PubkeyScriptHashHex())
+	if err != nil {
+		// We are not closing client.blockchain here, as it is reused per coin with
+		// different accounts.
+		account.fatalError = true
+		account.Config().OnEvent(accounts.EventStatusChanged)
+		return
+	}
 
-			defer account.Lock()()
-			address.HistoryStatus = history.Status()
-			if address.HistoryStatus != status {
-				account.log.Warning("client status should match after sync")
-			}
-			account.transactions.UpdateAddressHistory(address.PubkeyScriptHashHex(), history)
-			account.incAndEmitSyncCounter()
-			account.ensureAddresses()
-		},
-		func(err error) {
-			done()
-			if err != nil {
-				// We are not closing client.blockchain here, as it is reused per coin with
-				// different accounts.
-				account.fatalError = true
-				account.Config().OnEvent(accounts.EventStatusChanged)
-			}
-		},
-	)
+	address.HistoryStatus = history.Status()
+	if address.HistoryStatus != status {
+		account.log.Warning("client status should match after sync")
+	}
+	account.transactions.UpdateAddressHistory(address.PubkeyScriptHashHex(), history)
+	account.incAndEmitSyncCounter()
+	account.ensureAddresses()
 }
 
 // ensureAddresses is the entry point of syncing up the account. It extends the receive and change

--- a/backend/coins/btc/blockchain/blockchain.go
+++ b/backend/coins/btc/blockchain/blockchain.go
@@ -96,7 +96,7 @@ type Header struct {
 // other backends can implement the same interface.
 //go:generate mockery --name Interface
 type Interface interface {
-	ScriptHashGetHistory(ScriptHashHex, func(TxHistory), func(error))
+	ScriptHashGetHistory(ScriptHashHex) (TxHistory, error)
 	TransactionGet(chainhash.Hash) (*wire.MsgTx, error)
 	ScriptHashSubscribe(func() func(error), ScriptHashHex, func(string))
 	HeadersSubscribe(func() func(error), func(*Header))

--- a/backend/coins/btc/blockchain/mocks/Interface.go
+++ b/backend/coins/btc/blockchain/mocks/Interface.go
@@ -101,9 +101,27 @@ func (_m *Interface) RelayFee() (btcutil.Amount, error) {
 	return r0, r1
 }
 
-// ScriptHashGetHistory provides a mock function with given fields: _a0, _a1, _a2
-func (_m *Interface) ScriptHashGetHistory(_a0 blockchain.ScriptHashHex, _a1 func(blockchain.TxHistory), _a2 func(error)) {
-	_m.Called(_a0, _a1, _a2)
+// ScriptHashGetHistory provides a mock function with given fields: _a0
+func (_m *Interface) ScriptHashGetHistory(_a0 blockchain.ScriptHashHex) (blockchain.TxHistory, error) {
+	ret := _m.Called(_a0)
+
+	var r0 blockchain.TxHistory
+	if rf, ok := ret.Get(0).(func(blockchain.ScriptHashHex) blockchain.TxHistory); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(blockchain.TxHistory)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(blockchain.ScriptHashHex) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ScriptHashSubscribe provides a mock function with given fields: _a0, _a1, _a2

--- a/backend/coins/btc/blockchain/mocks/mock.go
+++ b/backend/coins/btc/blockchain/mocks/mock.go
@@ -25,7 +25,7 @@ import (
 
 // BlockchainMock implements blockchain.Interface for use in tests.
 type BlockchainMock struct {
-	MockScriptHashGetHistory func(blockchain.ScriptHashHex, func(blockchain.TxHistory), func(error))
+	MockScriptHashGetHistory func(blockchain.ScriptHashHex) (blockchain.TxHistory, error)
 	MockTransactionGet       func(chainhash.Hash) (*wire.MsgTx, error)
 	MockScriptHashSubscribe  func(func() func(error), blockchain.ScriptHashHex, func(string))
 	MockHeadersSubscribe     func(func() func(error), func(*blockchain.Header))
@@ -41,10 +41,11 @@ type BlockchainMock struct {
 }
 
 // ScriptHashGetHistory implements Interface.
-func (b *BlockchainMock) ScriptHashGetHistory(s blockchain.ScriptHashHex, success func(blockchain.TxHistory), cleanup func(error)) {
+func (b *BlockchainMock) ScriptHashGetHistory(s blockchain.ScriptHashHex) (blockchain.TxHistory, error) {
 	if b.MockScriptHashGetHistory != nil {
-		b.MockScriptHashGetHistory(s, success, cleanup)
+		return b.MockScriptHashGetHistory(s)
 	}
+	panic("ScriptHashGetHistory not mocked")
 }
 
 // TransactionGet implements Interface.

--- a/backend/coins/btc/electrum/client/client.go
+++ b/backend/coins/btc/electrum/client/client.go
@@ -160,26 +160,14 @@ func (client *ElectrumClient) CheckConnection() error {
 }
 
 // ScriptHashGetHistory does the blockchain.scripthash.get_history RPC call.
-func (client *ElectrumClient) ScriptHashGetHistory(
-	scriptHashHex blockchain.ScriptHashHex,
-	success func(blockchain.TxHistory),
-	cleanup func(error),
-) {
-	client.rpc.Method(
-		func(responseBytes []byte) error {
-			txs := blockchain.TxHistory{}
-			if err := json.Unmarshal(responseBytes, &txs); err != nil {
-				client.log.WithError(err).Error("Failed to unmarshal JSON response")
-				return errp.WithStack(err)
-			}
-			success(txs)
-			return nil
-		},
-		func() func(error) {
-			return cleanup
-		},
-		"blockchain.scripthash.get_history",
-		string(scriptHashHex))
+func (client *ElectrumClient) ScriptHashGetHistory(scriptHashHex blockchain.ScriptHashHex) (
+	blockchain.TxHistory, error) {
+	txs := blockchain.TxHistory{}
+	err := client.rpc.MethodSync(&txs, "blockchain.scripthash.get_history", string(scriptHashHex))
+	if err != nil {
+		return nil, err
+	}
+	return txs, nil
 }
 
 // ScriptHashSubscribe does the blockchain.scripthash.subscribe RPC call.

--- a/backend/coins/btc/transactions/verification.go
+++ b/backend/coins/btc/transactions/verification.go
@@ -92,6 +92,10 @@ func (transactions *Transactions) verifyTransaction(txHash chainhash.Hash, heigh
 	transactions.blockchain.GetMerkle(
 		txHash, height,
 		func(merkle []blockchain.TXHash, pos int) {
+			if transactions.isClosed() {
+				transactions.log.Debug("GetMerkle after the instance was closed")
+				return
+			}
 			expectedMerkleRoot := hashMerkleRoot(merkle, txHash, pos)
 			if expectedMerkleRoot != header.MerkleRoot {
 				transactions.log.Warning("Merkle root verification failed")


### PR DESCRIPTION
This will make it simpler to propagate and handle errors. It is also
easier to read.

There is no loss of performance, as this call already happens in a
goroutine as part of the callback to `ScriptHashSubscribe()`.