### PR TITLE
frontend: improved portfolio chart on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add translation feedback link in the guide
 - Fix a UI bug when checking a backup where the confirmation dialog is sometimes empty
 - Ethereum: remove Ropsten/Rinkeby testnet networks, which have been shut down
+- Re-style Portfolio Chart on mobile (Android) for better usability and a more modern look
 
 ## 4.34.0
 - Bundle BitBox02 firmware version v9.12.0

--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -10,11 +10,13 @@
 
 .chartUpdatingMessage {
   align-items: center;
+  color: var(--color-gray-alt);
   display: flex;
   flex-direction: row;
   justify-content: center;
   text-align: center;
 }
+
 
 .chart header {
   display: flex;
@@ -23,7 +25,12 @@
   min-height: 68px;
 }
 
-.summary {}
+.summary {
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
 
 .filters {
   align-items: baseline;
@@ -34,16 +41,42 @@
   margin: var(--spacing-half) 0 0 0;
 }
 
+@media (max-width: 640px){
+
+  .chart{
+    margin-bottom: var(--spacing-default);
+  }
+
+  .summary{
+    align-items: center;
+  }
+
+  .filters{
+    justify-content: center;
+    margin-top: var(--spacing-default);
+  }
+}
+
+
 .filters button {
   appearance: none;
   background: var(--color-white);
   border: 2px solid var(--color-white);
   border-radius: 2rem;
   color: var(--color-softblack);
+  font-size: var(--size-default);
   line-height: 1.75;
   margin-bottom: var(--spacing-half);
   margin-left: var(--spacing-half);
   padding: 0 calc(var(--spacing-default) * .75);
+}
+
+.filters button:hover:not([disabled]) {
+  cursor: pointer;
+}
+
+.filters button:hover:is([disabled]) {
+  cursor: not-allowed;
 }
 
 .filters button:focus {
@@ -99,6 +132,14 @@
 .chartCanvas {
   position: relative;
 }
+
+@media (max-width: 640px){
+  .chartCanvas {
+    width: 100vw;
+    margin-left: calc(var(--space-half) * -1);
+  } 
+}
+  
 
 .tooltip {
   background: white;

--- a/frontends/web/src/routes/account/summary/filters.tsx
+++ b/frontends/web/src/routes/account/summary/filters.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FunctionComponent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TChartFiltersProps } from './types';
+import styles from './chart.module.css';
+
+const Filters: FunctionComponent<TChartFiltersProps> = ({
+  display,
+  disableFilters,
+  onDisplayWeek,
+  onDisplayMonth,
+  onDisplayYear,
+  onDisplayAll
+}) => {
+  const { t } = useTranslation();
+  return (
+    <div className={styles.filters}>
+      <button
+        className={display === 'week' ? styles.filterActive : undefined}
+        disabled={disableFilters}
+        onClick={onDisplayWeek}>
+        {t('chart.filter.week')}
+      </button>
+      <button
+        className={display === 'month' ? styles.filterActive : undefined}
+        disabled={disableFilters}
+        onClick={onDisplayMonth}>
+        {t('chart.filter.month')}
+      </button>
+      <button
+        className={display === 'year' ? styles.filterActive : undefined}
+        disabled={disableFilters}
+        onClick={onDisplayYear}>
+        {t('chart.filter.year')}
+      </button>
+      <button
+        className={display === 'all' ? styles.filterActive : undefined}
+        disabled={disableFilters}
+        onClick={onDisplayAll}>
+        {t('chart.filter.all')}
+      </button>
+    </div>
+  );
+};
+
+export default Filters;

--- a/frontends/web/src/routes/account/summary/types.ts
+++ b/frontends/web/src/routes/account/summary/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type TChartDisplay = 'week' | 'month' | 'year' | 'all';
+
+export type TChartFiltersProps = {
+  display: TChartDisplay
+  disableFilters: boolean;
+  onDisplayWeek: () => void;
+  onDisplayMonth: () => void;
+  onDisplayYear: () => void;
+  onDisplayAll: () => void;
+}
+


### PR DESCRIPTION
portfolio chart on mobile looked like it had uneven spacings
and whitespaces which made it not centered. This is due to 
the vertical label (y-axis) drawn by the library.

This commit is inteded to fix that chart’s UI by partly re-styling
it for mobile, where the vertical label and side paddings are
removed.

To interact with the chart on mobile, long-press on the chart and
move around the chart. To stop interacting, users can simply lift
their fingers (stop touching the chart).

(Updated) screenshots of the chart:


<img width="342" alt="Screen Shot 2022-11-02 at 15 03 40" src="https://user-images.githubusercontent.com/28676406/199510193-2b0dab1c-bbee-46a5-b521-d98109d0e17c.png">
<img width="345" alt="Screen Shot 2022-11-02 at 15 05 51" src="https://user-images.githubusercontent.com/28676406/199510238-5f9eb499-018a-4339-a600-d89f3cfe471c.png">
