### PR TITLE
ci: use macos 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           path: frontends/qt/build/linux/bitbox-*.rpm
           name: BitBoxApp-linux-${{github.sha}}.rpm
   macos:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
The macOS 10.15 Actions runner image is beeing deprecated.

See https://github.com/actions/runner-images/issues/5583