### PR TITLE
frontend: added extra margin for dialog modal

### DIFF
--- a/frontends/web/src/components/dialog/dialog.module.css
+++ b/frontends/web/src/components/dialog/dialog.module.css
@@ -31,6 +31,9 @@
     .header .title {
         --size-subheader: 16px;
     }
+    .modal {
+        margin-left: var(--sidebar-width-large);
+    }
     .modal .contentContainer p {
         --size-default: 14px;
     }


### PR DESCRIPTION
to centre the dialog's modal with respect to content when sidebar is opened, we needed to add an extra margin.

Extra margin's value is the width of the sidebar when it's opened.