### PR TITLE
frontend: full screen menu on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Re-style header for a better space utilisation
+- Re-style sidebar navigation on mobile (portrait) to be full-screen for better space utilisation and a more modern look
 
 ## 4.35.0
 - Add Arabic translation

--- a/frontends/web/src/components/sidebar/sidebar.css
+++ b/frontends/web/src/components/sidebar/sidebar.css
@@ -1,3 +1,15 @@
+.closeButton {
+    background: transparent;
+    border: none;
+    display: none;
+    padding: 12px;
+    transform: translateX(14px);
+}
+
+.closeButton:focus{
+    outline: none;
+}
+
 .sidebarOverlay {
     position: fixed;
     background-color: rgba(0, 0, 0, 0.3);
@@ -42,11 +54,11 @@
 }
 
 .sidebar .sidebarLogoContainer {
+    align-items: center;
     display: flex;
     flex-direction: row;
-    justify-content: center;
-    align-items: center;
     height: 70px;
+    justify-content: space-between;
     padding: calc(var(--spacing-default) + var(--spacing-half)) var(--spacing-large);
     background-size: cover;
     background-color: rgba(0, 0, 0, 0.1);
@@ -75,25 +87,6 @@
     line-height: var(--sidebar-header-line-height);
     color: var(--color-secondary);
     text-transform: uppercase;
-}
-
-.sidebarHeaderAction {
-    height: var(--sidebar-header-line-height);
-}
-
-.sidebarHeaderAction > a {
-    height: 100% !important;
-}
-
-.sidebarHeaderAction > a > svg {
-    height: var(--sidebar-header-line-height);
-    width: auto;
-    stroke: var(--color-gray);
-    transition: stroke 0.2s ease;
-}
-
-.sidebarHeaderAction:hover > a > svg {
-    stroke: var(--color-white);
 }
 
 .sidebarItem {
@@ -228,8 +221,16 @@ a.sidebar-active .single img,
         margin-left: 0;
         width: var(--sidebar-width-large);
     }
+}
 
-    .sidebarContainer:not(.forceHide) .sidebar .sidebarLogoContainer a {
-        display: none !important;
+@media (max-width: 560px) {
+    .closeButton {
+        display:block;
+    }
+
+    .sidebar {
+        margin-left: -100vw;
+        transition: margin-left 0.3s ease;
+        width: 100vw;
     }
 }

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -32,6 +32,7 @@ import { debug } from '../../utils/env';
 import { apiPost } from '../../utils/request';
 import Logo, { AppLogoInverted } from '../icon/logo';
 import { useLocation } from 'react-router';
+import { CloseXWhite } from '../icon';
 
 interface SidebarProps {
     deviceIDs: string[];
@@ -158,13 +159,17 @@ class Sidebar extends Component<Props> {
       <div className={['sidebarContainer', hidden ? 'forceHide' : ''].join(' ')}>
         <div className={['sidebarOverlay', activeSidebar ? 'active' : ''].join(' ')} onClick={toggleSidebar}></div>
         <nav className={['sidebar', activeSidebar ? 'forceShow' : '', shown ? 'withGuide' : ''].join(' ')}>
-          <Link
-            to={accounts.length ? '/account-summary' : '/'}
-            onClick={this.handleSidebarItemClick}>
-            <div className="sidebarLogoContainer">
+          <div className="sidebarLogoContainer">
+            <Link
+              to={accounts.length ? '/account-summary' : '/'}
+              onClick={this.handleSidebarItemClick}>
               <AppLogoInverted className="sidebarLogo" />
-            </div>
-          </Link>
+            </Link>
+            <button className="closeButton" onClick={toggleSidebar}>
+              <CloseXWhite />
+            </button>
+          </div>
+
           <div className="sidebarHeaderContainer">
             <span className="sidebarHeader" hidden={!keystores?.length}>
               {t('sidebar.accounts')}


### PR DESCRIPTION
to improve our app's UI and achieving a more modern look, we'd like to make the sidebar menu / navigation to be of full screen size on mobile.

[Preview] Screen recording on mobile:

https://user-images.githubusercontent.com/28676406/204563461-d42905f8-3f87-4935-9160-481d918f20b6.mov




[Preview] Screenshot on desktop (no change):
<img width="776" alt="Screen Shot 2022-11-29 at 15 45 51" src="https://user-images.githubusercontent.com/28676406/204560925-1330ef4c-9a82-4fa9-9eaf-b5e152b62859.png">
