### PR TITLE
frontend: convert multilineMarkup to JSX

### DIFF
--- a/frontends/web/src/components/alert/Alert.tsx
+++ b/frontends/web/src/components/alert/Alert.tsx
@@ -17,7 +17,7 @@
 
 import { Component } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import { multilineMarkup } from '../../utils/markup';
+import { MultilineMarkup } from '../../utils/markup';
 import { View, ViewButtons, ViewHeader } from '../view/view';
 import { Button } from '../forms';
 
@@ -88,10 +88,7 @@ class Alert extends Component<WithTranslation, State> {
           dialog={asDialog}
           textCenter={!asDialog}
           fullscreen>
-          <ViewHeader title={multilineMarkup({
-            tagName: 'span',
-            markup: message,
-          })} />
+          <ViewHeader title={<MultilineMarkup tagName="span" markup={message} />} />
           <ViewButtons>
             <Button
               autoFocus

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -18,7 +18,7 @@
 import React, { Component, FormEvent } from 'react';
 import { Backup } from '../components/backup';
 import { checkSDCard, errUserAbort, getVersion, setDeviceName, VersionInfo, verifyAttestation } from '../../../api/bitbox02';
-import { multilineMarkup } from '../../../utils/markup';
+import { MultilineMarkup } from '../../../utils/markup';
 import { convertDateToLocaleString } from '../../../utils/date';
 import { route } from '../../../utils/route';
 import { AppUpgradeRequired } from '../../../components/appupgraderequired';
@@ -744,13 +744,10 @@ class BitBox02 extends Component<Props, State> {
               ) : (
                 selectedBackup ? (
                   <div>
-                    {multilineMarkup({
-                      tagName: 'div',
-                      markup: t('backup.restore.selectedBackup', {
-                        backupName: selectedBackup.name,
-                        createdDateTime: convertDateToLocaleString(selectedBackup.date, this.props.i18n.language),
-                      })
-                    })}
+                    <MultilineMarkup tagName="div" markup={t('backup.restore.selectedBackup', {
+                      backupName: selectedBackup.name,
+                      createdDateTime: convertDateToLocaleString(selectedBackup.date, this.props.i18n.language),
+                    })}/>
                     <p className="text-small text-ellipsis">
                                             ID:&nbsp;{selectedBackup.id}
                     </p>

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -19,7 +19,7 @@ import { Component } from 'react';
 import { route } from '../../../utils/route';
 import { getDeviceInfo, setMnemonicPassphraseEnabled } from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
-import { multilineMarkup, SimpleMarkup } from '../../../utils/markup';
+import { MultilineMarkup, SimpleMarkup } from '../../../utils/markup';
 // This is the first time we use <View> in a <Main> component
 // keeping guide and header as example in the code
 import { /* Header, */ Main } from '../../../components/layout';
@@ -137,10 +137,7 @@ class Passphrase extends Component<Props, State> {
           width={CONTENT_WIDTH}>
           <ViewHeader title={t('passphrase.intro.title')} />
           <ViewContent>
-            {multilineMarkup({
-              tagName: 'p',
-              markup: t('passphrase.intro.message'),
-            })}
+            <MultilineMarkup tagName="p" markup={t('passphrase.intro.message')} />
           </ViewContent>
           <ViewButtons>
             <Button primary onClick={this.continueInfo}>
@@ -162,10 +159,7 @@ class Passphrase extends Component<Props, State> {
           width={CONTENT_WIDTH}>
           <ViewHeader title={t('passphrase.what.title')} />
           <ViewContent>
-            {multilineMarkup({
-              tagName: 'p',
-              markup: t('passphrase.what.message'),
-            })}
+            <MultilineMarkup tagName="p" markup={t('passphrase.what.message')} />
           </ViewContent>
           <ViewButtons>
             <Button primary onClick={this.continueInfo}>
@@ -187,10 +181,7 @@ class Passphrase extends Component<Props, State> {
           width={CONTENT_WIDTH}>
           <ViewHeader title={t('passphrase.why.title')} />
           <ViewContent>
-            {multilineMarkup({
-              tagName: 'p',
-              markup: t('passphrase.why.message'),
-            })}
+            <MultilineMarkup tagName="p" markup={t('passphrase.why.message')} />
           </ViewContent>
           <ViewButtons>
             <Button primary onClick={this.continueInfo}>
@@ -212,10 +203,7 @@ class Passphrase extends Component<Props, State> {
           width={CONTENT_WIDTH}>
           <ViewHeader title={t('passphrase.considerations.title')} />
           <ViewContent>
-            {multilineMarkup({
-              tagName: 'p',
-              markup: t('passphrase.considerations.message'),
-            })}
+            <MultilineMarkup tagName="p" markup={t('passphrase.considerations.message')} />
           </ViewContent>
           <ViewButtons>
             <Button primary onClick={this.continueInfo}>
@@ -237,10 +225,7 @@ class Passphrase extends Component<Props, State> {
           width={CONTENT_WIDTH}>
           <ViewHeader title={t('passphrase.how.title')} />
           <ViewContent>
-            {multilineMarkup({
-              tagName: 'p',
-              markup: t('passphrase.how.message'),
-            })}
+            <MultilineMarkup tagName="p" markup={t('passphrase.how.message')} />
           </ViewContent>
           <ViewButtons>
             <Button primary onClick={this.continueInfo}>
@@ -304,10 +289,7 @@ class Passphrase extends Component<Props, State> {
         width={CONTENT_WIDTH}>
         <ViewHeader title={t('passphrase.disable')} />
         <ViewContent>
-          {multilineMarkup({
-            tagName: 'p',
-            markup: t('passphrase.disableInfo.message'),
-          })}
+          <MultilineMarkup tagName="p" markup={t('passphrase.disableInfo.message')} />
         </ViewContent>
         <ViewButtons>
           <Button primary onClick={this.continueInfo}>
@@ -369,12 +351,9 @@ class Passphrase extends Component<Props, State> {
                 : 'passphrase.successEnabled.title')} >
             </ViewHeader>
             <ViewContent>
-              {multilineMarkup({
-                tagName: 'p',
-                markup: t(passphraseEnabled
-                  ? 'passphrase.successDisabled.message'
-                  : 'passphrase.successEnabled.message'),
-              })}
+              <MultilineMarkup tagName="p" markup={t(passphraseEnabled
+                ? 'passphrase.successDisabled.message'
+                : 'passphrase.successEnabled.message')} />
               {passphraseEnabled && (
                 <ul style={{ paddingLeft: 'var(--space-default)' }}>
                   <SimpleMarkup key="tip-1" tagName="li" markup={t('passphrase.successEnabled.tipsList.0')} />

--- a/frontends/web/src/utils/markup.test.tsx
+++ b/frontends/web/src/utils/markup.test.tsx
@@ -16,7 +16,7 @@
 
 import 'jest';
 import { render } from '@testing-library/react';
-import { multilineMarkup, SimpleMarkup } from './markup';
+import { MultilineMarkup, SimpleMarkup } from './markup';
 
 describe('SimpleMarkup', () => {
   it('contains a strong element with the text bar', () => {
@@ -35,11 +35,7 @@ describe('SimpleMarkup', () => {
 describe('multilineMarkup', () => {
   it('contains multiple lines with a strong element each', () => {
     const { container } = render(
-      <div>
-        {multilineMarkup({
-          tagName: 'p', markup: 'foo <strong>bar</strong> baz\n<strong>booz</strong>'
-        })}
-      </div>
+      <MultilineMarkup tagName="p" markup={'foo <strong>bar</strong> baz\n<strong>booz</strong>'}/>
     );
     const paragraphs = container.querySelectorAll('p');
     expect(paragraphs).toHaveLength(2);

--- a/frontends/web/src/utils/markup.tsx
+++ b/frontends/web/src/utils/markup.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { createElement } from 'react';
+import React, { createElement, FunctionComponent } from 'react';
 
 type MarkupProps = {
     tagName: keyof JSX.IntrinsicElements;
@@ -47,23 +47,16 @@ export function SimpleMarkup({ tagName, markup, ...props }: MarkupProps) {
 }
 
 /**
- * **multilineMarkup** splits a text by newline and renders each
+ * **<MultilineMarkup>** splits a text by newline and renders each
  * line with the `<SimmpleMarkup>` component.
- * **Note**: With current Preact 8 document fragments are not
- * supported so this has to be used as function, but once we move
- * to modern Preact/React we can use it as a normal component.
- * ### Example:
- * ```jsx
-    {multilineMarkup({ tagName: 'p', markup: 'messages\n\nwith <strong>newlines</strong>'})}
- * ```
  */
-export function multilineMarkup({ tagName, markup, ...props }: MarkupProps) {
-  return markup.split('\n').map((line: string, i: number) => (
-    SimpleMarkup({
-      key: `${line}-${i}`,
-      tagName,
-      markup: line,
-      ...props
-    })
-  ));
-}
+
+export const MultilineMarkup: FunctionComponent<MarkupProps> = ({ tagName, markup, ...props }) => {
+  return <>
+    {
+      markup.split('\n').map((line: string, i: number) => (
+        <SimpleMarkup key={`${line}-${i}`} tagName={tagName} markup={line} {...props} />
+      ))
+    }
+  </>;
+};


### PR DESCRIPTION
To follow the latest conventions in the frontend, we would like to convert `multilineMarkup()` into a "normal" JSX component, `<MultilineMarkup />`.

Previously, it's not possible to use the component as `<MultilineMarkup />` due to the usage of Preact 8 - which does not support document fragments.