### PR TITLE
Fix line break in osx-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ envinit:
 #  - add to $PATH: /usr/local/opt/go@1.18/bin
 osx-init:
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-	brew install go@1.18	brew install qt@5
+	brew install go@1.18
+	brew install qt@5
 	$(MAKE) envinit
 servewallet:
 	go run -mod=vendor ./cmd/servewallet


### PR DESCRIPTION
Missing line break leads to following error while running `make osx-init`:

```console
➜  bitbox-wallet-app git:(master) make osx-init
/bin/bash -c ""
brew install go@1.18    brew install qt@5
Running `brew update --auto-update`...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core and homebrew/cask).

Warning: No available formula with the name "brew". Did you mean brev?
==> Searching for similarly named formulae...
These similarly named formulae were found:
brew-cask-completion         brew-php-switcher            heroku/brew/heroku           nodebrew                     whalebrew
brew-gem                     brew-pip                     heroku/brew/heroku-node      phpbrew                      brev
To install one of them, run (for example):
  brew install brew-cask-completion
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
==> Searching taps on GitHub...
Error: No formulae found in taps.
make: *** [osx-init] Error 1
```

Was able to confirm locally just now that proposed change fixes this and installs all dependencies properly.