### PR TITLE
frontend: fix flickering sidebar when navigating to device settings

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -102,13 +102,6 @@ class BitBox02 extends Component<Props, State> {
 
   private unsubscribe!: () => void;
 
-  public UNSAFE_componentWillMount() {
-    const { sidebarStatus } = panelStore.state;
-    if (['', 'forceCollapsed'].includes(sidebarStatus)) {
-      setSidebarStatus('forceHidden');
-    }
-  }
-
   public componentDidMount() {
     getVersion(this.props.deviceID).then(versionInfo => {
       this.setState({ versionInfo });


### PR DESCRIPTION
Navigating to device settings triggered the sidebar to close, this was the reason that it looked like the whole app window flickered.

Forcing the sidebar to close on will mount is not necessary as it will open/close later depending on the device state.

Test on medium screen (when hamburger is visible)
- reset device
- navigate through app
- open app with unlocked BB
- plugin uninitialized BB on waiting screen or app settings
- other tests?