### PR TITLE
frontend: restyled buy/send/receive buttons on mobile

### DIFF
--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -85,7 +85,5 @@
     .buy {
         font-size: var(--size-small);
         width: auto;
-        height: calc(var(--item-height) / 2);
-        line-height: calc(var(--item-height) / 2);
     }
 }


### PR DESCRIPTION
To improve the UI on mobile, we'd like to increase the size (height) of these buttons.

Before:

<img width="433" alt="Screen Shot 2022-11-21 at 13 16 32" src="https://user-images.githubusercontent.com/28676406/203052243-ab6f922d-e83c-4ee4-b60d-628a84a683ee.png">

After:

<img width="470" alt="Screen Shot 2022-11-21 at 13 16 18" src="https://user-images.githubusercontent.com/28676406/203052389-f21f13cf-d3cc-4484-bcf5-5978b5b54f16.png">
