### PR TITLE
frontends: color variables refactoring

### DIFF
--- a/frontends/web/src/components/aopp/aopp.module.css
+++ b/frontends/web/src/components/aopp/aopp.module.css
@@ -1,6 +1,6 @@
 .banner {
     background-color: var(--color-blue);
-    color: var(--color-white);
+    color: var(--color-alt);
     font-weight: 400;
     font-size: var(--size-subheader);
     padding: var(--space-half);
@@ -13,7 +13,7 @@
 }
 
 .successText {
-    color: var(--color-gray);
+    color: var(--color-secondary);
     font-weight: 400;
     font-size: var(--size-subheader);
     margin-bottom: var(--space-quarter);
@@ -31,7 +31,7 @@
 }
 
 .message {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     border-color: var(--color-mediumgray);
     border-radius: 2px;
     border-style: solid;

--- a/frontends/web/src/components/badge/badge.module.css
+++ b/frontends/web/src/components/badge/badge.module.css
@@ -9,7 +9,7 @@
 }
 
 .generic {
-  color: var(--color-gray);
+  color: var(--color-secondary);
 }
 
 .primary {

--- a/frontends/web/src/components/balance/balance.module.css
+++ b/frontends/web/src/components/balance/balance.module.css
@@ -117,7 +117,7 @@
     display: inline-block;
     text-decoration: none;
     background-color: var(--color-blue);
-    color: var(--color-white);
+    color: var(--color-alt);
     width: 18px;
     height: 18px;
     line-height: 18px;

--- a/frontends/web/src/components/copy/Copy.module.css
+++ b/frontends/web/src/components/copy/Copy.module.css
@@ -1,6 +1,6 @@
 .button {
     align-items: center;
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     border: none;
     border-radius: 50%;
     cursor: pointer;

--- a/frontends/web/src/components/dialog/dialog.module.css
+++ b/frontends/web/src/components/dialog/dialog.module.css
@@ -137,7 +137,7 @@
 
 .disabledLabel,
 .disabledLabel span {
-    color: var(--color-mediumgray) !important;
+    color: var(--color-light) !important;
 }
 
 .noStep {

--- a/frontends/web/src/components/forms/button.module.css
+++ b/frontends/web/src/components/forms/button.module.css
@@ -33,7 +33,7 @@
 .primary {
     composes: button;
     background: var(--color-blue);
-    color: var(--color-white);
+    color: var(--color-alt);
 }
 
 .primary:not([disabled]):focus,
@@ -43,8 +43,8 @@
 
 .secondary {
     composes: button;
-    background-color: var(--color-white);
-    border-color: var(--color-gray-alt);
+    background-color: var(--background-secondary);
+    border-color: var(--background-tertiary);
     color: var(--color-default);
 }
 
@@ -55,7 +55,7 @@
 }
 
 .secondary[disabled] {
-    color: var(--color-gray-alt);
+    color: var(--color-tertiary);
     border-color: var(--color-mediumgray);
 }
 
@@ -63,7 +63,7 @@
     composes: button;
     background-color: var(--color-softred);
     border-color: var(--color-softred);
-    color: var(--color-white);
+    color: var(--color-alt);
 }
 
 .danger:not([disabled]):focus,

--- a/frontends/web/src/components/forms/checkbox.module.css
+++ b/frontends/web/src/components/forms/checkbox.module.css
@@ -12,7 +12,7 @@
 
 .checkbox input + label::before,
 .checkbox input + label::after {
-    background: rgb(255, 255, 255);
+    background: var(--background-secondary);
     box-sizing: border-box;
     content: '';
     display: inline-block;
@@ -31,21 +31,21 @@
     top: -1px;
 }
 .success input + label::before {
-    border-color: var(--color-white);
+    border-color: var(--background-secondary);
     outline: 1px solid var(--color-success);
 }
 .warning input + label::before {
-    border-color: var(--color-white);
+    border-color: var(--background-secondary);
     outline: 1px solid var(--color-warning);
 }
 .info input + label::before {
-    border-color: var(--color-white);
+    border-color: var(--background-secondary);
     outline: 1px solid var(--color-info);
 }
 
 .checkbox input + label::after {
     background: transparent;
-    border: solid var(--color-white);
+    border: solid var(--color-alt);
     border-width: 0px 2px 2px 0;
     width: 0.35em;
     height: 0.55em;
@@ -69,19 +69,19 @@
 .success input:checked + label::before {
     background-color: var(--color-success);
     border-color: var(--color-success);
-    color: var(--color-white);
+    color: var(--color-alt);
 }
 
 .warning input:checked + label::before {
     background-color: var(--color-warning);
     border-color: var(--color-warning);
-    color: var(--color-white);
+    color: var(--color-alt);
 }
 
 .info input:checked + label::before {
     background-color: var(--color-info);
     border-color: var(--color-info);
-    color: var(--color-white);
+    color: var(--color-alt);
 }
 
 .checkbox input:checked + label::after {

--- a/frontends/web/src/components/forms/input.module.css
+++ b/frontends/web/src/components/forms/input.module.css
@@ -24,7 +24,7 @@
 }
 
 .input input {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     border-color: var(--color-mediumgray);
     border-radius: 2px;
     border-style: solid;
@@ -49,7 +49,7 @@
 }
 
 .input input[disabled] {
-    background-color: var(--color-white) !important;
+    background-color: var(--background-secondary) !important;
     border-color: var(--color-lightgray) !important;
     color: var(--color-secondary) !important;
     cursor: not-allowed;

--- a/frontends/web/src/components/forms/radio.module.css
+++ b/frontends/web/src/components/forms/radio.module.css
@@ -19,7 +19,7 @@
 
 .radio input + label::before,
 .radio input + label::after {
-    background: rgb(255, 255, 255);
+    background: var(--background-secondary);
     content: '';
     display: inline-block;
     width: 12px;
@@ -50,7 +50,7 @@
 /* checked */
 
 .radio input:checked + label::before {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
 }
 
 .radio input:checked + label::after {

--- a/frontends/web/src/components/forms/select.module.css
+++ b/frontends/web/src/components/forms/select.module.css
@@ -12,7 +12,7 @@
 
 .select select {
     appearance: none;
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-labelledby='chevron down' color='%23777'%3E%3Cdefs/%3E%3Cpolyline points='6 10 12 16 18 10'/%3E%3C/svg%3E%0A");
     background-position: calc(100% - 12px);
     background-repeat: no-repeat;
@@ -40,5 +40,5 @@
 }
 
 .select option[disabled] {
-    color: var(--color-mediumgray);
+    color: var(--color-light);
 }

--- a/frontends/web/src/components/guide/guide.module.css
+++ b/frontends/web/src/components/guide/guide.module.css
@@ -11,7 +11,7 @@
 }
 
 .close {
-    color: var(--color-white);
+    color: var(--color-alt);
     font-size: var(--size-default) !important;
     text-decoration: none;
     display: flex;

--- a/frontends/web/src/components/headerssync/headerssync.module.css
+++ b/frontends/web/src/components/headerssync/headerssync.module.css
@@ -8,7 +8,7 @@
 .progressBar {
     width: 100%;
     height: 1px;
-    background-color: var(--color-lightgray);
+    background-color: var(--background);
 }
 
 .progressValue {

--- a/frontends/web/src/components/inlineMessage/InlineMessage.module.css
+++ b/frontends/web/src/components/inlineMessage/InlineMessage.module.css
@@ -6,7 +6,7 @@
 
 .inlineMessage.success {
 	background-color: var(--color-success);
-	color: var(--color-white);
+	color: var(--color-alt);
 }
 
 .inlineMessage.left {

--- a/frontends/web/src/components/language/language.module.css
+++ b/frontends/web/src/components/language/language.module.css
@@ -40,7 +40,7 @@
 }
 
 .language:hover {
-    background-color: var(--color-lightgray);
+    background-color: var(--background);
 }
 
 .checked {

--- a/frontends/web/src/components/layout/grid.module.css
+++ b/frontends/web/src/components/layout/grid.module.css
@@ -3,7 +3,7 @@
 }
 
 .columnAsCard {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     padding: var(--space-default);
 }
 

--- a/frontends/web/src/components/layout/header.module.css
+++ b/frontends/web/src/components/layout/header.module.css
@@ -1,5 +1,5 @@
 .container {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     width: 100%;
 }
 

--- a/frontends/web/src/components/settingsButton/settingsButton.module.css
+++ b/frontends/web/src/components/settingsButton/settingsButton.module.css
@@ -10,7 +10,7 @@
     text-align:left;
     border: none;
     color: var(--color-blue);
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     font-size: var(--size-default);
     font-weight: 400;
     padding: 0 var(--space-half);

--- a/frontends/web/src/components/sidebar/sidebar.css
+++ b/frontends/web/src/components/sidebar/sidebar.css
@@ -20,7 +20,7 @@
     position: fixed;
     margin-left: calc(var(--sidebar-width-large) * -1);
     align-content: stretch;
-    background-color: var(--color-softblack);
+    background-color: var(--background-dark);
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
@@ -73,7 +73,7 @@
 .sidebarHeader {
     font-size: var(--sidebar-header-size);
     line-height: var(--sidebar-header-line-height);
-    color: var(--color-gray);
+    color: var(--color-secondary);
     text-transform: uppercase;
 }
 
@@ -137,7 +137,7 @@
 a.sidebar-active .sidebar_label,
 .sidebar a:hover .sidebar_label,
 .activeGroup .sidebar_label {
-    color: var(--color-white);
+    color: var(--color-alt);
 }
 
 .sidebar a.sidebar-active .sidebar_label {
@@ -191,7 +191,7 @@ a.sidebar-active .single img,
 }
 
 .sidebar_label {
-    color: var(--color-mediumgray);
+    color: var(--color-light);
     line-height: 1;
     flex: 1;
     padding-top: 0;

--- a/frontends/web/src/components/status/status.module.css
+++ b/frontends/web/src/components/status/status.module.css
@@ -33,7 +33,7 @@
 .success label, /* also force label elements to use color white */
 .warning label,
 .info label {
-    color: var(--color-white);
+    color: var(--color-alt);
 }
 
 .close-success {

--- a/frontends/web/src/components/toast/Toast.module.css
+++ b/frontends/web/src/components/toast/Toast.module.css
@@ -36,7 +36,7 @@
 
 .toast p {
     margin: 0;
-    color: var(--color-white);
+    color: var(--color-alt);
 }
 
 @media (max-width: 768px) {

--- a/frontends/web/src/components/transactions/transaction.module.css
+++ b/frontends/web/src/components/transactions/transaction.module.css
@@ -3,7 +3,7 @@
 }
 
 .row {
-    background-color: var(--color-white) !important;
+    background-color: var(--background-secondary) !important;
     min-height: 52px;
 }
 
@@ -30,7 +30,7 @@
     width: 9px;
     height: 9px;
     border-radius: 50%;
-    background-color: var(--color-lightgray);
+    background-color: var(--background);
     margin-right: var(--space-quarter);
 }
 
@@ -112,7 +112,7 @@
 .label,
 .columnLabel,
 .inlineLabel {
-    color: var(--color-gray);
+    color: var(--color-secondary);
     font-size: var(--size-default);
 }
 
@@ -203,7 +203,7 @@
 
 .editButton path,
 .editButton polyline {
-    stroke: var(--color-gray-alt);
+    stroke: var(--background-tertiary);
 }
 
 .editButton:focus path,

--- a/frontends/web/src/components/transactions/transactions.module.css
+++ b/frontends/web/src/components/transactions/transactions.module.css
@@ -16,7 +16,7 @@
 
 .columns {
   align-items: center;
-  background-color: var(--color-white);
+  background-color: var(--background-secondary);
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
@@ -25,7 +25,6 @@
 }
 
 .headers {
-  color: var(--color-softblack);
   font-weight: bold;
   height: 48px;
 }
@@ -86,7 +85,7 @@
 }
 
 .empty {
-  background-color: var(--color-white);
+  background-color: var(--background-secondary);
   height: 52px;
   display: flex;
   flex-direction: row;

--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -1,5 +1,5 @@
 .fullscreen {
-    background: var(--color-lightgray);
+    background: var(--background);
     bottom: 0;
     display: flex;
     flex-grow: 1;
@@ -77,7 +77,7 @@
     }
 }
 .dialog .inner {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     box-shadow: 0px 3px 5px rgba(0, 0, 0, 0.3);
     flex-grow: 0;
 }

--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -30,7 +30,7 @@
 .send {
     background-color: var(--color-blue);
     border-radius: 2px;
-    color: var(--color-white);
+    color: var(--color-alt);
     display: inline-block;
     font-size: var(--size-default);
     height: calc(var(--item-height) / 1.5);

--- a/frontends/web/src/routes/account/add/add.module.css
+++ b/frontends/web/src/routes/account/add/add.module.css
@@ -18,7 +18,7 @@
 }
 
 .successMessage {
-    color: var(--color-gray);
+    color: var(--color-secondary);
 }
 
 .successMessage strong {

--- a/frontends/web/src/routes/account/add/components/steps.module.css
+++ b/frontends/web/src/routes/account/add/components/steps.module.css
@@ -79,7 +79,7 @@
 }
 
 .wait {
-    color: var(--color-gray-alt);
+    color: var(--color-tertiary);
 }
 
 .finish .dot::before,
@@ -88,7 +88,7 @@
 }
 
 .wait .dot::before {
-    background: var(--color-mediumgray);
+    background: var(--background-quaternary);
     height: var(--icon-size-small);
     width: var(--icon-size-small);
 }

--- a/frontends/web/src/routes/account/receive/receive.module.css
+++ b/frontends/web/src/routes/account/receive/receive.module.css
@@ -52,7 +52,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
 }
 
 .changeType {

--- a/frontends/web/src/routes/account/send/send.module.css
+++ b/frontends/web/src/routes/account/send/send.module.css
@@ -74,7 +74,7 @@
 
 .qrButton {
     border: none;
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     width: 18px;
     height: 18px;
     padding: 0;

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -57,14 +57,9 @@
 
 .table thead th,
 .table tfoot th {
-    background-color: var(--color-white);
-    color: var(--color-softblack);
+    background-color: var(--background-secondary);
     font-size: var(--size-default);
     font-weight: bold;
-}
-
-.table strong {
-    color: var(--color-softblack);
 }
 
 .table thead th:first-child,
@@ -79,7 +74,7 @@
 }
 
 .table tbody td {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
 }
 
 .clickable {
@@ -92,7 +87,7 @@
 
 .table tfoot th,
 .table tfoot td {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     padding-bottom: calc(var(--space-quarter) + var(--space-half));
 }
 
@@ -148,7 +143,7 @@
     }
 
     .table tfoot tr {
-        background-color: var(--color-white);
+        background-color: var(--background-secondary);
         display: flex;
         justify-content: space-between;
     }

--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -10,7 +10,7 @@
 
 .chartUpdatingMessage {
   align-items: center;
-  color: var(--color-gray-alt);
+  color: var(--color-tertiary);
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -60,10 +60,10 @@
 
 .filters button {
   appearance: none;
-  background: var(--color-white);
-  border: 2px solid var(--color-white);
+  background: var(--background-secondary);
+  border: 2px solid var(--background-secondary);
   border-radius: 2rem;
-  color: var(--color-softblack);
+  color: var(--color-default);
   font-size: var(--size-default);
   line-height: 1.75;
   margin-bottom: var(--spacing-half);
@@ -87,13 +87,13 @@
 .filters button.filterActive {
   background: var(--color-blue);
   border-color: var(--color-blue);
-  color: var(--color-white);
+  color: var(--color-alt);
 }
 
 .filters button[disabled] {
-  background: var(--color-mediumgray);
+  background: var(--background-quaternary);
   border-color: var(--color-mediumgray);
-  color: var(--color-white);
+  color: var(--color-alt);
 }
 
 .arrow svg {

--- a/frontends/web/src/routes/device/bitbox01/bitbox01.module.css
+++ b/frontends/web/src/routes/device/bitbox01/bitbox01.module.css
@@ -117,7 +117,7 @@
 .waitingContent {
     max-width: 540px;
     width: 100%;
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     padding: var(--space-default);
     margin: 0 auto;
     text-align: center;

--- a/frontends/web/src/routes/device/components/backups.module.css
+++ b/frontends/web/src/routes/device/components/backups.module.css
@@ -45,7 +45,7 @@
 }
 
 .backupItem + label {
-    color: var(--color-dark);
+    color: var(--color-default);
     word-break: break-all;
 }
 

--- a/frontends/web/src/routes/exchanges/exchanges.module.css
+++ b/frontends/web/src/routes/exchanges/exchanges.module.css
@@ -100,7 +100,7 @@
 }
 
 :global(.exchange-hostname) {
-    color: var(--color-gray);
+    color: var(--color-secondary);
     padding-top: calc(var(--space-half) * .5);
 }
 

--- a/frontends/web/src/routes/settings/components/fiat/fiat.module.css
+++ b/frontends/web/src/routes/settings/components/fiat/fiat.module.css
@@ -1,5 +1,5 @@
 .defaultFiat {
-    color: var(--color-gray);
+    color: var(--color-secondary);
 }
 
 .star {
@@ -14,7 +14,7 @@
 }
 
 .star img {
-    color: var(--color-gray-alt);
+    color: var(--color-tertiary);
     height: 18px;
     width: 18px;
 }

--- a/frontends/web/src/routes/settings/electrum.module.css
+++ b/frontends/web/src/routes/settings/electrum.module.css
@@ -21,7 +21,7 @@
 }
 
 .servers {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     list-style: none;
     padding: var(--space-quarter) var(--space-half);
     margin: 0;
@@ -89,7 +89,7 @@
 
 .primary {
     background-color: var(--color-blue);
-    color: var(--color-white);
+    color: var(--color-alt);
     transition: background-color 0.2s ease-in-out;
     will-change: background-color;
 }
@@ -100,7 +100,7 @@
 
 .warning {
     background-color: var(--color-softred);
-    color: var(--color-white);
+    color: var(--color-alt);
     transition: background-color 0.2s ease-in-out;
     will-change: background-color;
 }
@@ -124,7 +124,7 @@
 .addServer {
     margin-top: var(--space-half);
     margin-bottom: var(--space-default);
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     padding: var(--space-half);
 }
 

--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -12,10 +12,6 @@
     flex-shrink: 0;
 }
 
-.setting.disabled > p {
-    color: var(--color-gray-alt);
-}
-
 .coinLogo {
     position: relative;
     z-index: 2;
@@ -113,7 +109,7 @@
 .tokenActive {}
 
 .tokenInactive {
-    color: var(--color-gray-alt);
+    color: var(--color-tertiary);
     transition: color 0.2s ease;
 }
 

--- a/frontends/web/src/routes/settings/settings.module.css
+++ b/frontends/web/src/routes/settings/settings.module.css
@@ -10,7 +10,3 @@
 .setting > label {
     flex-shrink: 0;
 }
-
-.setting.disabled > p {
-    color: var(--color-gray-alt);
-}

--- a/frontends/web/src/style/base.css
+++ b/frontends/web/src/style/base.css
@@ -92,7 +92,7 @@ svg {
 }
 
 pre {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     display: block;
     font-family: monospace;
     font-size: 20px;

--- a/frontends/web/src/style/forms.css
+++ b/frontends/web/src/style/forms.css
@@ -46,7 +46,7 @@ dt {
 .labelButton {
     padding: var(--space-quarter) var(--space-half);
     border-radius: 2px;
-    color: var(--color-white);
+    color: var(--color-alt);
     transition: background-color ease-in-out 0.2s;
     will-change: background-color;
 }

--- a/frontends/web/src/style/layout.css
+++ b/frontends/web/src/style/layout.css
@@ -31,16 +31,10 @@
     font-size: var(--size-default);
     text-transform: none;
 }
-.text-bold { font-weight: bold; }
 .text-blue { color: var(--color-blue); }
 .text-red { color: var(--color-danger); }
 .text-green { color: var(--color-success); }
 .text-gray { color: var(--color-secondary); }
-.text-darkgray { color: var(--color-gray); }
-.text-black { color: var(--color-dark) !important; }
-.text-black + label {
-    color: var(--color-dark);
-}
 
 .show-on-small {
     display: none;
@@ -207,7 +201,7 @@
 
 .tabs .tab.active a {
     color: var(--color-blue);
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
 }
 
 @media (max-width: 768px) {
@@ -235,7 +229,7 @@
 }
 
 .box {
-    background-color: var(--color-white);
+    background-color: var(--background-secondary);
     padding: var(--space-half);
 }
 

--- a/frontends/web/src/style/variables.css
+++ b/frontends/web/src/style/variables.css
@@ -21,10 +21,13 @@
     --color-lightorange: #F9AC60;
 
     /* font colors */
+    /* all fonts should use these colors and not from the main colors directly */
     --color-default: var(--color-dark);
     --color-primary: var(--color-blue);
     --color-secondary: var(--color-gray);
     --color-light: var(--color-mediumgray);
+    --color-alt: var(--color-white);
+    --color-tertiary: var(--color-gray-alt);
 
     /* status colors */
     --color-success: var(--color-green);
@@ -35,8 +38,13 @@
     --color-disabled: var(--color-mediumgray);
 
     /* background colors */
+    /* all backgrounds should use these colors and not from the main colors directly */
     --background: var(--color-lightgray);
     --bg-transparent-dark: rgba(0, 0, 0, 0.4);
+    --background-secondary: var(--color-white);
+    --background-dark: var(--color-softblack);
+    --background-tertiary: var(--color-gray-alt);
+    --background-quaternary: var(--color-mediumgray);
 
     /* font sizes */
     --size-extra-large: 2.2rem;


### PR DESCRIPTION
Separated text and background colors into their own variables. This makes colors easier to maintain because now it's possible to change text and background colors without affecting each other.

Also some text used --color-softblack instead of a designated /* font colors */ variable. Changed this text to --color-default so it is consistent with the other text colors.

- changed text using color-grey to color-secondary
- created --color-tertiary and --background-tertiary that use --color-gray-alt
- removed unused text-darkgray, text-black and text-bold

TODO: for the future --color-blue to --color-info