### PR TITLE
backend/btc/headers: fix broken headers database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Re-style header for a better space utilisation
 - Re-style sidebar navigation on mobile (portrait) to be full-screen for better space utilisation and a more modern look
+- Automatically recover from a corrupt headers database (caused e.g. by the computer shutting down during a database write)
 
 ## 4.35.1
 - Fix issue where the app sometimes shows a blank screen after unlock

--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -109,7 +109,8 @@ func (coin *Coin) Initialize() {
 		}
 
 		db, err := headersdb.NewDB(
-			path.Join(coin.dbFolder, fmt.Sprintf("headers-%s.bin", coin.code)))
+			path.Join(coin.dbFolder, fmt.Sprintf("headers-%s.bin", coin.code)),
+			coin.log)
 		if err != nil {
 			coin.log.WithError(err).Panic("Could not open headers DB")
 		}

--- a/backend/coins/btc/db/headersdb/headersdb_test.go
+++ b/backend/coins/btc/db/headersdb/headersdb_test.go
@@ -1,0 +1,79 @@
+// Copyright 2022 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package headersdb
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+var log = logging.Get().WithGroup("headersdb_test")
+
+func testDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := NewDB(test.TstTempFile("headersdb"), log)
+	require.NoError(t, err)
+	return db
+}
+
+func TestTip(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	tip, err := db.Tip()
+	require.NoError(t, err)
+	require.Equal(t, -1, tip)
+
+	require.NoError(t, db.PutHeader(20, &wire.BlockHeader{}))
+
+	tip, err = db.Tip()
+	require.NoError(t, err)
+	require.Equal(t, 20, tip)
+
+	require.NoError(t, db.RevertTo(10))
+
+	tip, err = db.Tip()
+	require.NoError(t, err)
+	require.Equal(t, 10, tip)
+}
+
+func TestFixTrailingZeroes(t *testing.T) {
+	f, err := ioutil.TempFile("", "headersdb")
+	require.NoError(t, err)
+	filename := f.Name()
+
+	_, err = f.Write([]byte(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	))
+	require.NoError(t, err)
+	// Add 10 zero-byte headers that will be stripped off.
+	_, err = f.Write(make([]byte, 80*10))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	db, err := NewDB(filename, log)
+	require.NoError(t, err)
+	defer db.Close()
+
+	tip, err := db.Tip()
+	require.NoError(t, err)
+	require.Equal(t, 1, tip)
+}


### PR DESCRIPTION
A user reported a crash. A header was loaded (at a valid height) but nil was returned, so there was a crash:

```
github.com/btcsuite/btcd/wire.writeBlockHeader({0xd50a00, 0xc0003b0db0}, 0x5e2cc5?, 0x40?)
	/home/marko/go/src/github.com/digitalbitbox/bitbox-wallet-app/vendor/github.com/btcsuite/btcd/wire/blockheader.go:125 +0x36
github.com/btcsuite/btcd/wire.(*BlockHeader).BlockHash(0xc0000af940?)
	/home/marko/go/src/github.com/digitalbitbox/bitbox-wallet-app/vendor/github.com/btcsuite/btcd/wire/blockheader.go:54 +0x99
github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers.(*Headers).canConnect(0xc00036f680, {0xd58318, 0xc00027fb20}, 0x54444, 0xc00032a000)
	/home/marko/go/src/github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers/headers.go:317 +0x1ee
github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers.(*Headers).processBatch(0xc00036f680, {0xd58318, 0xc00027fb20}, 0xc000136000?, {0xc00037c180, 0xa, 0x127f240?}, 0x7e0)
	/home/marko/go/src/github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers/headers.go:390 +0xcb
github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers.(*Headers).download.func2()
	/home/marko/go/src/github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers/headers.go:219 +0x1d7
github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers.(*Headers).download(0xc00036f680)
	/home/marko/go/src/github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers/headers.go:233 +0xe9
created by github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers.(*Headers).Initialize
	/home/marko/go/src/github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/headers/headers.go:176
    +0xb6
```

See the comments in the code in this commit for a detailed explanation for why this happens and how it is fixed.