### PR TITLE
git: ignore unfinished locales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,25 @@ Session.vim
 tags
 # Persistent undo
 [._]*.un~
+
+# Ignore unfinished locales
+/frontends/web/src/locales/
+# Except the following:
+!/frontends/web/src/locales/ar/
+!/frontends/web/src/locales/bg/
+!/frontends/web/src/locales/de/
+!/frontends/web/src/locales/en/
+!/frontends/web/src/locales/es/
+!/frontends/web/src/locales/fa/
+!/frontends/web/src/locales/fr/
+!/frontends/web/src/locales/he/
+!/frontends/web/src/locales/hi/
+!/frontends/web/src/locales/it/
+!/frontends/web/src/locales/ja/
+!/frontends/web/src/locales/ms/
+!/frontends/web/src/locales/nl/
+!/frontends/web/src/locales/pt/
+!/frontends/web/src/locales/ru/
+!/frontends/web/src/locales/sl/
+!/frontends/web/src/locales/tr/
+!/frontends/web/src/locales/zh/


### PR DESCRIPTION
Was removed in b21fd73fa1b1fa87f684b76c1ce1a00a93bb0634 because in VS Code the content of the files could not be searched, probably because one rule ignores the locales directory, and other rules unignore the currently active languages that are supported in the BitBoxApp.

Searching in VS Code is still a bit buggy and content cannot be found unless one of the parent directories is specifically added in 'files to include'. This is good enough.

Added back the ignores that unfinished locales are not accidentally commited.