### PR TITLE
frontend: remove the redundant manageAccounts.addAccount i18n key

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -918,7 +918,6 @@
   },
   "loading": "loading…",
   "manageAccounts": {
-    "addAccount": "$t(addAccount.title)",
     "editAccount": "Edit",
     "editAccountNameTitle": "Edit account name",
     "noAccounts": "no accounts found",

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -219,7 +219,7 @@ class ManageAccounts extends Component<Props, State> {
                   <Button
                     primary
                     onClick={() => route('/add-account', true)}>
-                    {t('manageAccounts.addAccount')}
+                    {t('addAccount.title')}
                   </Button>
                 </div>
                 <div className="box slim divide m-bottom-large">


### PR DESCRIPTION
It is translated as `$t(addAccount.title)` in all languages.