### PR TITLE
Draft: frontend: fix regression in dialog

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/reset.tsx
+++ b/frontends/web/src/routes/device/bitbox02/reset.tsx
@@ -85,7 +85,7 @@ class Reset extends Component<Props, State> {
         <Dialog
           open={activeDialog}
           title={t('reset.title')}
-          onClose={this.abort}
+          onClose={() => this.setState({ activeDialog: false, understand: false })}
           disabledClose={isConfirming}
           small>
           <div className="columnsContainer half">


### PR DESCRIPTION
The dialog behavior changed slightly it shows depending on the open prop controlled by the state of the parent component. This introduced a small regression, that the onClose callback is called later after the dialog open prop is set to false, passed to the dialog again and then it hides during render.

This is not a problem if onClose was only used to reset the dialog, but if onClose does anything else then it will overwrite the state at a later point and cause bugs.

In reset.tsx when clickin on reset there should be a blocking. confirmation is overwritten by onClose and does not show anymore.

In send-qr there is a function to toggle open and close the scan dialog. The back button toggles close, but the onClose callback toggles open again, so when clicking back the dialog shows again.

regressio introduced in a229726d8cd5424d502aa9610bad5962088ce7bb

components with onClose that should be tested:
- Confirm dialog
- Language switch (should be good as only used to close dialog)
- Transaction details
- QR scan dialog in send (fix in this commit)
- coincontrol (should be good)
- BB01 create (maybe fine)
- BB01 check (maybe fine)
- BB01 restore (should have bug, there are other dialogs controlled by the same state)
- BB01 changepin (should have bug with isConfirming)
- BB01 randomnumber (looks ok)
- BB01 reset (should have the bug)
- BB01 mobile-pairing (looks ok)
- BB02 manage backups / check backup
- BB02 reset, blocking confirm missing
- BB02 set device name (looks ok)
- manage account (looks ok)
- settings proxy (looks ok)