### PR TITLE
backend/sendtx: don't clear note until the tx was successfully sent

### DIFF
--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -214,8 +214,6 @@ func (account *Account) SendTx() error {
 		return errp.New("No active tx proposal")
 	}
 
-	note := account.BaseAccount.GetAndClearProposedTxNote()
-
 	account.log.Info("Signing and sending transaction")
 	utxos := account.transactions.SpendableOutputs()
 	if err := account.signTransaction(txProposal, utxos, account.coin.Blockchain().TransactionGet); err != nil {
@@ -226,6 +224,8 @@ func (account *Account) SendTx() error {
 	if err := account.coin.Blockchain().TransactionBroadcast(txProposal.Transaction); err != nil {
 		return err
 	}
+
+	note := account.BaseAccount.GetAndClearProposedTxNote()
 	if err := account.SetTxNote(txProposal.Transaction.TxHash().String(), note); err != nil {
 		// Not critical.
 		account.log.WithError(err).Error("Failed to save transaction note when sending a tx")

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -587,8 +587,6 @@ func (account *Account) SendTx() error {
 		return errp.New("No active tx proposal")
 	}
 
-	note := account.BaseAccount.GetAndClearProposedTxNote()
-
 	account.log.Info("Signing and sending transaction")
 	if err := account.Config().Keystore.SignTransaction(txProposal); err != nil {
 		return err
@@ -602,6 +600,8 @@ func (account *Account) SendTx() error {
 	if err := account.storePendingOutgoingTransaction(txProposal.Tx); err != nil {
 		return err
 	}
+
+	note := account.BaseAccount.GetAndClearProposedTxNote()
 	if err := account.SetTxNote(txProposal.Tx.Hash().Hex(), note); err != nil {
 		// Not critical.
 		account.log.WithError(err).Error("Failed to save transaction note when sending a tx")


### PR DESCRIPTION
Bug: the note proposal in the send screen was cleared when send-tx is invoked before signing. If signing can be aborted, e.g. on a BitBox02, the note is wrongly cleared in the backend, while it is still present in the frontend sendtx form.

Solution: clear the note right before assigning it to the tx after successful broadcast.