### PR TITLE
backend/pocket: refactor `PocketUrl` to use devservers argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ servewallet-regtest:
 	rm -f appfolder.dev/cache/headers-rbtc.bin && rm -rf appfolder.dev/cache/account-*rbtc* && go run -mod=vendor ./cmd/servewallet -regtest
 servewallet-prodservers:
 	go run -mod=vendor ./cmd/servewallet -devservers=false
+servewallet-mainnet-prodservers:
+	go run -mod=vendor ./cmd/servewallet -mainnet -devservers=false
 buildweb:
 	node --version
 	npm --version

--- a/backend/arguments/arguments.go
+++ b/backend/arguments/arguments.go
@@ -51,7 +51,10 @@ type Arguments struct {
 	// devmode stores whether the application is in dev mode
 	devmode bool
 
-	//devservers stores wether the app should connect to the dev servers. The devservers configuration is not persisted when switching back to production.
+	// devservers stores wether the app should connect to the dev servers.
+	// This also applies to the Pocket widget environment: if devserver is true, the widget
+	// will be loaded from the staging environment, otherwise from production.
+	// The devservers configuration is not persisted when switching back to production.
 	devservers bool
 
 	// gapLimits optionally forces the gap limits used in btc/ltc.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -333,6 +333,11 @@ func (backend *Backend) defaultElectrumXServers(code coinpkg.Code) []*config.Ser
 	return backend.defaultProdServers(code)
 }
 
+// DevServers returns the value of the `devservers` flag.
+func (backend *Backend) DevServers() bool {
+	return backend.arguments.DevServers()
+}
+
 // Coin returns the coin with the given code or an error if no such coin exists.
 func (backend *Backend) Coin(code coinpkg.Code) (coinpkg.Coin, error) {
 	defer backend.coinsLock.Lock()()

--- a/backend/exchanges/pocket.go
+++ b/backend/exchanges/pocket.go
@@ -65,20 +65,12 @@ type PocketRegion struct {
 }
 
 // PocketURL returns the url needed to incorporate the widget in the frontend, verifying
-// if the account is mainnet or testnet.
-func PocketURL(acct accounts.Interface, locale string) (string, error) {
-	apiURL := ""
-	switch acct.Coin().Code() {
-	case coin.CodeBTC:
-		apiURL = pocketMainLiveURL + "/" + locale + "/" + pocketWidgetLive
-	case coin.CodeTBTC:
-		apiURL = pocketMainTestURL + "/" + locale + "/" + pocketWidgetTest
-	default:
-		err := fmt.Errorf("unsupported cryptocurrency code %q", acct.Coin().Code())
-		return "", err
-
+// if the `devservers` argument is enabled.
+func PocketURL(devServers bool, locale string) string {
+	if devServers {
+		return pocketMainTestURL + "/" + locale + "/" + pocketWidgetTest
 	}
-	return apiURL, nil
+	return pocketMainLiveURL + "/" + locale + "/" + pocketWidgetLive
 }
 
 // IsPocketSupported is true if coin.Code is supported by Pocket.

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -88,10 +88,8 @@ export const verifyAddress = (address: string, accountCode: AccountCode): Promis
   return apiPost('exchange/pocket/verify-address', { address, accountCode });
 };
 
-export const getPocketURL = (accountCode: string) => {
-  return (): Promise<string> => {
-    return apiGet(`exchange/pocket/api-url/${accountCode}`);
-  };
+export const getPocketURL = (): Promise<string> => {
+  return apiGet('exchange/pocket/api-url');
 };
 
 export type SupportedExchanges= {

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -43,7 +43,7 @@ export const Pocket = ({ code }: TProps) => {
   const [agreedTerms, setAgreedTerms] = useState(false);
   const [verifying, setVerifying] = useState(false);
 
-  const iframeURL = useLoad(getPocketURL(code));
+  const iframeURL = useLoad(getPocketURL);
   const config = useLoad(getConfig);
   const accountInfo = useLoad(getInfo(code));
 


### PR DESCRIPTION
This updates`PocketUrl`to return the address of the Pocket widget from staging or production environment depending on the `devservers` flag, instead of the net used, which was the previous approach.

It also adds a `servewallet-mainnet-prodservers` target in the Makefile, which runs the server on mainnet and with devservers flag disabled.

The reason for this PR is that address signing is currently disabled for the btc testnet at a firmware level, which forces using the mainnet when working on Pocket integration. This update allows choosing which Pocket environment should be used with a proper flag.