### PR TITLE
frontend: pre-select region from user's native locale and config

### DIFF
--- a/frontends/web/src/api/nativelocale.ts
+++ b/frontends/web/src/api/nativelocale.ts
@@ -1,0 +1,5 @@
+import { apiGet } from '../utils/request';
+
+export const getNativeLocale = (): Promise<string> => {
+  return apiGet('native-locale');
+};

--- a/frontends/web/src/i18n/config.js
+++ b/frontends/web/src/i18n/config.js
@@ -16,18 +16,9 @@
  */
 
 import { apiGet } from '../utils/request';
+import { i18nextFormat } from './utils';
 
 const defaultUserLanguage = 'en';
-
-// A hack around https://github.com/i18next/i18next/issues/1484 which ignores
-// underscore "_" as tag separator.
-function i18nextFormat(locale) {
-  return locale.replace('_', '-');
-}
-
-export const localeMainLanguage = (locale) => {
-  return i18nextFormat(locale).split('-')[0];
-};
 
 export const languageFromConfig = {
   type: 'languageDetector',

--- a/frontends/web/src/i18n/i18n.js
+++ b/frontends/web/src/i18n/i18n.js
@@ -34,7 +34,8 @@ import appTranslationsES from '../locales/es/app.json';
 import appTranslationsSL from '../locales/sl/app.json';
 import appTranslationsHE from '../locales/he/app.json';
 import appTranslationsIT from '../locales/it/app.json';
-import { languageFromConfig, localeMainLanguage } from './config';
+import { languageFromConfig } from './config';
+import { localeMainLanguage } from './utils';
 import { apiGet } from '../utils/request';
 import { setConfig } from '../utils/config';
 

--- a/frontends/web/src/i18n/utils.test.ts
+++ b/frontends/web/src/i18n/utils.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getRegionNameFromLocale } from './utils';
+
+describe('getRegionNameFromLocale', () => {
+  describe('when given an invalid locale', () => {
+    it('should return empty string ', () => {
+      const LOCALE = 'es-es419';
+
+      const regionName = getRegionNameFromLocale(LOCALE);
+      expect(regionName).toBe('');
+    });
+  });
+
+  describe('when given an valid locale', () => {
+    it('should return the correct region when locale formatted with `-`', () => {
+      const LOCALE = 'en-de';
+
+      const regionName = getRegionNameFromLocale(LOCALE);
+      expect(regionName).toBe('DE');
+    });
+
+    it('should return the correct region when locale formatted with `_`', () => {
+      const LOCALE = 'fr_FR';
+
+      const regionName = getRegionNameFromLocale(LOCALE);
+      expect(regionName).toBe('FR');
+    });
+  });
+});

--- a/frontends/web/src/i18n/utils.ts
+++ b/frontends/web/src/i18n/utils.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// A hack around https://github.com/i18next/i18next/issues/1484 which ignores
+// underscore "_" as tag separator.
+export function i18nextFormat(locale: string) {
+  return locale.replace('_', '-');
+}
+
+export const localeMainLanguage = (locale: string) => {
+  return i18nextFormat(locale).split('-')[0];
+};
+
+/**
+ * Finds the region name from locale.
+ * Example: `en-DE` will return `DE`
+ */
+export const getRegionNameFromLocale = (nativeLocale: string): string => {
+  // `try` statement to safely use Intl.Locale.
+  // Preventing the page from crashing when
+  // `formattedLocale` is still invalid.
+  try {
+    // some locale may be formatted
+    // with an '_'. Example: en_GB
+    const formattedLocale = i18nextFormat(nativeLocale);
+    return (new Intl.Locale(formattedLocale).region as unknown as string) || '';
+  } catch {
+    return '';
+  }
+};


### PR DESCRIPTION
To improve our UX, it would be nice to have a pre-selected value for the region selector in the exchange / buy page.

This value is taken from user's config, which gets set the first time a user selects a region. If it's not available yet, the value (region) is taken from `native-locale` API.

If `native-locale` api doesn't provide a proper value, e.g `es-es419`, then there will be no pre-selected / default value for the selector.

[Preview] 

https://user-images.githubusercontent.com/28676406/214209426-ff63800a-2414-40f8-918c-a0e11037f1c7.mp4



explanation: The first time loading the exchange page, the region selected was France due to user's native locale as there's no saved region yet in the config. Then the user picks a region (Finland), and it gets saved in the config. `Finland` is then used the next time user loads the exchange page.