### PR TITLE
frontend: conditionally renders Spinner in buy/pocket

### DIFF
--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -35,6 +35,8 @@ export const Pocket = ({ code }: TProps) => {
   const { t } = useTranslation();
 
   const [height, setHeight] = useState(0);
+  const [iframeLoaded, setIframeLoaded] = useState(false);
+
   const iframeURL = useLoad(getPocketURL(code));
 
 
@@ -126,8 +128,11 @@ export const Pocket = ({ code }: TProps) => {
         </div>
         <div ref={ref} className="innerContainer">
           <div className="noSpace" style={{ height }}>
-            <Spinner text={t('loading')} />
+            {!iframeLoaded && <Spinner text={t('loading')} /> }
             <iframe
+              onLoad={() => {
+                setIframeLoaded(true);
+              }}
               ref={iframeRef}
               title="Pocket"
               width="100%"


### PR DESCRIPTION
To fix the UI bug where Guide icon on the header appears twice

[Preview] Before
<img width="353" alt="Screen Shot 2022-12-21 at 04 01 08" src="https://user-images.githubusercontent.com/28676406/208810723-39521b4a-c505-4883-b0f9-7fd51b4d8540.png">


[Preview] After
<img width="353" alt="Screen Shot 2022-12-21 at 03 57 39" src="https://user-images.githubusercontent.com/28676406/208810732-81fff68c-d9b1-46d3-a68f-fc8422fb9eca.png">
