### PR TITLE
frontend: reword pairing code verification

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -216,9 +216,9 @@
     "noPasswordMatch": "Passwords did not match, please try again.",
     "pairing": {
       "failed": "Unconfirmed pairing. Please replug your BitBox02.",
-      "paired": "You have confirmed on your device that the code matches. If this is correct, you can continue by clicking the button below.",
+      "paired": "You have confirmed the following code on your device. Please continue.",
       "title": "Verify pairing code",
-      "unpaired": "A new BitBox02 has been detected. Please verify that the following code matches what is shown on your device. If the code matches, touch underneath the check mark on your BitBox02 and then click the button below to continue."
+      "unpaired": "An unpaired BitBox02 has been detected. Please verify the pairing code matches what is shown on your BitBox02."
     },
     "restoreFromMnemonic": {
       "failed": "Restoring from recovery words failed, please try again."
@@ -260,9 +260,6 @@
       "restoreMicroSD": "Restore from microSD card",
       "restoreMnemonic": "Restore from recovery words",
       "title": "Setup your BitBox02"
-    },
-    "stepUnpaired": {
-      "verify": "Please verify the pairing code matches what is shown on your BitBox02."
     },
     "success": {
       "text": "Hooray! Your BitBox02 is now ready to use. \n\nFor further information on how to use the BitBoxApp, please use the in-app guide by clicking the question mark on the top right corner.",

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -480,36 +480,39 @@ class BitBox02 extends Component<Props, State> {
             withBottomBar
             width="670px">
             <ViewHeader title={t('bitbox02Wizard.pairing.title')}>
+              { (attestationResult === false && status !== 'pairingFailed') && (
+                <Status key="attestation" type="warning">
+                  {t('bitbox02Wizard.attestationFailed')}
+                </Status>
+              )}
               { status === 'pairingFailed' ? (
-                <Status type="warning">
+                <Status key="pairingFailed" type="warning">
                   {t('bitbox02Wizard.pairing.failed')}
                 </Status>
               ) : (
-                <p>{t('bitbox02Wizard.stepUnpaired.verify')}</p>
-              )}
-              { (attestationResult === false && status !== 'pairingFailed') && (
-                <Status type="warning">
-                  {t('bitbox02Wizard.attestationFailed')}
-                </Status>
+                <p>
+                  { deviceVerified
+                    ? t('bitbox02Wizard.pairing.paired')
+                    : t('bitbox02Wizard.pairing.unpaired') }
+                </p>
               )}
             </ViewHeader>
             <ViewContent fullWidth>
               { status !== 'pairingFailed' && (
-                <pre>{hash}</pre>
+                <>
+                  <pre>{hash}</pre>
+                  { !deviceVerified && <PointToBitBox02 /> }
+                </>
               )}
             </ViewContent>
             <ViewButtons>
-              {status !== 'pairingFailed' ? (
-                deviceVerified ? (
-                  <Button
-                    primary
-                    onClick={() => verifyChannelHash(deviceID, true)}>
-                    {t('button.continue')}
-                  </Button>
-                ) : (
-                  <PointToBitBox02 />
-                )
-              ) : null}
+              { (status !== 'pairingFailed' && deviceVerified) && (
+                <Button
+                  primary
+                  onClick={() => verifyChannelHash(deviceID, true)}>
+                  {t('button.continue')}
+                </Button>
+              )}
             </ViewButtons>
           </View>
         )}


### PR DESCRIPTION
The pairing code prompt does not give any information about why that
the user should confirm and has no visual feedback after confirming
on the device.

There are also unused and inconsistent pairing translations.

Changed:
- added new device detected sentence to unpaired message.
- change to previously unused pairing.unpaired translation to be
  consistent with the other keys
- show a paired message after confirming on the device using unused
  pairing.paired translation
- move attestation error before the pairing messages (this should
  be the first information the user reads if it ever happens)