### PR TITLE
Draft: route to device-settings directly and reduce layout shift

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -212,7 +212,7 @@ class Sidebar extends Component<Props> {
           { deviceIDs.map(deviceID => (
             <div key={deviceID} className={style.sidebarItem}>
               <NavLink
-                to={`/device/${deviceID}`}
+                to={`/device-settings/${deviceID}`}
                 className={({ isActive }) => isActive ? style.sidebarActive : ''}
                 title={t('sidebar.device')}
                 onClick={this.handleSidebarItemClick}>

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -86,14 +86,14 @@ class Passphrase extends Component<Props, State> {
         });
       })
       .catch((e) => {
-        route(`/device/${deviceID}`);
+        route(`/device-settings/${deviceID}`);
         alertUser(t(`passphrase.error.e${e.code}`, {
           defaultValue: e.message || t('genericError'),
         }));
       });
   };
 
-  private stopInfo = () => route(`/device/${this.props.deviceID}`);
+  private stopInfo = () => route(`/device-settings/${this.props.deviceID}`);
 
   private continueInfo = () => {
     if (this.state.infoStep === 0) {

--- a/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
+++ b/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
@@ -62,6 +62,7 @@ const SDCardCheck = ({ deviceID, children }: TProps) => {
             </Button>
             <ButtonLink
               transparent
+              // could link to /device-settings/${deviceID} instead, keeping as is for now
               to={`/device/${deviceID}`}>
               {t('button.back')}
             </ButtonLink>

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -32,6 +32,7 @@ import { alertUser } from '../../../components/alert/Alert';
 import { ManageDeviceGuide } from './settings-guide';
 import { View, ViewContent } from '../../../components/view/view';
 import { Column, Grid, GuidedContent, GuideWrapper, Header, Main } from '../../../components/layout';
+import { Skeleton } from '../../../components/skeleton/skeleton';
 
 type TProps = {
     deviceID: string;
@@ -56,9 +57,6 @@ export const Settings = ({ deviceID }: TProps) => {
     route(`/passphrase/${deviceID}`);
   };
 
-  if (deviceInfo === undefined) {
-    return null;
-  }
   return (
     <Main>
       <GuideWrapper>
@@ -77,21 +75,23 @@ export const Settings = ({ deviceID }: TProps) => {
                 </Column>
                 <Column>
                   <h3 className="subTitle">{t('deviceSettings.hardware.title')}</h3>
-                  <SetDeviceName
-                    deviceName={deviceInfo.name}
-                    deviceID={deviceID} />
-                  { deviceInfo && deviceInfo.securechipModel !== '' && (
+                  { deviceInfo ? (
+                    <SetDeviceName
+                      deviceName={deviceInfo.name}
+                      deviceID={deviceID} />
+                  ) : <Skeleton fontSize="var(--item-height)" /> }
+                  { (deviceInfo && deviceInfo.securechipModel !== '') ? (
                     <SettingsItem optionalText={deviceInfo.securechipModel}>
                       {t('deviceSettings.hardware.securechip')}
                     </SettingsItem>
-                  ) }
-                  {attestation !== null && (
+                  ) : <Skeleton fontSize="var(--item-height)" /> }
+                  { attestation !== null ? (
                     <SettingsItem
                       optionalText={t(`deviceSettings.hardware.attestation.${attestation}`)}
                       optionalIcon={attestation ? <Checked/> : <Warning/>}>
                       {t('deviceSettings.hardware.attestation.label')}
                     </SettingsItem>
-                  )}
+                  ) : <Skeleton fontSize="var(--item-height)" />}
                 </Column>
               </Grid>
               <Grid>
@@ -101,24 +101,26 @@ export const Settings = ({ deviceID }: TProps) => {
                     <UpgradeButton
                       deviceID={deviceID}
                       versionInfo={versionInfo}/>
-                  ) : versionInfo && (
+                  ) : versionInfo ? (
                     <SettingsItem
                       optionalText={versionInfo.currentVersion}
                       optionalIcon={<Checked/>}>
                       {t('deviceSettings.firmware.upToDate')}
                     </SettingsItem>
-                  )}
+                  ) : <Skeleton fontSize="var(--item-height)" />}
                 </Column>
                 <Column>
                   <h3 className="subTitle">{t('settings.expert.title')}</h3>
-                  <SettingsButton onClick={routeToPassphrase}>
-                    { deviceInfo.mnemonicPassphraseEnabled
-                      ? t('passphrase.disable')
-                      : t('passphrase.enable')}
-                  </SettingsButton>
+                  { deviceInfo ? (
+                    <SettingsButton onClick={routeToPassphrase}>
+                      { deviceInfo.mnemonicPassphraseEnabled
+                        ? t('passphrase.disable')
+                        : t('passphrase.enable')}
+                    </SettingsButton>
+                  ) : <Skeleton fontSize="var(--item-height)" /> }
                   { versionInfo && versionInfo.canGotoStartupSettings ? (
                     <GotoStartupSettings apiPrefix={apiPrefix} />
-                  ) : null }
+                  ) : <Skeleton fontSize="var(--item-height)" /> }
                 </Column>
               </Grid>
             </ViewContent>

--- a/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
+++ b/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
@@ -40,6 +40,7 @@ class ManageBackups extends Component {
     return (
       <ButtonLink
         transparent
+        // could link to /device-settings/${deviceID} instead, keeping as is for now
         to={`/device/${this.props.deviceID}`}>
         {this.props.t('button.back')}
       </ButtonLink>

--- a/frontends/web/src/routes/device/settingsswitch.tsx
+++ b/frontends/web/src/routes/device/settingsswitch.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TDevices } from '../../api/devices';
+import Settings from './bitbox01/settings/settings';
+import { Settings as BitBox02Settings } from './bitbox02/settings';
+import { Waiting } from './waiting';
+
+type TProps = {
+  devices: TDevices;
+  deviceID: string | null;
+};
+
+export const SettingsSwitch = ({ deviceID, devices }: TProps) => {
+  if (deviceID === null || !Object.keys(devices).includes(deviceID)) {
+    return <Waiting />;
+  }
+  switch (devices[deviceID]) {
+  case 'bitbox':
+    return <Settings deviceID={deviceID} />;
+  case 'bitbox02':
+    return <BitBox02Settings deviceID={deviceID}/>;
+  default:
+    return <Waiting />;
+  }
+};

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -10,6 +10,7 @@ import { Receive } from './account/receive';
 import { Send } from './account/send/send';
 import { AccountsSummary } from './account/summary/accountssummary';
 import { DeviceSwitch } from './device/deviceswitch';
+import { SettingsSwitch } from './device/settingsswitch';
 import ManageBackups from './device/manage-backups/manage-backups';
 import { ManageAccounts } from './settings/manage-accounts';
 import { Exchanges } from './exchanges/exchanges';
@@ -45,6 +46,13 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
   const Device = <InjectParams>
     <DeviceSwitch
       key={devicesKey('device-switch')}
+      deviceID={null}
+      devices={devices} />
+  </InjectParams>;
+
+  const DeviceSettings = <InjectParams>
+    <SettingsSwitch
+      key={devicesKey('settings-switch')}
       deviceID={null}
       devices={devices} />
   </InjectParams>;
@@ -99,6 +107,7 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
     <Route path="/">
       <Route index element={Homepage} />
       <Route path="device/:deviceID" element={Device} />
+      <Route path="device-settings/:deviceID" element={DeviceSettings} />
       <Route path="account/:code">
         <Route index element={Acc} />
         <Route path="send" element={AccSend} />

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -238,30 +238,27 @@ class Settings extends Component<Props, State> {
                             <h3 className="subTitle">{t('settings.info.title')}</h3>
                             <div className="box slim divide m-bottom-large">
                               { version !== undefined && update !== undefined ? (
-                                <div>
-                                  { update ? (
-                                    <SettingsButton
-                                      optionalText={version}
-                                      secondaryText={
-                                        <>
-                                          {t('settings.info.out-of-date')}
-                                          {' '}
-                                          <RedDot />
-                                        </>
-                                      }
-                                      disabled={false}
-                                      onClick={() => update && apiPost('open', updatePath)}>
-                                      {t('settings.info.version')}
-                                    </SettingsButton>) : (
-                                    <SettingsItem
-                                      optionalText={version}
-                                      optionalIcon={<Checked/>}>
-                                      {t('settings.info.up-to-date')}
-                                    </SettingsItem>
-                                  )
-                                  }
-                                </div>
-                              ) : <Skeleton />}
+                                update ? (
+                                  <SettingsButton
+                                    optionalText={version}
+                                    secondaryText={
+                                      <>
+                                        {t('settings.info.out-of-date')}
+                                        {' '}
+                                        <RedDot />
+                                      </>
+                                    }
+                                    disabled={false}
+                                    onClick={() => update && apiPost('open', updatePath)}>
+                                    {t('settings.info.version')}
+                                  </SettingsButton>) : (
+                                  <SettingsItem
+                                    optionalText={version}
+                                    optionalIcon={<Checked/>}>
+                                    {t('settings.info.up-to-date')}
+                                  </SettingsItem>
+                                )
+                              ) : <Skeleton fontSize="var(--item-height)" />}
                             </div>
                           </div>
                           { manageAccountsLen ? (


### PR DESCRIPTION
The whole app window flickered when the user navigated to the
device settings, including the sidebar. Reason: device settings
route first load: deviceswitch that checks if device is bb01, bb02
or bootloader, for bb02 next the bitbox02.tsx is loaded, that
also handles unlock, pairing, create and restore, this component
does many api requests and is most likely the reason for the
flicker as it takes some time and will eventually load the bb02
settings component.

Involving deviceswtich/bitbox02 before loading device settings
seems to be the cause for completely blank view if for example
btc nodes are misconfigured, probably due to accounts not being
initialized correctly.

This change adds a new settingsswitch component that can load the
bb01 or bb02 settings component directly without going trough
deviceswitch.

Drawback: some shared components such as manage-backup or sdcard
check have a back button, this should not leave the setup if the
component is used in setup. therefore keeping the back buttons
pointing to deviceswitch.



also further reduced flickering content with another commit:

Added appropriate skeleton component as placeholder that the layout
does not shift while loading the view.
