### PR TITLE
frontend: add additional condition on closing pages using "ESC"

### DIFF
--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -75,9 +75,12 @@ export const Receive = ({
   // first array index: address types. second array index: unused addresses of that address type.
   const receiveAddresses = useLoad(accountApi.getReceiveAddressList(code));
 
-  useEsc(() => !verifying && route(`/account/${code}`));
-
   const availableScriptTypes = useRef<accountApi.ScriptType[]>();
+
+  const hasManyScriptTypes = availableScriptTypes.current && availableScriptTypes.current.length > 1;
+  const scriptTypeDialogOpened = !!(addressDialog && hasManyScriptTypes);
+
+  useEsc(() => !scriptTypeDialogOpened && !verifying && route(`/account/${code}`));
 
   useEffect(() => {
     if (receiveAddresses) {
@@ -151,8 +154,6 @@ export const Receive = ({
     }
   }
 
-  const hasManyScriptTypes = availableScriptTypes.current && availableScriptTypes.current.length > 1;
-
   return (
     <div className="contentWithGuide">
       <div className="container">
@@ -201,7 +202,7 @@ export const Receive = ({
                     </button>
                   )}
                   <form onSubmit={handleSubmit}>
-                    <Dialog open={!!(addressDialog && hasManyScriptTypes)} medium title={t('receive.changeScriptType')} >
+                    <Dialog open={scriptTypeDialogOpened} onClose={() => setAddressDialog(undefined)} medium title={t('receive.changeScriptType')} >
                       {availableScriptTypes.current && availableScriptTypes.current.map((scriptType, i) => (
                         <div key={scriptType}>
                           {addressDialog && <>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -228,7 +228,9 @@ class Send extends Component<Props, State> {
     if (e.keyCode === 27) {
       if (this.state.activeScanQR) {
         this.toggleScanQR();
-      } else {
+        return;
+      }
+      if (!this.state.activeCoinControl) {
         route(`/account/${this.props.code}`);
       }
     }


### PR DESCRIPTION
to prevent page (send & receive screen) **also getting closed** when a user intends to close an opened dialog using "ESC" key.

[Preview] (actions: pressed "ESC" and then "ESC" once more):


_please ignore favicon,it's cached from a different app_
**Send Screen**

https://user-images.githubusercontent.com/28676406/211244484-f796c837-8740-41e2-805b-a4fa856c8770.mov


**Receive Screen**

https://user-images.githubusercontent.com/28676406/211244499-20605e1a-3e80-45da-8951-3806d9d9474a.mov




