### PR TITLE
frontend: use native-locale to pre-select region dropdown in exchange page.

### DIFF
--- a/frontends/web/src/i18n/utils.test.ts
+++ b/frontends/web/src/i18n/utils.test.ts
@@ -18,8 +18,22 @@ import { getRegionNameFromLocale } from './utils';
 
 describe('getRegionNameFromLocale', () => {
   describe('when given an invalid locale', () => {
-    it('should return empty string ', () => {
+    it('should return empty string', () => {
       const LOCALE = 'es-es419';
+
+      const regionName = getRegionNameFromLocale(LOCALE);
+      expect(regionName).toBe('');
+    });
+
+    it('should return empty string when the invalid locale is also an empty string', () => {
+      const LOCALE = '';
+
+      const regionName = getRegionNameFromLocale(LOCALE);
+      expect(regionName).toBe('');
+    });
+
+    it('should return empty string when the invalid locale is a random string', () => {
+      const LOCALE = 'anystring here';
 
       const regionName = getRegionNameFromLocale(LOCALE);
       expect(regionName).toBe('');

--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -34,9 +34,10 @@ import { Dialog } from '../../components/dialog/dialog';
 import { InfoButton } from '../../components/infobutton/infobutton';
 import { InfoContent } from './components/infocontent';
 import { Globe } from '../../components/icon';
-import style from './exchange.module.css';
+import { getNativeLocale } from '../../api/nativelocale';
 import { setConfig } from '../../utils/config';
 import { getConfig } from '../../api/backend';
+import style from './exchange.module.css';
 
 type TProps = {
     code: string;
@@ -68,6 +69,7 @@ export const Exchange = ({ code, accounts }: TProps) => {
 
   const regionList = useLoad(exchangesAPI.getExchangesByRegion(code));
   const exchangeDeals = useLoad(exchangesAPI.getExchangeDeals);
+  const nativeLocale = useLoad(getNativeLocale);
   const supportedExchanges = useLoad<exchangesAPI.SupportedExchanges>(exchangesAPI.getExchangeBuySupported(code));
   const config = useLoad(getConfig);
 
@@ -92,12 +94,12 @@ export const Exchange = ({ code, accounts }: TProps) => {
       return;
     }
 
-    const userRegion = getRegionNameFromLocale(i18n.language);
+    const userRegion = getRegionNameFromLocale(nativeLocale || '');
     //Region is available in the list
     const regionAvailable = !!(regionList.regions.find(region => region.code === userRegion));
     //Pre-selecting the region
     setSelectedRegion(regionAvailable ? userRegion : '');
-  }, [regionList, config]);
+  }, [regionList, config, nativeLocale]);
 
   useEffect(() => {
     if (!exchangeDeals) {
@@ -201,7 +203,7 @@ export const Exchange = ({ code, accounts }: TProps) => {
                       },
                       ...regions]
                       }
-                      value={selectedRegion || ''}
+                      value={selectedRegion}
                       onChange={handleChangeRegion}
                       id="exchangeRegions"
                     />


### PR DESCRIPTION
We have preivously used native-locale but we didn't take into account that native-locale may sometimes return nothing (empty).

Another PR then was created to fix this, using `i18n.language` - which is not exactly correct.

Thus, in this PR we used native-locale back. But, we are now handling empty native-locale gracefully so it won't crash the page whenever native-locale returns empty/nothing.