### PR TITLE
frontend: use view component for device settings

### DIFF
--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -24,11 +24,15 @@
     justify-content: center;
 }
 
+/* this will be applied if fullscreen is false */
 .fill {
+    align-self: center;
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    padding-bottom: var(--space-default);
+    padding: 0 var(--space-default) var(--space-default) var(--space-default);
+    max-width: var(--content-width);
+    width: 100%;
 }
 
 .inner {
@@ -39,6 +43,10 @@
     padding-bottom: var(--space-half);
     padding-top: var(--space-half);
     width: 480px;
+}
+.fill .inner {
+    margin: 0;
+    width: 100%;
 }
 .inner.fit {
     flex-shrink: 0;
@@ -94,6 +102,9 @@
     padding-right: var(--space-default);
 }
 @media (max-width: 768px) {
+    .fill {
+        padding: 0 0 var(--space-default) 0;
+    }
     .header {
         padding-left: var(--space-half);
         padding-top: var(--space-default);
@@ -104,12 +115,18 @@
         margin-bottom: var(--space-half);
         padding-top: var(--space-half);
     }
+    .fill .header {
+        padding-top: 0;
+    }
 }
 @media (max-width: 1199px) {
     .header {
         padding-top: var(--space-large);
     }
     .smallHeader {
+        padding-top: 0;
+    }
+    .fill .header {
         padding-top: 0;
     }
     .dialog .header {

--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -272,3 +272,48 @@
         --size-default: 14px;
     }
 }
+
+.footer {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    margin: var(--space-default) auto 0 auto;
+    max-width: var(--content-width);
+    padding: 0;
+    width: 100%;
+}
+.fullscreen .footer {
+    margin: var(--space-default) auto;
+    padding: 0 var(--space-default);
+}
+
+.footer p {
+    color: var(--color-secondary);
+    font-size: var(--size-default);
+    margin: 0;
+}
+
+.footer img {
+    width: 120px;
+    margin: 0 auto 0 0;
+}
+
+@media (max-width: 768px) {
+    .footer {
+        padding: 0 var(--space-half);
+        margin: var(--space-half) 0 0 0;
+    }
+    .fullscreen .footer {
+        margin: var(--space-half) 0;
+    }
+
+    .footer p {
+        text-align: right;
+        font-size: var(--size-small);
+    }
+
+    .footer img {
+        width: 80px;
+    }
+}

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2022 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 
 import { FunctionComponent, ReactNode } from 'react';
-import { AppLogo } from '../icon';
-import { Footer } from '../layout';
-import { SwissMadeOpenSource } from '../icon/logo';
+import { LanguageSwitch } from '../language/language';
+import { Version } from '../layout/version';
+import { AppLogo, SwissMadeOpenSource } from '../icon/logo';
 import { AnimatedChecked, Close } from '../icon/icon';
 import style from './view.module.css';
 
@@ -85,9 +85,13 @@ export const View = ({
       )}
       {withBottomBar && (
         <div style={{ marginTop: 'auto' }}>
-          <Footer>
+          <footer className={style.footer}>
             <SwissMadeOpenSource />
-          </Footer>
+            <div className="m-right-half hide-on-small">
+              <Version />
+            </div>
+            <LanguageSwitch />
+          </footer>
         </div>
       )}
     </div>

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -20,10 +20,7 @@ import { route } from '../../../utils/route';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../../hooks/api';
 import { getDeviceInfo, DeviceInfo, getVersion, verifyAttestation } from '../../../api/bitbox02';
-import { SwissMadeOpenSource } from '../../../components/icon/logo';
 import { Checked, Warning } from '../../../components/icon/icon';
-import { Footer } from '../../../components/layout';
-import { Header } from '../../../components/layout/header';
 import { SettingsButton } from '../../../components/settingsButton/settingsButton';
 import { SettingsItem } from '../../../components/settingsButton/settingsItem';
 import { GotoStartupSettings } from './gotostartupsettings';
@@ -33,6 +30,8 @@ import { ShowMnemonic } from './showmnemonic';
 import { UpgradeButton } from './upgradebutton';
 import { alertUser } from '../../../components/alert/Alert';
 import { ManageDeviceGuide } from './settings-guide';
+import { View, ViewContent, ViewHeader } from '../../../components/view/view';
+import { Column, Grid, Header, Main } from '../../../components/layout';
 
 type TProps = {
     deviceID: string;
@@ -61,86 +60,69 @@ export const Settings = ({ deviceID }: TProps) => {
     return null;
   }
   return (
-    <div className="contentWithGuide">
-      <div className="container">
-        <div className="innerContainer scrollableContainer">
-          <Header title={<h2>{t('sidebar.device')}</h2>} />
-          <div className="content padded">
-            <div className="columnsContainer">
-              <div className="columns">
-                <div className="column column-1-2">
-                  <h3 className="subTitle">{t('deviceSettings.secrets.title')}</h3>
-                  <div className="box slim divide">
-                    <SettingsButton onClick={() => route(`/manage-backups/${deviceID}`)}>
-                      {t('deviceSettings.secrets.manageBackups')}
-                    </SettingsButton>
-                    <ShowMnemonic apiPrefix={apiPrefix} />
-                    <Reset apiPrefix={apiPrefix} />
-                  </div>
-                </div>
-                <div className="column column-1-2">
-                  <h3 className="subTitle">{t('deviceSettings.hardware.title')}</h3>
-                  <div className="box slim divide">
-                    <SetDeviceName
-                      deviceName={deviceInfo.name}
-                      deviceID={deviceID} />
-                    { deviceInfo && deviceInfo.securechipModel !== '' && (
-                      <SettingsItem optionalText={deviceInfo.securechipModel}>
-                        {t('deviceSettings.hardware.securechip')}
-                      </SettingsItem>
-                    ) }
-                    {attestation !== null && (
-                      <SettingsItem
-                        optionalText={t(`deviceSettings.hardware.attestation.${attestation}`)}
-                        optionalIcon={attestation ? <Checked/> : <Warning/>}>
-                        {t('deviceSettings.hardware.attestation.label')}
-                      </SettingsItem>
-                    )}
-                  </div>
-                </div>
-              </div>
-              <div className="columns">
-                <div className="column column-1-2">
-                  <h3 className="subTitle">{t('deviceSettings.firmware.title')}</h3>
-                  <div className="box slim divide">
-                    {
-                      versionInfo && versionInfo.canUpgrade ? (
-                        <UpgradeButton
-                          deviceID={deviceID}
-                          versionInfo={versionInfo}/>
-                      ) : versionInfo && (
-                        <SettingsItem
-                          optionalText={versionInfo.currentVersion}
-                          optionalIcon={<Checked/>}>
-                          {t('deviceSettings.firmware.upToDate')}
-                        </SettingsItem>
-                      )
-                    }
-                  </div>
-                </div>
-                <div className="column column-1-2">
-                  <h3 className="subTitle">{t('settings.expert.title')}</h3>
-                  <div className="box slim divide">
-                    <SettingsButton onClick={routeToPassphrase}>
-                      { deviceInfo.mnemonicPassphraseEnabled
-                        ? t('passphrase.disable')
-                        : t('passphrase.enable')}
-                    </SettingsButton>
-                    { versionInfo && versionInfo.canGotoStartupSettings ? (
-                      <GotoStartupSettings apiPrefix={apiPrefix} />
-                    ) : null
-                    }
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <Footer>
-            <SwissMadeOpenSource />
-          </Footer>
-        </div>
-      </div>
+    <Main>
+      <Header />
+      <View fullscreen={false} withBottomBar>
+        <ViewHeader small title={t('sidebar.device')} />
+        <ViewContent>
+          <Grid>
+            <Column>
+              <h3 className="subTitle">{t('deviceSettings.secrets.title')}</h3>
+              <SettingsButton onClick={() => route(`/manage-backups/${deviceID}`)}>
+                {t('deviceSettings.secrets.manageBackups')}
+              </SettingsButton>
+              <ShowMnemonic apiPrefix={apiPrefix} />
+              <Reset apiPrefix={apiPrefix} />
+            </Column>
+            <Column>
+              <h3 className="subTitle">{t('deviceSettings.hardware.title')}</h3>
+              <SetDeviceName
+                deviceName={deviceInfo.name}
+                deviceID={deviceID} />
+              { deviceInfo && deviceInfo.securechipModel !== '' && (
+                <SettingsItem optionalText={deviceInfo.securechipModel}>
+                  {t('deviceSettings.hardware.securechip')}
+                </SettingsItem>
+              ) }
+              {attestation !== null && (
+                <SettingsItem
+                  optionalText={t(`deviceSettings.hardware.attestation.${attestation}`)}
+                  optionalIcon={attestation ? <Checked/> : <Warning/>}>
+                  {t('deviceSettings.hardware.attestation.label')}
+                </SettingsItem>
+              )}
+            </Column>
+          </Grid>
+          <Grid>
+            <Column>
+              <h3 className="subTitle">{t('deviceSettings.firmware.title')}</h3>
+              { versionInfo && versionInfo.canUpgrade ? (
+                <UpgradeButton
+                  deviceID={deviceID}
+                  versionInfo={versionInfo}/>
+              ) : versionInfo && (
+                <SettingsItem
+                  optionalText={versionInfo.currentVersion}
+                  optionalIcon={<Checked/>}>
+                  {t('deviceSettings.firmware.upToDate')}
+                </SettingsItem>
+              )}
+            </Column>
+            <Column>
+              <h3 className="subTitle">{t('settings.expert.title')}</h3>
+              <SettingsButton onClick={routeToPassphrase}>
+                { deviceInfo.mnemonicPassphraseEnabled
+                  ? t('passphrase.disable')
+                  : t('passphrase.enable')}
+              </SettingsButton>
+              { versionInfo && versionInfo.canGotoStartupSettings ? (
+                <GotoStartupSettings apiPrefix={apiPrefix} />
+              ) : null }
+            </Column>
+          </Grid>
+        </ViewContent>
+      </View>
       <ManageDeviceGuide />
-    </div>
+    </Main>
   );
 };

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -30,7 +30,7 @@ import { ShowMnemonic } from './showmnemonic';
 import { UpgradeButton } from './upgradebutton';
 import { alertUser } from '../../../components/alert/Alert';
 import { ManageDeviceGuide } from './settings-guide';
-import { View, ViewContent, ViewHeader } from '../../../components/view/view';
+import { View, ViewContent } from '../../../components/view/view';
 import { Column, Grid, Header, Main } from '../../../components/layout';
 
 type TProps = {
@@ -61,9 +61,8 @@ export const Settings = ({ deviceID }: TProps) => {
   }
   return (
     <Main>
-      <Header />
+      <Header title={<h2>{t('sidebar.device')}</h2>} />
       <View fullscreen={false} withBottomBar>
-        <ViewHeader small title={t('sidebar.device')} />
         <ViewContent>
           <Grid>
             <Column>


### PR DESCRIPTION
Settings can use View, Grid and Column component for layout instead of plain div's. The View component is mostly used in fullscreen mode but an early version did support normal mode with sidebar and guide. Fixed some minor CSS issues (spacing etc.) so that normal mode should now be fully working.

This could also be used for normal settings and exchange integration in the future.