### PR TITLE
frontend: fix buy container

### DIFF
--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -100,26 +100,24 @@ class Moonpay extends Component<Props, State> {
     return (
       <div className="contentWithGuide">
         <div className="container">
-          <div ref={this.ref} className="innerContainer scrollableContainer">
+          <div className="innerContainer">
             <div className={style.header}>
               <Header title={<h2>{t('buy.info.title', { name })}</h2>} />
             </div>
-            <div ref={this.ref} className="innerContainer">
-              <div className="noSpace">
-                {!iframeLoaded && <Spinner text={t('loading')} />}
-                <iframe
-                  onLoad={() => {
-                    this.setState({ iframeLoaded: true });
-                  }}
-                  title="Moonpay"
-                  width="100%"
-                  height={iframeLoaded ? height : 0}
-                  frameBorder="0"
-                  className={style.iframe}
-                  allow="camera; payment"
-                  src={`${moonpay.url}&colorCode=%235E94BF`}>
-                </iframe>
-              </div>
+            <div ref={this.ref} className="iframeContainer">
+              {!iframeLoaded && <Spinner text={t('loading')} />}
+              <iframe
+                onLoad={() => {
+                  this.setState({ iframeLoaded: true });
+                }}
+                title="Moonpay"
+                width="100%"
+                height={iframeLoaded ? height : 0}
+                frameBorder="0"
+                className={style.iframe}
+                allow="camera; payment"
+                src={`${moonpay.url}&colorCode=%235E94BF`}>
+              </iframe>
             </div>
           </div>
         </div>

--- a/frontends/web/src/style/layout.css
+++ b/frontends/web/src/style/layout.css
@@ -101,6 +101,13 @@
     height: 100%;
 }
 
+.iframeContainer {
+    flex-basis: 100vh;
+    flex-grow: 1;
+    flex-shrink: 1;
+    overflow: hidden;
+}
+
 .fluid {
     max-width: none;
 }


### PR DESCRIPTION
In f30df4f4a64f50789541fe153a24389b5fc1954d the iframe container accidentally contained 2 this.ref, which is wrong.

As the iframe scrolls anyway the header is always sticky. Removed scrollContainer classes, so that there is no double scroll.