### PR TITLE
frontend: improve dialog on mobile

### DIFF
--- a/frontends/web/src/components/confirm/Confirm.tsx
+++ b/frontends/web/src/components/confirm/Confirm.tsx
@@ -60,10 +60,8 @@ export const Confirm = () => {
   };
 
   const { message, active, customButtonText } = state;
-  if (!active) {
-    return null;
-  }
-  return <Dialog title={t('dialog.confirmTitle')} onClose={() => respond(false)}>
+
+  return <Dialog open={active} title={t('dialog.confirmTitle')} onClose={() => respond(false)}>
     <div className="columnsContainer half">
       <div className="columns">
         <div className="column">
@@ -79,6 +77,7 @@ export const Confirm = () => {
         </div>
       </div>
     </div>
+
     <DialogButtons>
       <Button primary onClick={() => respond(true)}>{customButtonText ? customButtonText : t('dialog.confirm')}</Button>
       <Button transparent onClick={() => respond(false)}>{t('dialog.cancel')}</Button>

--- a/frontends/web/src/components/dialog/dialog.module.css
+++ b/frontends/web/src/components/dialog/dialog.module.css
@@ -8,13 +8,12 @@
     left: 0;
     height: 100%;
     width: 100%;
-    background-color: var(--bg-transparent-dark);
+    background: transparent;
     z-index: 4010;
-    opacity: 0;
 }
 
 .overlay.activeOverlay {
-    opacity: 1;
+    background-color: var(--bg-transparent-dark);
 }
 
 .modal {
@@ -26,14 +25,7 @@
     text-align: left;
     max-height: 100vh;
     overflow: auto;
-    opacity: 0;
 }
-
-.modal.activeModal {
-    opacity: 1;
-}
-
-.active {}
 
 .modal.small {
     max-width: 340px;
@@ -236,9 +228,34 @@
     width: 100%;
 }
 
+@media (min-width: 769px) {
+    .closingOverlay {
+        display: none;
+    }
+}
+
 @media (max-width: 768px) {
+
+    .header .title{
+        font-size: var(--header-default-font-size);
+    }
+
     .modal {
         padding: 0;
+    }
+
+    .modal, .modal.small, .modal.medium, .modal.large{
+        max-width: 100vw;
+        height: 100vh;
+        transform: translateY(100vh);
+        transition: transform 300ms;
+        border-top-right-radius: var(--space-half);
+        border-top-left-radius: var(--space-half);
+    }
+
+    .modal.open {
+      transition: transform 300ms;
+      transform: translateY(0);
     }
 
     .contentContainer.padded {

--- a/frontends/web/src/components/language/language.tsx
+++ b/frontends/web/src/components/language/language.tsx
@@ -19,8 +19,8 @@ import { useState } from 'react';
 import { i18n as Ii18n } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { Dialog } from '../dialog/dialog';
-import style from './language.module.css';
 import { TActiveLanguageCodes, TLanguagesList } from './types';
+import style from './language.module.css';
 
 type TLanguageSwitchProps = {
     languages?: TLanguagesList;
@@ -113,44 +113,40 @@ const LanguageSwitch = ({ languages }: TLanguageSwitchProps) => {
         </svg>
         {allLanguages[selectedIndex].code === 'en' ? 'Other languages' : 'English'}
       </button>
-      {
-        activeDialog && (
-          <Dialog small slim title={t('language.title')} onClose={() => setActiveDialog(false)}>
-            {
-              allLanguages.map((language, i) => {
-                const selected = selectedIndex === i;
-                return (
-                  <button
-                    key={language.code}
-                    className={[style.language, selected ? style.selected : ''].join(' ')}
-                    onClick={() => changeLanguage(language.code, i)}
-                    data-testid={`language-selection-${language.code}`}
-                  >
-                    {language.display}
-                    {
-                      selected && (
-                        <svg
-                          className={style.checked}
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="24"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round">
-                          <polyline points="20 6 9 17 4 12" />
-                        </svg>
-                      )
-                    }
-                  </button>
-                );
-              })
-            }
-          </Dialog>
-        )
-      }
+      <Dialog small slim title={t('language.title')} onClose={() => setActiveDialog(false)} open={activeDialog}>
+        {
+          allLanguages.map((language, i) => {
+            const selected = selectedIndex === i;
+            return (
+              <button
+                key={language.code}
+                className={[style.language, selected ? style.selected : ''].join(' ')}
+                onClick={() => changeLanguage(language.code, i)}
+                data-testid={`language-selection-${language.code}`}
+              >
+                {language.display}
+                {
+                  selected && (
+                    <svg
+                      className={style.checked}
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round">
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  )
+                }
+              </button>
+            );
+          })
+        }
+      </Dialog>
     </div>
   );
 };

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -222,197 +222,197 @@ class Transaction extends Component<Props, State> {
             </div>
           </div>
         </div>
-        {
-          transactionDialog && transactionInfo && (
-            // Amount and Confirmations info are displayed using props data instead of transactionInfo
-            // because they are live updated
-            <Dialog title="Transaction Details" onClose={this.hideDetails} slim medium>
-              <form onSubmit={this.handleEdit} className={style.detailInput}>
-                <label htmlFor="note">{t('note.title')}</label>
-                <Input
-                  align="right"
-                  autoFocus={editMode}
-                  className={style.textOnlyInput}
-                  readOnly={!editMode}
-                  type="text"
-                  id="note"
-                  transparent
-                  placeholder={t('note.input.placeholder')}
-                  value={newNote}
-                  maxLength={256}
-                  onInput={this.handleNoteInput}
-                  ref={this.input}/>
-                <button
-                  className={style.editButton}
-                  onClick={this.handleEdit}
-                  title={t(`transaction.note.${editMode ? 'save' : 'edit'}`)}
-                  type="button"
-                  ref={this.editButton}>
-                  {editMode ? <Save /> : <Edit />}
-                </button>
-              </form>
-              <div className={style.detail}>
-                <label>{t('transaction.details.type')}</label>
-                <p>{arrow}</p>
-              </div>
-              <div className={style.detail}>
-                <label>{t('transaction.confirmation')}</label>
-                <p>{numConfirmations}</p>
-              </div>
-              <div className={style.detail}>
-                <label>{t('transaction.details.status')}</label>
-                <p className="flex flex-items-center">
-                  <ProgressRing
-                    className="m-right-quarter"
-                    width={14}
-                    value={progress}
-                    isComplete={numConfirmations >= numConfirmationsComplete}
-                  />
-                  <span className={style.status}>
-                    {statusText} {
-                      status === 'pending' && (
-                        <span>({numConfirmations}/{numConfirmationsComplete})</span>
-                      )
-                    }
-                  </span>
-                </p>
-              </div>
-              <div className={style.detail}>
-                <label>{t('transaction.details.date')}</label>
-                <p>{sDate}</p>
-              </div>
-              <div className={style.detail}>
-                <label>{t('transaction.details.fiat')}</label>
-                <p>
-                  <span className={`${style.fiat} ${typeClassName}`}>
-                    <FiatConversion amount={amount} sign={sign} noAction />
-                  </span>
-                </p>
-              </div>
-              <div className={style.detail}>
-                <label>{t('transaction.details.fiatAtTime')}</label>
-                <p>
-                  <span className={`${style.fiat} ${typeClassName}`}>
-                    { transactionInfo.amountAtTime ?
-                      <FiatConversion amount={transactionInfo.amountAtTime} sign={sign} noAction />
-                      :
-                      <FiatConversion noAction />
-                    }
-                  </span>
-                </p>
-              </div>
-              <div className={style.detail}>
-                <label>{t('transaction.details.amount')}</label>
-                <p className={typeClassName}>
-                  <span className={style.amount}>{sign}{amount.amount}</span>
-                  {' '}
-                  <span className={style.currencyUnit}>{transactionInfo.amount.unit}</span>
-                </p>
-              </div>
-              <div className={style.detail}>
-                <label>{t('transaction.fee')}</label>
-                {
-                  transactionInfo.fee && transactionInfo.fee.amount ? (
-                    <p title={feeRatePerKb.amount ? feeRatePerKb.amount + ' ' + feeRatePerKb.unit + '/Kb' : ''}>
-                      {transactionInfo.fee.amount}
-                      {' '}
-                      <span className={style.currencyUnit}>{transactionInfo.fee.unit}</span>
-                    </p>
-                  ) : (
-                    <p>---</p>
-                  )
-                }
-              </div>
-              <div className={[style.detail, style.addresses].join(' ')}>
-                <label>{t('transaction.details.address')}</label>
-                <div className={style.detailAddresses}>
-                  { transactionInfo.addresses.map((address) => (
-                    <CopyableInput
-                      key={address}
-                      alignRight
-                      borderLess
-                      flexibleHeight
-                      className={style.detailAddress}
-                      value={address} />
-                  )) }
-                </div>
-              </div>
+        {/*
+            Amount and Confirmations info are displayed using props data
+            instead of transactionInfo because they are live updated.
+          */}
+        <Dialog open={transactionDialog} title="Transaction Details" onClose={this.hideDetails} slim medium>
+          {transactionInfo && <>
+            <form onSubmit={this.handleEdit} className={style.detailInput}>
+              <label htmlFor="note">{t('note.title')}</label>
+              <Input
+                align="right"
+                autoFocus={editMode}
+                className={style.textOnlyInput}
+                readOnly={!editMode}
+                type="text"
+                id="note"
+                transparent
+                placeholder={t('note.input.placeholder')}
+                value={newNote}
+                maxLength={256}
+                onInput={this.handleNoteInput}
+                ref={this.input}/>
+              <button
+                className={style.editButton}
+                onClick={this.handleEdit}
+                title={t(`transaction.note.${editMode ? 'save' : 'edit'}`)}
+                type="button"
+                ref={this.editButton}>
+                {editMode ? <Save /> : <Edit />}
+              </button>
+            </form>
+            <div className={style.detail}>
+              <label>{t('transaction.details.type')}</label>
+              <p>{arrow}</p>
+            </div>
+            <div className={style.detail}>
+              <label>{t('transaction.confirmation')}</label>
+              <p>{numConfirmations}</p>
+            </div>
+            <div className={style.detail}>
+              <label>{t('transaction.details.status')}</label>
+              <p className="flex flex-items-center">
+                <ProgressRing
+                  className="m-right-quarter"
+                  width={14}
+                  value={progress}
+                  isComplete={numConfirmations >= numConfirmationsComplete}
+                />
+                <span className={style.status}>
+                  {statusText} {
+                    status === 'pending' && (
+                      <span>({numConfirmations}/{numConfirmationsComplete})</span>
+                    )
+                  }
+                </span>
+              </p>
+            </div>
+            <div className={style.detail}>
+              <label>{t('transaction.details.date')}</label>
+              <p>{sDate}</p>
+            </div>
+            <div className={style.detail}>
+              <label>{t('transaction.details.fiat')}</label>
+              <p>
+                <span className={`${style.fiat} ${typeClassName}`}>
+                  <FiatConversion amount={amount} sign={sign} noAction />
+                </span>
+              </p>
+            </div>
+            <div className={style.detail}>
+              <label>{t('transaction.details.fiatAtTime')}</label>
+              <p>
+                <span className={`${style.fiat} ${typeClassName}`}>
+                  { transactionInfo.amountAtTime ?
+                    <FiatConversion amount={transactionInfo.amountAtTime} sign={sign} noAction />
+                    :
+                    <FiatConversion noAction />
+                  }
+                </span>
+              </p>
+            </div>
+            <div className={style.detail}>
+              <label>{t('transaction.details.amount')}</label>
+              <p className={typeClassName}>
+                <span className={style.amount}>{sign}{amount.amount}</span>
+                {' '}
+                <span className={style.currencyUnit}>{transactionInfo.amount.unit}</span>
+              </p>
+            </div>
+            <div className={style.detail}>
+              <label>{t('transaction.fee')}</label>
               {
-                transactionInfo.gas ? (
-                  <div className={style.detail}>
-                    <label>{t('transaction.gas')}</label>
-                    <p>{transactionInfo.gas}</p>
-                  </div>
-                ) : null
+                transactionInfo.fee && transactionInfo.fee.amount ? (
+                  <p title={feeRatePerKb.amount ? feeRatePerKb.amount + ' ' + feeRatePerKb.unit + '/Kb' : ''}>
+                    {transactionInfo.fee.amount}
+                    {' '}
+                    <span className={style.currencyUnit}>{transactionInfo.fee.unit}</span>
+                  </p>
+                ) : (
+                  <p>---</p>
+                )
               }
-              {
-                transactionInfo.nonce !== null ? (
-                  <div className={style.detail}>
-                    <label>Nonce</label>
-                    <p>{transactionInfo.nonce}</p>
-                  </div>
-                ) : null
-              }
-              {
-                transactionInfo.weight ? (
-                  <div className={style.detail}>
-                    <label>{t('transaction.weight')}</label>
-                    <p>
-                      {transactionInfo.weight}
-                      {' '}
-                      <span className={style.currencyUnit}>WU</span>
-                    </p>
-                  </div>
-                ) : null
-              }
-              {
-                transactionInfo.vsize ? (
-                  <div className={style.detail}>
-                    <label>{t('transaction.vsize')}</label>
-                    <p>
-                      {transactionInfo.vsize}
-                      {' '}
-                      <span className={style.currencyUnit}>b</span>
-                    </p>
-                  </div>
-                ) : null
-              }
-              {
-                transactionInfo.size ? (
-                  <div className={style.detail}>
-                    <label>{t('transaction.size')}</label>
-                    <p>
-                      {transactionInfo.size}
-                      {' '}
-                      <span className={style.currencyUnit}>b</span>
-                    </p>
-                  </div>
-                ) : null
-              }
-              <div className={[style.detail, style.addresses].join(' ')}>
-                <label>{t('transaction.explorer')}</label>
-                <div className={style.detailAddresses}>
+            </div>
+            <div className={[style.detail, style.addresses].join(' ')}>
+              <label>{t('transaction.details.address')}</label>
+              <div className={style.detailAddresses}>
+                { transactionInfo.addresses.map((address) => (
                   <CopyableInput
+                    key={address}
                     alignRight
                     borderLess
                     flexibleHeight
                     className={style.detailAddress}
-                    value={transactionInfo.txID} />
+                    value={address} />
+                )) }
+              </div>
+            </div>
+            {
+              transactionInfo.gas ? (
+                <div className={style.detail}>
+                  <label>{t('transaction.gas')}</label>
+                  <p>{transactionInfo.gas}</p>
                 </div>
+              ) : null
+            }
+            {
+              transactionInfo.nonce !== null ? (
+                <div className={style.detail}>
+                  <label>Nonce</label>
+                  <p>{transactionInfo.nonce}</p>
+                </div>
+              ) : null
+            }
+            {
+              transactionInfo.weight ? (
+                <div className={style.detail}>
+                  <label>{t('transaction.weight')}</label>
+                  <p>
+                    {transactionInfo.weight}
+                    {' '}
+                    <span className={style.currencyUnit}>WU</span>
+                  </p>
+                </div>
+              ) : null
+            }
+            {
+              transactionInfo.vsize ? (
+                <div className={style.detail}>
+                  <label>{t('transaction.vsize')}</label>
+                  <p>
+                    {transactionInfo.vsize}
+                    {' '}
+                    <span className={style.currencyUnit}>b</span>
+                  </p>
+                </div>
+              ) : null
+            }
+            {
+              transactionInfo.size ? (
+                <div className={style.detail}>
+                  <label>{t('transaction.size')}</label>
+                  <p>
+                    {transactionInfo.size}
+                    {' '}
+                    <span className={style.currencyUnit}>b</span>
+                  </p>
+                </div>
+              ) : null
+            }
+            <div className={[style.detail, style.addresses].join(' ')}>
+              <label>{t('transaction.explorer')}</label>
+              <div className={style.detailAddresses}>
+                <CopyableInput
+                  alignRight
+                  borderLess
+                  flexibleHeight
+                  className={style.detailAddress}
+                  value={transactionInfo.txID} />
               </div>
-              <div className={[style.detail, 'flex-center'].join(' ')}>
-                <p>
-                  <A
-                    className={style.externalLink}
-                    href={explorerURL + transactionInfo.txID}
-                    title={t('transaction.explorerTitle') + '\n' + explorerURL + transactionInfo.txID}>
-                    {t('transaction.explorerTitle')}
-                  </A>
-                </p>
-              </div>
-            </Dialog>
-          )
-        }
+            </div>
+            <div className={[style.detail, 'flex-center'].join(' ')}>
+              <p>
+                <A
+                  className={style.externalLink}
+                  href={explorerURL + transactionInfo.txID}
+                  title={t('transaction.explorerTitle') + '\n' + explorerURL + transactionInfo.txID}>
+                  {t('transaction.explorerTitle')}
+                </A>
+              </p>
+            </div>
+          </> }
+        </Dialog>
       </div>
     );
   }

--- a/frontends/web/src/hooks/matchmedia.ts
+++ b/frontends/web/src/hooks/matchmedia.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2022 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+
+const getMatches = (query: string): boolean => window.matchMedia(query).matches;
+
+export const useMatchMedia = (query: string): boolean => {
+  const [matches, setMatches] = useState<boolean>(getMatches(query));
+
+  useEffect(() => {
+    const handleChange = () => {
+      setMatches(getMatches(query));
+    };
+    const matchMedia = window.matchMedia(query);
+    handleChange();
+    matchMedia.addEventListener('change', handleChange);
+    return () => {
+      matchMedia.removeEventListener('change', handleChange);
+    };
+  }, [query]);
+
+  return matches;
+};

--- a/frontends/web/src/routes/account/receive/receive-bb01.tsx
+++ b/frontends/web/src/routes/account/receive/receive-bb01.tsx
@@ -201,16 +201,16 @@ export const Receive = ({
                       {t('receive.changeScriptType')}
                     </button>
                   )}
-                  { hasManyScriptTypes && addressDialog && (
-                    <form onSubmit={e => {
-                      e.preventDefault();
-                      setActiveIndex(0);
-                      setAddressType(addressDialog.addressType);
-                      setAddressDialog(undefined);
-                    }}>
-                      <Dialog medium title={t('receive.changeScriptType')} >
-                        {availableScriptTypes.current && availableScriptTypes.current.map((scriptType, i) => (
-                          <div key={scriptType}>
+                  <form onSubmit={e => {
+                    e.preventDefault();
+                    setActiveIndex(0);
+                    setAddressType(addressDialog ? addressDialog?.addressType : addressType);
+                    setAddressDialog(undefined);
+                  }}>
+                    <Dialog open={(!!addressDialog)} medium title={t('receive.changeScriptType')} >
+                      {availableScriptTypes.current && availableScriptTypes.current.map((scriptType, i) => (
+                        <div key={scriptType}>
+                          {addressDialog && <>
                             <Radio
                               checked={addressDialog.addressType === i}
                               id={scriptType}
@@ -224,16 +224,16 @@ export const Receive = ({
                                 {t('receive.taprootWarning')}
                               </Message>
                             )}
-                          </div>
-                        ))}
-                        <DialogButtons>
-                          <Button primary type="submit">
-                            {t('button.done')}
-                          </Button>
-                        </DialogButtons>
-                      </Dialog>
-                    </form>
-                  )}
+                          </>}
+                        </div>
+                      ))}
+                      <DialogButtons>
+                        <Button primary type="submit">
+                          {t('button.done')}
+                        </Button>
+                      </DialogButtons>
+                    </Dialog>
+                  </form>
                   <div className="buttons">
                     <VerifyButton
                       device="bitbox"
@@ -249,12 +249,13 @@ export const Receive = ({
                   { forceVerification && verifying && (
                     <div className={style.hide}></div>
                   )}
-                  { account && forceVerification && verifying && (
-                    <Dialog
-                      title={verifyLabel}
-                      disableEscape={true}
-                      medium centered>
-                      <div className="text-center">
+                  <Dialog
+                    open={((!!account) && forceVerification && verifying)}
+                    title={verifyLabel}
+                    disableEscape={true}
+                    medium centered>
+                    <div className="text-center">
+                      {account && <>
                         { isEthereumBased(account.coinCode) && (
                           <p>
                             <strong>
@@ -267,12 +268,12 @@ export const Receive = ({
                         )}
                         <QRCode data={uriPrefix + address} />
                         <p>{t('receive.verifyInstruction')}</p>
-                      </div>
-                      <div className="m-bottom-half">
-                        <CopyableInput value={address} flexibleHeight />
-                      </div>
-                    </Dialog>
-                  )}
+                      </>}
+                    </div>
+                    <div className="m-bottom-half">
+                      <CopyableInput value={address} flexibleHeight />
+                    </div>
+                  </Dialog>
                 </div>
               )}
             </div>

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -69,6 +69,7 @@ export const Receive = ({
   const [currentAddresses, setCurrentAddresses] = useState<accountApi.IReceiveAddress[]>();
   const [currentAddressIndex, setCurrentAddressIndex] = useState<number>(0);
 
+
   const account = accounts.find(({ code: accountCode }) => accountCode === code);
 
   // first array index: address types. second array index: unused addresses of that address type.
@@ -95,6 +96,15 @@ export const Receive = ({
       setCurrentAddresses(receiveAddresses[addressIndex].addresses);
     }
   }, [addressType, availableScriptTypes, receiveAddresses]);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    if (addressDialog) {
+      e.preventDefault();
+      setActiveIndex(0);
+      setAddressType(addressDialog.addressType);
+      setAddressDialog(undefined);
+    }
+  };
 
   const verifyAddress = (addressesIndex: number) => {
     if (receiveAddresses) {
@@ -190,16 +200,11 @@ export const Receive = ({
                       {t('receive.changeScriptType')}
                     </button>
                   )}
-                  { hasManyScriptTypes && addressDialog && (
-                    <form onSubmit={e => {
-                      e.preventDefault();
-                      setActiveIndex(0);
-                      setAddressType(addressDialog.addressType);
-                      setAddressDialog(undefined);
-                    }}>
-                      <Dialog medium title={t('receive.changeScriptType')} >
-                        {availableScriptTypes.current && availableScriptTypes.current.map((scriptType, i) => (
-                          <div key={scriptType}>
+                  <form onSubmit={handleSubmit}>
+                    <Dialog open={!!(addressDialog && hasManyScriptTypes)} medium title={t('receive.changeScriptType')} >
+                      {availableScriptTypes.current && availableScriptTypes.current.map((scriptType, i) => (
+                        <div key={scriptType}>
+                          {addressDialog && <>
                             <Radio
                               checked={addressDialog.addressType === i}
                               id={scriptType}
@@ -213,16 +218,17 @@ export const Receive = ({
                                 {t('receive.taprootWarning')}
                               </Message>
                             )}
-                          </div>
-                        ))}
-                        <DialogButtons>
-                          <Button primary type="submit">
-                            {t('button.done')}
-                          </Button>
-                        </DialogButtons>
-                      </Dialog>
-                    </form>
-                  )}
+                          </>
+                          }
+                        </div>
+                      ))}
+                      <DialogButtons>
+                        <Button primary type="submit">
+                          {t('button.done')}
+                        </Button>
+                      </DialogButtons>
+                    </Dialog>
+                  </form>
                   <div className="buttons">
                     <Button
                       disabled={verifying}
@@ -240,11 +246,12 @@ export const Receive = ({
                   { verifying && (
                     <div className={style.hide}></div>
                   )}
-                  { account && verifying && (
-                    <Dialog
-                      title={t('receive.verifyBitBox02')}
-                      disableEscape={true}
-                      medium centered>
+                  <Dialog
+                    open={!!(account && verifying)}
+                    title={t('receive.verifyBitBox02')}
+                    disableEscape={true}
+                    medium centered>
+                    {account && <>
                       <div className="text-center">
                         { isEthereumBased(account.coinCode) && (
                           <p>
@@ -262,8 +269,8 @@ export const Receive = ({
                       <div className="m-bottom-half">
                         <CopyableInput value={address} flexibleHeight />
                       </div>
-                    </Dialog>
-                  )}
+                    </>}
+                  </Dialog>
                 </div>
               )}
             </div>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -852,28 +852,25 @@ class Send extends Component<Props, State> {
               </WaitDialog>
             )
           }
-          {
-            activeScanQR && (
-              <Dialog
-                title={t('send.scanQR')}
-                onClose={this.toggleScanQR}>
-                {videoLoading && <Spinner />}
-                <video
-                  id="video"
-                  width={400}
-                  height={300 /* fix height to avoid ugly resize effect after open */}
-                  className={style.qrVideo}
-                  onLoadedData={this.handleVideoLoad} />
-                <div className={['buttons', 'flex', 'flex-row', 'flex-between'].join(' ')}>
-                  <Button
-                    secondary
-                    onClick={this.toggleScanQR}>
-                    {t('button.back')}
-                  </Button>
-                </div>
-              </Dialog>
-            )
-          }
+          <Dialog
+            open={activeScanQR}
+            title={t('send.scanQR')}
+            onClose={this.toggleScanQR}>
+            {videoLoading && <Spinner />}
+            <video
+              id="video"
+              width={400}
+              height={300 /* fix height to avoid ugly resize effect after open */}
+              className={style.qrVideo}
+              onLoadedData={this.handleVideoLoad} />
+            <div className={['buttons', 'flex', 'flex-row', 'flex-between'].join(' ')}>
+              <Button
+                secondary
+                onClick={this.toggleScanQR}>
+                {t('button.back')}
+              </Button>
+            </div>
+          </Dialog>
         </div>
         <Guide>
           <Entry key="guide.send.whyFee" entry={t('guide.send.whyFee')} />

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -161,11 +161,8 @@ export class UTXOsClass extends Component<Props, State> {
 
   public render() {
     const { t, active, onClose } = this.props;
-    if (!active) {
-      return null;
-    }
     return (
-      <Dialog title={t('send.coincontrol.title')} large onClose={onClose}>
+      <Dialog open={active} title={t('send.coincontrol.title')} large onClose={onClose}>
         <div>
           { accountApi.allScriptTypes.map(this.renderUTXOs) }
           <div className="buttons text-center m-top-none m-bottom-half">

--- a/frontends/web/src/routes/device/bitbox01/check.jsx
+++ b/frontends/web/src/routes/device/bitbox01/check.jsx
@@ -92,40 +92,37 @@ class Check extends Component {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.check')}
         </Button>
-        {
-          activeDialog && (
-            <Dialog
-              title={t('backup.check.title')}
-              onClose={this.abort}>
-              { message ? (
-                <div>
-                  <p style={{ minHeight: '3rem' }}>{message}</p>
-                  <div className={style.actions}>
-                    <Button transparent onClick={this.abort}>
-                      {t('button.back')}
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <form onSubmit={this.check}>
-                  <PasswordSingleInput
-                    label={t('backup.check.password.label')}
-                    placeholder={t('backup.check.password.placeholder')}
-                    showLabel={t('backup.check.password.showLabel')}
-                    onValidPassword={this.setValidPassword} />
-                  <div className={style.actions}>
-                    <Button type="submit" primary disabled={!this.validate()}>
-                      {t('button.check')}
-                    </Button>
-                    <Button transparent onClick={this.abort}>
-                      {t('button.back')}
-                    </Button>
-                  </div>
-                </form>
-              )}
-            </Dialog>
-          )
-        }
+        <Dialog
+          open={activeDialog}
+          title={t('backup.check.title')}
+          onClose={this.abort}>
+          { message ? (
+            <div>
+              <p style={{ minHeight: '3rem' }}>{message}</p>
+              <div className={style.actions}>
+                <Button transparent onClick={this.abort}>
+                  {t('button.back')}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={this.check}>
+              <PasswordSingleInput
+                label={t('backup.check.password.label')}
+                placeholder={t('backup.check.password.placeholder')}
+                showLabel={t('backup.check.password.showLabel')}
+                onValidPassword={this.setValidPassword} />
+              <div className={style.actions}>
+                <Button type="submit" primary disabled={!this.validate()}>
+                  {t('button.check')}
+                </Button>
+                <Button transparent onClick={this.abort}>
+                  {t('button.back')}
+                </Button>
+              </div>
+            </form>
+          )}
+        </Dialog>
       </div>
     );
   }

--- a/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
+++ b/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
@@ -89,23 +89,19 @@ class UpgradeFirmware extends Component {
             </SettingsButton>
           )
         }
-        {
-          activeDialog && (
-            <Dialog title={t('upgradeFirmware.title')}>
-              <p className="m-top-none">{t('upgradeFirmware.description', {
-                currentVersion, newVersion
-              })}</p>
-              <DialogButtons>
-                <Button primary onClick={this.upgradeFirmware}>
-                  {t('button.upgrade')}
-                </Button>
-                <Button transparent onClick={this.abort}>
-                  {t('button.back')}
-                </Button>
-              </DialogButtons>
-            </Dialog>
-          )
-        }
+        <Dialog open={activeDialog} title={t('upgradeFirmware.title')}>
+          <p className="m-top-none">{t('upgradeFirmware.description', {
+            currentVersion, newVersion
+          })}</p>
+          <DialogButtons>
+            <Button primary onClick={this.upgradeFirmware}>
+              {t('button.upgrade')}
+            </Button>
+            <Button transparent onClick={this.abort}>
+              {t('button.back')}
+            </Button>
+          </DialogButtons>
+        </Dialog>
         {
           isConfirming && (
             <WaitDialog title={t('upgradeFirmware.title')} includeDefault={!unlocked}>

--- a/frontends/web/src/routes/device/bitbox01/create.jsx
+++ b/frontends/web/src/routes/device/bitbox01/create.jsx
@@ -86,38 +86,35 @@ class Create extends Component {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.create')}
         </Button>
-        {
-          activeDialog && (
-            <Dialog
-              title={t('backup.create.title')}
-              onClose={this.abort}>
-              <form onSubmit={this.create}>
-                <Input
-                  autoFocus
-                  id="backupName"
-                  label={t('backup.create.name.label')}
-                  placeholder={t('backup.create.name.placeholder')}
-                  onInput={this.handleFormChange}
-                  value={backupName} />
-                <p>{t('backup.create.info')}</p>
-                <PasswordInput
-                  id="recoveryPassword"
-                  label={t('backup.create.password.label')}
-                  placeholder={t('backup.create.password.placeholder')}
-                  onInput={this.handleFormChange}
-                  value={recoveryPassword} />
-                <div className={style.actions}>
-                  <Button type="submit" primary disabled={waiting || !this.validate()}>
-                    {t('button.create')}
-                  </Button>
-                  <Button transparent onClick={this.abort}>
-                    {t('button.abort')}
-                  </Button>
-                </div>
-              </form>
-            </Dialog>
-          )
-        }
+        <Dialog
+          open={activeDialog}
+          title={t('backup.create.title')}
+          onClose={this.abort}>
+          <form onSubmit={this.create}>
+            <Input
+              autoFocus
+              id="backupName"
+              label={t('backup.create.name.label')}
+              placeholder={t('backup.create.name.placeholder')}
+              onInput={this.handleFormChange}
+              value={backupName} />
+            <p>{t('backup.create.info')}</p>
+            <PasswordInput
+              id="recoveryPassword"
+              label={t('backup.create.password.label')}
+              placeholder={t('backup.create.password.placeholder')}
+              onInput={this.handleFormChange}
+              value={recoveryPassword} />
+            <div className={style.actions}>
+              <Button type="submit" primary disabled={waiting || !this.validate()}>
+                {t('button.create')}
+              </Button>
+              <Button transparent onClick={this.abort}>
+                {t('button.abort')}
+              </Button>
+            </div>
+          </form>
+        </Dialog>
       </div>
     );
   }

--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -134,45 +134,42 @@ class Restore extends Component<Props, State> {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.restore')}
         </Button>
-        {
-          activeDialog && (
-            <Dialog
-              title={t('backup.restore.title')}
-              disableEscape={isConfirming || isLoading}
-              onClose={this.abort}>
-              <form onSubmit={this.restore}>
-                <PasswordRepeatInput
-                  label={t('backup.restore.password.label')}
-                  placeholder={t('backup.restore.password.placeholder')}
-                  repeatPlaceholder={t('backup.restore.password.repeatPlaceholder')}
-                  showLabel={t('backup.restore.password.showLabel')}
-                  onValidPassword={this.setValidPassword} />
-                <div className={style.agreements}>
-                  <Checkbox
-                    id="funds_access"
-                    label={t('backup.restore.understand')}
-                    checked={understand}
-                    onChange={this.handleUnderstandChange} />
-                </div>
-                <DialogButtons>
-                  <Button
-                    type="submit"
-                    danger={requireConfirmation}
-                    primary={!requireConfirmation}
-                    disabled={!understand || !this.validate() || isConfirming}>
-                    {t('button.restore')}
-                  </Button>
-                  <Button
-                    transparent
-                    onClick={this.abort}
-                    disabled={isConfirming}>
-                    {t('button.back')}
-                  </Button>
-                </DialogButtons>
-              </form>
-            </Dialog>
-          )
-        }
+        <Dialog
+          open={activeDialog}
+          title={t('backup.restore.title')}
+          disableEscape={isConfirming || isLoading}
+          onClose={this.abort}>
+          <form onSubmit={this.restore}>
+            <PasswordRepeatInput
+              label={t('backup.restore.password.label')}
+              placeholder={t('backup.restore.password.placeholder')}
+              repeatPlaceholder={t('backup.restore.password.repeatPlaceholder')}
+              showLabel={t('backup.restore.password.showLabel')}
+              onValidPassword={this.setValidPassword} />
+            <div className={style.agreements}>
+              <Checkbox
+                id="funds_access"
+                label={t('backup.restore.understand')}
+                checked={understand}
+                onChange={this.handleUnderstandChange} />
+            </div>
+            <DialogButtons>
+              <Button
+                type="submit"
+                danger={requireConfirmation}
+                primary={!requireConfirmation}
+                disabled={!understand || !this.validate() || isConfirming}>
+                {t('button.restore')}
+              </Button>
+              <Button
+                transparent
+                onClick={this.abort}
+                disabled={isConfirming}>
+                {t('button.back')}
+              </Button>
+            </DialogButtons>
+          </form>
+        </Dialog>
         {
           (isConfirming && requireConfirmation) && (
             <WaitDialog title={t('backup.restore.confirmTitle')} />

--- a/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
@@ -94,37 +94,34 @@ class ChangePIN extends Component {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.changepin')}
         </SettingsButton>
-        {
-          activeDialog && (
-            <Dialog
-              title={t('button.changepin')}
-              onClose={this.abort}>
-              <form onSubmit={this.changePin}>
-                <PasswordInput
-                  idPrefix="oldPIN"
-                  label={t('changePin.oldLabel')}
-                  value={oldPIN}
-                  onInput={this.setValidOldPIN} />
-                {t('changePin.newTitle') && <h4>{t('changePin.newTitle')}</h4>}
-                <PasswordRepeatInput
-                  idPrefix="newPIN"
-                  pattern="^.{4,}$"
-                  label={t('initialize.input.label')}
-                  repeatLabel={t('initialize.input.labelRepeat')}
-                  repeatPlaceholder={t('initialize.input.placeholderRepeat')}
-                  onValidPassword={this.setValidNewPIN} />
-                <DialogButtons>
-                  <Button type="submit" danger disabled={!this.validate() || isConfirming}>
-                    {t('button.changepin')}
-                  </Button>
-                  <Button transparent onClick={this.abort} disabled={isConfirming}>
-                    {t('button.back')}
-                  </Button>
-                </DialogButtons>
-              </form>
-            </Dialog>
-          )
-        }
+        <Dialog
+          open={activeDialog}
+          title={t('button.changepin')}
+          onClose={this.abort}>
+          <form onSubmit={this.changePin}>
+            <PasswordInput
+              idPrefix="oldPIN"
+              label={t('changePin.oldLabel')}
+              value={oldPIN}
+              onInput={this.setValidOldPIN} />
+            {t('changePin.newTitle') && <h4>{t('changePin.newTitle')}</h4>}
+            <PasswordRepeatInput
+              idPrefix="newPIN"
+              pattern="^.{4,}$"
+              label={t('initialize.input.label')}
+              repeatLabel={t('initialize.input.labelRepeat')}
+              repeatPlaceholder={t('initialize.input.placeholderRepeat')}
+              onValidPassword={this.setValidNewPIN} />
+            <DialogButtons>
+              <Button type="submit" danger disabled={!this.validate() || isConfirming}>
+                {t('button.changepin')}
+              </Button>
+              <Button transparent onClick={this.abort} disabled={isConfirming}>
+                {t('button.back')}
+              </Button>
+            </DialogButtons>
+          </form>
+        </Dialog>
         {
           isConfirming && (
             <WaitDialog title={t('button.changepin')} />

--- a/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
@@ -69,25 +69,22 @@ class DeviceLock extends Component {
           optionalText={t(`deviceSettings.pairing.lock.${lock}`)}>
           {t('deviceLock.button')}
         </SettingsButton>
-        {
-          activeDialog && (
-            <Dialog
-              title={t('deviceLock.title')}
-              onClose={this.abort}>
-              <p>{t('deviceLock.condition1')}</p>
-              <p>{t('deviceLock.condition2')}</p>
-              <p>{t('deviceLock.condition3')}</p>
-              <div className={style.actions}>
-                <Button danger onClick={this.resetDevice}>
-                  {t('deviceLock.confirm')}
-                </Button>
-                <Button transparent onClick={this.abort}>
-                  {t('button.back')}
-                </Button>
-              </div>
-            </Dialog>
-          )
-        }
+        <Dialog
+          open={activeDialog}
+          title={t('deviceLock.title')}
+          onClose={this.abort}>
+          <p>{t('deviceLock.condition1')}</p>
+          <p>{t('deviceLock.condition2')}</p>
+          <p>{t('deviceLock.condition3')}</p>
+          <div className={style.actions}>
+            <Button danger onClick={this.resetDevice}>
+              {t('deviceLock.confirm')}
+            </Button>
+            <Button transparent onClick={this.abort}>
+              {t('button.back')}
+            </Button>
+          </div>
+        </Dialog>
         {
           isConfirming && (
             <WaitDialog title={t('deviceLock.title')} />

--- a/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
@@ -100,38 +100,34 @@ class HiddenWallet extends Component {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.hiddenwallet')}
         </SettingsButton>
-        {
-          activeDialog && (
-            <Dialog title={t('button.hiddenwallet')}
-              onClose={this.abort}>
-              <SimpleMarkup tagName="p" markup={t('hiddenWallet.info1HTML')} />
-              <SimpleMarkup tagName="p" markup={t('hiddenWallet.info2HTML')} />
-              <form onSubmit={this.createHiddenWallet}>
-                <PasswordRepeatInput
-                  idPrefix="pin"
-                  pattern="^.{4,}$"
-                  label={t('hiddenWallet.pinLabel')}
-                  repeatLabel={t('hiddenWallet.pinRepeatLabel')}
-                  repeatPlaceholder={t('hiddenWallet.pinRepeatPlaceholder')}
-                  onValidPassword={this.setValidPIN} />
-                <PasswordRepeatInput
-                  idPrefix="password"
-                  label={t('hiddenWallet.passwordLabel')}
-                  repeatPlaceholder={t('hiddenWallet.passwordPlaceholder')}
-                  onValidPassword={this.setValidPassword}
-                />
-                <DialogButtons>
-                  <Button type="submit" danger disabled={!this.validate() || isConfirming}>
-                    {t('button.hiddenwallet')}
-                  </Button>
-                  <Button transparent onClick={this.abort} disabled={isConfirming}>
-                    {t('button.abort')}
-                  </Button>
-                </DialogButtons>
-              </form>
-            </Dialog>
-          )
-        }
+        <Dialog open={activeDialog} title={t('button.hiddenwallet')}
+          onClose={this.abort}>
+          <SimpleMarkup tagName="p" markup={t('hiddenWallet.info1HTML')} />
+          <SimpleMarkup tagName="p" markup={t('hiddenWallet.info2HTML')} />
+          <form onSubmit={this.createHiddenWallet}>
+            <PasswordRepeatInput
+              idPrefix="pin"
+              pattern="^.{4,}$"
+              label={t('hiddenWallet.pinLabel')}
+              repeatLabel={t('hiddenWallet.pinRepeatLabel')}
+              repeatPlaceholder={t('hiddenWallet.pinRepeatPlaceholder')}
+              onValidPassword={this.setValidPIN} />
+            <PasswordRepeatInput
+              idPrefix="password"
+              label={t('hiddenWallet.passwordLabel')}
+              repeatPlaceholder={t('hiddenWallet.passwordPlaceholder')}
+              onValidPassword={this.setValidPassword}
+            />
+            <DialogButtons>
+              <Button type="submit" danger disabled={!this.validate() || isConfirming}>
+                {t('button.hiddenwallet')}
+              </Button>
+              <Button transparent onClick={this.abort} disabled={isConfirming}>
+                {t('button.abort')}
+              </Button>
+            </DialogButtons>
+          </form>
+        </Dialog>
         {
           isConfirming && (
             <WaitDialog title={t('button.hiddenwallet')} />

--- a/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
@@ -218,29 +218,26 @@ class MobilePairing extends Component<Props, State> {
             (hasMobileChannel && !paired) ? t('pairing.reconnectOnly.button') : t('pairing.button')
           )}
         </SettingsButton>
-        {
-          status && (
-            <Dialog
-              title={t('pairing.title')}
-              onClose={this.abort}
-              medium>
-              <div className="flex flex-column flex-center flex-items-center">
-                {
-                  channel ? (
-                    content
-                  ) : (
-                    <p>{t('loading')}</p>
-                  )
-                }
-              </div>
-              <DialogButtons>
-                <Button transparent onClick={this.abort}>
-                  {t('button.back')}
-                </Button>
-              </DialogButtons>
-            </Dialog>
-          )
-        }
+        <Dialog
+          open={!!status}
+          title={t('pairing.title')}
+          onClose={this.abort}
+          medium>
+          <div className="flex flex-column flex-center flex-items-center">
+            {
+              channel ? (
+                content
+              ) : (
+                <p>{t('loading')}</p>
+              )
+            }
+          </div>
+          <DialogButtons>
+            <Button transparent onClick={this.abort}>
+              {t('button.back')}
+            </Button>
+          </DialogButtons>
+        </Dialog>
       </div>
     );
   }

--- a/frontends/web/src/routes/device/bitbox01/settings/components/randomnumber.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/randomnumber.jsx
@@ -55,27 +55,21 @@ class RandomNumber extends Component {
         <SettingsButton onClick={this.getRandomNumber}>
           {t('random.button')}
         </SettingsButton>
-        {
-          // @ts-ignore Object is possibly 'undefined'.
-          active && number ? (
-            <Dialog title="Generate Random Number" onClose={this.abort}>
-              <div className="columnsContainer half">
-                <div className="columns">
-                  <div className="column">
-                    <p>{t('random.description', {
-                      // @ts-ignore
-                      bits: number.length * 4
-                    })}</p>
-                    <CopyableInput value={number} flexibleHeight />
-                  </div>
-                </div>
+        <Dialog open={!!(active && number)} title="Generate Random Number" onClose={this.abort}>
+          <div className="columnsContainer half">
+            <div className="columns">
+              <div className="column">
+                <p>{t('random.description', {
+                  bits: number.length * 4
+                })}</p>
+                <CopyableInput value={number} flexibleHeight />
               </div>
-              <DialogButtons>
-                <Button primary onClick={this.abort}>{t('button.ok')}</Button>
-              </DialogButtons>
-            </Dialog>
-          ) : null
-        }
+            </div>
+          </div>
+          <DialogButtons>
+            <Button primary onClick={this.abort}>{t('button.ok')}</Button>
+          </DialogButtons>
+        </Dialog>
       </div>
     );
   }

--- a/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
@@ -84,37 +84,34 @@ class Reset extends Component {
         <SettingsButton danger onClick={() => this.setState({ activeDialog: true })}>
           {t('reset.title')}
         </SettingsButton>
-        {
-          activeDialog && (
-            <Dialog
-              title={t('reset.title')}
-              onClose={this.abort}>
-              <p>
-                {t('reset.description')}
-              </p>
-              <PasswordInput
-                idPrefix="pin"
-                label={t('initialize.input.label')}
-                value={pin}
-                onInput={this.setValidPIN} />
-              <div className={style.agreements}>
-                <Checkbox
-                  id="funds_access"
-                  label={t('reset.understand')}
-                  checked={understand}
-                  onChange={this.handleUnderstandChange} />
-              </div>
-              <DialogButtons>
-                <Button danger disabled={!pin || !understand} onClick={this.resetDevice}>
-                  {t('reset.title')}
-                </Button>
-                <Button transparent onClick={this.abort} disabled={isConfirming}>
-                  {t('button.back')}
-                </Button>
-              </DialogButtons>
-            </Dialog>
-          )
-        }
+        <Dialog
+          active={activeDialog}
+          title={t('reset.title')}
+          onClose={this.abort}>
+          <p>
+            {t('reset.description')}
+          </p>
+          <PasswordInput
+            idPrefix="pin"
+            label={t('initialize.input.label')}
+            value={pin}
+            onInput={this.setValidPIN} />
+          <div className={style.agreements}>
+            <Checkbox
+              id="funds_access"
+              label={t('reset.understand')}
+              checked={understand}
+              onChange={this.handleUnderstandChange} />
+          </div>
+          <DialogButtons>
+            <Button danger disabled={!pin || !understand} onClick={this.resetDevice}>
+              {t('reset.title')}
+            </Button>
+            <Button transparent onClick={this.abort} disabled={isConfirming}>
+              {t('button.back')}
+            </Button>
+          </DialogButtons>
+        </Dialog>
         { isConfirming ? (
           <WaitDialog title={t('reset.title')} />
         ) : null }

--- a/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
@@ -81,38 +81,32 @@ class Check extends Component<Props, State> {
         >
           {t('button.check')}
         </Button>
-        {
-          activeDialog && (
-            <Dialog title={message}>
-              {
-                <div className="columnsContainer half">
-                  <div className="columns">
-                    <div className="column">
-                      {
-                        foundBackup !== undefined && (
-                          <BackupsListItem
-                            backup={foundBackup}
-                            handleChange={() => undefined}
-                            onFocus={() => undefined}
-                            radio={false} />
-                        )
-                      }
-                    </div>
-                  </div>
-                  <DialogButtons>
-                    <Button
-                      primary
-                      onClick={this.abort}
-                      disabled={!userVerified}
-                    >
-                      { userVerified ? t('button.ok') : t('accountInfo.verify') }
-                    </Button>
-                  </DialogButtons>
-                </div>
-              }
-            </Dialog>
-          )
-        }
+        <Dialog open={activeDialog} title={message}>
+          <div className="columnsContainer half">
+            <div className="columns">
+              <div className="column">
+                {
+                  foundBackup !== undefined && (
+                    <BackupsListItem
+                      backup={foundBackup}
+                      handleChange={() => undefined}
+                      onFocus={() => undefined}
+                      radio={false} />
+                  )
+                }
+              </div>
+            </div>
+            <DialogButtons>
+              <Button
+                primary
+                onClick={this.abort}
+                disabled={!userVerified}
+              >
+                { userVerified ? t('button.ok') : t('accountInfo.verify') }
+              </Button>
+            </DialogButtons>
+          </div>
+        </Dialog>
       </div>
     );
   }

--- a/frontends/web/src/routes/device/bitbox02/reset.tsx
+++ b/frontends/web/src/routes/device/bitbox02/reset.tsx
@@ -82,35 +82,32 @@ class Reset extends Component<Props, State> {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('reset.title')}
         </SettingsButton>
-        {
-          activeDialog && (
-            <Dialog
-              title={t('reset.title')}
-              onClose={this.abort}
-              disabledClose={isConfirming}
-              small>
-              <div className="columnsContainer half">
-                <div className="columns">
-                  <div className="column">
-                    <p>{t('reset.description')}</p>
-                    <div>
-                      <Checkbox
-                        id="reset_understand"
-                        label={t('reset.understandBB02')}
-                        checked={understand}
-                        onChange={this.handleUnderstandChange} />
-                    </div>
-                  </div>
+        <Dialog
+          open={activeDialog}
+          title={t('reset.title')}
+          onClose={this.abort}
+          disabledClose={isConfirming}
+          small>
+          <div className="columnsContainer half">
+            <div className="columns">
+              <div className="column">
+                <p>{t('reset.description')}</p>
+                <div>
+                  <Checkbox
+                    id="reset_understand"
+                    label={t('reset.understandBB02')}
+                    checked={understand}
+                    onChange={this.handleUnderstandChange} />
                 </div>
               </div>
-              <DialogButtons>
-                <Button danger disabled={!understand} onClick={this.reset}>
-                  {t('reset.title')}
-                </Button>
-              </DialogButtons>
-            </Dialog>
-          )
-        }
+            </div>
+          </div>
+          <DialogButtons>
+            <Button danger disabled={!understand} onClick={this.reset}>
+              {t('reset.title')}
+            </Button>
+          </DialogButtons>
+        </Dialog>
         {
           isConfirming && (
             <WaitDialog

--- a/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
+++ b/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
@@ -43,34 +43,30 @@ const SDCardCheck = ({ deviceID, children }: TProps) => {
     return null;
   }
 
-  if (!sdCardInserted) {
-    return (
-      <Dialog title="Check your device" small>
-        <div className="columnsContainer half">
-          <div className="columns">
-            <div className="column">
-              <p>{t('backup.insert')}</p>
-            </div>
-          </div>
-        </div>
-        <DialogButtons>
-          <Button
-            primary
-            onClick={check}>
-            {t('button.ok')}
-          </Button>
-          <ButtonLink
-            transparent
-            to={`/device/${deviceID}`}>
-            {t('button.back')}
-          </ButtonLink>
-        </DialogButtons>
-      </Dialog>
-    );
-  }
   return (
     <div>
-      {children}
+      {!sdCardInserted ?
+        <Dialog open={!sdCardInserted} title="Check your device" small>
+          <div className="columnsContainer half">
+            <div className="columns">
+              <div className="column">
+                <p>{t('backup.insert')}</p>
+              </div>
+            </div>
+          </div>
+          <DialogButtons>
+            <Button
+              primary
+              onClick={check}>
+              {t('button.ok')}
+            </Button>
+            <ButtonLink
+              transparent
+              to={`/device/${deviceID}`}>
+              {t('button.back')}
+            </ButtonLink>
+          </DialogButtons>
+        </Dialog> : children}
     </div>
   );
 };

--- a/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
@@ -66,43 +66,42 @@ export const SetDeviceName = ({
         optionalText={currentName}>
         {t('bitbox02Settings.deviceName.title')}
       </SettingsButton>
-      { active ? (
-        <Dialog
-          onClose={() => setActive(false)}
-          title={t('bitbox02Settings.deviceName.title')}
-          small>
-          <div className="columnsContainer half">
-            <div className="columns half">
-              <div className="column">
-                <label>
-                  {t('bitbox02Settings.deviceName.current')}
-                </label>
-                <p className="m-bottom-half">
-                  {currentName}
-                </p>
-              </div>
-              <div className="column">
-                <Input
-                  pattern="^.{0,63}$"
-                  label={t('bitbox02Settings.deviceName.input')}
-                  onInput={e => setName(e.target.value)}
-                  ref={inputRef}
-                  placeholder={t('bitbox02Settings.deviceName.placeholder')}
-                  value={name}
-                  id="deviceName" />
-              </div>
+      <Dialog
+        open={active}
+        onClose={() => setActive(false)}
+        title={t('bitbox02Settings.deviceName.title')}
+        small>
+        <div className="columnsContainer half">
+          <div className="columns half">
+            <div className="column">
+              <label>
+                {t('bitbox02Settings.deviceName.current')}
+              </label>
+              <p className="m-bottom-half">
+                {currentName}
+              </p>
+            </div>
+            <div className="column">
+              <Input
+                pattern="^.{0,63}$"
+                label={t('bitbox02Settings.deviceName.input')}
+                onInput={e => setName(e.target.value)}
+                ref={inputRef}
+                placeholder={t('bitbox02Settings.deviceName.placeholder')}
+                value={name}
+                id="deviceName" />
             </div>
           </div>
-          <DialogButtons>
-            <Button
-              primary
-              disabled={!(name && inputRef?.current?.validity.valid)}
-              onClick={() => updateName()}>
-              {t('button.ok')}
-            </Button>
-          </DialogButtons>
-        </Dialog>
-      ) : null }
+        </div>
+        <DialogButtons>
+          <Button
+            primary
+            disabled={!(name && inputRef?.current?.validity.valid)}
+            onClick={() => updateName()}>
+            {t('button.ok')}
+          </Button>
+        </DialogButtons>
+      </Dialog>
       { inProgress && (
         <WaitDialog>
           {t('bitbox02Interact.followInstructions')}

--- a/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
+++ b/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
@@ -80,30 +80,26 @@ class UpgradeButton extends Component<Props, State> {
             </SettingsButton>
           )
         }
-        {
-          activeDialog && (
-            <Dialog title={t('upgradeFirmware.title')}>
-              {confirming ? t('confirmOnDevice') : (
-                <p>{t('upgradeFirmware.description', {
-                  currentVersion: versionInfo.currentVersion,
-                  newVersion: versionInfo.newVersion,
-                })}</p>
-              )}
-              { !confirming && (
-                <DialogButtons>
-                  <Button
-                    primary
-                    onClick={this.upgradeFirmware}>
-                    {t('button.upgrade')}
-                  </Button>
-                  <Button transparent onClick={this.abort}>
-                    {t('button.back')}
-                  </Button>
-                </DialogButtons>
-              )}
-            </Dialog>
-          )
-        }
+        <Dialog open={activeDialog} title={t('upgradeFirmware.title')}>
+          {confirming ? t('confirmOnDevice') : (
+            <p>{t('upgradeFirmware.description', {
+              currentVersion: versionInfo.currentVersion,
+              newVersion: versionInfo.newVersion,
+            })}</p>
+          )}
+          { !confirming && (
+            <DialogButtons>
+              <Button
+                primary
+                onClick={this.upgradeFirmware}>
+                {t('button.upgrade')}
+              </Button>
+              <Button transparent onClick={this.abort}>
+                {t('button.back')}
+              </Button>
+            </DialogButtons>
+          )}
+        </Dialog>
       </div>
     );
   }

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -226,28 +226,27 @@ class ManageAccounts extends Component<Props, State> {
                   { (accountList && accountList.length) ? accountList : t('manageAccounts.noAccounts') }
                 </div>
               </div>
-              { editAccountCode ? (
-                <Dialog
-                  onClose={() => this.setState({ editAccountCode: undefined, editAccountNewName: '', editErrorMessage: undefined })}
-                  title={t('manageAccounts.editAccountNameTitle')}>
-                  <form onSubmit={this.updateAccountName}>
-                    <Message type="error" hidden={!editErrorMessage}>
-                      {editErrorMessage}
-                    </Message>
-                    <Input
-                      onInput={e => this.setState({ editAccountNewName: e.target.value })}
-                      value={editAccountNewName} />
-                    <DialogButtons>
-                      <Button
-                        disabled={!editAccountNewName}
-                        primary
-                        type="submit">
-                        {t('button.update')}
-                      </Button>
-                    </DialogButtons>
-                  </form>
-                </Dialog>
-              ) : null}
+              <Dialog
+                open={!!(editAccountCode)}
+                onClose={() => this.setState({ editAccountCode: undefined, editAccountNewName: '', editErrorMessage: undefined })}
+                title={t('manageAccounts.editAccountNameTitle')}>
+                <form onSubmit={this.updateAccountName}>
+                  <Message type="error" hidden={!editErrorMessage}>
+                    {editErrorMessage}
+                  </Message>
+                  <Input
+                    onInput={e => this.setState({ editAccountNewName: e.target.value })}
+                    value={editAccountNewName} />
+                  <DialogButtons>
+                    <Button
+                      disabled={!editAccountNewName}
+                      primary
+                      type="submit">
+                      {t('button.update')}
+                    </Button>
+                  </DialogButtons>
+                </form>
+              </Dialog>
             </div>
           </div>
         </div>

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -315,37 +315,33 @@ class Settings extends Component<Props, State> {
                               optionalText={t('generic.enabled', { context: config.backend.proxy.useProxy.toString() })}>
                               {t('settings.expert.useProxy')}
                             </SettingsButton>
-                            {
-                              activeProxyDialog && (
-                                <Dialog onClose={this.hideProxyDialog} title={t('settings.expert.setProxyAddress')} small>
-                                  <div className="flex flex-row flex-between flex-items-center">
-                                    <div>
-                                      <p className="m-none">{t('settings.expert.useProxy')}</p>
-                                    </div>
-                                    <Toggle
-                                      id="useProxy"
-                                      checked={config.backend.proxy.useProxy}
-                                      onChange={this.handleToggleProxy} />
-                                  </div>
-                                  <div className="m-top-half">
-                                    <Input
-                                      name="proxyAddress"
-                                      onInput={this.handleFormChange}
-                                      value={proxyAddress}
-                                      placeholder="127.0.0.1:9050"
-                                      disabled={!config.backend.proxy.useProxy}
-                                    />
-                                    <DialogButtons>
-                                      <Button primary
-                                        onClick={this.setProxyAddress}
-                                        disabled={!config.backend.proxy.useProxy || proxyAddress === config.backend.proxy.proxyAddress}>
-                                        {t('settings.expert.setProxyAddress')}
-                                      </Button>
-                                    </DialogButtons>
-                                  </div>
-                                </Dialog>
-                              )
-                            }
+                            <Dialog open={activeProxyDialog} onClose={this.hideProxyDialog} title={t('settings.expert.setProxyAddress')} small>
+                              <div className="flex flex-row flex-between flex-items-center">
+                                <div>
+                                  <p className="m-none">{t('settings.expert.useProxy')}</p>
+                                </div>
+                                <Toggle
+                                  id="useProxy"
+                                  checked={config.backend.proxy.useProxy}
+                                  onChange={this.handleToggleProxy} />
+                              </div>
+                              <div className="m-top-half">
+                                <Input
+                                  name="proxyAddress"
+                                  onInput={this.handleFormChange}
+                                  value={proxyAddress}
+                                  placeholder="127.0.0.1:9050"
+                                  disabled={!config.backend.proxy.useProxy}
+                                />
+                                <DialogButtons>
+                                  <Button primary
+                                    onClick={this.setProxyAddress}
+                                    disabled={!config.backend.proxy.useProxy || proxyAddress === config.backend.proxy.proxyAddress}>
+                                    {t('settings.expert.setProxyAddress')}
+                                  </Button>
+                                </DialogButtons>
+                              </div>
+                            </Dialog>
                             <SettingsButton onClick={() => route('/settings/electrum', true)}>
                               {t('settings.expert.electrum.title')}
                             </SettingsButton>


### PR DESCRIPTION
To maximise spacing and achieving a more modern look on mobile, we want to re-style the Dialog component to become a "modal bottom sheet" (or a bottom sheet).

Some screenshots and a screen recording:


https://user-images.githubusercontent.com/28676406/201877070-d82b3737-ed6d-4649-815c-bfd7c81afce1.mov


<img width="776" alt="Screen Shot 2022-11-15 at 07 25 38" src="https://user-images.githubusercontent.com/28676406/201876867-a80f3c33-dc1c-44e4-9414-aef49f27b99b.png">
<img width="776" alt="Screen Shot 2022-11-15 at 07 25 59" src="https://user-images.githubusercontent.com/28676406/201876881-670976ad-e5c2-46f1-be85-1b8e3e3d0e61.png">
<img width="776" alt="Screen Shot 2022-11-15 at 07 26 10" src="https://user-images.githubusercontent.com/28676406/201876899-e3906945-451d-48f6-ae84-f272cacf34ed.png">
