### PR TITLE
frontend: fix space between amount and unit

### DIFF
--- a/frontends/web/src/components/transactions/transaction.module.css
+++ b/frontends/web/src/components/transactions/transaction.module.css
@@ -61,9 +61,14 @@
 
 .amountOverflow {
     overflow: hidden;
-    padding-right: 40px;
     position: relative;
     text-overflow: ellipsis;
+}
+
+/* invisible element that creates the exact space for the used unit */
+.amountOverflow::after {
+    content: attr(data-unit);
+    color: transparent;
 }
 
 .send {

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -208,7 +208,9 @@ class Transaction extends Component<Props, State> {
               </span>
             </div>
             <div className={`${parentStyle.currency} ${typeClassName}`}>
-              <span className={`${style.amount} ${style.amountOverflow}`}>
+              <span
+                className={`${style.amount} ${style.amountOverflow}`}
+                data-unit={` ${amount.unit}`}>
                 {sign}{amount.amount}
                 <span className={style.currencyUnit}>&nbsp;{amount.unit}</span>
               </span>


### PR DESCRIPTION
In the last commit that improved support for large amounts or coins with lots of decimal, the space for the unit was fixed to 40px and the cause for some visual bug and inconsistent space between amount and unit. Sometimes too large or almost overlapping in case of GOETH.

This change creates a dynamic 'spacer' element with the correct width by passing the unit + 1 white-space to an invisible elemenet.