### PR TITLE
frontend/send: fix duplicate/no key in UTXOsClass

### DIFF
--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -105,7 +105,7 @@ export class UTXOsClass extends Component<Props, State> {
       return null;
     }
     return (
-      <div>
+      <div key={'utxos-' + scriptType}>
         <h2 className="subTitle">{ getScriptName(scriptType) }</h2>
         <ul className={style.utxosList}>
           { filteredUTXOs.map(utxo => (


### PR DESCRIPTION
Fixes this error:

```
react_devtools_backend.js:4012 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `UTXOsClass`. See https://reactjs.org/link/warning-keys for more information.
    at div
    at UTXOsClass (http://localhost:8080/static/js/bundle.js:23710:5)
```