### PR TITLE
frontend/pocket: add xpub sharing logic

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -16,7 +16,7 @@
         "react-dom": "17.0.2",
         "react-i18next": "11.16.8",
         "react-router-dom": "6.3.0",
-        "request-address": "0.0.4"
+        "request-address": "0.0.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.14.1",
@@ -13697,9 +13697,9 @@
       }
     },
     "node_modules/request-address": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.4.tgz",
-      "integrity": "sha512-WlgNKQ8YWMqEGGgaDy+EXlJdmLkoqz5+WHDWhDn6HmiFDWmIRb2i3U2SnsqStmRILMNFwI45jnTfYmqGc5DQHQ=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.6.tgz",
+      "integrity": "sha512-+2K4JU/m1ERJ/7Pt3x+N0RqC+Pbdp9Ry6B7OVCDD9J8En3YGX6aAt1Zw6jkQLdY87dJsYPWG/hTrEFAJ2tSnMA=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -26450,9 +26450,9 @@
       }
     },
     "request-address": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.4.tgz",
-      "integrity": "sha512-WlgNKQ8YWMqEGGgaDy+EXlJdmLkoqz5+WHDWhDn6HmiFDWmIRb2i3U2SnsqStmRILMNFwI45jnTfYmqGc5DQHQ=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/request-address/-/request-address-0.0.6.tgz",
+      "integrity": "sha512-+2K4JU/m1ERJ/7Pt3x+N0RqC+Pbdp9Ry6B7OVCDD9J8En3YGX6aAt1Zw6jkQLdY87dJsYPWG/hTrEFAJ2tSnMA=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -23,7 +23,7 @@
     "react-dom": "17.0.2",
     "react-i18next": "11.16.8",
     "react-router-dom": "6.3.0",
-    "request-address": "0.0.4"
+    "request-address": "0.0.6"
   },
   "eslintConfig": {
     "extends": [

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -408,6 +408,7 @@
         "p2": "Please note that Pocket’s exchange rates can differ from the ones used in the BitBoxApp, resulting in slightly different amounts.",
         "title": "Payment methods and fees"
       },
+      "previousTransactions": "The transaction history of this account is not empty. Sharing this account will make all its past and future transactions visible for Pocket. Proceed anyway?",
       "security": {
         "link": "BitBox02 security threat model",
         "p1": "When you buy bitcoin via Pocket, you are using an external service. This service is out of scope of the BitBox02 Security Threat model and relies on the safety and security of the environment which the BitBoxApp software is running in. However we work together to improve security by using a two factor authentication mechanism to verify the address you are receiving to.",


### PR DESCRIPTION
This pushes the version of `request-address` js library to 0.0.6 and adds the handling of `RequestExtendedPublicKeyV0Message` requests, that allows sharing the account xpub with the Pocket widget.

NOTE: in order to test this PR, please force the staging environment for Pocket:
```
apiURL = pocketMainTestURL + "/" + locale + "/" + pocketWidgetTest
```
 in https://github.com/Beerosagos/bitbox-wallet-app/blob/xpub-sharing/backend/exchanges/pocket.go#L73

I opened a separate PR to avoid needing this workaround in the future, see https://github.com/digitalbitbox/bitbox-wallet-app/pull/1946