### PR TITLE
frontend: conversions can be missing

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -137,7 +137,7 @@ export type Conversions = {
 
 export interface IAmount {
     amount: string;
-    conversions: Conversions;
+    conversions?: Conversions;
     unit: Coin;
 }
 

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -131,7 +131,7 @@ function Conversion({
   let isAvailable = false;
 
   // amount.conversions[active] can be empty in recent transactions.
-  if (amount && amount.conversions[active] && amount.conversions[active] !== '') {
+  if (amount && amount.conversions && amount.conversions[active] && amount.conversions[active] !== '') {
     isAvailable = true;
     formattedValue = amount.conversions[active];
     if (noBtcZeroes) {


### PR DESCRIPTION
Conversions can sometimes be missing, as some of the logic in rates.tsx is executed before React, an error here seems to cause the app to fail resulting in a blank screen.

How to test:

1) unlock BB02, enable Tor and configure a inexistent port
2) quit and restart the app again
3) should show no blank screen