### PR TITLE
backend: fix deprecated ioutil import in util.go

### DIFF
--- a/backend/exchanges/util.go
+++ b/backend/exchanges/util.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
@@ -41,7 +40,7 @@ func APIGet(httpClient *http.Client, endpoint string, result interface{}) error 
 		return errp.Newf("%s - bad response code %d", endpoint, res.StatusCode)
 	}
 	const max = 81920
-	responseBody, err := ioutil.ReadAll(io.LimitReader(res.Body, max+1))
+	responseBody, err := io.ReadAll(io.LimitReader(res.Body, max+1))
 	if err != nil {
 		return errp.WithStack(err)
 	}


### PR DESCRIPTION
Since the upgrade of Go to v1.19 in 257253c3a06862e755f9438afb76e52d2846395d import of ioutil is deprecated, causing the CI flow to fail. This fixes the import.