### PR TITLE
buy/exchange: add logic for exchange selection

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1,5 +1,5 @@
 // Copyright 2018 Shift Devices AG
-// Copyright 2020 Shift Crypto AG
+// Copyright 2022 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -450,6 +450,11 @@ func (backend *Backend) Start() <-chan interface{} {
 // DevicesRegistered returns a map of device IDs to device of registered devices.
 func (backend *Backend) DevicesRegistered() map[string]device.Interface {
 	return backend.devices
+}
+
+// HTTPClient is a getter method for the HTTPClient instance.
+func (backend *Backend) HTTPClient() *http.Client {
+	return backend.httpClient
 }
 
 // Keystore returns the keystore registered at this backend, or nil if no keystore is registered.

--- a/backend/exchanges/exchanges.go
+++ b/backend/exchanges/exchanges.go
@@ -1,0 +1,110 @@
+// Copyright 2022 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exchanges
+
+import (
+	"net/http"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
+)
+
+// regionCodes is an array containing ISO 3166-1 alpha-2 code of all regions.
+// Source: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+var regionCodes = []string{
+	"AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR", "AS", "AT", "AU", "AW", "AX", "AZ",
+	"BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ", "BR", "BS",
+	"BT", "BV", "BW", "BY", "BZ", "CA", "CC", "CD", "CF", "CG", "CH", "CI", "CK", "CL", "CM", "CN",
+	"CO", "CR", "CU", "CV", "CW", "CX", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE",
+	"EG", "EH", "ER", "ES", "ET", "FI", "FJ", "FK", "FM", "FO", "FR", "GA", "GB", "GD", "GE", "GF",
+	"GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS", "GT", "GU", "GW", "GY", "HK", "HM",
+	"HN", "HR", "HT", "HU", "ID", "IE", "IL", "IM", "IN", "IO", "IQ", "IR", "IS", "IT", "JE", "JM",
+	"JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC",
+	"LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MF", "MG", "MH", "MK",
+	"ML", "MM", "MN", "MO", "MP", "MQ", "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA",
+	"NC", "NE", "NF", "NG", "NI", "NL", "NO", "NP", "NR", "NU", "NZ", "OM", "PA", "PE", "PF", "PG",
+	"PH", "PK", "PL", "PM", "PN", "PR", "PS", "PT", "PW", "PY", "QA", "RE", "RO", "RS", "RU", "RW",
+	"SA", "SB", "SC", "SD", "SE", "SG", "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS",
+	"ST", "SV", "SX", "SY", "SZ", "TC", "TD", "TF", "TG", "TH", "TJ", "TK", "TL", "TM", "TN", "TO",
+	"TR", "TT", "TV", "TW", "TZ", "UA", "UG", "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI",
+	"VN", "VU", "WF", "WS", "YE", "YT", "ZA", "ZM", "ZW"}
+
+// ExchangeRegionList contains a list of ExchangeRegion objects.
+type ExchangeRegionList struct {
+	Regions []ExchangeRegion `json:"regions"`
+}
+
+// ExchangeRegion contains the ISO 3166-1 alpha-2 code of a specific region and a boolean
+//for each exchange, indicating if that exchange is enabled for the region.
+type ExchangeRegion struct {
+	Code             string `json:"code"`
+	IsMoonpayEnabled bool   `json:"isMoonpayEnabled"`
+	IsPocketEnabled  bool   `json:"isPocketEnabled"`
+}
+
+// PaymentMethod type is used for payment options in exchange deals.
+type PaymentMethod string
+
+const (
+	// CardPayment is a payment with credit/debit card.
+	CardPayment PaymentMethod = "card"
+	// BankTransferPayment is a payment with bank transfer.
+	BankTransferPayment PaymentMethod = "bank-transfer"
+)
+
+// ExchangeDeal represents a specific purchase option of an exchange.
+// - Fee indicates form the percentage that goes to the exchange in a float representation (e.g. 0.01 -> 1%).
+// - Payment is the payment method offered in the deal (usually different payment methods bring different fees).
+// - IsFast is usually associated with card payments. It is used by the frontend to display the `fast` tag in deals list.
+type ExchangeDeal struct {
+	Fee     float32       `json:"fee"`
+	Payment PaymentMethod `json:"payment"`
+	IsFast  bool          `json:"isFast"`
+}
+
+// ListExchangesByRegion populates an array of `ExchangeRegion` objects representing the availability
+// of the various exchanges in each of them.
+// NOTE: if one of the endpoint fails for any reason, the related exchange will be set as available in any
+// region by default.
+func ListExchangesByRegion(httpClient *http.Client) ExchangeRegionList {
+	moonpayRegions, moonpayError := GetMoonpaySupportedRegions(httpClient)
+	log := logging.Get().WithGroup("exchanges")
+	if moonpayError != nil {
+		log.Error(moonpayError)
+	}
+
+	pocketRegions, pocketError := GetPocketSupportedRegions(httpClient)
+	if pocketError != nil {
+		log.Error(pocketError)
+	}
+
+	exchangeRegions := ExchangeRegionList{}
+	for _, code := range regionCodes {
+		// default behavior is to show the exchange if the supported regions check fails.
+		moonpayEnabled, pocketEnabled := true, true
+		if moonpayError == nil {
+			_, moonpayEnabled = moonpayRegions[code]
+		}
+		if pocketError == nil {
+			_, pocketEnabled = pocketRegions[code]
+		}
+		exchangeRegions.Regions = append(exchangeRegions.Regions, ExchangeRegion{
+			Code:             code,
+			IsMoonpayEnabled: moonpayEnabled,
+			IsPocketEnabled:  pocketEnabled,
+		})
+	}
+
+	return exchangeRegions
+}

--- a/backend/exchanges/moonpay.go
+++ b/backend/exchanges/moonpay.go
@@ -1,7 +1,22 @@
+// Copyright 2022 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package exchanges
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -21,13 +36,16 @@ const (
 	// - KYC always succeeds; simply click on "submit anyway"
 	// - need to provide a valid email addr to receive a check code;
 	//   any temp email service like fakermail.com will do
-	moonpayAPITestPubKey = "pk_test_e9i4oaa4J7eKo8UI3Wm8QLagoskWGjXN"
-	moonpayAPITestURL    = "https://buy-staging.moonpay.com"
+	moonpayBuyAPITestPubKey = "pk_test_e9i4oaa4J7eKo8UI3Wm8QLagoskWGjXN"
+	moonpayBuyAPITestURL    = "https://buy-staging.moonpay.com"
 
 	// moonpayAPILivePubKey is the production API key for real transactions.
 	// It is ok for it to be public.
-	moonpayAPILivePubKey = "pk_live_jfhWEt55szMLar8DhQWWiDwteX1mftY"
-	moonpayAPILiveURL    = "https://buy.moonpay.com"
+	moonpayBuyAPILivePubKey = "pk_live_jfhWEt55szMLar8DhQWWiDwteX1mftY"
+	moonpayBuyAPILiveURL    = "https://buy.moonpay.com"
+
+	// moonpayAPILiveURL is the API url for REST calls.
+	moonpayAPILiveURL = "https://api.moonpay.com/v3"
 )
 
 // Here's the list of all supported currencies:
@@ -77,6 +95,48 @@ type BuyMoonpayParams struct {
 	Lang string // user preferred language in ISO 639-1; falls back to "en"
 }
 
+// BuyMoonpayRegion represents informations collected by Moonpay supported countries REST call.
+type BuyMoonpayRegion struct {
+	Alpha2       string `json:"alpha2"`       // ISO 3166-1 alpha-2 code of the region (e.g. `CH` for Switzerland)
+	IsBuyAllowed bool   `json:"isBuyAllowed"` // true if Moonpay supports this region
+}
+
+// GetMoonpaySupportedRegions query moonpay API and returns a map of regions where buy is allowed.
+func GetMoonpaySupportedRegions(httpClient *http.Client) (map[string]BuyMoonpayRegion, error) {
+	regionsMap := make(map[string]BuyMoonpayRegion)
+	var regionsList []BuyMoonpayRegion
+	endpoint := fmt.Sprintf("%s/countries", moonpayAPILiveURL)
+
+	err := APIGet(httpClient, endpoint, &regionsList)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, region := range regionsList {
+		if region.IsBuyAllowed {
+			regionsMap[region.Alpha2] = region
+		}
+	}
+
+	return regionsMap, nil
+}
+
+// MoonpayDeals returns the purchase conditions (fee and payment methods) offered by Moonpay.
+func MoonpayDeals() []ExchangeDeal {
+	return []ExchangeDeal{
+		{
+			Fee:     0.049, //4.9%
+			Payment: CardPayment,
+			IsFast:  true,
+		},
+		{
+			Fee:     0.019, //1.9%
+			Payment: BankTransferPayment,
+			IsFast:  false,
+		},
+	}
+}
+
 // BuyMoonpay returns info for the frontend to initiate an onramp flow.
 func BuyMoonpay(acct accounts.Interface, params BuyMoonpayParams) (BuyMoonpayInfo, error) {
 	if !IsMoonpaySupported(acct.Coin().Code()) {
@@ -86,11 +146,11 @@ func BuyMoonpay(acct accounts.Interface, params BuyMoonpayParams) (BuyMoonpayInf
 	if !ok {
 		return BuyMoonpayInfo{}, fmt.Errorf("unknown cryptocurrency code %q", acct.Coin().Code())
 	}
-	apiKey := moonpayAPILivePubKey
-	apiURL := moonpayAPILiveURL
+	apiKey := moonpayBuyAPILivePubKey
+	apiURL := moonpayBuyAPILiveURL
 	if _, isTestnet := coin.TestnetCoins[acct.Coin().Code()]; isTestnet {
-		apiKey = moonpayAPITestPubKey
-		apiURL = moonpayAPITestURL
+		apiKey = moonpayBuyAPITestPubKey
+		apiURL = moonpayBuyAPITestURL
 	}
 	unused := acct.GetUnusedReceiveAddresses()
 	addr := unused[0].Addresses[0] // TODO: Let them choose sub acct?

--- a/backend/exchanges/util.go
+++ b/backend/exchanges/util.go
@@ -1,0 +1,56 @@
+// Copyright 2022 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exchanges
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
+)
+
+// APIGet performs a HTTP Get call to a given endpoint and unmarshal the result
+// populating a given object.
+func APIGet(httpClient *http.Client, endpoint string, result interface{}) error {
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return errp.WithStack(err)
+	}
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return errp.WithStack(err)
+	}
+	defer res.Body.Close() //nolint:errcheck
+	if res.StatusCode != http.StatusOK {
+		return errp.Newf("%s - bad response code %d", endpoint, res.StatusCode)
+	}
+	const max = 81920
+	responseBody, err := ioutil.ReadAll(io.LimitReader(res.Body, max+1))
+	if err != nil {
+		return errp.WithStack(err)
+	}
+	if len(responseBody) > max {
+		return errp.Newf("%s - response too long (> %d bytes)", endpoint, max)
+	}
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return errp.WithMessage(err,
+			fmt.Sprintf("%s - could not parse response: %s", endpoint, string(responseBody)))
+	}
+	return nil
+}

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -24,6 +24,34 @@ export type AddressSignResponse = {
   address: string;
   error: string;
 }
+export type ExchangeRegionList = {
+  regions: ExchangeRegion[];
+}
+
+export type ExchangeRegion = {
+  code: string;
+  isMoonpayEnabled: boolean;
+  isPocketEnabled: boolean;
+}
+
+export type ExchangeDeal = {
+  fee: number;
+  payment: 'card' | 'bank-transfer';
+  isFast: boolean;
+}
+
+export type ExchangeDeals = {
+  pocket: ExchangeDeal[];
+  moonpay: ExchangeDeal[];
+}
+
+export const getExchangesByRegion = (): Promise<ExchangeRegionList> => {
+  return apiGet('exchange/by-region');
+};
+
+export const getExchangeDeals = (): Promise<ExchangeDeals> => {
+  return apiGet('exchange/deals');
+};
 
 export const isMoonpayBuySupported = (code: string) => {
   return (): Promise<boolean> => {
@@ -45,4 +73,8 @@ export const isPocketSupported = (accountCode: string) => {
   return (): Promise<boolean> => {
     return apiGet(`exchange/pocket/buy-supported/${accountCode}`);
   };
+};
+
+export const isExchangeBuySupported = (code: string): Promise<boolean> => {
+  return apiGet(`exchange/buy-supported/${code}`);
 };

--- a/frontends/web/src/i18n/config.js
+++ b/frontends/web/src/i18n/config.js
@@ -25,6 +25,10 @@ function i18nextFormat(locale) {
   return locale.replace('_', '-');
 }
 
+export const localeMainLanguage = (locale) => {
+  return i18nextFormat(locale).split('-')[0];
+};
+
 export const languageFromConfig = {
   type: 'languageDetector',
   async: true,

--- a/frontends/web/src/i18n/i18n.js
+++ b/frontends/web/src/i18n/i18n.js
@@ -34,7 +34,7 @@ import appTranslationsES from '../locales/es/app.json';
 import appTranslationsSL from '../locales/sl/app.json';
 import appTranslationsHE from '../locales/he/app.json';
 import appTranslationsIT from '../locales/it/app.json';
-import { languageFromConfig } from './config';
+import { languageFromConfig, localeMainLanguage } from './config';
 import { apiGet } from '../utils/request';
 import { setConfig } from '../utils/config';
 
@@ -100,8 +100,8 @@ i18n.on('languageChanged', (lng) => {
     if (!match) {
       // There are too many combinations. So, we compare only the main
       // language tag.
-      const lngLang = lng.replace('_', '-').split('-')[0];
-      const localeLang = nativeLocale.replace('_', '-').split('-')[0];
+      const lngLang = localeMainLanguage(lng);
+      const localeLang = localeMainLanguage(nativeLocale);
       match = lngLang === localeLang;
     }
     const uiLang = match ? null : lng;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -304,6 +304,15 @@
     "upgrade": "Upgrade"
   },
   "buy": {
+    "exchange": {
+      "bankTransfer": "Bank transfer",
+      "creditCard": "Credit card",
+      "fee": "fee",
+      "noExchanges": "Sorry, there are no available exchanges in this region.",
+      "region": "Region",
+      "selectRegion": "Select region",
+      "title": "Buy {{name}}"
+    },
     "info": {
       "continue": "Agree and continue",
       "crypto": "crypto",

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -39,7 +39,7 @@ import { translate, TranslateProps } from '../../../decorators/translate';
 import { debug } from '../../../utils/env';
 import { apiGet, apiPost } from '../../../utils/request';
 import { apiWebsocket } from '../../../utils/websocket';
-import { isBitcoinBased, customFeeUnit, isBitcoinOnly } from '../utils';
+import { isBitcoinBased, customFeeUnit, isBitcoinOnly, findAccount } from '../utils';
 import { FeeTargets } from './feetargets';
 import style from './send.module.css';
 import { SelectedUTXO, UTXOs, UTXOsClass } from './utxos';
@@ -473,10 +473,10 @@ class Send extends Component<Props, State> {
   };
 
   private getAccount = (): accountApi.IAccount | undefined => {
-    if (!this.props.accounts) {
+    if (!this.props.code) {
       return undefined;
     }
-    return this.props.accounts.find(({ code }) => code === this.props.code);
+    return findAccount(this.props.accounts, this.props.code);
   };
 
   private toggleCoinControl = () => {

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -15,7 +15,18 @@
  * limitations under the License.
  */
 
-import { CoinCode, ScriptType } from '../../api/account';
+import { CoinCode, ScriptType, IAccount } from '../../api/account';
+
+export function findAccount(accounts: IAccount[], accountCode: string): IAccount | undefined {
+  return accounts.find(({ code }) => accountCode === code);
+}
+
+export function getCryptoName(cryptoLabel: string, account?: IAccount): string {
+  if (account && isBitcoinOnly(account.coinCode)) {
+    return 'Bitcoin';
+  }
+  return cryptoLabel;
+}
 
 export function isBitcoinOnly(coinCode: CoinCode): boolean {
   switch (coinCode) {

--- a/frontends/web/src/routes/buy/exchange.module.css
+++ b/frontends/web/src/routes/buy/exchange.module.css
@@ -1,0 +1,8 @@
+.container {
+    margin-top: calc(var(--space-default) * 1.5);
+}
+
+.header {
+    position: relative;
+    z-index: 2200;
+}

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -22,7 +22,7 @@ import { Header } from '../../components/layout';
 import { load } from '../../decorators/load';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { Spinner } from '../../components/spinner/Spinner';
-import { isBitcoinOnly } from '../account/utils';
+import { findAccount, getCryptoName } from '../account/utils';
 import { Button, Checkbox } from '../../components/forms';
 import { setConfig } from '../../utils/config';
 import A from '../../components/anchor/anchor';
@@ -57,7 +57,6 @@ class Moonpay extends Component<Props, State> {
 
   public componentDidMount() {
     window.addEventListener('resize', this.onResize);
-    console.log(this.props.config.frontend.skipBuyDisclaimer);
   }
 
   public componentWillUnmount() {
@@ -84,33 +83,15 @@ class Moonpay extends Component<Props, State> {
     }, 200);
   };
 
-  private getAccount = (): IAccount | undefined => {
-    if (!this.props.accounts) {
-      return undefined;
-    }
-    return this.props.accounts.find(({ code }) => code === this.props.code);
-  };
-
-  private getCryptoName = (): string => {
-    const { t } = this.props;
-    const account = this.getAccount();
-    if (account) {
-      return isBitcoinOnly(account.coinCode) ? 'Bitcoin' : t('buy.info.crypto');
-    }
-    return t('buy.info.crypto');
-  };
-
-
   public render() {
     const { moonpay, t } = this.props;
     const { agreedTerms, height, iframeLoaded } = this.state;
-    const account = this.getAccount();
-
+    const account = findAccount(this.props.accounts, this.props.code);
     if (!account || moonpay.url === '') {
       return null;
     }
 
-    const name = this.getCryptoName();
+    const name = getCryptoName(t('buy.info.crypto'), account);
     return (
 
       <div className="contentWithGuide">

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -81,6 +81,7 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
 
   const BuyInfoEl = <InjectParams>
     <BuyInfo
+      code={''}
       accounts={activeAccounts} />
   </InjectParams>;
 
@@ -92,7 +93,8 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
 
   const ExchangeEl = <InjectParams>
     <Exchange
-      code={''} />
+      code={''}
+      accounts={activeAccounts} />
   </InjectParams>;
 
   const PocketEl = <InjectParams>


### PR DESCRIPTION
This adds:

** Dynamic header
- header logic to display different coin names based on what the user wants to buy (as already implemented for other pages in /buy/ workflow).

** Region support for exchanges
- region list encoded following ISO 3166-1
- moonpay availability based on region (exploiting moonpay API REST call)
- localization of region names when displayed in `exchanges.tsx`

~~Please note that Pocket API REST service for supported regions is not ready yet. For this reason at the moment Pocket is displayed as available in every region.~~

** Deal details for exchanges
- Details of the deals offered by Pocket and Moonpay are available in `exchanges.tsx` with `FAST` and `BEST DEAL` tags.

** What is still missing: 
- `exchange.tsx` layout is just drafted to verify the logic. It still misses completely the layout, which will be added in a separated PR.