### PR TITLE
backend: remove one default btc testnet dev server

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -307,10 +307,7 @@ mCMuGBNHsbrs6rI1hbI4Qq6GYazLaDRqdCufTA==
 	case coinpkg.CodeBTC:
 		return []*config.ServerInfo{{Server: "btc1.shiftcrypto.dev:50001", TLS: true, PEMCert: devShiftCA}}
 	case coinpkg.CodeTBTC:
-		return []*config.ServerInfo{
-			{Server: "tbtc1.shiftcrypto.dev:51001", TLS: true, PEMCert: devShiftCA},
-			{Server: "tbtc2.shiftcrypto.dev:51002", TLS: true, PEMCert: devShiftCA},
-		}
+		return []*config.ServerInfo{{Server: "tbtc1.shiftcrypto.dev:51001", TLS: true, PEMCert: devShiftCA}}
 	case coinpkg.CodeRBTC:
 		return []*config.ServerInfo{
 			{Server: "127.0.0.1:52001", TLS: false, PEMCert: ""},


### PR DESCRIPTION
Same as btc/ltc/tltc, one dev node is sufficient for testing. This will reduce maintanence and load on the backend.

Regtest can be used to test failover behavior etc. when two servers are needed for testing.