### PR TITLE
frontend: add red/green icons to firmware version on device settings

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -384,11 +384,13 @@
   },
   "deviceSettings": {
     "firmware": {
+      "firmwareVersion": "Firmware Version",
       "newVersion": {
         "label": "Available version"
       },
       "title": "Firmware",
       "upToDate": "Your device is up to date",
+      "upgradeAvailable": "New upgrade available",
       "version": {
         "label": "Version"
       }

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -109,7 +109,9 @@ export const Settings = ({ deviceID }: TProps) => {
                           apiPrefix={apiPrefix}
                           versionInfo={versionInfo}/>
                       ) : versionInfo && (
-                        <SettingsItem optionalText={versionInfo.currentVersion}>
+                        <SettingsItem
+                          optionalText={versionInfo.currentVersion}
+                          optionalIcon={<Checked/>}>
                           {t('deviceSettings.firmware.upToDate')}
                         </SettingsItem>
                       )

--- a/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
+++ b/frontends/web/src/routes/device/bitbox02/upgradebutton.tsx
@@ -22,6 +22,7 @@ import { apiPost } from '../../../utils/request';
 import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
 import { Button } from '../../../components/forms';
 import { SettingsButton } from '../../../components/settingsButton/settingsButton';
+import { RedDot } from '../../../components/icon/icon';
 
 interface UpgradeButtonProps {
     apiPrefix: string;
@@ -73,12 +74,22 @@ class UpgradeButton extends Component<Props, State> {
           asButton ? (
             <Button primary onClick={() => this.setState({ activeDialog: true })}>
               {t('button.upgrade')}
+              {' '}
+              <RedDot/>
             </Button>
           ) : (
-            <SettingsButton optionalText={versionInfo.newVersion} onClick={() => this.setState({ activeDialog: true })}>
-              {t('button.upgrade')}
-            </SettingsButton>
-          )
+            <SettingsButton
+              optionalText={versionInfo.newVersion}
+              secondaryText={
+                <>
+                  {t('deviceSettings.firmware.upgradeAvailable')}
+                  {' '}
+                  <RedDot />
+                </>
+              }
+              onClick={() => this.setState({ activeDialog: true })}>
+              {t('deviceSettings.firmware.firmwareVersion')}
+            </SettingsButton>)
         }
         <Dialog open={activeDialog} title={t('upgradeFirmware.title')}>
           {confirming ? t('confirmOnDevice') : (


### PR DESCRIPTION
In 9107a09 we added a new Info section in the settings page, showing a green or a red icon, depending on the availability of new updates for the app.

This refactors the firmware version section of the device page, applying the same style and icons for firmware upgrades.