### PR TITLE
frontend: change bb01 banner style to warning

### DIFF
--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -44,7 +44,7 @@ function Banner({ banner, i18n, t }: TProps) {
     return null;
   }
   return banner && (
-    <Status dismissable="" type="info">
+    <Status dismissable="" type="warning">
       { banner.message[i18n.language] || banner.message[(i18n.options.fallbackLng as string[])[0]] }&nbsp;
       { banner.link && (
         <A href={banner.link.href}>


### PR DESCRIPTION
As it has been 3 years since BitBox01 EOL and 3rd party services such as MEW silently dropped support, the banner in the BitBoxApp should be displayed in a more eye catchy warning style to encourage users moving their funds.