### PR TITLE
backend/coin/conversions: never return nil for Conversions

### DIFF
--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -51,7 +51,7 @@ func FormatAsCurrency(amount *big.Rat, fiatUnit string, formatBtcAsSats bool) st
 
 // Conversions handles fiat conversions.
 func Conversions(amount Amount, coin Coin, isFee bool, ratesUpdater *rates.RateUpdater, formatBtcAsSats bool) map[string]string {
-	var conversions map[string]string
+	conversions := map[string]string{}
 	rates := ratesUpdater.LatestPrice()
 	if rates != nil {
 		unit := coin.Unit(isFee)


### PR DESCRIPTION
The frontend types IAmount.Conversions to always be a map, never null. If null is returned, the frontend errors in rates.tsx when accessing `amount.conversions[active]`, crashing the whole frontend.

This fix has already been done before in
32387d1b9814eeeb44d69ff79dc8daaa1924f879, but accidentally undone again in f5a2a823cd406bde2a30f273a6e646606a38210f.