### PR TITLE
frontend: switch support and translation feedback links

### DIFF
--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -111,15 +111,16 @@ Description of the translation issue:
           <div className={style.content}>
             {children}
             <div className={style.entry}>
+              {t('guide.appendix.text')}
+              {' '}
+              <A href="https://shiftcrypto.ch/contact">{t('guide.appendix.link')}</A>
+              <br />
+              <br />
               Translation feedback:
               {' '}
               <A href={this.getEmailText()}>
                 translations@shiftcrypto.ch
               </A>
-              <br />
-              {t('guide.appendix.text')}
-              {' '}
-              <A href="https://shiftcrypto.ch/contact">{t('guide.appendix.link')}</A>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Sometimes users made support requests to the translation feedback email, changed the order so that support is first.