### PR TITLE
frontend: fix view component with guide on large screen

### DIFF
--- a/frontends/web/src/components/layout/guide-wrapper.module.css
+++ b/frontends/web/src/components/layout/guide-wrapper.module.css
@@ -1,0 +1,15 @@
+.contentWithGuide {
+  display: flex;
+  flex-grow: 1;
+  flex-direction: row;
+  overflow: hidden;
+}
+
+.container {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  overflow: auto;
+  position: relative;
+  width: 100%;
+}

--- a/frontends/web/src/components/layout/guide-wrapper.tsx
+++ b/frontends/web/src/components/layout/guide-wrapper.tsx
@@ -1,5 +1,4 @@
 /**
- * Copyright 2018 Shift Devices AG
  * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +14,25 @@
  * limitations under the License.
  */
 
-export { Header } from './header';
-export { Main } from './main';
-export { Column, ColumnButtons, Grid } from './grid';
-export { Footer } from './footer';
-export { GuidedContent, GuideWrapper } from './guide-wrapper';
+import { ReactNode } from 'react';
+import styles from './guide-wrapper.module.css';
+
+type TProps = {
+  children: ReactNode;
+}
+
+export const GuideWrapper = ({ children }: TProps) => {
+  return (
+    <div className={styles.contentWithGuide}>
+      {children}
+    </div>
+  );
+};
+
+export const GuidedContent = ({ children }: TProps) => {
+  return (
+    <div className={styles.container}>
+      {children}
+    </div>
+  );
+};

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -20,17 +20,12 @@ import { route } from '../../../utils/route';
 import { getDeviceInfo, setMnemonicPassphraseEnabled } from '../../../api/bitbox02';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { MultilineMarkup, SimpleMarkup } from '../../../utils/markup';
-// This is the first time we use <View> in a <Main> component
-// keeping guide and header as example in the code
-import { /* Header, */ Main } from '../../../components/layout';
+import { Main } from '../../../components/layout';
 import { Button, Checkbox } from '../../../components/forms';
 import { alertUser } from '../../../components/alert/Alert';
 import { View, ViewButtons, ViewContent, ViewHeader } from '../../../components/view/view';
 import { PointToBitBox02 } from '../../../components/icon';
 import Status from '../../../components/status/status';
-// keeing as example for using guides in the new main component
-// import { Guide } from '../../../components/guide/guide';
-// import { Entry } from '../../../components/guide/entry';
 
 // enabling has 6 dialogs with information
 const INFO_STEPS_ENABLE = 5;
@@ -115,7 +110,7 @@ class Passphrase extends Component<Props, State> {
     const enabled = this.state.passphraseEnabled;
     if (
       (!enabled && this.state.infoStep >= INFO_STEPS_ENABLE)
-            || (enabled && this.state.infoStep >= INFO_STEPS_DISABLE)
+      || (enabled && this.state.infoStep >= INFO_STEPS_DISABLE)
     ) {
       this.stopInfo();
       return;
@@ -311,7 +306,6 @@ class Passphrase extends Component<Props, State> {
     }
     return (
       <Main>
-        {/* <Header /> */}
         {status === 'info' && (
           passphraseEnabled
             ? this.renderDisableInfo()
@@ -367,9 +361,6 @@ class Passphrase extends Component<Props, State> {
             </ViewContent>
           </View>
         )}
-        {/* <Guide>
-                    <Entry key="whatisapassphrase" entry={t('guide.passphrase.whatisapassphrase')} />
-                </Guide> */}
       </Main>
     );
   }

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import { UpgradeButton } from './upgradebutton';
 import { alertUser } from '../../../components/alert/Alert';
 import { ManageDeviceGuide } from './settings-guide';
 import { View, ViewContent } from '../../../components/view/view';
-import { Column, Grid, Header, Main } from '../../../components/layout';
+import { Column, Grid, GuidedContent, GuideWrapper, Header, Main } from '../../../components/layout';
 
 type TProps = {
     deviceID: string;
@@ -61,67 +61,71 @@ export const Settings = ({ deviceID }: TProps) => {
   }
   return (
     <Main>
-      <Header title={<h2>{t('sidebar.device')}</h2>} />
-      <View fullscreen={false} withBottomBar>
-        <ViewContent>
-          <Grid>
-            <Column>
-              <h3 className="subTitle">{t('deviceSettings.secrets.title')}</h3>
-              <SettingsButton onClick={() => route(`/manage-backups/${deviceID}`)}>
-                {t('deviceSettings.secrets.manageBackups')}
-              </SettingsButton>
-              <ShowMnemonic deviceID={deviceID} />
-              <Reset apiPrefix={apiPrefix} />
-            </Column>
-            <Column>
-              <h3 className="subTitle">{t('deviceSettings.hardware.title')}</h3>
-              <SetDeviceName
-                deviceName={deviceInfo.name}
-                deviceID={deviceID} />
-              { deviceInfo && deviceInfo.securechipModel !== '' && (
-                <SettingsItem optionalText={deviceInfo.securechipModel}>
-                  {t('deviceSettings.hardware.securechip')}
-                </SettingsItem>
-              ) }
-              {attestation !== null && (
-                <SettingsItem
-                  optionalText={t(`deviceSettings.hardware.attestation.${attestation}`)}
-                  optionalIcon={attestation ? <Checked/> : <Warning/>}>
-                  {t('deviceSettings.hardware.attestation.label')}
-                </SettingsItem>
-              )}
-            </Column>
-          </Grid>
-          <Grid>
-            <Column>
-              <h3 className="subTitle">{t('deviceSettings.firmware.title')}</h3>
-              { versionInfo && versionInfo.canUpgrade ? (
-                <UpgradeButton
-                  deviceID={deviceID}
-                  versionInfo={versionInfo}/>
-              ) : versionInfo && (
-                <SettingsItem
-                  optionalText={versionInfo.currentVersion}
-                  optionalIcon={<Checked/>}>
-                  {t('deviceSettings.firmware.upToDate')}
-                </SettingsItem>
-              )}
-            </Column>
-            <Column>
-              <h3 className="subTitle">{t('settings.expert.title')}</h3>
-              <SettingsButton onClick={routeToPassphrase}>
-                { deviceInfo.mnemonicPassphraseEnabled
-                  ? t('passphrase.disable')
-                  : t('passphrase.enable')}
-              </SettingsButton>
-              { versionInfo && versionInfo.canGotoStartupSettings ? (
-                <GotoStartupSettings apiPrefix={apiPrefix} />
-              ) : null }
-            </Column>
-          </Grid>
-        </ViewContent>
-      </View>
-      <ManageDeviceGuide />
+      <GuideWrapper>
+        <GuidedContent>
+          <Header title={<h2>{t('sidebar.device')}</h2>} />
+          <View fullscreen={false} withBottomBar>
+            <ViewContent>
+              <Grid>
+                <Column>
+                  <h3 className="subTitle">{t('deviceSettings.secrets.title')}</h3>
+                  <SettingsButton onClick={() => route(`/manage-backups/${deviceID}`)}>
+                    {t('deviceSettings.secrets.manageBackups')}
+                  </SettingsButton>
+                  <ShowMnemonic deviceID={deviceID} />
+                  <Reset apiPrefix={apiPrefix} />
+                </Column>
+                <Column>
+                  <h3 className="subTitle">{t('deviceSettings.hardware.title')}</h3>
+                  <SetDeviceName
+                    deviceName={deviceInfo.name}
+                    deviceID={deviceID} />
+                  { deviceInfo && deviceInfo.securechipModel !== '' && (
+                    <SettingsItem optionalText={deviceInfo.securechipModel}>
+                      {t('deviceSettings.hardware.securechip')}
+                    </SettingsItem>
+                  ) }
+                  {attestation !== null && (
+                    <SettingsItem
+                      optionalText={t(`deviceSettings.hardware.attestation.${attestation}`)}
+                      optionalIcon={attestation ? <Checked/> : <Warning/>}>
+                      {t('deviceSettings.hardware.attestation.label')}
+                    </SettingsItem>
+                  )}
+                </Column>
+              </Grid>
+              <Grid>
+                <Column>
+                  <h3 className="subTitle">{t('deviceSettings.firmware.title')}</h3>
+                  { versionInfo && versionInfo.canUpgrade ? (
+                    <UpgradeButton
+                      deviceID={deviceID}
+                      versionInfo={versionInfo}/>
+                  ) : versionInfo && (
+                    <SettingsItem
+                      optionalText={versionInfo.currentVersion}
+                      optionalIcon={<Checked/>}>
+                      {t('deviceSettings.firmware.upToDate')}
+                    </SettingsItem>
+                  )}
+                </Column>
+                <Column>
+                  <h3 className="subTitle">{t('settings.expert.title')}</h3>
+                  <SettingsButton onClick={routeToPassphrase}>
+                    { deviceInfo.mnemonicPassphraseEnabled
+                      ? t('passphrase.disable')
+                      : t('passphrase.enable')}
+                  </SettingsButton>
+                  { versionInfo && versionInfo.canGotoStartupSettings ? (
+                    <GotoStartupSettings apiPrefix={apiPrefix} />
+                  ) : null }
+                </Column>
+              </Grid>
+            </ViewContent>
+          </View>
+        </GuidedContent>
+        <ManageDeviceGuide />
+      </GuideWrapper>
     </Main>
   );
 };


### PR DESCRIPTION
On large screen the guide on device settings broke onto a 2nd line,
this is a regression introduced in:
- https://github.com/digitalbitbox/bitbox-wallet-app/commit/484c42f59207f12f428f588935cd3628e603d83b

Fixed by adding the old solution with 2 containers but as react
components. This does duplicate some CSS, but in the long run,
using the global CSS should be phased out.

Added overflow auto to the '.container' CSS, so that longer content
is scrollable. This should only impact the new react components
that is used in device settings and not have any side effect on
other views.