### PR TITLE
frontend: migrate sidebar.css into a css module

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.module.css
+++ b/frontends/web/src/components/sidebar/sidebar.module.css
@@ -111,7 +111,7 @@
     display: none;
 }
 
-.sidebarItem a.sidebar-active {
+.sidebarItem a.sidebarActive {
     text-decoration: none;
     background-color: rgba(255, 255, 255, 0.1);
 }
@@ -121,47 +121,31 @@
     margin-right: var(--sidebar-margin);
 }
 
-.sidebarItem .stacked,
+.sidebarItem :global(.stacked),
 .sidebarItem .single {
     margin: 0 var(--sidebar-icon-margin) 0 var(--sidebar-margin);
     height: var(--sidebar-icon-size);
 }
 
-a.sidebar-active .sidebar_label,
-.sidebar a:hover .sidebar_label,
-.activeGroup .sidebar_label {
+a.sidebarActive .sidebarLabel,
+.sidebar a:hover .sidebarLabel,
+.activeGroup .sidebarLabel {
     color: var(--color-alt);
 }
 
-.sidebar a.sidebar-active .sidebar_label {
+.sidebar a.sidebarActive .sidebarLabel {
     font-weight: normal;
 }
 
-a.sidebar-active .stacked img:first-child,
-.sidebar a:hover .stacked img:first-child {
+a.sidebarActive :global(.stacked) img:first-child,
+.sidebar a:hover :global(.stacked) img:first-child {
     opacity: 0;
 }
 
-a.sidebar-active .stacked img:last-child,
-.sidebar a:hover .stacked img:last-child,
-.activeGroup .stacked img:last-child {
+a.sidebarActive :global(.stacked) img:last-child,
+.sidebar a:hover :global(.stacked) img:last-child,
+.activeGroup :global(.stacked) img:last-child {
     opacity: 1;
-}
-
-.stacked {
-    position: relative;
-}
-
-.stacked img {
-    transition: opacity 0.2s ease;
-}
-
-.stacked img:last-child {
-    opacity: 0;
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
 }
 
 .sidebar img {
@@ -178,12 +162,12 @@ a.sidebar-active .stacked img:last-child,
     transition: opacity 0.2s ease;
 }
 
-a.sidebar-active .single img,
+a.sidebarActive .single img,
 .sidebar a:hover .single img {
     opacity: 1;
 }
 
-.sidebar_label {
+.sidebarLabel {
     color: var(--color-light);
     line-height: 1;
     flex: 1;

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -33,6 +33,7 @@ import { apiPost } from '../../utils/request';
 import Logo, { AppLogoInverted } from '../icon/logo';
 import { useLocation } from 'react-router';
 import { CloseXWhite } from '../icon';
+import style from './sidebar.module.css';
 
 interface SidebarProps {
     deviceIDs: string[];
@@ -66,14 +67,14 @@ const GetAccountLink = ({ coinCode, code, name, handleSidebarItemClick }: TGetAc
   const { pathname } = useLocation();
   const active = (pathname === `/account/${code}`) || (pathname.startsWith(`/account/${code}/`));
   return (
-    <div key={code} className="sidebarItem">
+    <div key={code} className={style.sidebarItem}>
       <Link
-        className={active ? 'sidebar-active' : ''}
+        className={active ? style.sidebarActive : ''}
         to={`/account/${code}`}
         onClick={handleSidebarItemClick}
         title={name}>
-        <Logo stacked coinCode={coinCode} className="sidebar_icon" alt={name} />
-        <span className="sidebar_label">{name}</span>
+        <Logo stacked coinCode={coinCode} alt={name} />
+        <span className={style.sidebarLabel}>{name}</span>
       </Link>
     </div>
   );
@@ -139,7 +140,7 @@ class Sidebar extends Component<Props> {
 
   private handleSidebarItemClick = (e: React.SyntheticEvent) => {
     const el = (e.target as Element).closest('a');
-    if (el!.classList.contains('sidebar-active') && window.innerWidth <= 901) {
+    if (el!.classList.contains('sidebarActive') && window.innerWidth <= 901) {
       toggleSidebar();
     }
   };
@@ -156,117 +157,89 @@ class Sidebar extends Component<Props> {
     } = this.props;
     const hidden = ['forceHidden', 'forceCollapsed'].includes(sidebarStatus);
     return (
-      <div className={['sidebarContainer', hidden ? 'forceHide' : ''].join(' ')}>
-        <div className={['sidebarOverlay', activeSidebar ? 'active' : ''].join(' ')} onClick={toggleSidebar}></div>
-        <nav className={['sidebar', activeSidebar ? 'forceShow' : '', shown ? 'withGuide' : ''].join(' ')}>
-          <div className="sidebarLogoContainer">
+      <div className={[style.sidebarContainer, hidden ? style.forceHide : ''].join(' ')}>
+        <div className={[style.sidebarOverlay, activeSidebar ? style.active : ''].join(' ')} onClick={toggleSidebar}></div>
+        <nav className={[style.sidebar, activeSidebar ? style.forceShow : '', shown ? style.withGuide : ''].join(' ')}>
+          <div className={style.sidebarLogoContainer}>
             <Link
               to={accounts.length ? '/account-summary' : '/'}
               onClick={this.handleSidebarItemClick}>
-              <AppLogoInverted className="sidebarLogo" />
+              <AppLogoInverted className={style.sidebarLogo} />
             </Link>
-            <button className="closeButton" onClick={toggleSidebar}>
+            <button className={style.closeButton} onClick={toggleSidebar}>
               <CloseXWhite />
             </button>
           </div>
 
-          <div className="sidebarHeaderContainer">
-            <span className="sidebarHeader" hidden={!keystores?.length}>
+          <div className={style.sidebarHeaderContainer}>
+            <span className={style.sidebarHeader} hidden={!keystores?.length}>
               {t('sidebar.accounts')}
             </span>
           </div>
-          {/* <div className="activeGroup">
-                        <div className="sidebarItem">
-                            <a href="#" className="sidebar-active">
-                                <div className="single">
-                                    <img draggable={false} className="sidebar_settings" src={info} alt={t('sidebar.addAccount')} />
-                                </div>
-                                <span className="sidebar_label">Hello</span>
-                                <svg className="sidebarArrow" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="18" height="18" viewBox="0, 0, 18, 18">
-                                    <path d="M0,4.5 L9,13.5 L18,4.5" fill="#FFFFFF"/>
-                                </svg>
-                            </a>
-                            <div className="sidebarSubmenu">
-                                <a href="#">
-                                    <div className="single">
-                                        <img draggable={false} className="sidebar_settings" src={info} alt={t('sidebar.addAccount')} />
-                                    </div>
-                                    <span className="sidebar_label">One</span>
-                                </a>
-                                <a href="#">
-                                    <div className="single">
-                                        <img draggable={false} className="sidebar_settings" src={info} alt={t('sidebar.addAccount')} />
-                                    </div>
-                                    <span className="sidebar_label">Two</span>
-                                </a>
-                            </div>
-                        </div>
-                    </div> */}
           { accounts.length ? (
-            <div className="sidebarItem">
+            <div className={style.sidebarItem}>
               <NavLink
-                className={({ isActive }) => isActive ? 'sidebar-active' : ''}
+                className={({ isActive }) => isActive ? style.sidebarActive : ''}
                 to={'/account-summary'}
                 title={t('accountSummary.title')}
                 onClick={this.handleSidebarItemClick}>
-                <div className="single">
-                  <img draggable={false} className="sidebar_settings" src={info} alt={t('sidebar.addAccount')} />
+                <div className={style.single}>
+                  <img draggable={false} src={info} alt={t('sidebar.addAccount')} />
                 </div>
-                <span className="sidebar_label">{t('accountSummary.title')}</span>
+                <span className={style.sidebarLabel}>{t('accountSummary.title')}</span>
               </NavLink>
             </div>
           ) : null }
           { accounts && accounts.map(acc => <GetAccountLink key={acc.code} {...acc} handleSidebarItemClick={this.handleSidebarItemClick }/>) }
-          <div className="sidebarHeaderContainer end"></div>
+          <div className={[style.sidebarHeaderContainer, style.end].join(' ')}></div>
           { accounts.length ? (
-            <div key="buy" className="sidebarItem">
+            <div key="buy" className={style.sidebarItem}>
               <NavLink
-                className={({ isActive }) => isActive ? 'sidebar-active' : ''}
+                className={({ isActive }) => isActive ? style.sidebarActive : ''}
                 to="/buy/info"
               >
-                <div className="single">
-                  <img draggable={false} className="sidebar_settings" src={coins} alt={t('sidebar.exchanges')} />
+                <div className={style.single}>
+                  <img draggable={false} src={coins} alt={t('sidebar.exchanges')} />
                 </div>
-                <span className="sidebar_label">
+                <span className={style.sidebarLabel}>
                   {t('sidebar.buy')}
                 </span>
               </NavLink>
             </div>
           ) : null }
           { deviceIDs.map(deviceID => (
-            <div key={deviceID} className="sidebarItem">
+            <div key={deviceID} className={style.sidebarItem}>
               <NavLink
                 to={`/device/${deviceID}`}
-                className={({ isActive }) => isActive ? 'sidebar-active' : ''}
+                className={({ isActive }) => isActive ? style.sidebarActive : ''}
                 title={t('sidebar.device')}
                 onClick={this.handleSidebarItemClick}>
-                <div className="single">
-                  <img draggable={false} className="sidebar_settings" src={deviceSettings} alt={t('sidebar.device')} />
+                <div className={style.single}>
+                  <img draggable={false} src={deviceSettings} alt={t('sidebar.device')} />
                 </div>
-                <span className="sidebar_label">{t('sidebar.device')}</span>
+                <span className={style.sidebarLabel}>{t('sidebar.device')}</span>
               </NavLink>
             </div>
           )) }
-          <div key="settings" className="sidebarItem">
+          <div key="settings" className={style.sidebarItem}>
             <NavLink
-              className={({ isActive }) => isActive ? 'sidebar-active' : ''}
+              className={({ isActive }) => isActive ? style.sidebarActive : ''}
               to={'/settings'}
               title={t('sidebar.settings')}
               onClick={this.handleSidebarItemClick}>
               <div className="stacked">
-                <img draggable={false} className="sidebar_settings" src={settingsGrey} alt={t('sidebar.settings')} />
-                <img draggable={false} className="sidebar_settings" src={settings} alt={t('sidebar.settings')} />
+                <img draggable={false} src={settingsGrey} alt={t('sidebar.settings')} />
+                <img draggable={false} src={settings} alt={t('sidebar.settings')} />
               </div>
-              <span className="sidebar_label">{t('sidebar.settings')}</span>
+              <span className={style.sidebarLabel}>{t('sidebar.settings')}</span>
             </NavLink>
           </div>
           {(debug && keystores?.some(({ type }) => type === 'software') && deviceIDs.length === 0) && (
-            <div key="eject" className="sidebarItem">
+            <div key="eject" className={style.sidebarItem}>
               <a href="#" onClick={eject}>
-                <div className="single">
+                <div className={style.single}>
                   <img
                     draggable={false}
-                    className="sidebar_settings"
                     src={ejectIcon}
                     alt={t('sidebar.leave')} />
                 </div>

--- a/frontends/web/src/style/index.css
+++ b/frontends/web/src/style/index.css
@@ -2,7 +2,6 @@
 @import "./base.css";
 @import "./layout.css";
 @import "./grid.css";
-@import "../components/sidebar/sidebar.css";
 @import "./forms.css";
 @import "./icons.css";
 

--- a/frontends/web/src/style/layout.css
+++ b/frontends/web/src/style/layout.css
@@ -373,6 +373,22 @@
     margin: var(--space-quarter);
 }
 
+.stacked {
+    position: relative;
+}
+
+.stacked img {
+    transition: opacity 0.2s ease;
+}
+
+.stacked img:last-child {
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
 .transparent {
     display: none;
 }


### PR DESCRIPTION
As a part of our refactoring efforts in the FE, we'd like to use CSS modules whenever suitable.

**[Preview] Screenshot:**

<img width="475" alt="Screen Shot 2022-12-05 at 06 56 54" src="https://user-images.githubusercontent.com/28676406/205560098-d13865ea-bc1e-4952-abd7-833b97dd4855.png">

exactly the same as our current sidebar, which should be the case since practically no styling was changed ✅ 