### PR TITLE
backend/btc/transactionsdb: don't create buckets on Begin()

### DIFF
--- a/backend/coins/btc/db/transactionsdb/transactionsdb.go
+++ b/backend/coins/btc/db/transactionsdb/transactionsdb.go
@@ -31,12 +31,12 @@ import (
 )
 
 const (
-	bucketTransactions           = "transactions"
-	bucketUnverifiedTransactions = "unverifiedTransactions"
-	bucketInputs                 = "inputs"
-	bucketOutputs                = "outputs"
-	bucketAddressHistories       = "addressHistories"
-	bucketConfig                 = "config"
+	bucketTransactionsKey           = "transactions"
+	bucketUnverifiedTransactionsKey = "unverifiedTransactions"
+	bucketInputsKey                 = "inputs"
+	bucketOutputsKey                = "outputs"
+	bucketAddressHistoriesKey       = "addressHistories"
+	bucketConfigKey                 = "config"
 )
 
 // DB is a bbolt key/value database.
@@ -59,38 +59,8 @@ func (db *DB) Begin() (transactions.DBTxInterface, error) {
 	if err != nil {
 		return nil, errp.WithStack(err)
 	}
-	bucketTransactions, err := tx.CreateBucketIfNotExists([]byte(bucketTransactions))
-	if err != nil {
-		return nil, errp.WithStack(err)
-	}
-	bucketUnverifiedTransactions, err := tx.CreateBucketIfNotExists([]byte(bucketUnverifiedTransactions))
-	if err != nil {
-		return nil, errp.WithStack(err)
-	}
-	bucketInputs, err := tx.CreateBucketIfNotExists([]byte(bucketInputs))
-	if err != nil {
-		return nil, errp.WithStack(err)
-	}
-	bucketOutputs, err := tx.CreateBucketIfNotExists([]byte(bucketOutputs))
-	if err != nil {
-		return nil, errp.WithStack(err)
-	}
-	bucketAddressHistories, err := tx.CreateBucketIfNotExists([]byte(bucketAddressHistories))
-	if err != nil {
-		return nil, errp.WithStack(err)
-	}
-	bucketConfig, err := tx.CreateBucketIfNotExists([]byte(bucketConfig))
-	if err != nil {
-		return nil, errp.WithStack(err)
-	}
 	return &Tx{
-		tx:                           tx,
-		bucketTransactions:           bucketTransactions,
-		bucketUnverifiedTransactions: bucketUnverifiedTransactions,
-		bucketInputs:                 bucketInputs,
-		bucketOutputs:                bucketOutputs,
-		bucketAddressHistories:       bucketAddressHistories,
-		bucketConfig:                 bucketConfig,
+		tx: tx,
 	}, nil
 }
 
@@ -102,13 +72,6 @@ func (db *DB) Close() error {
 // Tx implements transactions.DBTxInterface.
 type Tx struct {
 	tx *bbolt.Tx
-
-	bucketTransactions           *bbolt.Bucket
-	bucketUnverifiedTransactions *bbolt.Bucket
-	bucketInputs                 *bbolt.Bucket
-	bucketOutputs                *bbolt.Bucket
-	bucketAddressHistories       *bbolt.Bucket
-	bucketConfig                 *bbolt.Bucket
 }
 
 // Rollback implements transactions.DBTxInterface.
@@ -131,6 +94,9 @@ func newWalletTransaction() *transactions.DBTxInfo {
 }
 
 func readJSON(bucket *bbolt.Bucket, key []byte, value interface{}) (bool, error) {
+	if bucket == nil {
+		return false, nil
+	}
 	if jsonBytes := bucket.Get(key); jsonBytes != nil {
 		return true, errp.WithStack(json.Unmarshal(jsonBytes, value))
 	}
@@ -147,7 +113,12 @@ func writeJSON(bucket *bbolt.Bucket, key []byte, value interface{}) error {
 
 func (tx *Tx) modifyTx(key []byte, f func(value *transactions.DBTxInfo)) error {
 	walletTx := newWalletTransaction()
-	found, err := readJSON(tx.bucketTransactions, key, walletTx)
+	bucketTransactions, err := tx.tx.CreateBucketIfNotExists([]byte(bucketTransactionsKey))
+	if err != nil {
+		return errp.WithStack(err)
+	}
+
+	found, err := readJSON(bucketTransactions, key, walletTx)
 	if err != nil {
 		return err
 	}
@@ -156,14 +127,15 @@ func (tx *Tx) modifyTx(key []byte, f func(value *transactions.DBTxInfo)) error {
 		walletTx.CreatedTimestamp = &now
 	}
 	f(walletTx)
-	return writeJSON(tx.bucketTransactions, key, walletTx)
+	return writeJSON(bucketTransactions, key, walletTx)
 }
 
 // TxInfo implements transactions.DBTxInterface.
 func (tx *Tx) TxInfo(txHash chainhash.Hash) (
 	*transactions.DBTxInfo, error) {
+	bucketTransactions := tx.tx.Bucket([]byte(bucketTransactionsKey))
 	walletTx := newWalletTransaction()
-	if _, err := readJSON(tx.bucketTransactions, txHash[:], walletTx); err != nil {
+	if _, err := readJSON(bucketTransactions, txHash[:], walletTx); err != nil {
 		return nil, err
 	}
 	walletTx.TxHash = txHash
@@ -182,7 +154,12 @@ func (tx *Tx) PutTx(txHash chainhash.Hash, msgTx *wire.MsgTx, height int) error 
 		return err
 	}
 	if verified == nil {
-		return tx.bucketUnverifiedTransactions.Put(txHash[:], nil)
+		bucketUnverifiedTransactions, err := tx.tx.CreateBucketIfNotExists([]byte(bucketUnverifiedTransactionsKey))
+		if err != nil {
+			return errp.WithStack(err)
+		}
+
+		return bucketUnverifiedTransactions.Put(txHash[:], nil)
 	}
 	return nil
 }
@@ -190,7 +167,11 @@ func (tx *Tx) PutTx(txHash chainhash.Hash, msgTx *wire.MsgTx, height int) error 
 // DeleteTx implements transactions.DBTxInterface. It panics if called from a read-only db
 // transaction.
 func (tx *Tx) DeleteTx(txHash chainhash.Hash) {
-	if err := tx.bucketTransactions.Delete(txHash[:]); err != nil {
+	bucketTransactions, err := tx.tx.CreateBucketIfNotExists([]byte(bucketTransactionsKey))
+	if err != nil {
+		panic(errp.WithStack(err))
+	}
+	if err := bucketTransactions.Delete(txHash[:]); err != nil {
 		panic(errp.WithStack(err))
 	}
 }
@@ -214,6 +195,9 @@ func (tx *Tx) RemoveAddressFromTx(txHash chainhash.Hash, scriptHashHex blockchai
 
 func getTransactions(bucket *bbolt.Bucket) ([]chainhash.Hash, error) {
 	result := []chainhash.Hash{}
+	if bucket == nil {
+		return result, nil
+	}
 	cursor := bucket.Cursor()
 	for txHashBytes, _ := cursor.First(); txHashBytes != nil; txHashBytes, _ = cursor.Next() {
 		var txHash chainhash.Hash
@@ -227,17 +211,22 @@ func getTransactions(bucket *bbolt.Bucket) ([]chainhash.Hash, error) {
 
 // Transactions implements transactions.DBTxInterface.
 func (tx *Tx) Transactions() ([]chainhash.Hash, error) {
-	return getTransactions(tx.bucketTransactions)
+	bucketTransactions := tx.tx.Bucket([]byte(bucketTransactionsKey))
+	return getTransactions(bucketTransactions)
 }
 
 // UnverifiedTransactions implements transactions.DBTxInterface.
 func (tx *Tx) UnverifiedTransactions() ([]chainhash.Hash, error) {
-	return getTransactions(tx.bucketUnverifiedTransactions)
+	return getTransactions(tx.tx.Bucket([]byte(bucketUnverifiedTransactionsKey)))
 }
 
 // MarkTxVerified implements transactions.DBTxInterface.
 func (tx *Tx) MarkTxVerified(txHash chainhash.Hash, headerTimestamp time.Time) error {
-	if err := tx.bucketUnverifiedTransactions.Delete(txHash[:]); err != nil {
+	bucketUnverifiedTransactions, err := tx.tx.CreateBucketIfNotExists([]byte(bucketUnverifiedTransactionsKey))
+	if err != nil {
+		panic(errp.WithStack(err))
+	}
+	if err := bucketUnverifiedTransactions.Delete(txHash[:]); err != nil {
 		panic(errp.WithStack(err))
 	}
 	return tx.modifyTx(txHash[:], func(walletTx *transactions.DBTxInfo) {
@@ -249,12 +238,20 @@ func (tx *Tx) MarkTxVerified(txHash chainhash.Hash, headerTimestamp time.Time) e
 
 // PutInput implements transactions.DBTxInterface.
 func (tx *Tx) PutInput(outPoint wire.OutPoint, txHash chainhash.Hash) error {
-	return tx.bucketInputs.Put([]byte(outPoint.String()), txHash[:])
+	bucketInputs, err := tx.tx.CreateBucketIfNotExists([]byte(bucketInputsKey))
+	if err != nil {
+		return errp.WithStack(err)
+	}
+	return bucketInputs.Put([]byte(outPoint.String()), txHash[:])
 }
 
 // Input implements transactions.DBTxInterface.
 func (tx *Tx) Input(outPoint wire.OutPoint) (*chainhash.Hash, error) {
-	if value := tx.bucketInputs.Get([]byte(outPoint.String())); value != nil {
+	bucketInputs := tx.tx.Bucket([]byte(bucketInputsKey))
+	if bucketInputs == nil {
+		return nil, nil
+	}
+	if value := bucketInputs.Get([]byte(outPoint.String())); value != nil {
 		return chainhash.NewHash(value)
 	}
 	return nil, nil
@@ -263,20 +260,32 @@ func (tx *Tx) Input(outPoint wire.OutPoint) (*chainhash.Hash, error) {
 // DeleteInput implements transactions.DBTxInterface. It panics if called from a read-only db
 // transaction.
 func (tx *Tx) DeleteInput(outPoint wire.OutPoint) {
-	if err := tx.bucketInputs.Delete([]byte(outPoint.String())); err != nil {
+	bucketInputs, err := tx.tx.CreateBucketIfNotExists([]byte(bucketInputsKey))
+	if err != nil {
+		panic(errp.WithStack(err))
+	}
+	if err := bucketInputs.Delete([]byte(outPoint.String())); err != nil {
 		panic(errp.WithStack(err))
 	}
 }
 
 // PutOutput implements transactions.DBTxInterface.
 func (tx *Tx) PutOutput(outPoint wire.OutPoint, txOut *wire.TxOut) error {
-	return writeJSON(tx.bucketOutputs, []byte(outPoint.String()), txOut)
+	bucketOutputs, err := tx.tx.CreateBucketIfNotExists([]byte(bucketOutputsKey))
+	if err != nil {
+		return errp.WithStack(err)
+	}
+	return writeJSON(bucketOutputs, []byte(outPoint.String()), txOut)
 }
 
 // Output implements transactions.DBTxInterface.
 func (tx *Tx) Output(outPoint wire.OutPoint) (*wire.TxOut, error) {
+	bucketOutputs := tx.tx.Bucket([]byte(bucketOutputsKey))
+	if bucketOutputs == nil {
+		return nil, nil
+	}
 	txOut := &wire.TxOut{}
-	found, err := readJSON(tx.bucketOutputs, []byte(outPoint.String()), txOut)
+	found, err := readJSON(bucketOutputs, []byte(outPoint.String()), txOut)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +298,11 @@ func (tx *Tx) Output(outPoint wire.OutPoint) (*wire.TxOut, error) {
 // Outputs implements transactions.DBTxInterface.
 func (tx *Tx) Outputs() (map[wire.OutPoint]*wire.TxOut, error) {
 	outputs := map[wire.OutPoint]*wire.TxOut{}
-	cursor := tx.bucketOutputs.Cursor()
+	bucketOutputs := tx.tx.Bucket([]byte(bucketOutputsKey))
+	if bucketOutputs == nil {
+		return outputs, nil
+	}
+	cursor := bucketOutputs.Cursor()
 	for outPointBytes, txOutJSONBytes := cursor.First(); outPointBytes != nil; outPointBytes, txOutJSONBytes = cursor.Next() {
 		txOut := &wire.TxOut{}
 		if err := json.Unmarshal(txOutJSONBytes, txOut); err != nil {
@@ -307,25 +320,39 @@ func (tx *Tx) Outputs() (map[wire.OutPoint]*wire.TxOut, error) {
 // DeleteOutput implements transactions.DBTxInterface. It panics if called from a read-only db
 // transaction.
 func (tx *Tx) DeleteOutput(outPoint wire.OutPoint) {
-	if err := tx.bucketOutputs.Delete([]byte(outPoint.String())); err != nil {
+	bucketOutputs, err := tx.tx.CreateBucketIfNotExists([]byte(bucketOutputsKey))
+	if err != nil {
+		panic(errp.WithStack(err))
+	}
+	if err := bucketOutputs.Delete([]byte(outPoint.String())); err != nil {
 		panic(errp.WithStack(err))
 	}
 }
 
 // PutAddressHistory implements transactions.DBTxInterface.
 func (tx *Tx) PutAddressHistory(scriptHashHex blockchain.ScriptHashHex, history blockchain.TxHistory) error {
-	return writeJSON(tx.bucketAddressHistories, []byte(string(scriptHashHex)), history)
+	bucketAddressHistories, err := tx.tx.CreateBucketIfNotExists([]byte(bucketAddressHistoriesKey))
+	if err != nil {
+		return errp.WithStack(err)
+	}
+	return writeJSON(bucketAddressHistories, []byte(string(scriptHashHex)), history)
 }
 
 // AddressHistory implements transactions.DBTxInterface.
 func (tx *Tx) AddressHistory(scriptHashHex blockchain.ScriptHashHex) (blockchain.TxHistory, error) {
 	history := blockchain.TxHistory{}
-	_, err := readJSON(tx.bucketAddressHistories, []byte(string(scriptHashHex)), &history)
+	bucketAddressHistories := tx.tx.Bucket([]byte(bucketAddressHistoriesKey))
+	_, err := readJSON(bucketAddressHistories, []byte(string(scriptHashHex)), &history)
 	return history, err
 }
 
 // PutGapLimits implements transactions.DBTxInterface.
 func (tx *Tx) PutGapLimits(limits types.GapLimits) error {
+	bucketConfig, err := tx.tx.CreateBucketIfNotExists([]byte(bucketConfigKey))
+	if err != nil {
+		return errp.WithStack(err)
+	}
+
 	buf := new(bytes.Buffer)
 	if err := binary.Write(buf, binary.LittleEndian, limits.Receive); err != nil {
 		return errp.WithStack(err)
@@ -333,12 +360,16 @@ func (tx *Tx) PutGapLimits(limits types.GapLimits) error {
 	if err := binary.Write(buf, binary.LittleEndian, limits.Change); err != nil {
 		return errp.WithStack(err)
 	}
-	return tx.bucketConfig.Put([]byte("gapLimits"), buf.Bytes())
+	return bucketConfig.Put([]byte("gapLimits"), buf.Bytes())
 }
 
 // GapLimits implements transactions.DBTxInterface.
 func (tx *Tx) GapLimits() (types.GapLimits, error) {
-	if value := tx.bucketConfig.Get([]byte(`gapLimits`)); value != nil {
+	bucketConfig := tx.tx.Bucket([]byte(bucketConfigKey))
+	if bucketConfig == nil {
+		return types.GapLimits{}, nil
+	}
+	if value := bucketConfig.Get([]byte(`gapLimits`)); value != nil {
 		limits := types.GapLimits{}
 		reader := bytes.NewReader(value)
 		if err := binary.Read(reader, binary.LittleEndian, &limits.Receive); err != nil {


### PR DESCRIPTION
Begin() currently always opens a write-transaction, so we could init the buckets there. Most of the time we don't need write-transactions as read-only transactions suffice. This commit prepares using read-only transactions, which improve code clarity and performance.