### PR TITLE
frontend: created language-aware download link component 

### DIFF
--- a/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
+++ b/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import i18n from '../../i18n/i18n';
+import { URL_CONSTANTS } from '../../utils/url_constants';
+import A from '../anchor/anchor';
+
+export const downloadLinkByLanguage = () => {
+  const language = i18n.language;
+  switch (language) {
+  case 'de':
+    return URL_CONSTANTS.DOWNLOAD_LINK_DE;
+  default:
+    return URL_CONSTANTS.DOWNLOAD_LINK_GLOBAL;
+  }
+};
+
+const AppDownloadLink = ({ ...props }) => {
+  const { t } = useTranslation();
+
+  return <A href={downloadLinkByLanguage()} {...props}>{t('button.download')}</A>;
+};
+
+export { AppDownloadLink };

--- a/frontends/web/src/components/appupgraderequired.tsx
+++ b/frontends/web/src/components/appupgraderequired.tsx
@@ -16,7 +16,7 @@
  */
 
 import { translate, TranslateProps } from '../decorators/translate';
-import A from './anchor/anchor';
+import { AppDownloadLink } from './appdownloadlink/appdownloadlink';
 
 function AppUpgradeRequired({ t }: TranslateProps) {
   return (
@@ -27,9 +27,7 @@ function AppUpgradeRequired({ t }: TranslateProps) {
             <div className="box large">
               <p className="m-top-none">{t('device.appUpradeRequired')}</p>
               <div className="buttons m-top-half">
-                <A href="https://shiftcrypto.ch/download/?source=bitboxapp" className="text-medium text-blue">
-                  {t('button.download')}
-                </A>
+                <AppDownloadLink className="text-medium text-blue" />
               </div>
             </div>
           </div>

--- a/frontends/web/src/components/update/update.tsx
+++ b/frontends/web/src/components/update/update.tsx
@@ -19,19 +19,15 @@ import { useTranslation } from 'react-i18next';
 import { load } from '../../decorators/load';
 import { runningInAndroid } from '../../utils/env';
 import { TUpdateFile } from '../../api/version';
-import A from '../anchor/anchor';
 import Status from '../status/status';
+import { AppDownloadLink } from '../appdownloadlink/appdownloadlink';
 
 type TProps = {
     file: TUpdateFile | null;
 }
 
-export const updatePath: string = 'https://shiftcrypto.ch/download/?source=bitboxapp';
-
 const Update = ({ file }: TProps) => {
   const { t } = useTranslation();
-  const downloadElement = <A href={updatePath}>{t('button.download')}</A>;
-
   return file && (
     <Status dismissable={`update-${file.version}`} type="info">
       {t('app.upgrade', {
@@ -41,7 +37,7 @@ const Update = ({ file }: TProps) => {
       {file.description}
       {' '}
       {/* Don't show download link on Android because they should update from stores */}
-      {!runningInAndroid() && downloadElement}
+      {!runningInAndroid() && <AppDownloadLink />}
     </Status>
   );
 };

--- a/frontends/web/src/routes/settings/settings.tsx
+++ b/frontends/web/src/routes/settings/settings.tsx
@@ -21,7 +21,6 @@ import { route } from '../../utils/route';
 import { alertUser } from '../../components/alert/Alert';
 import { Badge } from '../../components/badge/badge';
 import { Skeleton } from '../../components/skeleton/skeleton';
-import { updatePath } from '../../components/update/update';
 import { Dialog, DialogButtons } from '../../components/dialog/dialog';
 import { Button, Input } from '../../components/forms';
 import { Entry } from '../../components/guide/entry';
@@ -40,6 +39,7 @@ import { apiGet, apiPost } from '../../utils/request';
 import { setBtcUnit, BtcUnit } from '../../api/coins';
 import { TUpdateFile, getVersion, getUpdate } from '../../api/version';
 import { FiatSelection } from './components/fiat/fiat';
+import { downloadLinkByLanguage } from '../../components/appdownloadlink/appdownloadlink';
 import style from './settings.module.css';
 
 interface SettingsProps {
@@ -250,7 +250,7 @@ class Settings extends Component<Props, State> {
                                         </>
                                       }
                                       disabled={false}
-                                      onClick={() => update && apiPost('open', updatePath)}>
+                                      onClick={() => update && apiPost('open', downloadLinkByLanguage())}>
                                       {t('settings.info.version')}
                                     </SettingsButton>) : (
                                     <SettingsItem

--- a/frontends/web/src/utils/url_constants.ts
+++ b/frontends/web/src/utils/url_constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const URL_CONSTANTS = {
+  DOWNLOAD_LINK_GLOBAL: 'https://shiftcrypto.ch/download/?source=bitboxapp',
+  DOWNLOAD_LINK_DE: 'https://shiftcrypto.ch/de/download/?source=bitboxapp'
+};


### PR DESCRIPTION
To improve our UX, it would be better to have a "language-aware" download link. E.g German language app will use the german download page.

In the case where localised download page isn't available, will be fallbacking to the "international" / "default" downlaod page.