### PR TITLE
Frontend type bitbox02 setpassword

### DIFF
--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,4 +138,11 @@ type TChannelHash = {
 
 export const getChannelHash = (deviceID: string): Promise<TChannelHash> => {
   return apiGet(`devices/bitbox02/${deviceID}/channel-hash`);
+};
+
+export const verifyChannelHash = (
+  deviceID: string,
+  ok: boolean,
+): Promise<void> => {
+  return apiPost(`devices/bitbox02/${deviceID}/channel-hash-verify`, ok);
 };

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -130,3 +130,12 @@ export type TStatus = 'connected'
 export const getStatus = (deviceID: string): Promise<TStatus> => {
   return apiGet(`devices/bitbox02/${deviceID}/status`);
 };
+
+type TChannelHash = {
+  hash: string;
+  deviceVerified: boolean;
+};
+
+export const getChannelHash = (deviceID: string): Promise<TChannelHash> => {
+  return apiGet(`devices/bitbox02/${deviceID}/channel-hash`);
+};

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -152,3 +152,9 @@ export const verifyChannelHash = (
 ): Promise<void> => {
   return apiPost(`devices/bitbox02/${deviceID}/channel-hash-verify`, ok);
 };
+
+export const setPassword = (
+  deviceID: string,
+): Promise<SuccessResponse | FailResponse> => {
+  return apiPost(`devices/bitbox02/${deviceID}/set-password`);
+};

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -50,6 +50,12 @@ export const checkSDCard = (
   return apiGet(`devices/bitbox02/${deviceID}/check-sdcard`);
 };
 
+export const insertSDCard = (
+  deviceID: string,
+): Promise<SuccessResponse | FailResponse> => {
+  return apiPost(`devices/bitbox02/${deviceID}/insert-sdcard`);
+};
+
 export const setDeviceName = (
   deviceID: string,
   newDeviceName: string,

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -117,3 +117,16 @@ export const upgradeDeviceFirmware = (deviceID: string): Promise<void> => {
 export const showMnemonic = (deviceID: string): Promise<void> => {
   return apiPost(`devices/bitbox02/${deviceID}/show-mnemonic`);
 };
+
+export type TStatus = 'connected'
+  | 'initialized'
+  | 'pairingFailed'
+  | 'require_firmware_upgrade'
+  | 'require_app_upgrade'
+  | 'seeded'
+  | 'unpaired'
+  | 'uninitialized';
+
+export const getStatus = (deviceID: string): Promise<TStatus> => {
+  return apiGet(`devices/bitbox02/${deviceID}/status`);
+};

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -17,7 +17,7 @@
 
 import React, { Component, FormEvent } from 'react';
 import { Backup } from '../components/backup';
-import { checkSDCard, errUserAbort, getChannelHash, getStatus, getVersion, insertSDCard, setDeviceName, VersionInfo, verifyAttestation, TStatus, verifyChannelHash } from '../../../api/bitbox02';
+import { checkSDCard, errUserAbort, getChannelHash, getStatus, getVersion, insertSDCard, setDeviceName, setPassword, VersionInfo, verifyAttestation, TStatus, verifyChannelHash } from '../../../api/bitbox02';
 import { MultilineMarkup } from '../../../utils/markup';
 import { convertDateToLocaleString } from '../../../utils/date';
 import { route } from '../../../utils/route';
@@ -151,10 +151,6 @@ class BitBox02 extends Component<Props, State> {
     });
   };
 
-  private apiPrefix = () => {
-    return 'devices/bitbox02/' + this.props.deviceID;
-  };
-
   private handleGetStarted = () => {
     route('/account-summary', true);
   };
@@ -264,9 +260,9 @@ class BitBox02 extends Component<Props, State> {
       settingPassword: true,
       createWalletStatus: 'setPassword',
     });
-    apiPost(this.apiPrefix() + '/set-password').then(({ code, success }) => {
-      if (!success) {
-        if (code === errUserAbort) {
+    setPassword(this.props.deviceID).then((response) => {
+      if (!response.success) {
+        if (response.code === errUserAbort) {
           // On user abort, just go back to the first screen. This is a bit lazy, as we should show
           // a screen to ask the user to go back or try again.
           this.setState({

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -17,7 +17,7 @@
 
 import React, { Component, FormEvent } from 'react';
 import { Backup } from '../components/backup';
-import { checkSDCard, errUserAbort, getChannelHash, getStatus, getVersion, setDeviceName, VersionInfo, verifyAttestation, TStatus, verifyChannelHash } from '../../../api/bitbox02';
+import { checkSDCard, errUserAbort, getChannelHash, getStatus, getVersion, insertSDCard, setDeviceName, VersionInfo, verifyAttestation, TStatus, verifyChannelHash } from '../../../api/bitbox02';
 import { MultilineMarkup } from '../../../utils/markup';
 import { convertDateToLocaleString } from '../../../utils/date';
 import { route } from '../../../utils/route';
@@ -243,13 +243,16 @@ class BitBox02 extends Component<Props, State> {
         title: this.props.t('bitbox02Wizard.stepInsertSD.insertSDcardTitle'),
         text: this.props.t('bitbox02Wizard.stepInsertSD.insertSDCard'),
       } });
-      return apiPost('devices/bitbox02/' + this.props.deviceID + '/insert-sdcard').then(({ success, errorMessage }) => {
-        this.setState({ sdCardInserted: success, waitDialog: undefined });
-        if (success) {
+      return insertSDCard(this.props.deviceID).then((response) => {
+        this.setState({
+          sdCardInserted: response.success,
+          waitDialog: undefined,
+        });
+        if (response.success) {
           return true;
         }
-        if (errorMessage) {
-          alertUser(errorMessage, { asDialog: false });
+        if (response.message) {
+          alertUser(response.message, { asDialog: false });
         }
         return false;
       });

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -17,7 +17,7 @@
 
 import React, { Component, FormEvent } from 'react';
 import { Backup } from '../components/backup';
-import { checkSDCard, errUserAbort, getStatus, getVersion, setDeviceName, VersionInfo, verifyAttestation, TStatus } from '../../../api/bitbox02';
+import { checkSDCard, errUserAbort, getChannelHash, getStatus, getVersion, setDeviceName, VersionInfo, verifyAttestation, TStatus } from '../../../api/bitbox02';
 import { MultilineMarkup } from '../../../utils/markup';
 import { convertDateToLocaleString } from '../../../utils/date';
 import { route } from '../../../utils/route';
@@ -27,7 +27,7 @@ import { Button, Checkbox, Input } from '../../../components/forms';
 import { Column, ColumnButtons, Grid, Main } from '../../../components/layout';
 import { View, ViewButtons, ViewContent, ViewHeader } from '../../../components/view/view';
 import { translate, TranslateProps } from '../../../decorators/translate';
-import { apiGet, apiPost } from '../../../utils/request';
+import { apiPost } from '../../../utils/request';
 import { apiWebsocket } from '../../../utils/websocket';
 import { alertUser } from '../../../components/alert/Alert';
 import { store as panelStore } from '../../../components/guide/guide';
@@ -160,7 +160,7 @@ class BitBox02 extends Component<Props, State> {
   };
 
   private onChannelHashChanged = () => {
-    apiGet(this.apiPrefix() + '/channel-hash').then(({ hash, deviceVerified }) => {
+    getChannelHash(this.props.deviceID).then(({ hash, deviceVerified }) => {
       this.setState({ hash, deviceVerified });
     });
   };

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -17,7 +17,7 @@
 
 import React, { Component, FormEvent } from 'react';
 import { Backup } from '../components/backup';
-import { checkSDCard, errUserAbort, getVersion, setDeviceName, VersionInfo, verifyAttestation } from '../../../api/bitbox02';
+import { checkSDCard, errUserAbort, getStatus, getVersion, setDeviceName, VersionInfo, verifyAttestation, TStatus } from '../../../api/bitbox02';
 import { MultilineMarkup } from '../../../utils/markup';
 import { convertDateToLocaleString } from '../../../utils/date';
 import { route } from '../../../utils/route';
@@ -51,15 +51,7 @@ interface State {
     hash?: string;
     attestationResult: boolean | null;
     deviceVerified: boolean;
-    status: '' |
-    'require_firmware_upgrade' |
-    'require_app_upgrade' |
-    'connected' |
-    'unpaired' |
-    'pairingFailed' |
-    'uninitialized' |
-    'seeded' |
-    'initialized';
+    status: '' | TStatus;
     appStatus: 'createWallet' | 'restoreBackup' | 'restoreFromMnemonic' | 'agreement' | 'complete' | '';
     createWalletStatus: 'intro' | 'setPassword' | 'createBackup';
     restoreBackupStatus: 'intro' | 'restore' | 'setPassword';
@@ -176,7 +168,7 @@ class BitBox02 extends Component<Props, State> {
   private onStatusChanged = () => {
     const { showWizard, unlockOnly, appStatus } = this.state;
     const { sidebarStatus } = panelStore.state;
-    apiGet(this.apiPrefix() + '/status').then(status => {
+    getStatus(this.props.deviceID).then(status => {
       const restoreSidebar = status === 'initialized' && !['createWallet', 'restoreBackup'].includes(appStatus) && sidebarStatus !== '';
       if (restoreSidebar) {
         setSidebarStatus('');

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -17,7 +17,7 @@
 
 import React, { Component, FormEvent } from 'react';
 import { Backup } from '../components/backup';
-import { checkSDCard, errUserAbort, getChannelHash, getStatus, getVersion, setDeviceName, VersionInfo, verifyAttestation, TStatus } from '../../../api/bitbox02';
+import { checkSDCard, errUserAbort, getChannelHash, getStatus, getVersion, setDeviceName, VersionInfo, verifyAttestation, TStatus, verifyChannelHash } from '../../../api/bitbox02';
 import { MultilineMarkup } from '../../../utils/markup';
 import { convertDateToLocaleString } from '../../../utils/date';
 import { route } from '../../../utils/route';
@@ -202,10 +202,6 @@ class BitBox02 extends Component<Props, State> {
     }
     this.unsubscribe();
   }
-
-  private channelVerify = (ok: boolean) => {
-    apiPost(this.apiPrefix() + '/channel-hash-verify', ok);
-  };
 
   private uninitializedStep = () => {
     this.setState({ appStatus: '' });
@@ -515,7 +511,7 @@ class BitBox02 extends Component<Props, State> {
                 deviceVerified ? (
                   <Button
                     primary
-                    onClick={() => this.channelVerify(true)}>
+                    onClick={() => verifyChannelHash(deviceID, true)}>
                     {t('button.continue')}
                   </Button>
                 ) : (


### PR DESCRIPTION
Ongoing effort to type all api calls, see:
- backend/devices/bitbox02/handlers/handlers.go

This was the last api call in bitbox02.tsx that used apiPrefix,
removed this internal function.

on top of https://github.com/digitalbitbox/bitbox-wallet-app/pull/1915