### PR TITLE
backend/eth: return ErrInsufficientFunds if gas estimation failed

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -31,6 +31,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/db"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/erc20"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/etherscan"
 	ethtypes "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
@@ -514,6 +515,9 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (*TxProposal, error
 	}
 	gasLimit, err := account.coin.client.EstimateGas(context.TODO(), message)
 	if err != nil {
+		if strings.Contains(err.Error(), etherscan.ERC20GasErr) {
+			return nil, errp.WithStack(errors.ErrInsufficientFunds)
+		}
 		account.log.WithError(err).Error("Could not estimate the gas limit.")
 		return nil, errp.WithStack(errors.TxValidationError(err.Error()))
 	}


### PR DESCRIPTION
Similar to 7a25ac8720989b2215806f802e42d5bf1ccc263a.

EtherScan returns this error during when estimating the gas if there are not enough funds to pay for the transaction.

This is likely a change in behavior in Etherscan, as the check below `// Check that the entered value and the estimated fee are not greater than the balance.` used to work. We keep that code in case we move away from Etherscan or Etherscan changes the behavior and returns a gas  anyway.

This is not a robust check as it compares strings, but it is the best we can do for now.