### PR TITLE
frontend: fix progress bar styling

### DIFF
--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -114,16 +114,6 @@
     font-variant: tabular-nums;
 }
 
-.table progress {
-    appearance: none;
-}
-
-.table progress::-webkit-progress-bar {
-}
-
-.table progress::-webkit-progress-value {
-}
-
 .showOnTableView {
     display: block;
 }

--- a/frontends/web/src/style/base.css
+++ b/frontends/web/src/style/base.css
@@ -100,3 +100,8 @@ pre {
     padding: var(--space-default);
     text-align: center;
 }
+
+progress {
+    display: block;
+    width: 100%;
+}


### PR DESCRIPTION
The native progress element that shows the progress of upgrading the firmware has a visual regression and does not use the full available width anymore but is rendered at around 150px.

Looks like the default styling for the progress element changed in chrome and uses `display: inline-block;` and `width: 160px;`.

This is older but could be related:
- https://bugs.webkit.org/attachment.cgi?id=50959&action=diff#WebCore/css/html.css_sec1