### PR TITLE
Exchange widget language

### DIFF
--- a/backend/exchanges/pocket.go
+++ b/backend/exchanges/pocket.go
@@ -25,11 +25,17 @@ import (
 )
 
 const (
-	// pocketWidgetTestURL is the url of the pocket widget in test environment.
-	pocketWidgetTestURL = "https://widget.staging.pocketbitcoin.com/widget_mjxWDmSUkMvdQdXDCeHrjC"
+	// pocketMainTestURL is the url of the pocket test environment.
+	pocketMainTestURL = "https://widget.staging.pocketbitcoin.com"
 
-	// pocketWidgetLiveURL is the url of the pocket widget in production environment.
-	pocketWidgetLiveURL = "https://widget.pocketbitcoin.com/widget_vqx25E6kzvGBYGjN2QoXVH"
+	// pocketWidgetTest is the url of the pocket widget in test environment.
+	pocketWidgetTest = "widget_mjxWDmSUkMvdQdXDCeHrjC"
+
+	// pocketMainLiceURL is the url of the pocket production environment.
+	pocketMainLiveURL = "https://widget.pocketbitcoin.com"
+
+	// pocketWidgetLive is the url of the pocket widget in production environment.
+	pocketWidgetLive = "widget_vqx25E6kzvGBYGjN2QoXVH"
 
 	// pocketAPILiveURL is the base url of pocket API in production environment.
 	pocketAPILiveURL = "https://widget.pocketbitcoin.com/api"
@@ -46,13 +52,13 @@ type PocketRegion struct {
 
 // PocketURL returns the url needed to incorporate the widget in the frontend, verifying
 // if the account is mainnet or testnet.
-func PocketURL(acct accounts.Interface) (string, error) {
+func PocketURL(acct accounts.Interface, locale string) (string, error) {
 	apiURL := ""
 	switch acct.Coin().Code() {
 	case coin.CodeBTC:
-		apiURL = pocketWidgetLiveURL
+		apiURL = pocketMainLiveURL + "/" + locale + "/" + pocketWidgetLive
 	case coin.CodeTBTC:
-		apiURL = pocketWidgetTestURL
+		apiURL = pocketMainTestURL + "/" + locale + "/" + pocketWidgetTest
 	default:
 		err := fmt.Errorf("unsupported cryptocurrency code %q", acct.Coin().Code())
 		return "", err

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -1140,7 +1140,14 @@ func (handlers *Handlers) getExchangePocketURL(r *http.Request) (interface{}, er
 		return errorResult{Error: err.Error()}, nil
 	}
 
-	url, err := exchanges.PocketURL(acct)
+	lang := handlers.backend.Config().AppConfig().Backend.UserLanguage
+	if len(lang) == 0 {
+		// userLanguace config is empty if the set locale matches the system locale, so we have
+		// to retrieve that.
+		lang = utilConfig.MainLocaleFromNative(handlers.backend.Environment().NativeLocale())
+	}
+
+	url, err := exchanges.PocketURL(acct, lang)
 	if err != nil {
 		handlers.log.Error(err)
 		return errorResult{Error: err.Error()}, nil

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -1106,9 +1106,15 @@ func (handlers *Handlers) getExchangeMoonpayBuyInfo(r *http.Request) (interface{
 		return nil, err
 	}
 
+	lang := handlers.backend.Config().AppConfig().Backend.UserLanguage
+	if len(lang) == 0 {
+		// userLanguace config is empty if the set locale matches the system locale, so we have
+		// to retrieve that.
+		lang = utilConfig.MainLocaleFromNative(handlers.backend.Environment().NativeLocale())
+	}
 	params := exchanges.BuyMoonpayParams{
 		Fiat: handlers.backend.Config().AppConfig().Backend.MainFiat,
-		Lang: handlers.backend.Config().AppConfig().Backend.UserLanguage,
+		Lang: lang,
 	}
 	buy, err := exchanges.MoonpayInfo(acct, params)
 	if err != nil {

--- a/util/config/locale.go
+++ b/util/config/locale.go
@@ -1,0 +1,27 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"strings"
+)
+
+// MainLocaleFromNative takes as input the nativeLocale as given by
+// backend.Environment().NativeLocale() and returns the language as
+// in ISO 639-1.
+func MainLocaleFromNative(nativeLocale string) string {
+	nativeLocale = strings.Replace(nativeLocale, "_", "-", -1)
+	return strings.Split(nativeLocale, "-")[0]
+}

--- a/util/config/locale_test.go
+++ b/util/config/locale_test.go
@@ -1,0 +1,32 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/util/config"
+)
+
+func TestMainLocaleFromNative(t *testing.T) {
+	locales := []string{"it_IT", "en-US", "fr"}
+	results := []string{"it", "en", "fr"}
+
+	for i, locale := range locales {
+		if config.MainLocaleFromNative(locale) != results[i] {
+			t.Errorf("MainLocaleFromNative(%s) = %s; expected %s", locale, config.MainLocaleFromNative(locale), results[i])
+		}
+	}
+}

--- a/util/config/locale_test.go
+++ b/util/config/locale_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/util/config"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMainLocaleFromNative(t *testing.T) {
@@ -25,8 +26,6 @@ func TestMainLocaleFromNative(t *testing.T) {
 	results := []string{"it", "en", "fr"}
 
 	for i, locale := range locales {
-		if config.MainLocaleFromNative(locale) != results[i] {
-			t.Errorf("MainLocaleFromNative(%s) = %s; expected %s", locale, config.MainLocaleFromNative(locale), results[i])
-		}
+		assert.Equal(t, results[i], config.MainLocaleFromNative(locale))
 	}
 }


### PR DESCRIPTION
This PR fixes a bug in the language param used to call the Moonpay widget and adds the language param in the URL used to call  Pocket widget. See commit messages for details