### PR TITLE
scripts/regtest.sh: fix datadir, define port vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ servewallet:
 servewallet-mainnet:
 	go run -mod=vendor ./cmd/servewallet -mainnet
 servewallet-regtest:
-	rm -f appfolder.dev/cache/headers-rbtc.bin && go run -mod=vendor ./cmd/servewallet -regtest
+	rm -f appfolder.dev/cache/headers-rbtc.bin && rm -rf appfolder.dev/cache/account-*rbtc* && go run -mod=vendor ./cmd/servewallet -regtest
 servewallet-prodservers:
 	go run -mod=vendor ./cmd/servewallet -devservers=false
 buildweb:

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -312,7 +312,10 @@ mCMuGBNHsbrs6rI1hbI4Qq6GYazLaDRqdCufTA==
 			{Server: "tbtc2.shiftcrypto.dev:51002", TLS: true, PEMCert: devShiftCA},
 		}
 	case coinpkg.CodeRBTC:
-		return []*config.ServerInfo{{Server: "127.0.0.1:52001", TLS: false, PEMCert: ""}}
+		return []*config.ServerInfo{
+			{Server: "127.0.0.1:52001", TLS: false, PEMCert: ""},
+			{Server: "127.0.0.1:52002", TLS: false, PEMCert: ""},
+		}
 	case coinpkg.CodeLTC:
 		return []*config.ServerInfo{{Server: "ltc1.shiftcrypto.dev:50011", TLS: true, PEMCert: devShiftCA}}
 	case coinpkg.CodeTLTC:

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -180,6 +180,11 @@ func NewDefaultAppConfig() AppConfig {
 						TLS:     false,
 						PEMCert: "",
 					},
+					{
+						Server:  "127.0.0.1:52002",
+						TLS:     false,
+						PEMCert: "",
+					},
 				},
 			},
 			LTC: btcCoinConfig{

--- a/scripts/run_regtest.sh
+++ b/scripts/run_regtest.sh
@@ -106,6 +106,7 @@ echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -
 echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 generatetoaddress 101 <newaddress>"
 echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 sendtoaddress <address> <amount>"
 echo "Delete headers-rbtc.bin in the app cache folder before running the BitBoxApp, otherwise it can conflict the fresh regtest chain."
+echo "Also delete all rbtc account caches in the app cache folder before running the BitBoxApp."
 echo "You may need to disable VPN, as it can prevent Electrs/bitcoin-cli from connecting to bitcoind."
 
 while true; do sleep 1; done

--- a/scripts/run_regtest.sh
+++ b/scripts/run_regtest.sh
@@ -101,10 +101,10 @@ docker run \
         --db-dir=/data &
 
 echo "Interact with the regtest chain (e.g. generate 101 blocks and send coins):"
-echo "    bitcoin-cli -regtest -datadir=${BITCOIN_DATADIR} -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 createwallet"
-echo "    bitcoin-cli -regtest -datadir=${BITCOIN_DATADIR} -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 getnewaddress"
-echo "    bitcoin-cli -regtest -datadir=${BITCOIN_DATADIR} -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 generatetoaddress 101 <newaddress>"
-echo "    bitcoin-cli -regtest -datadir=${BITCOIN_DATADIR} -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 sendtoaddress <address> <amount>"
+echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 createwallet"
+echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 getnewaddress"
+echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 generatetoaddress 101 <newaddress>"
+echo "    docker exec --user=`id -u` -it bitcoind-regtest bitcoin-cli -regtest -datadir=/bitcoin -rpcuser=dbb -rpcpassword=dbb -rpcport=10332 sendtoaddress <address> <amount>"
 echo "Delete headers-rbtc.bin in the app cache folder before running the BitBoxApp, otherwise it can conflict the fresh regtest chain."
 echo "You may need to disable VPN, as it can prevent Electrs/bitcoin-cli from connecting to bitcoind."
 


### PR DESCRIPTION
The kylemanna/bitcoind Dockerfile specifies `/bitcoin` as `$HOME`, making the btc data dir default to `/bitcoin/.bitcoin` (`-datadir` wasn't specified).

Also we define ports in variables for clarity.