### PR TITLE
CHANGELOG: move entry out of 4.35 to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Gracefully deal with corrupt bbolt database files
 
 ## 4.35.0
 - Render number of blocks scanned and percentage progress using fixed-width digits for a more stable UI
@@ -19,7 +20,6 @@
 - Fix a UI bug when checking a backup where the confirmation dialog is sometimes empty
 - Ethereum: remove Ropsten/Rinkeby testnet networks, which have been shut down
 - Re-style Portfolio Chart on mobile (Android) for better usability and a more modern look
-- Gracefully deal with corrupt bbolt database files
 
 ## 4.34.0
 - Bundle BitBox02 firmware version v9.12.0


### PR DESCRIPTION
This change added a 0.5s-1s delay when launching the app, which should be addressed before releasing it. Moving out of the 4.35 release.