### PR TITLE
frontend: new guide entry for entering tracking mode on mobile

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -827,6 +827,10 @@
       "close": "Close guide",
       "open": "Guide"
     },
+    "trackingModePortfolioChart": {
+      "text": "On desktop, hover the cursor over the chart. On mobile, hold your finger on the chart and drag horizontally.",
+      "title": "How to see historical values on the chart?"
+    },
     "unlock": {
       "forgotDevicePassword": {
         "text": "You have to reset the device and restore the wallet from a backup, using the recovery password.",

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -381,6 +381,7 @@ class AccountsSummary extends Component<Props, State> {
             text: t('guide.accountSummaryAmount.text'),
             title: t('guide.accountSummaryAmount.title')
           }} />
+          <Entry key="trackingModePortfolioChart" entry={t('guide.trackingModePortfolioChart')} />
         </Guide>
       </div>
     );


### PR DESCRIPTION
New entry guide to help users understand the action needed to be able to
explore (entering the tracking mode of) the portfolio graph.

This allows them to see the historical value of their
portfolio.

<img width="776" alt="Screen Shot 2022-11-09 at 11 18 27" src="https://user-images.githubusercontent.com/28676406/200804292-0e3af9d1-df06-49c8-9d10-3b8175486007.png">
