### PR TITLE
frontend: fix regression on Dialog and created dialog-legacy

### DIFF
--- a/frontends/web/src/components/confirm/Confirm.tsx
+++ b/frontends/web/src/components/confirm/Confirm.tsx
@@ -17,7 +17,7 @@
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SimpleMarkup } from '../../utils/markup';
-import { Dialog, DialogButtons } from '../dialog/dialog';
+import { DialogLegacy, DialogButtons } from '../dialog/dialog-legacy';
 import { Button } from '../forms';
 
 type TCallback = (response: boolean) => void;
@@ -60,8 +60,10 @@ export const Confirm = () => {
   };
 
   const { message, active, customButtonText } = state;
-
-  return <Dialog open={active} title={t('dialog.confirmTitle')} onClose={() => respond(false)}>
+  if (!active) {
+    return null;
+  }
+  return <DialogLegacy title={t('dialog.confirmTitle')} onClose={() => respond(false)}>
     <div className="columnsContainer half">
       <div className="columns">
         <div className="column">
@@ -77,10 +79,9 @@ export const Confirm = () => {
         </div>
       </div>
     </div>
-
     <DialogButtons>
       <Button primary onClick={() => respond(true)}>{customButtonText ? customButtonText : t('dialog.confirm')}</Button>
       <Button transparent onClick={() => respond(false)}>{t('dialog.cancel')}</Button>
     </DialogButtons>
-  </Dialog>;
+  </DialogLegacy>;
 };

--- a/frontends/web/src/components/dialog/dialog-legacy.module.css
+++ b/frontends/web/src/components/dialog/dialog-legacy.module.css
@@ -1,0 +1,247 @@
+.overlay {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    background-color: var(--bg-transparent-dark);
+    z-index: 4010;
+    opacity: 0;
+}
+
+.overlay.activeOverlay {
+    opacity: 1;
+}
+
+.modal {
+    background-color: white;
+    width: 100%;
+    max-width: 420px;
+    border-radius: 2px;
+    box-shadow: 0px 3px 5px rgba(0, 0, 0, 0.3);
+    text-align: left;
+    max-height: 100vh;
+    overflow: auto;
+    opacity: 0;
+}
+
+.modal.activeModal {
+    opacity: 1;
+}
+
+.active {}
+
+.modal.small {
+    max-width: 340px;
+    width: 100%;
+}
+
+.modal.medium {
+    /* long enough to fit a bc1... address in the receive screen on desktop */
+    max-width: 520px;
+    width: 100%;
+}
+
+.modal.large {
+    max-width: 800px;
+    width: 100%;
+}
+
+.header {
+    height: var(--item-height);
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 var(--space-half);
+    border-bottom: solid 1px var(--color-lightgray);
+}
+
+.header.centered {
+    justify-content: center;
+}
+
+.header .title {
+    margin: 0;
+    font-size: var(--size-subheader);
+    font-weight: 400;
+}
+
+.closeButton {
+    background: none;
+    border: none;
+    padding: 0;
+    width: auto !important;
+}
+
+.closeButton:focus {
+    outline: none;
+}
+
+.closeButton:disabled {
+    color: var(--color-secondary);
+}
+
+.header .closeButton,
+.header .closeButton img {
+    width: 18px;
+    height: 18px;
+}
+
+.contentContainer {
+    font-size: var(--size-default);
+    font-weight: 400;
+    padding: var(--space-half);
+}
+
+.contentContainer.slim {
+    padding: 0;
+}
+
+.contentContainer.padded {
+    padding: var(--space-default);
+}
+
+.content p {
+    word-break: break-word;
+}
+
+.actions button,
+.actions a,
+.small .actions button,
+.small .actions a {
+    width: 100%;
+}
+
+.actions > *:not(:last-child),
+.small .actions > *:not(:last-child) {
+    margin-bottom: var(--space-quarter);
+}
+
+.actions {
+    margin-top: var(--space-quarter);
+}
+
+
+/* WAIT DIALOG */
+.confirmationLabel {
+    position: relative;
+    line-height: 1.3;
+    font-size: var(--size-default);
+    font-weight: 400;
+    margin-top: var(--space-half);
+    padding-left: 24px;
+}
+
+.confirmationLabelNumber {
+    display: inline-block;
+    position: absolute;
+    left: 0;
+}
+
+.disabledLabel,
+.disabledLabel span {
+    color: var(--color-mediumgray) !important;
+}
+
+.noStep {
+    padding-left: 0;
+}
+
+.confirmationInstructions {
+    margin: 0;
+    padding: var(--space-half) 0 var(--space-quarter) 0;
+}
+
+.confirmationInstructions > div {
+  width: 50%;
+}
+
+.confirmationInstructions p {
+    line-height: 1;
+    margin-top: var(--space-quarter);
+}
+
+.confirmationInstructions.confirm {
+    text-align: center;
+    font-size: var(--size-subheader);
+    padding: var(--space-half) calc(var(--space-half) * 1.5);
+}
+
+.image {
+    height: 120px;
+    margin-right: var(--space-half);
+}
+
+.modalContent p {
+    font-size: var(--size-default);
+    font-weight: 400;
+}
+
+.modalContent > *:first-child {
+    margin-top: 0;
+}
+
+.detail {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    min-height: var(--item-height);
+    padding: var(--space-half);
+}
+
+.detail:not(:first-child) {
+    border-top: solid 1px var(--color-lightgray);
+}
+
+.detail label {
+    white-space: nowrap;
+    margin-right: var(--space-half) !important;
+}
+
+.detail label,
+.detail p {
+    margin: 0;
+    line-height: 1;
+}
+
+.detail.description > span {
+    text-align: right;
+}
+
+.buttons {
+    padding: var(--space-quarter);
+}
+
+.buttons button:first-child {
+    margin-right: 10px;
+}
+
+.buttons button {
+    width: 50%;
+}
+
+.dialogButtons {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+    margin-top: var(--space-default);
+}
+.dialogButtons > *:only-child {
+    width: 100%;
+}
+
+@media (max-width: 768px) {
+    .modal {
+        padding: 0;
+    }
+
+    .contentContainer.padded {
+        padding: var(--space-half);
+    }
+}

--- a/frontends/web/src/components/wait-dialog/wait-dialog.tsx
+++ b/frontends/web/src/components/wait-dialog/wait-dialog.tsx
@@ -139,7 +139,7 @@ class WaitDialog extends Component<Props, State> {
         className={style.overlay}
         ref={this.overlay}
         style={{ zIndex: 10001 }}>
-        <div className={style.modal} ref={this.modal}>
+        <div className={[style.modal, style.open].join(' ')} ref={this.modal}>
           {
             title && (
               <div className={style.header}>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -225,14 +225,8 @@ class Send extends Component<Props, State> {
   };
 
   private handleKeyDown = (e: KeyboardEvent) => {
-    if (e.keyCode === 27) {
-      if (this.state.activeScanQR) {
-        this.toggleScanQR();
-        return;
-      }
-      if (!this.state.activeCoinControl) {
-        route(`/account/${this.props.code}`);
-      }
+    if (e.keyCode === 27 && !this.state.activeCoinControl && !this.state.activeScanQR) {
+      route(`/account/${this.props.code}`);
     }
   };
 

--- a/frontends/web/src/routes/device/bitbox01/check.jsx
+++ b/frontends/web/src/routes/device/bitbox01/check.jsx
@@ -17,7 +17,7 @@
 import { Component } from 'react';
 import { withTranslation } from 'react-i18next';
 import { Button } from '../../../components/forms';
-import { Dialog } from '../../../components/dialog/dialog';
+import { DialogLegacy } from '../../../components/dialog/dialog-legacy';
 import { PasswordSingleInput } from '../../../components/password';
 import { apiPost } from '../../../utils/request';
 // TODO: use DialogButtons
@@ -92,37 +92,40 @@ class Check extends Component {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.check')}
         </Button>
-        <Dialog
-          open={activeDialog}
-          title={t('backup.check.title')}
-          onClose={this.abort}>
-          { message ? (
-            <div>
-              <p style={{ minHeight: '3rem' }}>{message}</p>
-              <div className={style.actions}>
-                <Button transparent onClick={this.abort}>
-                  {t('button.back')}
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <form onSubmit={this.check}>
-              <PasswordSingleInput
-                label={t('backup.check.password.label')}
-                placeholder={t('backup.check.password.placeholder')}
-                showLabel={t('backup.check.password.showLabel')}
-                onValidPassword={this.setValidPassword} />
-              <div className={style.actions}>
-                <Button type="submit" primary disabled={!this.validate()}>
-                  {t('button.check')}
-                </Button>
-                <Button transparent onClick={this.abort}>
-                  {t('button.back')}
-                </Button>
-              </div>
-            </form>
-          )}
-        </Dialog>
+        {
+          activeDialog && (
+            <DialogLegacy
+              title={t('backup.check.title')}
+              onClose={this.abort}>
+              { message ? (
+                <div>
+                  <p style={{ minHeight: '3rem' }}>{message}</p>
+                  <div className={style.actions}>
+                    <Button transparent onClick={this.abort}>
+                      {t('button.back')}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <form onSubmit={this.check}>
+                  <PasswordSingleInput
+                    label={t('backup.check.password.label')}
+                    placeholder={t('backup.check.password.placeholder')}
+                    showLabel={t('backup.check.password.showLabel')}
+                    onValidPassword={this.setValidPassword} />
+                  <div className={style.actions}>
+                    <Button type="submit" primary disabled={!this.validate()}>
+                      {t('button.check')}
+                    </Button>
+                    <Button transparent onClick={this.abort}>
+                      {t('button.back')}
+                    </Button>
+                  </div>
+                </form>
+              )}
+            </DialogLegacy>
+          )
+        }
       </div>
     );
   }

--- a/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
+++ b/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
@@ -18,7 +18,7 @@
 import { Component } from 'react';
 import { withTranslation } from 'react-i18next';
 import { Button } from '../../../../components/forms';
-import { Dialog, DialogButtons } from '../../../../components/dialog/dialog';
+import { DialogLegacy, DialogButtons } from '../../../../components/dialog/dialog-legacy';
 import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
 import { apiGet, apiPost } from '../../../../utils/request';
 import { SettingsButton } from '../../../../components/settingsButton/settingsButton';
@@ -89,19 +89,23 @@ class UpgradeFirmware extends Component {
             </SettingsButton>
           )
         }
-        <Dialog open={activeDialog} title={t('upgradeFirmware.title')}>
-          <p className="m-top-none">{t('upgradeFirmware.description', {
-            currentVersion, newVersion
-          })}</p>
-          <DialogButtons>
-            <Button primary onClick={this.upgradeFirmware}>
-              {t('button.upgrade')}
-            </Button>
-            <Button transparent onClick={this.abort}>
-              {t('button.back')}
-            </Button>
-          </DialogButtons>
-        </Dialog>
+        {
+          activeDialog && (
+            <DialogLegacy title={t('upgradeFirmware.title')}>
+              <p className="m-top-none">{t('upgradeFirmware.description', {
+                currentVersion, newVersion
+              })}</p>
+              <DialogButtons>
+                <Button primary onClick={this.upgradeFirmware}>
+                  {t('button.upgrade')}
+                </Button>
+                <Button transparent onClick={this.abort}>
+                  {t('button.back')}
+                </Button>
+              </DialogButtons>
+            </DialogLegacy>
+          )
+        }
         {
           isConfirming && (
             <WaitDialog title={t('upgradeFirmware.title')} includeDefault={!unlocked}>

--- a/frontends/web/src/routes/device/bitbox01/create.jsx
+++ b/frontends/web/src/routes/device/bitbox01/create.jsx
@@ -20,7 +20,7 @@ import { Button, Input } from '../../../components/forms';
 import { PasswordInput } from '../../../components/password';
 import { alertUser } from '../../../components/alert/Alert';
 import { apiPost } from '../../../utils/request';
-import { Dialog } from '../../../components/dialog/dialog';
+import { DialogLegacy } from '../../../components/dialog/dialog-legacy';
 // TODO: use DialogButtons
 import style from '../../../components/dialog/dialog.module.css';
 
@@ -86,35 +86,38 @@ class Create extends Component {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.create')}
         </Button>
-        <Dialog
-          open={activeDialog}
-          title={t('backup.create.title')}
-          onClose={this.abort}>
-          <form onSubmit={this.create}>
-            <Input
-              autoFocus
-              id="backupName"
-              label={t('backup.create.name.label')}
-              placeholder={t('backup.create.name.placeholder')}
-              onInput={this.handleFormChange}
-              value={backupName} />
-            <p>{t('backup.create.info')}</p>
-            <PasswordInput
-              id="recoveryPassword"
-              label={t('backup.create.password.label')}
-              placeholder={t('backup.create.password.placeholder')}
-              onInput={this.handleFormChange}
-              value={recoveryPassword} />
-            <div className={style.actions}>
-              <Button type="submit" primary disabled={waiting || !this.validate()}>
-                {t('button.create')}
-              </Button>
-              <Button transparent onClick={this.abort}>
-                {t('button.abort')}
-              </Button>
-            </div>
-          </form>
-        </Dialog>
+        {
+          activeDialog && (
+            <DialogLegacy
+              title={t('backup.create.title')}
+              onClose={this.abort}>
+              <form onSubmit={this.create}>
+                <Input
+                  autoFocus
+                  id="backupName"
+                  label={t('backup.create.name.label')}
+                  placeholder={t('backup.create.name.placeholder')}
+                  onInput={this.handleFormChange}
+                  value={backupName} />
+                <p>{t('backup.create.info')}</p>
+                <PasswordInput
+                  id="recoveryPassword"
+                  label={t('backup.create.password.label')}
+                  placeholder={t('backup.create.password.placeholder')}
+                  onInput={this.handleFormChange}
+                  value={recoveryPassword} />
+                <div className={style.actions}>
+                  <Button type="submit" primary disabled={waiting || !this.validate()}>
+                    {t('button.create')}
+                  </Button>
+                  <Button transparent onClick={this.abort}>
+                    {t('button.abort')}
+                  </Button>
+                </div>
+              </form>
+            </DialogLegacy>
+          )
+        }
       </div>
     );
   }

--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -20,7 +20,7 @@ import { route } from '../../../utils/route';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiPost } from '../../../utils/request';
 import { alertUser } from '../../../components/alert/Alert';
-import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
+import { DialogLegacy, DialogButtons } from '../../../components/dialog/dialog-legacy';
 import { Button, Checkbox } from '../../../components/forms';
 import { PasswordRepeatInput } from '../../../components/password';
 import { Spinner } from '../../../components/spinner/Spinner';
@@ -134,42 +134,45 @@ class Restore extends Component<Props, State> {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.restore')}
         </Button>
-        <Dialog
-          open={activeDialog}
-          title={t('backup.restore.title')}
-          disableEscape={isConfirming || isLoading}
-          onClose={this.abort}>
-          <form onSubmit={this.restore}>
-            <PasswordRepeatInput
-              label={t('backup.restore.password.label')}
-              placeholder={t('backup.restore.password.placeholder')}
-              repeatPlaceholder={t('backup.restore.password.repeatPlaceholder')}
-              showLabel={t('backup.restore.password.showLabel')}
-              onValidPassword={this.setValidPassword} />
-            <div className={style.agreements}>
-              <Checkbox
-                id="funds_access"
-                label={t('backup.restore.understand')}
-                checked={understand}
-                onChange={this.handleUnderstandChange} />
-            </div>
-            <DialogButtons>
-              <Button
-                type="submit"
-                danger={requireConfirmation}
-                primary={!requireConfirmation}
-                disabled={!understand || !this.validate() || isConfirming}>
-                {t('button.restore')}
-              </Button>
-              <Button
-                transparent
-                onClick={this.abort}
-                disabled={isConfirming}>
-                {t('button.back')}
-              </Button>
-            </DialogButtons>
-          </form>
-        </Dialog>
+        {
+          activeDialog && (
+            <DialogLegacy
+              title={t('backup.restore.title')}
+              disableEscape={isConfirming || isLoading}
+              onClose={this.abort}>
+              <form onSubmit={this.restore}>
+                <PasswordRepeatInput
+                  label={t('backup.restore.password.label')}
+                  placeholder={t('backup.restore.password.placeholder')}
+                  repeatPlaceholder={t('backup.restore.password.repeatPlaceholder')}
+                  showLabel={t('backup.restore.password.showLabel')}
+                  onValidPassword={this.setValidPassword} />
+                <div className={style.agreements}>
+                  <Checkbox
+                    id="funds_access"
+                    label={t('backup.restore.understand')}
+                    checked={understand}
+                    onChange={this.handleUnderstandChange} />
+                </div>
+                <DialogButtons>
+                  <Button
+                    type="submit"
+                    danger={requireConfirmation}
+                    primary={!requireConfirmation}
+                    disabled={!understand || !this.validate() || isConfirming}>
+                    {t('button.restore')}
+                  </Button>
+                  <Button
+                    transparent
+                    onClick={this.abort}
+                    disabled={isConfirming}>
+                    {t('button.back')}
+                  </Button>
+                </DialogButtons>
+              </form>
+            </DialogLegacy>
+          )
+        }
         {
           (isConfirming && requireConfirmation) && (
             <WaitDialog title={t('backup.restore.confirmTitle')} />

--- a/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
@@ -19,7 +19,7 @@ import { Component } from 'react';
 import { withTranslation } from 'react-i18next';
 import { Button } from '../../../../../components/forms';
 import { alertUser } from '../../../../../components/alert/Alert';
-import { Dialog, DialogButtons } from '../../../../../components/dialog/dialog';
+import { DialogLegacy, DialogButtons } from '../../../../../components/dialog/dialog-legacy';
 import { WaitDialog } from '../../../../../components/wait-dialog/wait-dialog';
 import { PasswordInput, PasswordRepeatInput } from '../../../../../components/password';
 import { apiPost } from '../../../../../utils/request';
@@ -94,34 +94,37 @@ class ChangePIN extends Component {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.changepin')}
         </SettingsButton>
-        <Dialog
-          open={activeDialog}
-          title={t('button.changepin')}
-          onClose={this.abort}>
-          <form onSubmit={this.changePin}>
-            <PasswordInput
-              idPrefix="oldPIN"
-              label={t('changePin.oldLabel')}
-              value={oldPIN}
-              onInput={this.setValidOldPIN} />
-            {t('changePin.newTitle') && <h4>{t('changePin.newTitle')}</h4>}
-            <PasswordRepeatInput
-              idPrefix="newPIN"
-              pattern="^.{4,}$"
-              label={t('initialize.input.label')}
-              repeatLabel={t('initialize.input.labelRepeat')}
-              repeatPlaceholder={t('initialize.input.placeholderRepeat')}
-              onValidPassword={this.setValidNewPIN} />
-            <DialogButtons>
-              <Button type="submit" danger disabled={!this.validate() || isConfirming}>
-                {t('button.changepin')}
-              </Button>
-              <Button transparent onClick={this.abort} disabled={isConfirming}>
-                {t('button.back')}
-              </Button>
-            </DialogButtons>
-          </form>
-        </Dialog>
+        {
+          activeDialog && (
+            <DialogLegacy
+              title={t('button.changepin')}
+              onClose={this.abort}>
+              <form onSubmit={this.changePin}>
+                <PasswordInput
+                  idPrefix="oldPIN"
+                  label={t('changePin.oldLabel')}
+                  value={oldPIN}
+                  onInput={this.setValidOldPIN} />
+                {t('changePin.newTitle') && <h4>{t('changePin.newTitle')}</h4>}
+                <PasswordRepeatInput
+                  idPrefix="newPIN"
+                  pattern="^.{4,}$"
+                  label={t('initialize.input.label')}
+                  repeatLabel={t('initialize.input.labelRepeat')}
+                  repeatPlaceholder={t('initialize.input.placeholderRepeat')}
+                  onValidPassword={this.setValidNewPIN} />
+                <DialogButtons>
+                  <Button type="submit" danger disabled={!this.validate() || isConfirming}>
+                    {t('button.changepin')}
+                  </Button>
+                  <Button transparent onClick={this.abort} disabled={isConfirming}>
+                    {t('button.back')}
+                  </Button>
+                </DialogButtons>
+              </form>
+            </DialogLegacy>
+          )
+        }
         {
           isConfirming && (
             <WaitDialog title={t('button.changepin')} />

--- a/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
@@ -18,7 +18,7 @@
 import { Component } from 'react';
 import { withTranslation } from 'react-i18next';
 import { Button } from '../../../../../components/forms';
-import { Dialog } from '../../../../../components/dialog/dialog';
+import { DialogLegacy } from '../../../../../components/dialog/dialog-legacy';
 import { WaitDialog } from '../../../../../components/wait-dialog/wait-dialog';
 import { apiPost } from '../../../../../utils/request';
 import { SettingsButton } from '../../../../../components/settingsButton/settingsButton';
@@ -69,22 +69,25 @@ class DeviceLock extends Component {
           optionalText={t(`deviceSettings.pairing.lock.${lock}`)}>
           {t('deviceLock.button')}
         </SettingsButton>
-        <Dialog
-          open={activeDialog}
-          title={t('deviceLock.title')}
-          onClose={this.abort}>
-          <p>{t('deviceLock.condition1')}</p>
-          <p>{t('deviceLock.condition2')}</p>
-          <p>{t('deviceLock.condition3')}</p>
-          <div className={style.actions}>
-            <Button danger onClick={this.resetDevice}>
-              {t('deviceLock.confirm')}
-            </Button>
-            <Button transparent onClick={this.abort}>
-              {t('button.back')}
-            </Button>
-          </div>
-        </Dialog>
+        {
+          activeDialog && (
+            <DialogLegacy
+              title={t('deviceLock.title')}
+              onClose={this.abort}>
+              <p>{t('deviceLock.condition1')}</p>
+              <p>{t('deviceLock.condition2')}</p>
+              <p>{t('deviceLock.condition3')}</p>
+              <div className={style.actions}>
+                <Button danger onClick={this.resetDevice}>
+                  {t('deviceLock.confirm')}
+                </Button>
+                <Button transparent onClick={this.abort}>
+                  {t('button.back')}
+                </Button>
+              </div>
+            </DialogLegacy>
+          )
+        }
         {
           isConfirming && (
             <WaitDialog title={t('deviceLock.title')} />

--- a/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
@@ -19,7 +19,7 @@ import { Component } from 'react';
 import { withTranslation } from 'react-i18next';
 import { Button } from '../../../../../components/forms';
 import { alertUser } from '../../../../../components/alert/Alert';
-import { Dialog, DialogButtons } from '../../../../../components/dialog/dialog';
+import { DialogLegacy, DialogButtons } from '../../../../../components/dialog/dialog-legacy';
 import { WaitDialog } from '../../../../../components/wait-dialog/wait-dialog';
 import { PasswordRepeatInput } from '../../../../../components/password';
 import { apiPost } from '../../../../../utils/request';
@@ -100,34 +100,38 @@ class HiddenWallet extends Component {
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.hiddenwallet')}
         </SettingsButton>
-        <Dialog open={activeDialog} title={t('button.hiddenwallet')}
-          onClose={this.abort}>
-          <SimpleMarkup tagName="p" markup={t('hiddenWallet.info1HTML')} />
-          <SimpleMarkup tagName="p" markup={t('hiddenWallet.info2HTML')} />
-          <form onSubmit={this.createHiddenWallet}>
-            <PasswordRepeatInput
-              idPrefix="pin"
-              pattern="^.{4,}$"
-              label={t('hiddenWallet.pinLabel')}
-              repeatLabel={t('hiddenWallet.pinRepeatLabel')}
-              repeatPlaceholder={t('hiddenWallet.pinRepeatPlaceholder')}
-              onValidPassword={this.setValidPIN} />
-            <PasswordRepeatInput
-              idPrefix="password"
-              label={t('hiddenWallet.passwordLabel')}
-              repeatPlaceholder={t('hiddenWallet.passwordPlaceholder')}
-              onValidPassword={this.setValidPassword}
-            />
-            <DialogButtons>
-              <Button type="submit" danger disabled={!this.validate() || isConfirming}>
-                {t('button.hiddenwallet')}
-              </Button>
-              <Button transparent onClick={this.abort} disabled={isConfirming}>
-                {t('button.abort')}
-              </Button>
-            </DialogButtons>
-          </form>
-        </Dialog>
+        {
+          activeDialog && (
+            <DialogLegacy title={t('button.hiddenwallet')}
+              onClose={this.abort}>
+              <SimpleMarkup tagName="p" markup={t('hiddenWallet.info1HTML')} />
+              <SimpleMarkup tagName="p" markup={t('hiddenWallet.info2HTML')} />
+              <form onSubmit={this.createHiddenWallet}>
+                <PasswordRepeatInput
+                  idPrefix="pin"
+                  pattern="^.{4,}$"
+                  label={t('hiddenWallet.pinLabel')}
+                  repeatLabel={t('hiddenWallet.pinRepeatLabel')}
+                  repeatPlaceholder={t('hiddenWallet.pinRepeatPlaceholder')}
+                  onValidPassword={this.setValidPIN} />
+                <PasswordRepeatInput
+                  idPrefix="password"
+                  label={t('hiddenWallet.passwordLabel')}
+                  repeatPlaceholder={t('hiddenWallet.passwordPlaceholder')}
+                  onValidPassword={this.setValidPassword}
+                />
+                <DialogButtons>
+                  <Button type="submit" danger disabled={!this.validate() || isConfirming}>
+                    {t('button.hiddenwallet')}
+                  </Button>
+                  <Button transparent onClick={this.abort} disabled={isConfirming}>
+                    {t('button.abort')}
+                  </Button>
+                </DialogButtons>
+              </form>
+            </DialogLegacy>
+          )
+        }
         {
           isConfirming && (
             <WaitDialog title={t('button.hiddenwallet')} />

--- a/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
@@ -20,7 +20,7 @@ import appStoreBadge from '../../../../../assets/badges/app-store-badge.svg';
 import playStoreBadge from '../../../../../assets/badges/google-play-badge.png';
 import { alertUser } from '../../../../../components/alert/Alert';
 import { confirmation } from '../../../../../components/confirm/Confirm';
-import { Dialog, DialogButtons } from '../../../../../components/dialog/dialog';
+import { DialogLegacy, DialogButtons } from '../../../../../components/dialog/dialog-legacy';
 import { Button } from '../../../../../components/forms';
 import { QRCode } from '../../../../../components/qrcode/qrcode';
 import { SettingsButton } from '../../../../../components/settingsButton/settingsButton';
@@ -215,26 +215,29 @@ class MobilePairing extends Component<Props, State> {
             (hasMobileChannel && !paired) ? t('pairing.reconnectOnly.button') : t('pairing.button')
           )}
         </SettingsButton>
-        <Dialog
-          open={!!status}
-          title={t('pairing.title')}
-          onClose={this.abort}
-          medium>
-          <div className="flex flex-column flex-center flex-items-center">
-            {
-              channel ? (
-                content
-              ) : (
-                <p>{t('loading')}</p>
-              )
-            }
-          </div>
-          <DialogButtons>
-            <Button transparent onClick={this.abort}>
-              {t('button.back')}
-            </Button>
-          </DialogButtons>
-        </Dialog>
+        {
+          status && (
+            <DialogLegacy
+              title={t('pairing.title')}
+              onClose={this.abort}
+              medium>
+              <div className="flex flex-column flex-center flex-items-center">
+                {
+                  channel ? (
+                    content
+                  ) : (
+                    <p>{t('loading')}</p>
+                  )
+                }
+              </div>
+              <DialogButtons>
+                <Button transparent onClick={this.abort}>
+                  {t('button.back')}
+                </Button>
+              </DialogButtons>
+            </DialogLegacy>
+          )
+        }
       </div>
     );
   }

--- a/frontends/web/src/routes/device/bitbox01/settings/components/randomnumber.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/randomnumber.jsx
@@ -18,7 +18,7 @@ import { Component } from 'react';
 import { withTranslation } from 'react-i18next';
 import { Button } from '../../../../../components/forms';
 import { apiPost } from '../../../../../utils/request';
-import { Dialog, DialogButtons } from '../../../../../components/dialog/dialog';
+import { DialogLegacy, DialogButtons } from '../../../../../components/dialog/dialog-legacy';
 import { CopyableInput } from '../../../../../components/copy/Copy';
 import { SettingsButton } from '../../../../../components/settingsButton/settingsButton';
 
@@ -55,21 +55,27 @@ class RandomNumber extends Component {
         <SettingsButton onClick={this.getRandomNumber}>
           {t('random.button')}
         </SettingsButton>
-        <Dialog open={!!(active && number)} title="Generate Random Number" onClose={this.abort}>
-          <div className="columnsContainer half">
-            <div className="columns">
-              <div className="column">
-                <p>{t('random.description', {
-                  bits: number.length * 4
-                })}</p>
-                <CopyableInput value={number} flexibleHeight />
+        {
+          // @ts-ignore Object is possibly 'undefined'.
+          active && number ? (
+            <DialogLegacy title="Generate Random Number" onClose={this.abort}>
+              <div className="columnsContainer half">
+                <div className="columns">
+                  <div className="column">
+                    <p>{t('random.description', {
+                      // @ts-ignore
+                      bits: number.length * 4
+                    })}</p>
+                    <CopyableInput value={number} flexibleHeight />
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-          <DialogButtons>
-            <Button primary onClick={this.abort}>{t('button.ok')}</Button>
-          </DialogButtons>
-        </Dialog>
+              <DialogButtons>
+                <Button primary onClick={this.abort}>{t('button.ok')}</Button>
+              </DialogButtons>
+            </DialogLegacy>
+          ) : null
+        }
       </div>
     );
   }

--- a/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
@@ -19,7 +19,7 @@ import { Component } from 'react';
 import { route } from '../../../../../utils/route';
 import { withTranslation } from 'react-i18next';
 import { Button, Checkbox } from '../../../../../components/forms';
-import { Dialog, DialogButtons } from '../../../../../components/dialog/dialog';
+import { DialogLegacy, DialogButtons } from '../../../../../components/dialog/dialog-legacy';
 import { WaitDialog } from '../../../../../components/wait-dialog/wait-dialog';
 import { PasswordInput } from '../../../../../components/password';
 import { apiPost } from '../../../../../utils/request';
@@ -84,34 +84,37 @@ class Reset extends Component {
         <SettingsButton danger onClick={() => this.setState({ activeDialog: true })}>
           {t('reset.title')}
         </SettingsButton>
-        <Dialog
-          active={activeDialog}
-          title={t('reset.title')}
-          onClose={this.abort}>
-          <p>
-            {t('reset.description')}
-          </p>
-          <PasswordInput
-            idPrefix="pin"
-            label={t('initialize.input.label')}
-            value={pin}
-            onInput={this.setValidPIN} />
-          <div className={style.agreements}>
-            <Checkbox
-              id="funds_access"
-              label={t('reset.understand')}
-              checked={understand}
-              onChange={this.handleUnderstandChange} />
-          </div>
-          <DialogButtons>
-            <Button danger disabled={!pin || !understand} onClick={this.resetDevice}>
-              {t('reset.title')}
-            </Button>
-            <Button transparent onClick={this.abort} disabled={isConfirming}>
-              {t('button.back')}
-            </Button>
-          </DialogButtons>
-        </Dialog>
+        {
+          activeDialog && (
+            <DialogLegacy
+              title={t('reset.title')}
+              onClose={this.abort}>
+              <p>
+                {t('reset.description')}
+              </p>
+              <PasswordInput
+                idPrefix="pin"
+                label={t('initialize.input.label')}
+                value={pin}
+                onInput={this.setValidPIN} />
+              <div className={style.agreements}>
+                <Checkbox
+                  id="funds_access"
+                  label={t('reset.understand')}
+                  checked={understand}
+                  onChange={this.handleUnderstandChange} />
+              </div>
+              <DialogButtons>
+                <Button danger disabled={!pin || !understand} onClick={this.resetDevice}>
+                  {t('reset.title')}
+                </Button>
+                <Button transparent onClick={this.abort} disabled={isConfirming}>
+                  {t('button.back')}
+                </Button>
+              </DialogButtons>
+            </DialogLegacy>
+          )
+        }
         { isConfirming ? (
           <WaitDialog title={t('reset.title')} />
         ) : null }


### PR DESCRIPTION
During the development of the new Dialog (improving dialog for mobile), we introduced a regression that affected several places such as the:

1. Factory reset device
2. send-QR

This PR fixes it.

We also will use the old dialog for all of the bb01 components and the Confirm component (which uses dialog internally).

This PR also fixes some other random bugs that are not exactly in the Dialog component but still related to it, such as:
1. WaitDialog style on mobile
2. Closing send-QR with ESC only toggles the dialog, not actually closing it.

[Preview] Factory Reset Device:


https://user-images.githubusercontent.com/28676406/215662356-0cf40823-430f-4994-9c08-a107622619a1.mov

(the WaitDialog isn't immediately closing anymore).