### PR TITLE
frontend: fix fontsize in dialogs regression

### DIFF
--- a/frontends/web/src/components/dialog/dialog.module.css
+++ b/frontends/web/src/components/dialog/dialog.module.css
@@ -26,6 +26,15 @@
     max-height: 100vh;
     overflow: auto;
 }
+/* guard dialog and wait-dialog from view styles */
+@media (min-width: 1200px) {
+    .header .title {
+        --size-subheader: 16px;
+    }
+    .modal .contentContainer p {
+        --size-default: 14px;
+    }
+}
 
 .modal.small {
     max-width: 340px;


### PR DESCRIPTION
In 484c42f59207f12f428f588935cd3628e603d83b the device settings was refactored to use View component. This had a sideeffect that --size-default CSS variable was changed on large screens and the cause of a regression that paragraph text in dialogs are rendered with a larged font.

Fixed by adding some CSS to guard against View CSS.