### PR TITLE
frontend: sidebar to use "Buy Bitcoin" for BTC only wallet

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -34,6 +34,7 @@ import Logo, { AppLogoInverted } from '../icon/logo';
 import { useLocation } from 'react-router';
 import { CloseXWhite } from '../icon';
 import style from './sidebar.module.css';
+import { isBitcoinOnly } from '../../routes/account/utils';
 
 interface SidebarProps {
     deviceIDs: string[];
@@ -156,6 +157,7 @@ class Sidebar extends Component<Props> {
       sidebarStatus,
     } = this.props;
     const hidden = ['forceHidden', 'forceCollapsed'].includes(sidebarStatus);
+    const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
     return (
       <div className={[style.sidebarContainer, hidden ? style.forceHide : ''].join(' ')}>
         <div className={[style.sidebarOverlay, activeSidebar ? style.active : ''].join(' ')} onClick={toggleSidebar}></div>
@@ -202,7 +204,7 @@ class Sidebar extends Component<Props> {
                   <img draggable={false} src={coins} alt={t('sidebar.exchanges')} />
                 </div>
                 <span className={style.sidebarLabel}>
-                  {t('sidebar.buy')}
+                  {hasOnlyBTCAccounts ? t('accountInfo.buyCTA.buy', { unit: 'Bitcoin' }) : t('sidebar.buy')}
                 </span>
               </NavLink>
             </div>


### PR DESCRIPTION
to improve our UI, in the sidebar,  we'd like to have "Buy Bitcoin" instead of "Buy crypto" for wallets with only Bitcoin (and TBTC) account(s). 

Wallet with multiple of **only** bitcoin accounts:
<img width="1480" alt="Screen Shot 2022-12-07 at 14 02 11" src="https://user-images.githubusercontent.com/28676406/206186577-965407e5-edb8-438f-85af-50fb8100ba91.png">

Wallet with only 1 bitcoin account (preview in German):
<img width="1480" alt="Screen Shot 2022-12-07 at 14 01 29" src="https://user-images.githubusercontent.com/28676406/206186631-29fb3a3f-291e-4a12-81bb-0433319a7b27.png">

Wallet with multiple accounts of various coins:
<img width="1480" alt="Screen Shot 2022-12-07 at 14 02 06" src="https://user-images.githubusercontent.com/28676406/206186597-22b3fb1e-3cbb-494f-8960-b855df4ce1e3.png">

Small note: "Buy crypto" is translated. 
