### PR TITLE
backend: fix unit error on ERC20 fees

### DIFF
--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -161,7 +161,7 @@ func (coin *Coin) SetFormatUnit(unit coinpkg.BtcUnit) {
 }
 
 // GetFormatUnit implements coin.Coin.
-func (coin *Coin) GetFormatUnit() string {
+func (coin *Coin) GetFormatUnit(bool) string {
 	if coin.formatUnit == coinpkg.BtcUnitSats {
 		switch coin.code {
 		case coinpkg.CodeBTC:

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -94,7 +94,7 @@ func (handlers *Handlers) formatAmountAsJSON(amount coin.Amount, isFee bool) For
 	accountCoin := handlers.account.Coin()
 	return FormattedAmount{
 		Amount: accountCoin.FormatAmount(amount, isFee),
-		Unit:   accountCoin.GetFormatUnit(),
+		Unit:   accountCoin.GetFormatUnit(isFee),
 		Conversions: coin.Conversions(
 			amount,
 			accountCoin,
@@ -109,7 +109,7 @@ func (handlers *Handlers) formatAmountAtTimeAsJSON(amount coin.Amount, timeStamp
 	accountCoin := handlers.account.Coin()
 	return &FormattedAmount{
 		Amount: accountCoin.FormatAmount(amount, false),
-		Unit:   accountCoin.GetFormatUnit(),
+		Unit:   accountCoin.GetFormatUnit(false),
 		Conversions: coin.ConversionsAtTime(
 			amount,
 			handlers.account.Coin(),

--- a/backend/coins/coin/coin.go
+++ b/backend/coins/coin/coin.go
@@ -42,7 +42,7 @@ type Coin interface {
 	Unit(isFee bool) string
 
 	// GetFormatUnit sets the unit used to format the amount, e.g. "BTC" or "sat".
-	GetFormatUnit() string
+	GetFormatUnit(isFee bool) string
 
 	// Number of decimal places in the standard unit, e.g. 8 for Bitcoin. Must be in the range
 	// [0..31].

--- a/backend/coins/coin/mocks/coin.go
+++ b/backend/coins/coin/mocks/coin.go
@@ -35,7 +35,7 @@ var _ coin.Coin = &CoinMock{}
 // 			FormatAmountFunc: func(amount coin.Amount, isFee bool) string {
 // 				panic("mock out the FormatAmount method")
 // 			},
-// 			GetFormatUnitFunc: func() string {
+// 			GetFormatUnitFunc: func(isFee bool) string {
 // 				panic("mock out the GetFormatUnit method")
 // 			},
 // 			InitializeFunc: func()  {
@@ -52,9 +52,6 @@ var _ coin.Coin = &CoinMock{}
 // 			},
 // 			SetAmountFunc: func(amount *big.Rat, isFee bool) coin.Amount {
 // 				panic("mock out the SetAmount method")
-// 			},
-// 			SetFormatUnitFunc: func(unit string)  {
-// 				panic("mock out the SetFormatUnit method")
 // 			},
 // 			SmallestUnitFunc: func() string {
 // 				panic("mock out the SmallestUnit method")
@@ -88,7 +85,7 @@ type CoinMock struct {
 	FormatAmountFunc func(amount coin.Amount, isFee bool) string
 
 	// GetFormatUnitFunc mocks the GetFormatUnit method.
-	GetFormatUnitFunc func() string
+	GetFormatUnitFunc func(isFee bool) string
 
 	// InitializeFunc mocks the Initialize method.
 	InitializeFunc func()
@@ -104,9 +101,6 @@ type CoinMock struct {
 
 	// SetAmountFunc mocks the SetAmount method.
 	SetAmountFunc func(amount *big.Rat, isFee bool) coin.Amount
-
-	// SetFormatUnitFunc mocks the SetFormatUnit method.
-	SetFormatUnitFunc func(unit string)
 
 	// SmallestUnitFunc mocks the SmallestUnit method.
 	SmallestUnitFunc func() string
@@ -142,6 +136,8 @@ type CoinMock struct {
 		}
 		// GetFormatUnit holds details about calls to the GetFormatUnit method.
 		GetFormatUnit []struct {
+			// IsFee is the isFee argument value.
+			IsFee bool
 		}
 		// Initialize holds details about calls to the Initialize method.
 		Initialize []struct {
@@ -165,11 +161,6 @@ type CoinMock struct {
 			Amount *big.Rat
 			// IsFee is the isFee argument value.
 			IsFee bool
-		}
-		// SetFormatUnit holds details about calls to the SetFormatUnit method.
-		SetFormatUnit []struct {
-			// Unit is the unit argument value.
-			Unit string
 		}
 		// SmallestUnit holds details about calls to the SmallestUnit method.
 		SmallestUnit []struct {
@@ -198,7 +189,6 @@ type CoinMock struct {
 	lockObserve                           sync.RWMutex
 	lockParseAmount                       sync.RWMutex
 	lockSetAmount                         sync.RWMutex
-	lockSetFormatUnit                     sync.RWMutex
 	lockSmallestUnit                      sync.RWMutex
 	lockToUnit                            sync.RWMutex
 	lockUnit                              sync.RWMutex
@@ -349,24 +339,29 @@ func (mock *CoinMock) FormatAmountCalls() []struct {
 }
 
 // GetFormatUnit calls GetFormatUnitFunc.
-func (mock *CoinMock) GetFormatUnit() string {
+func (mock *CoinMock) GetFormatUnit(isFee bool) string {
 	if mock.GetFormatUnitFunc == nil {
 		panic("CoinMock.GetFormatUnitFunc: method is nil but Coin.GetFormatUnit was just called")
 	}
 	callInfo := struct {
-	}{}
+		IsFee bool
+	}{
+		IsFee: isFee,
+	}
 	mock.lockGetFormatUnit.Lock()
 	mock.calls.GetFormatUnit = append(mock.calls.GetFormatUnit, callInfo)
 	mock.lockGetFormatUnit.Unlock()
-	return mock.GetFormatUnitFunc()
+	return mock.GetFormatUnitFunc(isFee)
 }
 
 // GetFormatUnitCalls gets all the calls that were made to GetFormatUnit.
 // Check the length with:
 //     len(mockedCoin.GetFormatUnitCalls())
 func (mock *CoinMock) GetFormatUnitCalls() []struct {
+	IsFee bool
 } {
 	var calls []struct {
+		IsFee bool
 	}
 	mock.lockGetFormatUnit.RLock()
 	calls = mock.calls.GetFormatUnit
@@ -520,37 +515,6 @@ func (mock *CoinMock) SetAmountCalls() []struct {
 	mock.lockSetAmount.RLock()
 	calls = mock.calls.SetAmount
 	mock.lockSetAmount.RUnlock()
-	return calls
-}
-
-// SetFormatUnit calls SetFormatUnitFunc.
-func (mock *CoinMock) SetFormatUnit(unit string) {
-	if mock.SetFormatUnitFunc == nil {
-		panic("CoinMock.SetFormatUnitFunc: method is nil but Coin.SetFormatUnit was just called")
-	}
-	callInfo := struct {
-		Unit string
-	}{
-		Unit: unit,
-	}
-	mock.lockSetFormatUnit.Lock()
-	mock.calls.SetFormatUnit = append(mock.calls.SetFormatUnit, callInfo)
-	mock.lockSetFormatUnit.Unlock()
-	mock.SetFormatUnitFunc(unit)
-}
-
-// SetFormatUnitCalls gets all the calls that were made to SetFormatUnit.
-// Check the length with:
-//     len(mockedCoin.SetFormatUnitCalls())
-func (mock *CoinMock) SetFormatUnitCalls() []struct {
-	Unit string
-} {
-	var calls []struct {
-		Unit string
-	}
-	mock.lockSetFormatUnit.RLock()
-	calls = mock.calls.SetFormatUnit
-	mock.lockSetFormatUnit.RUnlock()
 	return calls
 }
 

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -120,8 +120,8 @@ func (coin *Coin) Unit(isFee bool) string {
 }
 
 // GetFormatUnit implements coin.Coin.
-func (coin *Coin) GetFormatUnit() string {
-	return coin.unit
+func (coin *Coin) GetFormatUnit(isFee bool) string {
+	return coin.Unit(isFee)
 }
 
 // Decimals implements coin.Coin.

--- a/backend/coins/eth/coin_test.go
+++ b/backend/coins/eth/coin_test.go
@@ -49,7 +49,7 @@ func (s *testSuite) SetupTest() {
 		"ERC20TEST",
 		"ERC20Test",
 		"TOK",
-		"TOK",
+		"ETH",
 		params.MainnetChainConfig,
 		"",
 		nil,
@@ -129,4 +129,18 @@ func (s *testSuite) TestParseAmount() {
 	intAmount, err = coinAmount.Int64()
 	require.Equal(s.T(), err, nil)
 	require.Equal(s.T(), intWeiAmount, intAmount)
+}
+
+func (s *testSuite) TestGetFormatUnit() {
+	require.Equal(s.T(), "ETH", s.coin.GetFormatUnit(true))
+	require.Equal(s.T(), "ETH", s.coin.GetFormatUnit(false))
+	require.Equal(s.T(), "ETH", s.ERC20Coin.GetFormatUnit(true))
+	require.Equal(s.T(), "TOK", s.ERC20Coin.GetFormatUnit(false))
+}
+
+func (s *testSuite) TestUnit() {
+	require.Equal(s.T(), "ETH", s.coin.Unit(true))
+	require.Equal(s.T(), "ETH", s.coin.Unit(false))
+	require.Equal(s.T(), "ETH", s.ERC20Coin.Unit(true))
+	require.Equal(s.T(), "TOK", s.ERC20Coin.Unit(false))
 }

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -574,7 +574,7 @@ func (handlers *Handlers) getAccountsTotalBalanceHandler(_ *http.Request) (inter
 		}
 		totalAmount[k] = accountHandlers.FormattedAmount{
 			Amount:      currentCoin.FormatAmount(coin.NewAmount(v), false),
-			Unit:        currentCoin.GetFormatUnit(),
+			Unit:        currentCoin.GetFormatUnit(false),
 			Conversions: conversionsPerCoin[k],
 		}
 	}


### PR DESCRIPTION
Merge of sat unit feature introduced a regression in the display of ERC20 token fee unit, caused by the absence of a boolean `isFee` argument for `GetFormatUnit` coin method.