### PR TITLE
frontend: changed return types & children types for FC

### DIFF
--- a/frontends/web/src/components/anchor/anchor.tsx
+++ b/frontends/web/src/components/anchor/anchor.tsx
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, SyntheticEvent } from 'react';
+import { ReactNode, SyntheticEvent } from 'react';
 import { route } from '../../utils/route';
 import { hide } from '../guide/guide';
 import { debug } from '../../utils/env';
 import { apiPost } from '../../utils/request';
 import style from './anchor.module.css';
 
-interface Props {
+type TProps = {
     href: string;
+    children: ReactNode;
     [property: string]: any;
 }
 
-const A: FunctionComponent<Props> = ({ href, icon, children, ...props }) => {
+const A = ({ href, icon, children, ...props }: TProps) => {
   return (
     <span className={style.link} onClick={(e: SyntheticEvent) => {
       e.preventDefault();

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { Component, PropsWithChildren } from 'react';
+import React, { Component, ReactNode } from 'react';
 import * as accountAPI from '../../api/account';
 import * as aoppAPI from '../../api/aopp';
 import { subscribe } from '../../decorators/subscribe';
@@ -30,7 +30,11 @@ import { VerifyAddress } from './verifyaddress';
 import { Vasp } from './vasp';
 import styles from './aopp.module.css';
 
-const Banner = ({ children }: PropsWithChildren<{}>) => (
+type TProps = {
+  children: ReactNode;
+}
+
+const Banner = ({ children }: TProps) => (
   <div className={styles.banner}>{children}</div>
 );
 

--- a/frontends/web/src/components/aopp/vasp.tsx
+++ b/frontends/web/src/components/aopp/vasp.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from 'react';
 import styles from './vasp.module.css';
 import AOPPGroupLogo from '../../assets/exchanges/logos/aoppgroup.svg';
 import BitcoinSuisseLogo from '../../assets/exchanges/logos/bitcoin_suisse.png';
@@ -22,7 +21,7 @@ import BittrLogo from '../../assets/exchanges/logos/bittr.png';
 import BityLogo from '../../assets/exchanges/logos/bity.png';
 import PocketBitcoinLogo from '../../assets/exchanges/logos/pocketbitcoin.svg';
 
-interface VASPProps {
+type TVASPProps = {
     fallback?: JSX.Element;
     hostname: string;
     prominent?: boolean;
@@ -47,12 +46,12 @@ const VASPHostnameMap: TVASPMap = {
   'testing.aopp.group': 'AOPP.group',
 };
 
-export function Vasp({
+export const Vasp = ({
   fallback,
   hostname,
   prominent,
   withLogoText,
-}: PropsWithChildren<VASPProps>) {
+}: TVASPProps) => {
   const hasLogo = hostname in VASPLogoMap;
   if (!hasLogo) {
     return fallback || (<p className={styles.hostname}>{hostname}</p>);
@@ -67,4 +66,4 @@ export function Vasp({
       {withLogoText ? (<p>{withLogoText}</p>) : null}
     </div>
   );
-}
+};

--- a/frontends/web/src/components/appupgraderequired.tsx
+++ b/frontends/web/src/components/appupgraderequired.tsx
@@ -15,13 +15,10 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from 'react';
 import { translate, TranslateProps } from '../decorators/translate';
 import A from './anchor/anchor';
 
-type Props = TranslateProps;
-
-function AppUpgradeRequired({ t }: PropsWithChildren<Props>): JSX.Element {
+function AppUpgradeRequired({ t }: TranslateProps) {
   return (
     <div className="contentWithGuide">
       <div className="container">

--- a/frontends/web/src/components/badge/badge.tsx
+++ b/frontends/web/src/components/badge/badge.tsx
@@ -1,12 +1,13 @@
-import { FunctionComponent } from 'react';
+import { ReactNode } from 'react';
 import style from './badge.module.css';
 
-interface Props {
-    type: string;
-    className?: string;
+type TProps = {
+  type: string;
+  className?: string;
+  children: ReactNode;
 }
 
-export const Badge: FunctionComponent<Props> = ({ type, className, children }) => {
+export const Badge = ({ type, className, children }: TProps) => {
   return (
     <span className={[style.container, style[type], className].join(' ')}>
       {children}

--- a/frontends/web/src/components/balance/balance.tsx
+++ b/frontends/web/src/components/balance/balance.tsx
@@ -15,22 +15,21 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IBalance } from '../../api/account';
 import { FiatConversion } from '../../components/rates/rates';
 import { bitcoinRemoveTrailingZeroes } from '../../utils/trailing-zeroes';
 import style from './balance.module.css';
 
-interface Props {
+type TProps = {
     balance?: IBalance;
     noRotateFiat?: boolean;
 }
 
-export const Balance: FunctionComponent<Props> = ({
+export const Balance = ({
   balance,
   noRotateFiat,
-}) => {
+}: TProps) => {
   const { t } = useTranslation();
   if (!balance) {
     return (

--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from 'react';
 import { subscribe } from '../../decorators/subscribe';
 import { translate, TranslateProps } from '../../decorators/translate';
 import A from '../anchor/anchor';
 import Status from '../status/status';
 
-interface BannerInfo {
+type TBannerInfo = {
     id: string;
     message: { [key: string]: string; };
     link?: {
@@ -29,18 +28,18 @@ interface BannerInfo {
     };
 }
 
-interface LoadedProps {
-    banner: BannerInfo | null;
+type TLoadedProps = {
+    banner: TBannerInfo | null;
 }
 
-interface BannerProps {
+type TBannerProps = {
     // eslint-disable-next-line react/no-unused-prop-types
     msgKey: 'bitbox01';
 }
 
-type Props = LoadedProps & BannerProps & TranslateProps;
+type TProps = TLoadedProps & TBannerProps & TranslateProps;
 
-function Banner({ banner, i18n, t }: PropsWithChildren<Props>): JSX.Element | null {
+function Banner({ banner, i18n, t }: TProps) {
   if (!i18n.options.fallbackLng) {
     return null;
   }
@@ -57,7 +56,7 @@ function Banner({ banner, i18n, t }: PropsWithChildren<Props>): JSX.Element | nu
 }
 
 const HOC = translate()(
-  subscribe<LoadedProps, BannerProps & TranslateProps>(
+  subscribe<TLoadedProps, TBannerProps & TranslateProps>(
     ({ msgKey }) => ({ banner: 'banners/' + msgKey }),
     true,
     false,

--- a/frontends/web/src/components/centeredcontent/centeredcontent.tsx
+++ b/frontends/web/src/components/centeredcontent/centeredcontent.tsx
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
+import { ReactNode } from 'react';
 import style from './style.module.css';
 
-export const CenteredContent: FunctionComponent = ({ children }) => {
+type TProps = {
+  children: ReactNode;
+}
+
+export const CenteredContent = ({ children }: TProps) => {
   return (
     <div className="contentWithGuide">
       <div className={style.container}>

--- a/frontends/web/src/components/confirm/Confirm.tsx
+++ b/frontends/web/src/components/confirm/Confirm.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SimpleMarkup } from '../../utils/markup';
 import { Dialog, DialogButtons } from '../dialog/dialog';
@@ -38,7 +38,7 @@ interface State {
  * Confirm alert that activates on confirmation module export call,
  * this should be mounted only once in the App
  */
-export const Confirm: FunctionComponent = () => {
+export const Confirm = () => {
   const [state, setState] = useState<State>({ active: false });
   const { t } = useTranslation();
   const callback = useRef<TCallback>(() => {});

--- a/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, FunctionComponent, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { load } from '../../../decorators/load';
 import { apiPost } from '../../../utils/request';
 import { Toggle } from '../../toggle/toggle';
 
-interface ToggleProps {
+type TToggleProps = {
     deviceID: string;
 }
 
-interface LoadedProps {
+type TLoadedProps = {
     enabled: boolean;
 }
 
-type Props = ToggleProps & LoadedProps;
+type TProps = TToggleProps & TLoadedProps;
 
-const ToggleFWHash: FunctionComponent<Props> = ({ enabled, deviceID }) => {
+const ToggleFWHash = ({ enabled, deviceID }: TProps) => {
   const { t } = useTranslation();
   const [enabledState, setEnabledState] = useState<boolean>(enabled);
 
@@ -57,5 +57,5 @@ const ToggleFWHash: FunctionComponent<Props> = ({ enabled, deviceID }) => {
   );
 };
 
-const HOC = load<LoadedProps, ToggleProps>(({ deviceID }) => ({ enabled: 'devices/bitbox02-bootloader/' + deviceID + '/show-firmware-hash-enabled' }))(ToggleFWHash);
+const HOC = load<TLoadedProps, TToggleProps>(({ deviceID }) => ({ enabled: 'devices/bitbox02-bootloader/' + deviceID + '/show-firmware-hash-enabled' }))(ToggleFWHash);
 export { HOC as ToggleShowFirmwareHash };

--- a/frontends/web/src/components/forms/button.tsx
+++ b/frontends/web/src/components/forms/button.tsx
@@ -15,19 +15,20 @@
  * limitations under the License.
  */
 
-import { ComponentPropsWithoutRef, FunctionComponent } from 'react';
+import { ComponentPropsWithoutRef, ReactNode } from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 import style from './button.module.css';
 
-type Props = {
+type TProps = {
     danger?: boolean;
     disabled?: boolean;
     primary?: boolean;
     secondary?: boolean;
     transparent?: boolean;
+    children: ReactNode;
 }
 
-export const ButtonLink: FunctionComponent<Props & LinkProps> = ({
+export const ButtonLink = ({
   primary = false,
   secondary = false,
   transparent = false,
@@ -36,7 +37,7 @@ export const ButtonLink: FunctionComponent<Props & LinkProps> = ({
   children,
   disabled,
   ...props
-}) => {
+}: TProps & LinkProps) => {
   const classNames = [
     style[
       (primary && 'primary')
@@ -65,7 +66,7 @@ export const ButtonLink: FunctionComponent<Props & LinkProps> = ({
   );
 };
 
-export const Button: FunctionComponent<Props & ComponentPropsWithoutRef<'button'>> = ({
+export const Button = ({
   type = 'button',
   primary = false,
   secondary = false,
@@ -74,7 +75,7 @@ export const Button: FunctionComponent<Props & ComponentPropsWithoutRef<'button'
   className = '',
   children,
   ...props
-}) => {
+}: TProps & ComponentPropsWithoutRef<'button'>) => {
   const classNames = [
     style[(primary && 'primary')
             || (secondary && 'secondary')

--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -18,7 +18,7 @@ import { FunctionComponent, useState } from 'react';
 import A from '../anchor/anchor';
 import style from './guide.module.css';
 
-export interface EntryProp {
+export type TEntryProp = {
     title: string;
     text: string;
     link?: {
@@ -27,14 +27,14 @@ export interface EntryProp {
     };
 }
 
-interface EntryProps {
-    entry: EntryProp;
+type TEntryProps = {
+    entry: TEntryProp;
     shown?: boolean;
 }
 
-type Props = EntryProps;
+type TProps = TEntryProps;
 
-export const Entry: FunctionComponent<Props> = props => {
+export const Entry: FunctionComponent<TProps> = props => {
   const [shown, setShown] = useState<boolean>(props.shown || false);
 
   const toggle = () => {

--- a/frontends/web/src/components/headerssync/headerssync.tsx
+++ b/frontends/web/src/components/headerssync/headerssync.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMountedRef } from '../../hooks/utils';
 import { CoinCode } from '../../api/account';
@@ -24,11 +24,11 @@ import { useSubscribe } from '../../hooks/api';
 import Spinner from '../spinner/ascii';
 import style from './headerssync.module.css';
 
-interface Props {
+type TProps = {
     coinCode: CoinCode;
 }
 
-export const HeadersSync: FunctionComponent<Props> = ({ coinCode }) => {
+export const HeadersSync = ({ coinCode }: TProps) => {
   const { i18n, t } = useTranslation();
   const status = useSubscribe(subscribeCoinHeaders(coinCode));
   const [hidden, setHidden] = useState<boolean>(false);

--- a/frontends/web/src/components/icon/icon.tsx
+++ b/frontends/web/src/components/icon/icon.tsx
@@ -38,7 +38,7 @@ import starSVG from './assets/icons/star.svg';
 import starInactiveSVG from './assets/icons/star-inactive.svg';
 import style from './icon.module.css';
 
-export const ExpandOpen = (): JSX.Element => (
+export const ExpandOpen = () => (
   <svg
     className={style.expandIcon}
     xmlns="http://www.w3.org/2000/svg"
@@ -57,7 +57,7 @@ export const ExpandOpen = (): JSX.Element => (
   </svg>
 );
 
-export const ExpandClose = (): JSX.Element => (
+export const ExpandClose = () => (
   <svg
     className={style.expandIcon}
     xmlns="http://www.w3.org/2000/svg"
@@ -96,7 +96,7 @@ interface ExpandIconProps {
 
 export const ExpandIcon = ({
   expand = true,
-}: ExpandIconProps): JSX.Element => (
+}: ExpandIconProps) => (
   expand ? <ExpandOpen /> : <ExpandClose />
 );
 

--- a/frontends/web/src/components/language/language.tsx
+++ b/frontends/web/src/components/language/language.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, useState } from 'react';
+import { useState } from 'react';
 import { i18n as Ii18n } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { Dialog } from '../dialog/dialog';
@@ -72,7 +72,7 @@ const getSelectedIndex = (languages: TLanguagesList, i18n: Ii18n) => {
   return index;
 };
 
-const LanguageSwitch: FunctionComponent<TLanguageSwitchProps> = ({ languages }) => {
+const LanguageSwitch = ({ languages }: TLanguageSwitchProps) => {
 
   const { t, i18n } = useTranslation();
   const allLanguages = languages || defaultLanguages;

--- a/frontends/web/src/components/layout/footer.tsx
+++ b/frontends/web/src/components/layout/footer.tsx
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from 'react';
+import { ReactNode } from 'react';
 import { LanguageSwitch } from '../language/language';
 import style from './footer.module.css';
 import { Version } from './version';
 
-export function Footer({ children }: PropsWithChildren<{}>) {
+type TProps = {
+  children: ReactNode;
+}
+
+export function Footer({ children }: TProps) {
   return (
     <footer className={[style.footer, 'flex flex-row flex-items-center flex-end'].join(' ')}>
       {children}

--- a/frontends/web/src/components/layout/grid.tsx
+++ b/frontends/web/src/components/layout/grid.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
+import { ReactNode } from 'react';
 import style from './grid.module.css';
 
-type GridProps = {}
+type TGridProps = {
+  children: ReactNode;
+}
 
-export const Grid: FunctionComponent<GridProps> = ({ children }) => {
+export const Grid = ({ children }: TGridProps) => {
   return (
     <section className={style.grid}>
       {children}
@@ -27,14 +29,15 @@ export const Grid: FunctionComponent<GridProps> = ({ children }) => {
   );
 };
 
-type ColumnProps = {
-    asCard?: boolean;
+type TColumnProps = {
+  asCard?: boolean;
+  children: ReactNode;
 }
 
-export const Column: FunctionComponent<ColumnProps> = ({
+export const Column = ({
   asCard,
   children,
-}) => {
+}: TColumnProps) => {
   return (
     <div className={`${style.column} ${asCard ? style.columnAsCard : ''}`}>
       {children}
@@ -42,9 +45,11 @@ export const Column: FunctionComponent<ColumnProps> = ({
   );
 };
 
-type ColumnButtonsProps = {}
+type TColumnButtonsProps = {
+  children: ReactNode;
+}
 
-export const ColumnButtons: FunctionComponent<ColumnButtonsProps> = ({ children }) => {
+export const ColumnButtons = ({ children }: TColumnButtonsProps) => {
   return (
     <div className={style.columnButtons}>
       {children}

--- a/frontends/web/src/components/layout/main.tsx
+++ b/frontends/web/src/components/layout/main.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
+import { ReactNode } from 'react';
 import style from './main.module.css';
 
-type MainProps = {}
+type TMainProps = {
+  children: ReactNode;
+}
 
-export const Main: FunctionComponent<MainProps> = ({ children }) => {
+export const Main = ({ children }: TMainProps) => {
   return (
     <main className={style.main}>
       {children}

--- a/frontends/web/src/components/layout/version.tsx
+++ b/frontends/web/src/components/layout/version.tsx
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../hooks/api';
 import { getVersion } from '../../api/version';
 
-const Version: FunctionComponent = () => {
+const Version = () => {
   const { t } = useTranslation();
   const version = useLoad(getVersion);
 

--- a/frontends/web/src/components/message/message.tsx
+++ b/frontends/web/src/components/message/message.tsx
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from 'react';
+import { ReactNode } from 'react';
 import styles from './message.module.css';
 
 export interface Props {
     hidden?: boolean;
     type?: 'message' | 'success' | 'info' | 'warning' | 'error';
+    children: ReactNode;
 }
 
 export function Message({
   hidden,
   type = 'message',
   children,
-}: PropsWithChildren<Props>) {
+}: Props) {
   if (hidden) {
     return null;
   }

--- a/frontends/web/src/components/mobiledatawarning.tsx
+++ b/frontends/web/src/components/mobiledatawarning.tsx
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSync } from '../hooks/api';
 import { getUsingMobileData, subscribeUsingMobileData } from '../api/mobiledata';
 import Status from './status/status';
 
-export const MobileDataWarning: FunctionComponent = () => {
+export const MobileDataWarning = () => {
   const { t } = useTranslation();
   const isUsingMobileData = useSync(getUsingMobileData, subscribeUsingMobileData);
   if (isUsingMobileData === undefined) {

--- a/frontends/web/src/components/progressRing/progressRing.tsx
+++ b/frontends/web/src/components/progressRing/progressRing.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from 'react';
 import style from './progressRing.module.css';
 
-interface ProgressRingProps {
+type TProgressRingProps = {
     width: number;
     value: number;
     className?: string[] | string;
@@ -33,7 +32,7 @@ const ProgressRing = ({
   isError,
   value,
   width,
-}: PropsWithChildren<ProgressRingProps>) => {
+}: TProgressRingProps) => {
   const radius = (width - 3) / 2;
   const circumference = radius * 2 * Math.PI;
   const progress = isError ? 100 : value / 100;

--- a/frontends/web/src/components/qrcode/qrcode.tsx
+++ b/frontends/web/src/components/qrcode/qrcode.tsx
@@ -15,20 +15,19 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { useLoad } from '../../hooks/api';
 import { getQRCode } from '../../api/backend';
 import style from './qrcode.module.css';
 
-type Props = {
+type TProps = {
     data?: string;
     size?: number;
 };
 
-export const QRCode: FunctionComponent<Props> = ({
+export const QRCode = ({
   data,
   size = 256,
-}) => {
+}: TProps) => {
   const src = useLoad(data !== undefined ? getQRCode(data) : null, [data]);
   if (!src) {
     if (data !== undefined) {

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from 'react';
 import { Fiat, ConversionUnit, IAmount } from '../../api/account';
 import { BtcUnit } from '../../api/coins';
 import { share } from '../../decorators/share';
@@ -104,7 +103,7 @@ export function formatNumber(amount: number, maxDigits: number): string {
   return formatted;
 }
 
-interface ProvidedProps {
+type TProvidedProps = {
     amount?: IAmount;
     tableRow?: boolean;
     unstyled?: boolean;
@@ -114,7 +113,7 @@ interface ProvidedProps {
     noBtcZeroes?: boolean;
 }
 
-type Props = ProvidedProps & SharedProps;
+type TProps = TProvidedProps & SharedProps;
 
 function Conversion({
   amount,
@@ -126,7 +125,7 @@ function Conversion({
   sign,
   noBtcZeroes,
   btcUnit,
-}: PropsWithChildren<Props>): JSX.Element | null {
+}: TProps) {
 
   let formattedValue = '---';
   let isAvailable = false;
@@ -181,4 +180,4 @@ function Conversion({
   );
 }
 
-export const FiatConversion = share<SharedProps, ProvidedProps>(store)(Conversion);
+export const FiatConversion = share<SharedProps, TProvidedProps>(store)(Conversion);

--- a/frontends/web/src/components/settingsButton/settingsButton.tsx
+++ b/frontends/web/src/components/settingsButton/settingsButton.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { ReactNode } from 'react';
 import style from './settingsButton.module.css';
 
 interface SettingsButtonProps {
@@ -8,9 +8,10 @@ interface SettingsButtonProps {
     secondaryText?: string | JSX.Element;
     disabled?: boolean;
     optionalIcon?: JSX.Element;
+    children: ReactNode;
 }
 
-const SettingsButton: FunctionComponent<SettingsButtonProps> = ({
+const SettingsButton = ({
   onClick,
   danger,
   optionalText,
@@ -18,7 +19,7 @@ const SettingsButton: FunctionComponent<SettingsButtonProps> = ({
   disabled,
   children,
   optionalIcon,
-}) => {
+}: SettingsButtonProps) => {
   return (
     <button
       className={

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { Component, FunctionComponent } from 'react';
+import React, { Component } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { IAccount } from '../../api/account';
 import coins from '../../assets/icons/coins.svg';
@@ -44,6 +44,8 @@ interface SubscribedProps {
 
 type Props = SubscribedProps & SharedPanelProps & SidebarProps & TranslateProps;
 
+type TGetAccountLinkProps = IAccount & { handleSidebarItemClick: ((e: React.SyntheticEvent) => void) };
+
 interface SwipeAttributes {
     x: number;
     y: number;
@@ -59,7 +61,7 @@ export function setSidebarStatus(status: string) {
   panelStore.setState({ sidebarStatus: status });
 }
 
-const GetAccountLink: FunctionComponent<IAccount & { handleSidebarItemClick: ((e: React.SyntheticEvent) => any) }> = ({ coinCode, code, name, handleSidebarItemClick }) => {
+const GetAccountLink = ({ coinCode, code, name, handleSidebarItemClick }: TGetAccountLinkProps ) => {
   const { pathname } = useLocation();
   const active = ( pathname === `/account/${code}` ) || ( pathname.startsWith(`/account/${code}/`) );
   return (

--- a/frontends/web/src/components/skeleton/skeleton.tsx
+++ b/frontends/web/src/components/skeleton/skeleton.tsx
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import style from './skeleton.module.css';
 
-type Props = {
+type TProps = {
     fontSize?: string;
     minWidth?: string;
 };
 
-export const Skeleton: FunctionComponent<Props> = ({
+export const Skeleton = ({
   fontSize,
   minWidth = '100%',
-}) => {
+}: TProps) => {
   return (
     <span className={style.skeleton} style={{ fontSize, minWidth }} />
   );

--- a/frontends/web/src/components/spinner/Spinner.tsx
+++ b/frontends/web/src/components/spinner/Spinner.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { share } from '../../decorators/share';
 import { SharedProps, store, toggle as toggleGuide } from '../guide/guide';
@@ -22,13 +22,13 @@ import { toggleSidebar } from '../sidebar/sidebar';
 import { Menu } from '../icon';
 import style from './Spinner.module.css';
 
-interface SpinnerProps {
+type SpinnerProps = {
     text?: string;
 }
 
-type Props = SpinnerProps & SharedProps;
+type TProps = SpinnerProps & SharedProps;
 
-const Spinner: FunctionComponent<Props> = ({ text, guideExists }) => {
+const Spinner = ({ text, guideExists }: TProps) => {
   const { t } = useTranslation();
 
   const handleKeyDown = (e: KeyboardEvent) => {

--- a/frontends/web/src/components/transactions/components/icons.tsx
+++ b/frontends/web/src/components/transactions/components/icons.tsx
@@ -1,6 +1,6 @@
 import style from './icons.module.css';
 
-export const ArrowIn = (): JSX.Element => (
+export const ArrowIn = () => (
   <svg
     className={`${style.txArrowType} ${style.txArrowTypeIn}`}
     xmlns="http://www.w3.org/2000/svg"
@@ -16,7 +16,7 @@ export const ArrowIn = (): JSX.Element => (
   </svg>
 );
 
-export const ArrowOut = (): JSX.Element => (
+export const ArrowOut = () => (
   <svg
     className={`${style.txArrowType} ${style.txArrowTypeOut}`}
     xmlns="http://www.w3.org/2000/svg"
@@ -32,7 +32,7 @@ export const ArrowOut = (): JSX.Element => (
   </svg>
 );
 
-export const ArrowSelf = (): JSX.Element => (
+export const ArrowSelf = () => (
   <svg
     className={`${style.txArrowType} ${style.txArrowTypeSelf}`}
     xmlns="http://www.w3.org/2000/svg"
@@ -48,7 +48,7 @@ export const ArrowSelf = (): JSX.Element => (
   </svg>
 );
 
-export const Edit = (): JSX.Element => (
+export const Edit = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="20"
@@ -64,7 +64,7 @@ export const Edit = (): JSX.Element => (
   </svg>
 );
 
-export const Save = (): JSX.Element => (
+export const Save = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="20"

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ITransaction } from '../../api/account';
 import A from '../../components/anchor/anchor';
@@ -23,19 +22,19 @@ import { runningInAndroid } from '../../utils/env';
 import { Transaction } from './transaction';
 import style from './transactions.module.css';
 
-type Props = {
+type TProps = {
     accountCode: string;
     explorerURL: string;
     transactions?: ITransaction[];
     handleExport: () => void;
 };
 
-export const Transactions: FunctionComponent<Props> = ({
+export const Transactions = ({
   accountCode,
   explorerURL,
   transactions,
   handleExport,
-}) => {
+}: TProps) => {
   const { t } = useTranslation();
 
   // We don't support CSV export on Android yet, as it's a tricky to deal with the Downloads

--- a/frontends/web/src/components/update/update.tsx
+++ b/frontends/web/src/components/update/update.tsx
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { load } from '../../decorators/load';
 import { runningInAndroid } from '../../utils/env';
@@ -23,13 +22,13 @@ import { TUpdateFile } from '../../api/version';
 import A from '../anchor/anchor';
 import Status from '../status/status';
 
-interface Props {
+type TProps = {
     file: TUpdateFile | null;
 }
 
 export const updatePath: string = 'https://shiftcrypto.ch/download/?source=bitboxapp';
 
-const Update: FunctionComponent<Props> = ({ file }) => {
+const Update = ({ file }: TProps) => {
   const { t } = useTranslation();
   const downloadElement = <A href={updatePath}>{t('button.download')}</A>;
 
@@ -47,6 +46,6 @@ const Update: FunctionComponent<Props> = ({ file }) => {
   );
 };
 
-const HOC = load<Props>({ file: 'update' })(Update);
+const HOC = load<TProps>({ file: 'update' })(Update);
 
 export { HOC as Update };

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren, ReactNode } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 import { AppLogo } from '../icon';
 import { Footer } from '../layout';
 import { SwissMadeOpenSource } from '../icon/logo';
 import { AnimatedChecked, Close } from '../icon/icon';
 import style from './view.module.css';
 
-type ViewProps = {
+type TViewProps = {
     dialog?: boolean;
     fitContent?: boolean;
     fullscreen?: boolean;
+    children: ReactNode;
     minHeight?: string;
     onClose?: () => void;
     textCenter?: boolean;
@@ -43,7 +44,7 @@ type ViewProps = {
  * @param width can be used to overwrite the default width of the inner area
  * @param withBottomBar enables a footer with some logo and language switch
  */
-export function View({
+export const View = ({
   dialog = false,
   fitContent = false,
   fullscreen,
@@ -53,7 +54,7 @@ export function View({
   textCenter,
   width,
   withBottomBar,
-}: PropsWithChildren<ViewProps>) {
+}: TViewProps) => {
   const containerClasses = `${
     style[fullscreen ? 'fullscreen' : 'fill']
   } ${
@@ -91,9 +92,10 @@ export function View({
       )}
     </div>
   );
-}
+};
 
-type ViewContentProps = {
+type TViewContentProps = {
+    children: ReactNode;
     fullWidth?: boolean;
     minHeight?: string;
     textAlign?: 'center' | 'left';
@@ -107,14 +109,14 @@ type ViewContentProps = {
  * @param textAlign allows overwriting text alignment in the content area
  * @param withIcon supports success icon currently, but could support other icons in the future
  */
-export function ViewContent({
+export const ViewContent = ({
   children,
   fullWidth,
   minHeight,
   textAlign,
   withIcon,
   ...props
-}: PropsWithChildren<ViewContentProps>) {
+}: TViewContentProps) => {
   const align = textAlign ? style[`text-${textAlign}`] : '';
   const containerWidth = fullWidth ? style.fullWidth : '';
   const classes = `${style.content} ${containerWidth} ${align}`;
@@ -129,9 +131,9 @@ export function ViewContent({
       {children}
     </div>
   );
-}
+};
 
-type HeaderProps = {
+type THeaderProps = {
     small?: boolean;
     title: ReactNode;
     withAppLogo?: boolean;
@@ -143,12 +145,12 @@ type HeaderProps = {
  * @param title the title of the view
  * @param withAppLogo if true includes the BitBoxApp logo before the title
  */
-export function ViewHeader({
+export const ViewHeader: FunctionComponent<THeaderProps> = ({
   children,
   small,
   title,
   withAppLogo,
-}: PropsWithChildren<HeaderProps>) {
+}) => {
   const headerStyles = small ? `${style.header} ${style.smallHeader}` : style.header;
   return (
     <header className={headerStyles}>
@@ -157,17 +159,19 @@ export function ViewHeader({
       {children}
     </header>
   );
-}
+};
 
-type ViewButtonsProps = {}
+type TViewButtonsProps = {
+  children: ReactNode;
+}
 
 /**
  * ViewButtons component use as container for buttons
  */
-export function ViewButtons({ children }: PropsWithChildren<ViewButtonsProps>) {
+export const ViewButtons = ({ children }: TViewButtonsProps) => {
   return (
     <div className={style.buttons}>
       {children}
     </div>
   );
-}
+};

--- a/frontends/web/src/routes/account/add/components/coin-dropdown.tsx
+++ b/frontends/web/src/routes/account/add/components/coin-dropdown.tsx
@@ -14,25 +14,24 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from 'react';
 import * as backendAPI from '../../../../api/backend';
 import { Select } from '../../../../components/forms';
 import { translate, TranslateProps } from '../../../../decorators/translate';
 
-interface CoinDropDownProps {
+type TCoinDropDownProps = {
     onChange: (coin: backendAPI.ICoin) => void;
     supportedCoins: backendAPI.ICoin[];
     value: string;
 }
 
-type Props = CoinDropDownProps & TranslateProps;
+type TProps = TCoinDropDownProps & TranslateProps;
 
 function CoinDropDown({
   onChange,
   supportedCoins,
   t,
   value,
-}: PropsWithChildren<Props>) {
+}: TProps) {
   return (
     <Select
       autoFocus

--- a/frontends/web/src/routes/account/add/components/steps.tsx
+++ b/frontends/web/src/routes/account/add/components/steps.tsx
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import { cloneElement, FunctionComponent, PropsWithChildren } from 'react';
+import React, { ReactNode } from 'react';
+import { cloneElement } from 'react';
 import style from './steps.module.css';
 
-interface Props {
-    current: number;
+type TStepsProps = {
+  current: number;
+  children: ReactNode;
 }
 
-export const Steps: FunctionComponent<Props> = ({
+export const Steps = ({
   current,
   children
-}) => {
+}: TStepsProps) => {
   let childrens = React.Children.toArray(children).filter(React.isValidElement) as React.ReactElement[];
   return (
     <div className={style.steps}>
@@ -49,7 +50,8 @@ export const Steps: FunctionComponent<Props> = ({
   );
 };
 
-interface StepProps {
+type TStepProps = {
+    children: ReactNode;
     line?: boolean;
     status?: 'process' | 'finish' | 'wait';
     hidden?: boolean;
@@ -60,7 +62,7 @@ export function Step({
   hidden = false,
   line,
   status = 'wait',
-}: PropsWithChildren<StepProps>) {
+}: TStepProps) {
   if (hidden) {
     return null;
   }

--- a/frontends/web/src/routes/account/info/buyCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyCTA.tsx
@@ -1,4 +1,3 @@
-import { FunctionComponent } from 'react';
 import { route } from '../../../utils/route';
 import { Coin } from '../../../api/account';
 import { Button } from '../../../components/forms';
@@ -6,14 +5,14 @@ import { translate, TranslateProps } from '../../../decorators/translate';
 import { Balances } from '../summary/accountssummary';
 import styles from './buyCTA.module.css';
 
-interface BuyCTAProps {
+type TBuyCTAProps = {
     code?: string;
     unit?: string;
 }
 
-type Props = BuyCTAProps & TranslateProps;
+type TProps = TBuyCTAProps & TranslateProps;
 
-const BuyCTAComponent: FunctionComponent<Props> = ({ code, unit, t }) => {
+const BuyCTAComponent = ({ code, unit, t }: TProps) => {
   const onCTA = () => route(code ? `/buy/info/${code}` : '/buy/info');
   return (
     <div className={`${styles.main} columns-container`}>
@@ -29,7 +28,7 @@ export const BuyCTA = translate()(BuyCTAComponent);
 
 const isBitcoinCoin = (coin: Coin) => (coin === 'BTC') || (coin === 'TBTC');
 
-export const AddBuyOnEmptyBalances: FunctionComponent<{balances?: Balances}> = ({ balances }) => {
+export const AddBuyOnEmptyBalances = ({ balances }: {balances?: Balances}) => {
   if (balances === undefined) {
     return null;
   }

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../../hooks/api';
 import { useEsc } from '../../../hooks/keyboard';
@@ -28,15 +28,15 @@ import { SigningConfiguration } from './signingconfiguration';
 import { BitcoinBasedAccountInfoGuide } from './guide';
 import style from './info.module.css';
 
-type Props = {
+type TProps = {
     accounts: IAccount[];
     code: string;
 };
 
-export const Info: FunctionComponent<Props> = ({
+export const Info = ({
   accounts,
   code,
-}) => {
+}: TProps) => {
   const { t } = useTranslation();
   const info = useLoad(getInfo(code));
   const [viewXPub, setViewXPub] = useState<number>(0);

--- a/frontends/web/src/routes/account/receive/components/bb01paired.tsx
+++ b/frontends/web/src/routes/account/receive/components/bb01paired.tsx
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../../../hooks/api';
 import { hasMobileChannel } from '../../../../api/devices';
 import Status from '../../../../components/status/status';
 
-type Props = {
+type TProps = {
     deviceID: string;
 }
 
-export const PairedWarning: FunctionComponent<Props> = ({
+export const PairedWarning = ({
   deviceID,
-}) => {
+}: TProps) => {
   const { t } = useTranslation();
   const paired = useLoad(hasMobileChannel(deviceID));
   if (paired) {

--- a/frontends/web/src/routes/account/receive/components/verifybutton.tsx
+++ b/frontends/web/src/routes/account/receive/components/verifybutton.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TProductName } from '../../../../api/devices';
 import { Button } from '../../../../components/forms';
@@ -29,16 +28,16 @@ export const useVerifyLabel = (device?: TProductName): string => {
   return t('receive.verify'); // fallback
 };
 
-type Props = JSX.IntrinsicElements['button'] & {
+type TProps = JSX.IntrinsicElements['button'] & {
     device?: TProductName;
     forceVerification: boolean;
 };
 
-export const VerifyButton: FunctionComponent<Props> = ({
+export const VerifyButton = ({
   device,
   forceVerification,
   ...props
-}) => {
+}: TProps) => {
   const { t } = useTranslation();
   const verifyLabel = useVerifyLabel(device);
   return (

--- a/frontends/web/src/routes/account/receive/index.tsx
+++ b/frontends/web/src/routes/account/receive/index.tsx
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { IAccount } from '../../../api/account';
 import { TDevices } from '../../../api/devices';
 import { Receive as ReceiveBB02 } from './receive';
 import { Receive as ReceiveBB01 } from './receive-bb01';
 
-type Props = {
+type TProps = {
   accounts: IAccount[];
   code: string;
   deviceIDs: string[];
   devices: TDevices;
 };
 
-export const Receive: FunctionComponent<Props> = props => {
+export const Receive = (props: TProps) => {
   const {
     devices,
     deviceIDs,

--- a/frontends/web/src/routes/account/receive/receive-bb01.tsx
+++ b/frontends/web/src/routes/account/receive/receive-bb01.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../../hooks/api';
 import { useEsc } from '../../../hooks/keyboard';
@@ -35,7 +35,7 @@ import { PairedWarning } from './components/bb01paired';
 import { useVerifyLabel, VerifyButton } from './components/verifybutton';
 import style from './receive.module.css';
 
-type Props = {
+type TProps = {
   accounts: accountApi.IAccount[];
   code: string;
   deviceID: string;
@@ -58,11 +58,11 @@ const getIndexOfMatchingScriptType = (
   return receiveAddresses.findIndex(addrs => addrs.scriptType !== null && scriptType === addrs.scriptType);
 };
 
-export const Receive: FunctionComponent<Props> = ({
+export const Receive = ({
   accounts,
   code,
   deviceID,
-}) => {
+}: TProps) => {
   const { t } = useTranslation();
   const [verifying, setVerifying] = useState<boolean>(false);
   const [activeIndex, setActiveIndex] = useState<number>(0);

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../../hooks/api';
 import { useEsc } from '../../../hooks/keyboard';
@@ -32,7 +32,7 @@ import { QRCode } from '../../../components/qrcode/qrcode';
 import { ArrowCirlceLeft, ArrowCirlceLeftActive, ArrowCirlceRight, ArrowCirlceRightActive } from '../../../components/icon';
 import style from './receive.module.css';
 
-type Props = {
+type TProps = {
   accounts: accountApi.IAccount[];
   code: string;
   deviceID?: string;
@@ -55,11 +55,11 @@ const getIndexOfMatchingScriptType = (
   return receiveAddresses.findIndex(addrs => addrs.scriptType !== null && scriptType === addrs.scriptType);
 };
 
-export const Receive: FunctionComponent<Props> = ({
+export const Receive = ({
   accounts,
   code,
   deviceID,
-}) => {
+}: TProps) => {
   const { t } = useTranslation();
   const [verifying, setVerifying] = useState<boolean>(false);
   const [activeIndex, setActiveIndex] = useState<number>(0);

--- a/frontends/web/src/routes/account/summary/filters.tsx
+++ b/frontends/web/src/routes/account/summary/filters.tsx
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TChartFiltersProps } from './types';
 import styles from './chart.module.css';
 
-const Filters: FunctionComponent<TChartFiltersProps> = ({
+const Filters = ({
   display,
   disableFilters,
   onDisplayWeek,
   onDisplayMonth,
   onDisplayYear,
   onDisplayAll
-}) => {
+}: TChartFiltersProps) => {
   const { t } = useTranslation();
   return (
     <div className={styles.filters}>

--- a/frontends/web/src/routes/device/bitbox02/components/password-entry/password-entry.tsx
+++ b/frontends/web/src/routes/device/bitbox02/components/password-entry/password-entry.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { createRef, PropsWithChildren, useEffect } from 'react';
+import { createRef, useEffect } from 'react';
 import PasswordGestureVideo from './assets/password-gestures.webm';
 import styles from './password-entry.module.css';
 
-export interface IPasswordEntryProps {}
+
 
 function isVideoPlaying(video: HTMLVideoElement): boolean {
   return video.currentTime > 0 && !video.paused && !video.ended && video.readyState > 2;
@@ -33,7 +33,7 @@ function replayVideo(ref: HTMLVideoElement): void {
   }
 }
 
-export function PasswordEntry({ children }: PropsWithChildren<IPasswordEntryProps>) {
+export const PasswordEntry = () => {
   let ref = createRef<HTMLVideoElement>();
   useEffect(() => {
     if (ref.current) {
@@ -51,8 +51,7 @@ export function PasswordEntry({ children }: PropsWithChildren<IPasswordEntryProp
         height="338"
         width="600">
         <source src={PasswordGestureVideo} type="video/webm" />
-        {children}
       </video>
     </div>
   );
-}
+};

--- a/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
+++ b/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, useCallback, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { TranslateProps } from '../../../decorators/translate';
 import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
 import { Button, ButtonLink } from '../../../components/forms';
@@ -22,12 +22,13 @@ import { checkSDCard } from '../../../api/bitbox02';
 import { useTranslation } from 'react-i18next';
 
 type SDCardCheckProps = {
-    deviceID: string;
+  deviceID: string;
+  children: ReactNode;
 }
 
-type Props = SDCardCheckProps & TranslateProps;
+type TProps = SDCardCheckProps & TranslateProps;
 
-const SDCardCheck: FunctionComponent<Props> = ({ deviceID, children }) => {
+const SDCardCheck = ({ deviceID, children }: TProps) => {
   const { t } = useTranslation();
   const [sdCardInserted, setSdCardInserted] = useState<boolean | undefined>();
   const check = useCallback(() => checkSDCard(deviceID).then(setSdCardInserted), [deviceID]);

--- a/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState, useRef, FunctionComponent } from 'react';
+import { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getDeviceInfo, setDeviceName } from '../../../api/bitbox02';
 import { Button, Input } from '../../../components/forms';
@@ -24,15 +24,15 @@ import { alertUser } from '../../../components/alert/Alert';
 import { SettingsButton } from '../../../components/settingsButton/settingsButton';
 import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
 
-type Props = {
+type TProps = {
     deviceName?: string;
     deviceID: string;
 }
 
-export const SetDeviceName: FunctionComponent<Props> = ({
+export const SetDeviceName = ({
   deviceName,
   deviceID,
-}) => {
+}: TProps) => {
   const { t } = useTranslation();
 
   const [active, setActive] = useState(false);

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { route } from '../../../utils/route';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../../hooks/api';
@@ -34,11 +34,11 @@ import { UpgradeButton } from './upgradebutton';
 import { alertUser } from '../../../components/alert/Alert';
 import { ManageDeviceGuide } from './settings-guide';
 
-type Props = {
+type TProps = {
     deviceID: string;
 }
 
-export const Settings: FunctionComponent<Props> = ({ deviceID }) => {
+export const Settings = ({ deviceID }: TProps) => {
   const { t } = useTranslation();
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo>();
   const [attestation, setAttestation] = useState<boolean | null>(null);

--- a/frontends/web/src/routes/device/deviceswitch.tsx
+++ b/frontends/web/src/routes/device/deviceswitch.tsx
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-import { FunctionComponent } from 'react';
 import { TDevices } from '../../api/devices';
 import BitBox01 from './bitbox01/bitbox01';
 import { BitBox02 } from './bitbox02/bitbox02';
 import { BitBox02Bootloader } from '../../components/devices/bitbox02bootloader/bitbox02bootloader';
 import { Waiting } from './waiting';
 
-interface Props {
+type TProps = {
     devices: TDevices;
     deviceID: string | null;
 }
 
-const DeviceSwitch: FunctionComponent<Props> = ({ deviceID, devices }) => {
+const DeviceSwitch = ({ deviceID, devices }: TProps) => {
   if (deviceID === null || !Object.keys(devices).includes(deviceID)) {
     return <Waiting />;
   }

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import i18n from '../../i18n/i18n';
 import { useLoad } from '../../hooks/api';
@@ -28,7 +28,7 @@ import { debug } from '../../utils/env';
 import { SkipForTesting } from './components/skipfortesting';
 import style from './bitbox01/bitbox01.module.css';
 
-export const Waiting: FunctionComponent = () => {
+export const Waiting = () => {
   const { t } = useTranslation();
   const testing = useLoad(debug ? getTesting : () => Promise.resolve(false));
 

--- a/frontends/web/src/routes/exchanges/exchanges.tsx
+++ b/frontends/web/src/routes/exchanges/exchanges.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, PropsWithChildren } from 'react';
+import { Component, ReactNode } from 'react';
 import A from '../../components/anchor/anchor';
 import { Button } from '../../components/forms/button';
 import { Entry } from '../../components/guide/entry';
@@ -37,7 +37,7 @@ interface State {
     method: Method | null;
 }
 
-interface Exchange extends ExchangeData {
+type TExchange = ExchangeData & {
     hostname?: string;
 }
 
@@ -56,7 +56,7 @@ class Exchanges extends Component<Props, State> {
     };
   }
 
-  private data: Exchange[];
+  private data: TExchange[];
 
   private toggleRegion = (code: Region) => {
     this.setState(({ region }) => ({ region: region !== code ? code : null }));
@@ -157,17 +157,17 @@ class Exchanges extends Component<Props, State> {
   }
 }
 
-interface FilterButtonProps {
+type TFilterButtonProps = {
     active?: boolean;
     onClick: () => void;
-    children: JSX.Element;
+    children: ReactNode;
 }
 
 function FilterButton({
   active = false,
   onClick,
   children,
-}: PropsWithChildren<FilterButtonProps>): JSX.Element {
+}: TFilterButtonProps) {
   return (
     <Button
       primary={active}
@@ -182,7 +182,7 @@ function Row({
   key,
   description,
   hostname,
-}: PropsWithChildren<Exchange>): JSX.Element {
+}: TExchange) {
   return (
     <A
       key={key}

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { ReactChild } from 'react';
 import { Route, Routes, useParams } from 'react-router';
 import { IAccount } from '../api/account';
 import { TDevices } from '../api/devices';
@@ -18,7 +18,7 @@ import { Settings } from './settings/settings';
 import { Passphrase } from './device/bitbox02/passphrase';
 import { Account } from './account/account';
 
-interface Props {
+type TAppRouterProps = {
     devices: TDevices;
     deviceIDs: string[];
     accounts: IAccount[];
@@ -26,12 +26,16 @@ interface Props {
     devicesKey: ((input: string) => string)
 }
 
-const InjectParams: FunctionComponent = ({ children }) => {
+type TInjectParamsProps = {
+  children: ReactChild;
+}
+
+const InjectParams = ({ children }: TInjectParamsProps) => {
   const params = useParams();
   return React.cloneElement(children as React.ReactElement, params);
 };
 
-export const AppRouter: FunctionComponent<Props> = ({ devices, deviceIDs, devicesKey, accounts, activeAccounts }) => {
+export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAccounts }: TAppRouterProps) => {
   const Homepage = <DeviceSwitch
     key={devicesKey('device-switch-default')}
     deviceID={null}

--- a/frontends/web/src/routes/settings/components/fiat/fiat.tsx
+++ b/frontends/web/src/routes/settings/components/fiat/fiat.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import { Fiat } from '../../../../api/account';
 import { Star, StarInactive } from '../../../../components/icon';
 import {
@@ -47,13 +47,13 @@ function setDefault(event: React.SyntheticEvent): void {
   event.preventDefault();
 }
 
-type Props = SharedProps & TranslateProps;
+type TProps = SharedProps & TranslateProps;
 
 function Selection({
   t,
   active,
   selected,
-}: PropsWithChildren<Props>): JSX.Element | null {
+}: TProps) {
   return (
     <div>
       <h3 className="subTitle">{t('fiat.title')}</h3>

--- a/frontends/web/src/utils/markup.tsx
+++ b/frontends/web/src/utils/markup.tsx
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import React, { createElement, FunctionComponent } from 'react';
+import React, { createElement } from 'react';
 
-type MarkupProps = {
+type TMarkupProps = {
     tagName: keyof JSX.IntrinsicElements;
     markup: string;
     key?: string;
@@ -35,7 +35,7 @@ const captureStrongElement = /^(.*)<strong>(.*)<\/strong>(.*)$/;
     <SimpleMarkup tagName="p" markup="foo <strong>bar</strong> baz" />
  * ```
  */
-export function SimpleMarkup({ tagName, markup, ...props }: MarkupProps) {
+export function SimpleMarkup({ tagName, markup, ...props }: TMarkupProps) {
   if (typeof markup !== 'string') {
     return null;
   }
@@ -51,7 +51,7 @@ export function SimpleMarkup({ tagName, markup, ...props }: MarkupProps) {
  * line with the `<SimmpleMarkup>` component.
  */
 
-export const MultilineMarkup: FunctionComponent<MarkupProps> = ({ tagName, markup, ...props }) => {
+export const MultilineMarkup = ({ tagName, markup, ...props }: TMarkupProps) => {
   return <>
     {
       markup.split('\n').map((line: string, i: number) => (

--- a/frontends/web/src/utils/route.tsx
+++ b/frontends/web/src/utils/route.tsx
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, useEffect } from 'react';
+import { useEffect } from 'react';
 import { NavigateFunction, useLocation, useNavigate } from 'react-router';
+
+
+type TProps = { onChange: (() => void) };
 
 let navigate: NavigateFunction | undefined;
 
@@ -27,7 +30,7 @@ export const route = (route: string, replace?: boolean) => {
 };
 
 // This component makes route fn work, and triggers an onChange function
-export const RouterWatcher: FunctionComponent<{onChange: (() => void)}> = ({ onChange }) => {
+export const RouterWatcher = ({ onChange }: TProps) => {
   navigate = useNavigate();
   const { pathname } = useLocation();
   useEffect(() => {


### PR DESCRIPTION
As a part of our refactoring effort in the FE to increase our code's readability and consistency as well as following the best practices and conventions, we'd like to change several things mentioned below for our functional components (FC):

1. If a component optionally accepts children we keep using `FunctionComponent` as we do already (or start to use one when it isn't used yet).

2. If a component does not accept any children we remove `FunctionComponent` and `PropsWithChildren`.

3. Remove return type `JSX.Element` or `JSX.Element | null`.

4. Children's type is mostly `ReactNode`. When component must only have exactly 1 child, the type is `ReactChild`.

Also changed Interface to Type whenever possible.