### PR TITLE
frontend: remove store decorator from `<Spinner/>`.

### DIFF
--- a/frontends/web/src/components/spinner/Spinner.tsx
+++ b/frontends/web/src/components/spinner/Spinner.tsx
@@ -16,17 +16,16 @@
 
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { share } from '../../decorators/share';
-import { SharedProps, store, toggle as toggleGuide } from '../guide/guide';
+import { toggle as toggleGuide } from '../guide/guide';
 import { toggleSidebar } from '../sidebar/sidebar';
 import { Menu } from '../icon';
 import style from './Spinner.module.css';
 
-type SpinnerProps = {
-    text?: string;
+type TProps = {
+  text?: string;
+  guideExists: boolean;
 }
 
-type TProps = SpinnerProps & SharedProps;
 
 const Spinner = ({ text, guideExists }: TProps) => {
   const { t } = useTranslation();
@@ -89,5 +88,4 @@ const Spinner = ({ text, guideExists }: TProps) => {
   );
 };
 
-const SharedSpinner = share<SharedProps, SpinnerProps>(store)(Spinner);
-export { SharedSpinner as Spinner };
+export { Spinner };

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -237,7 +237,7 @@ export function Account({
             </div>
 
             { !status.synced || offlineErrorTextLines.length || !hasDataLoaded || status.fatalError ? (
-              <Spinner text={
+              <Spinner guideExists text={
                 (status.fatalError && t('account.fatalError'))
                   || offlineErrorTextLines.join('\n')
                   || (!status.synced &&

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -855,7 +855,7 @@ class Send extends Component<Props, State> {
             open={activeScanQR}
             title={t('send.scanQR')}
             onClose={this.toggleScanQR}>
-            {videoLoading && <Spinner />}
+            {videoLoading && <Spinner guideExists />}
             <video
               id="video"
               width={400}

--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -253,7 +253,7 @@ export const Exchange = ({ code, accounts }: TProps) => {
                   </div>}
                 </div>
               </>
-            ) : <Spinner/>}
+            ) : <Spinner guideExists/>}
           </div>
         </div>
       </div>

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -81,7 +81,7 @@ class BuyInfo extends Component<Props, State> {
       options,
     } = this.state;
     if (options === undefined) {
-      return <Spinner text={t('loading')} />;
+      return <Spinner guideExists={false} text={t('loading')} />;
     }
 
     const account = findAccount(accounts, code);

--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -180,7 +180,7 @@ class Restore extends Component<Props, State> {
         }
         {
           isLoading && (
-            <Spinner text={t('backup.restore.restoring')} />
+            <Spinner guideExists={false} text={t('backup.restore.restoring')} />
           )
         }
       </span>

--- a/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
@@ -210,7 +210,7 @@ class Settings extends Component {
                 </div>
               </div>
             </div>
-            { spinner && <Spinner text={t('deviceSettings.loading')} /> }
+            { spinner && <Spinner guideExists text={t('deviceSettings.loading')} /> }
           </div>
         </div>
         <Guide>

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -175,7 +175,7 @@ class Initialize extends Component<Props, State> {
           </div>
           {
             status === stateEnum.WAITING && (
-              <Spinner text={t('initialize.creating')} />
+              <Spinner guideExists={false} text={t('initialize.creating')} />
             )
           }
         </div>

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
@@ -129,9 +129,9 @@ class SeedCreateNew extends Component {
   renderSpinner() {
     switch (this.state.status) {
     case STATUS.CHECKING:
-      return (<Spinner text={this.props.t('checkSDcard')} />);
+      return (<Spinner guideExists={false} text={this.props.t('checkSDcard')} />);
     case STATUS.CREATING:
-      return (<Spinner text={this.props.t('seed.creating')} />);
+      return (<Spinner guideExists={false} text={this.props.t('seed.creating')} />);
     default:
       return null;
     }

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
@@ -67,9 +67,9 @@ class SeedRestore extends Component {
   renderSpinner() {
     switch (this.state.status) {
     case STATUS.CHECKING:
-      return (<Spinner text={this.props.t('checkSDcard')} />);
+      return (<Spinner guideExists={false} text={this.props.t('checkSDcard')} />);
     case STATUS.CREATING:
-      return (<Spinner text={this.props.t('seed.creating')} />);
+      return (<Spinner guideExists={false} text={this.props.t('seed.creating')} />);
     default:
       return null;
     }

--- a/frontends/web/src/routes/device/bitbox01/unlock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/unlock.jsx
@@ -100,7 +100,7 @@ class Unlock extends Component {
       submissionState = <p>{t('unlock.description')}</p>;
       break;
     case stateEnum.WAITING:
-      submissionState = <Spinner text={t('unlock.unlocking')} />;
+      submissionState = <Spinner guideExists text={t('unlock.unlocking')} />;
       break;
     case stateEnum.ERROR:
       submissionState = (


### PR DESCRIPTION
To reduce ambiguity, we would like to manually pass `guideExists` prop to `<Spinner />` instead of relying totally on the `SharedProps` coming from the store (the `share` decorator).

The `guideExists` prop in the `<Spinner />` controls the render of the guide button when the `<Spinner />` component / view appears.