### PR TITLE
backend/eth/account: fix race condition on tx-proposal

### DIFF
--- a/backend/accounts/errors/errors.go
+++ b/backend/accounts/errors/errors.go
@@ -39,6 +39,8 @@ var (
 	// ErrFeeTooLow is returned when the custom fee the user entered is too low to be able to
 	// broadcast the transaction.
 	ErrFeeTooLow = TxValidationError("feeTooLow")
+	// ErrAccountNotsynced is used when the account sync has not successfully finished.
+	ErrAccountNotsynced = TxValidationError("accountNotSynced")
 
 	// ErrNotAvailable is returned if data required is not available yet. Example: the headers are
 	// not synced yet, which is a prerequisite to making a timeseries of the portfolio.

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -466,8 +466,9 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (*TxProposal, error
 		return nil, errp.WithStack(errors.ErrFeesNotAvailable)
 	}
 
-	// Make sure account.balance is up to date for calculations below.
-	account.Synchronizer.WaitSynchronized()
+	if !account.Synced() {
+		return nil, errp.WithStack(errors.ErrAccountNotsynced)
+	}
 
 	var value *big.Int
 	if args.Amount.SendAll() {

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -101,6 +101,7 @@ func newAccount(t *testing.T) *Account {
 func TestTxProposal(t *testing.T) {
 	acct := newAccount(t)
 	defer acct.Close()
+	acct.Synchronizer.WaitSynchronized()
 
 	t.Run("valid", func(t *testing.T) {
 		value, fee, total, err := acct.TxProposal(&accounts.TxProposalArgs{


### PR DESCRIPTION
A race condition between the `Initialize()` and `TxProposal()` methods was causing a deadlock where they were blocking each other in accessing `account.Synchronizer` and `account.updateLock`. This recently caused CI tests to timeout and fail from time to time.

This changes the behavior of `newTx()`, which is called by `TxProposal()`, making it returning an errror instead of waiting when the account is not yet synced. This should fix the race condition.