### PR TITLE
frontend/exchange: make exchange region selection optional

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -347,7 +347,7 @@
       },
       "noExchanges": "Sorry, there are no available exchanges in this region.",
       "region": "Region",
-      "selectRegion": "Select region",
+      "selectRegion": "Not specified",
       "title": "Buy {{name}}"
     },
     "info": {

--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -89,11 +89,18 @@ export const Exchange = ({ code, accounts }: TProps) => {
     regions.sort((a, b) => a.text.localeCompare(b.text, i18n.language));
     setRegions(regions);
 
+    // if user had selected no region before, do not pre-select any.
+    if (config.frontend.selectedExchangeRegion === '') {
+      return;
+    }
+
     if (config.frontend.selectedExchangeRegion) {
+      // pre-select config region
       setSelectedRegion(config.frontend.selectedExchangeRegion);
       return;
     }
 
+    // user never selected a region preference, will derive it from native locale.
     const userRegion = getRegionNameFromLocale(nativeLocale || '');
     //Region is available in the list
     const regionAvailable = !!(regionList.regions.find(region => region.code === userRegion));
@@ -198,7 +205,6 @@ export const Exchange = ({ code, accounts }: TProps) => {
                       className={style.extraLeftSpace}
                       options={[{
                         text: t('buy.exchange.selectRegion'),
-                        disabled: true,
                         value: '',
                       },
                       ...regions]
@@ -221,7 +227,6 @@ export const Exchange = ({ code, accounts }: TProps) => {
                   <div>
                     {!noExchangeAvailable && allExchangeDeals && allExchangeDeals.exchanges.map(exchange => exchange.supported && (<ExchangeSelectionRadio
                       key={exchange.exchangeName}
-                      disabled={!selectedRegion}
                       id={exchange.exchangeName}
                       exchangeName={exchange.exchangeName}
                       deals={exchange.deals}


### PR DESCRIPTION
Region selection in exchange page was mandatory in order to proceed with the buy workflow. This allows the user to explicitly avoid specifying the region.