### PR TITLE
frontend: fixed minor css issues in the exchange page(s).

### DIFF
--- a/frontends/web/src/routes/buy/exchange.module.css
+++ b/frontends/web/src/routes/buy/exchange.module.css
@@ -92,6 +92,9 @@
     margin-left: calc((var(--space-eight) + var(--space-quarter)));
 }
 
+.radioButtonsContainer {
+    min-height: 180px;
+}
 
 .title {
     font-size: 2rem;

--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -213,7 +213,7 @@ export const Exchange = ({ code, accounts }: TProps) => {
                   <InfoButton onClick={() => setInfo('region')} />
                 </div>
 
-                <div>
+                <div className={style.radioButtonsContainer}>
                   {noExchangeAvailable && (
                     <p className={style.noExchangeText}>{t('buy.exchange.noExchanges')}</p>
                   )}

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -91,7 +91,7 @@ export const Moonpay = ({ accounts, code }: TProps) => {
               />
             ) : (
               <div style={{ height }}>
-                {!iframeLoaded && <Spinner text={t('loading')} />}
+                {!iframeLoaded && <Spinner guideExists={false} text={t('loading')} />}
                 { moonpay && (
                   <iframe
                     onLoad={() => {

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -165,7 +165,7 @@ export const Pocket = ({ code }: TProps) => {
             />
           ) : (
             <div style={{ height }}>
-              {!iframeLoaded && <Spinner text={t('loading')} /> }
+              {!iframeLoaded && <Spinner guideExists={false} text={t('loading')} /> }
               <iframe
                 onLoad={() => {
                   setIframeLoaded(true);


### PR DESCRIPTION
1. Added min-height for radio buttons container in the
exchange page to prevent the layout shifting/jumping around

2. Set `guideExists` to be `false` for `<Spinner/>` to fix
"double guide" issue.