### PR TITLE
frontend: fix iframe scroll content

### DIFF
--- a/frontends/web/src/routes/buy/iframe.module.css
+++ b/frontends/web/src/routes/buy/iframe.module.css
@@ -1,6 +1,13 @@
 .container {
-    margin-top: calc(var(--space-default) * 1.5);
+    display: flex;
+    flex-basis: 100%;
+    flex-grow: 0;
+    flex-shrink: 1;
+    flex-direction: column;
+    overflow: hidden;
+    position: relative;
 }
+
 
 .iframe {
     max-width: 100%;

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -26,7 +26,7 @@ import { Header } from '../../components/layout';
 import { Spinner } from '../../components/spinner/Spinner';
 import { findAccount, getCryptoName } from '../account/utils';
 import { MoonpayTerms } from './moonpay-terms';
-import style from './terms.module.css';
+import style from './iframe.module.css';
 
 type TProps = {
     accounts: IAccount[];
@@ -77,38 +77,39 @@ export const Moonpay = ({ accounts, code }: TProps) => {
   }
 
   return (
-
     <div className="contentWithGuide">
       <div className="container">
         <div className="innerContainer">
           <div className={style.header}>
             <Header title={<h2>{t('buy.info.title', { name })}</h2>} />
           </div>
-          { !agreedTerms ? (
-            <MoonpayTerms
-              account={account}
-              onAgreedTerms={() => setAgreedTerms(true)}
-            />
-          ) : (
-            <div ref={ref} className="iframeContainer">
-              {!iframeLoaded && <Spinner text={t('loading')} />}
-              { moonpay && (
-                <iframe
-                  onLoad={() => {
-                    setIframeLoaded(true);
-                    onResize();
-                  }}
-                  title="Moonpay"
-                  width="100%"
-                  height={height}
-                  frameBorder="0"
-                  className={style.iframe}
-                  allow="camera; payment"
-                  src={`${moonpay.url}&colorCode=%235E94BF`}>
-                </iframe>
-              )}
-            </div>
-          )}
+          <div ref={ref} className={style.container}>
+            { !agreedTerms ? (
+              <MoonpayTerms
+                account={account}
+                onAgreedTerms={() => setAgreedTerms(true)}
+              />
+            ) : (
+              <div style={{ height }}>
+                {!iframeLoaded && <Spinner text={t('loading')} />}
+                { moonpay && (
+                  <iframe
+                    onLoad={() => {
+                      setIframeLoaded(true);
+                      onResize();
+                    }}
+                    title="Moonpay"
+                    width="100%"
+                    height={height}
+                    frameBorder="0"
+                    className={style.iframe}
+                    allow="camera; payment"
+                    src={`${moonpay.url}&colorCode=%235E94BF`}>
+                  </iframe>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </div>
       <Guide name={name} />

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -133,13 +133,13 @@ export const Pocket = ({ code }: TProps) => {
         <div className={style.header}>
           <Header title={<h2>{t('buy.info.title', { name })}</h2>} />
         </div>
-        <div ref={ref} className="innerContainer">
+        <div ref={ref} className={style.container}>
           { !agreedTerms ? (
             <PocketTerms
               onAgreedTerms={() => setAgreedTerms(true)}
             />
           ) : (
-            <div className="noSpace" style={{ height }}>
+            <div style={{ height }}>
               {!iframeLoaded && <Spinner text={t('loading')} /> }
               <iframe
                 onLoad={() => {

--- a/frontends/web/src/routes/buy/terms.module.css
+++ b/frontends/web/src/routes/buy/terms.module.css
@@ -1,18 +1,3 @@
-.container {
-    margin-top: calc(var(--space-default) * 1.5);
-}
-
-.iframe {
-    max-width: 100%;
-    position: relative;
-    z-index: 3000;
-}
-
-.header {
-    position: relative;
-    z-index: 2200;
-}
-
 .disclaimerContainer {
   align-items: center;
   display: flex;
@@ -35,9 +20,10 @@
 
 .disclaimer {
   background-color: white;
+  flex-basis: 100%;
   font-family: var(--font-family);
+  flex-grow: 0;
   flex-shrink: 1;
-  flex-basis: 70%;
   margin: var(--space-default) 0;
   max-width: 660px;
   overflow: auto;

--- a/frontends/web/src/style/layout.css
+++ b/frontends/web/src/style/layout.css
@@ -101,21 +101,6 @@
     height: 100%;
 }
 
-.iframeContainer {
-    flex-basis: 100vh;
-    flex-grow: 1;
-    flex-shrink: 1;
-    overflow: hidden;
-}
-
-.fluid {
-    max-width: none;
-}
-
-.innerContainer.withFixedContent {
-    padding-top: var(--header-height);
-}
-
 .scrollableContainer {
     overflow: auto;
 }
@@ -158,10 +143,6 @@
 
 .content.larger {
     max-width: var(--content-width-larger);
-}
-
-.content.noSpace {
-    padding: 0 !important;
 }
 
 .content.padded {
@@ -215,10 +196,6 @@
     .tabs .tab a {
         font-size: var(--size-small);
     }
-}
-
-.withFixedContent .content {
-    margin-top: 0;
 }
 
 .row:not(:first-child) {


### PR DESCRIPTION
The iframe could not be scrolled all the way to the end, about exactly the height of the headers. Turns out JavaScript read the wrong height, as it included the height of the header.

Fixed the CSS height of the iframe container, so that the script reads the correct height.

Also removed unused CSS and fixed duplicated styling in MoonPay component. For some reason MoonPay was using styles from terms instead of iframe.module.css. Now both Pocket and MoonPay should use the same CSS.