### PR TITLE
frontend/pocket: add address verification

### DIFF
--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -262,11 +262,6 @@ func (backend *Backend) AOPPApprove() {
 	backend.aoppKeystoreRegistered()
 }
 
-// AoppBTCScriptTypeMap allows to access the object from other packages.
-func (backend *Backend) AoppBTCScriptTypeMap() map[string]signing.ScriptType {
-	return aoppBTCScriptTypeMap
-}
-
 // aoppChooseAccount is called when an AOPP request is being processed and an account should be
 // selected. `accountsAndKeystoreLock` must be held when calling this function.
 func (backend *Backend) aoppChooseAccount(code accounts.Code) {

--- a/backend/exchanges/exchanges.go
+++ b/backend/exchanges/exchanges.go
@@ -29,8 +29,13 @@ func (e ErrorCode) Error() string {
 	return string(e)
 }
 
-// ErrAddressNotFound is returned if an account is being added which already exists.
-const ErrAddressNotFound ErrorCode = "addressNotFound"
+const (
+	// ErrAddressNotFound is returned if an address provided for verification is not in the list of unused addresses.
+	ErrAddressNotFound ErrorCode = "addressNotFound"
+
+	// ErrUserAbort is returned if the user aborted the current operation.
+	ErrUserAbort ErrorCode = "userAbort"
+)
 
 // regionCodes is an array containing ISO 3166-1 alpha-2 code of all regions.
 // Source: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2

--- a/backend/exchanges/exchanges.go
+++ b/backend/exchanges/exchanges.go
@@ -21,6 +21,17 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
 )
 
+// ErrorCode are errors that are represented by an error code. This helps the frontend to translate
+// error messages.
+type ErrorCode string
+
+func (e ErrorCode) Error() string {
+	return string(e)
+}
+
+// ErrAddressNotFound is returned if an account is being added which already exists.
+const ErrAddressNotFound ErrorCode = "addressNotFound"
+
 // regionCodes is an array containing ISO 3166-1 alpha-2 code of all regions.
 // Source: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 var regionCodes = []string{

--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -16,7 +16,7 @@
         "react-dom": "17.0.2",
         "react-i18next": "11.16.8",
         "react-router-dom": "6.3.0",
-        "request-address": "0.0.3"
+        "request-address": "0.0.4"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.14.1",
@@ -13697,9 +13697,9 @@
       }
     },
     "node_modules/request-address": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.3.tgz",
-      "integrity": "sha512-YGO9QrwBYuxYVxE46tIpfBBcOvFsvJ5fiqFgyJrXlpvKWiJIJAHTITkP8VRrkhppsGJgIOf1Wm8GPQ1/NTtO8A=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.4.tgz",
+      "integrity": "sha512-WlgNKQ8YWMqEGGgaDy+EXlJdmLkoqz5+WHDWhDn6HmiFDWmIRb2i3U2SnsqStmRILMNFwI45jnTfYmqGc5DQHQ=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -26450,9 +26450,9 @@
       }
     },
     "request-address": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.3.tgz",
-      "integrity": "sha512-YGO9QrwBYuxYVxE46tIpfBBcOvFsvJ5fiqFgyJrXlpvKWiJIJAHTITkP8VRrkhppsGJgIOf1Wm8GPQ1/NTtO8A=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.4.tgz",
+      "integrity": "sha512-WlgNKQ8YWMqEGGgaDy+EXlJdmLkoqz5+WHDWhDn6HmiFDWmIRb2i3U2SnsqStmRILMNFwI45jnTfYmqGc5DQHQ=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -23,7 +23,7 @@
     "react-dom": "17.0.2",
     "react-i18next": "11.16.8",
     "react-router-dom": "6.3.0",
-    "request-address": "0.0.3"
+    "request-address": "0.0.4"
   },
   "eslintConfig": {
     "extends": [

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -63,11 +63,14 @@ export const getMoonpayBuyInfo = (code: string) => {
   };
 };
 
+export type ExchangeErrorCode = 'userAbort' | 'addressNotFound';
+
 export type AddressSignResponse = {
-  status?: 'success' | 'abort';
+  success: boolean;
   signature: string;
   address: string;
-  error: string;
+  errorMessage?: string;
+  errorCode?: ExchangeErrorCode;
 }
 
 
@@ -77,8 +80,8 @@ export const signAddress = (format: string, msg: string, accountCode: AccountCod
 
 export type AddressVerificationResponse = {
   success: boolean;
-  error?: string;
-  errorCode?: string;
+  errorMessage?: string;
+  errorCode?: ExchangeErrorCode;
 }
 
 export const verifyAddress = (address: string, accountCode: AccountCode): Promise<AddressVerificationResponse> => {

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -75,6 +75,16 @@ export const signAddress = (format: string, msg: string, accountCode: AccountCod
   return apiPost('exchange/pocket/sign-address', { format, msg, accountCode });
 };
 
+export type AddressVerificationResponse = {
+  success: boolean;
+  error?: string;
+  errorCode?: string;
+}
+
+export const verifyAddress = (address: string, accountCode: AccountCode): Promise<AddressVerificationResponse> => {
+  return apiPost('exchange/pocket/verify-address', { address, accountCode });
+};
+
 export const getPocketURL = (accountCode: string) => {
   return (): Promise<string> => {
     return apiGet(`exchange/pocket/api-url/${accountCode}`);

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -413,6 +413,8 @@
         "p1": "When you buy bitcoin via Pocket, you are using an external service. This service is out of scope of the BitBox02 Security Threat model and relies on the safety and security of the environment which the BitBoxApp software is running in. However we work together to improve security by using a two factor authentication mechanism to verify the address you are receiving to.",
         "title": "Security model"
       },
+      "usedAddress": "The address {{address}} has been already used, please start again.",
+      "verifyBitBox02": "Please verify that the address you received via email matches the one displayed on your device. If possible, you should open the email on a second device for better security.",
       "welcome": {
         "p1": "We partner with Pocket to offer you a seamless way to buy bitcoin directly within the BitBoxApp. It's just a few clicks.",
         "p2": "Pocket is a Swiss platform that makes it quick and easy to buy bitcoin in most of Europe (anywhere where SEPA bank transfers are supported).",

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -17,8 +17,9 @@
 import { useTranslation } from 'react-i18next';
 import { useState, useEffect, createRef } from 'react';
 import { MessageVersion, parseMessage, serializeMessage, V0MessageType } from 'request-address';
-import { signAddress, getPocketURL } from '../../api/exchanges';
 import { getConfig } from '../../api/backend';
+import { Dialog } from '../../components/dialog/dialog';
+import { verifyAddress, signAddress, getPocketURL } from '../../api/exchanges';
 import { Header } from '../../components/layout';
 import { Spinner } from '../../components/spinner/Spinner';
 import { PocketTerms } from './pocket-terms';
@@ -37,6 +38,7 @@ export const Pocket = ({ code }: TProps) => {
   const [height, setHeight] = useState(0);
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const [agreedTerms, setAgreedTerms] = useState(false);
+  const [verifying, setVerifying] = useState(false);
 
   const iframeURL = useLoad(getPocketURL(code));
   const config = useLoad(getConfig);
@@ -90,8 +92,9 @@ export const Pocket = ({ code }: TProps) => {
     try {
       const message = parseMessage(e.data);
       if (message.type === V0MessageType.RequestAddress && message.withMessageSignature) {
+        const addressType = message.withScriptType ? String(message.withScriptType) : '';
         signAddress(
-          message.withScriptType ? message.withScriptType : 'p2wpkh',
+          addressType,
           String(message.withMessageSignature),
           code)
           .then(response => {
@@ -100,6 +103,20 @@ export const Pocket = ({ code }: TProps) => {
               alertUser('Message signing aborted by the user');
             } else {
               sendAddress(response.address, response.signature);
+            }
+          });
+      }
+      if (message.type === V0MessageType.VerifyAddress) {
+        setVerifying(true);
+        verifyAddress(message.bitcoinAddress, code)
+          .then(response => {
+            setVerifying(false);
+            if (!response.success) {
+              if (response.errorCode === 'addressNotFound') {
+                // This should not happen, unless the user receives a tx on the same address between the message signing
+                // and the address verification.
+                alertUser(t('buy.pocket.usedAddress', { address:  message.bitcoinAddress }));
+              }
             }
           });
       }
@@ -156,6 +173,13 @@ export const Pocket = ({ code }: TProps) => {
               </iframe>
             </div>
           )}
+          <Dialog
+            open={verifying}
+            title={t('receive.verifyBitBox02')}
+            disableEscape={true}
+            medium centered>
+            <div className="text-center">{t('buy.pocket.verifyBitBox02')}</div>
+          </Dialog>
         </div>
       </div>
       <Guide name={name} exchange={'pocket'}/>


### PR DESCRIPTION
A safe buy workflow requires a verification of the address that has been shared with the exchange. In this case pocket widget sends an email containing the address that has been shared by the user and requires a verification via `postMessage`. The address is displayed on the bb02 and should be ideally verified by the user opening the email con a second device (e.g. the phone) for better security.