### PR TITLE
backend/arguments: remove `devmode` argument

### DIFF
--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -231,7 +231,7 @@ func newBackend(t *testing.T, testing, regtest bool) *Backend {
 		arguments.NewArguments(
 			test.TstTempDir("appfolder"),
 			testing, regtest,
-			false, false,
+			false,
 			&types.GapLimits{Receive: 20, Change: 6}),
 		environment{},
 	)

--- a/backend/arguments/arguments.go
+++ b/backend/arguments/arguments.go
@@ -48,9 +48,6 @@ type Arguments struct {
 	// Testing stores whether the application is for regtest.
 	regtest bool
 
-	// devmode stores whether the application is in dev mode
-	devmode bool
-
 	//devservers stores wether the app should connect to the dev servers. The devservers configuration is not persisted when switching back to production.
 	devservers bool
 
@@ -66,7 +63,6 @@ func NewArguments(
 	mainDirectoryPath string,
 	testing bool,
 	regtest bool,
-	devmode bool,
 	devservers bool,
 	gapLimits *btctypes.GapLimits,
 ) *Arguments {
@@ -100,7 +96,6 @@ func NewArguments(
 		accountsConfigFilename: path.Join(mainDirectoryPath, "accounts.json"),
 		testing:                testing,
 		regtest:                regtest,
-		devmode:                devmode,
 		devservers:             devservers,
 		gapLimits:              gapLimits,
 		log:                    log,
@@ -147,11 +142,6 @@ func (arguments *Arguments) NotesDirectoryPath() string {
 // Testing returns whether the backend is for testing only.
 func (arguments *Arguments) Testing() bool {
 	return arguments.testing
-}
-
-// DevMode returns whether the backend is in developer mode.
-func (arguments *Arguments) DevMode() bool {
-	return arguments.devmode
 }
 
 // DevServers returns whether the backend should use the development servers.

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -222,7 +222,6 @@ func Serve(
 			testnet,
 			false,
 			false,
-			false,
 			gapLimits,
 		),
 		backendEnvironment)

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -63,7 +63,6 @@ func TestGetNativeLocale(t *testing.T) {
 		test.TstTempDir("getnativelocale"),
 		true,  // testing
 		false, // regtest
-		false, // devmode
 		true,  // devservers
 		nil,   // gap limits
 	)
@@ -98,7 +97,6 @@ func TestListRoutes(t *testing.T) {
 	connectionData := handlers.NewConnectionData(8082, "")
 	backend, err := backend.NewBackend(arguments.NewArguments(
 		test.TstTempDir("bitbox-wallet-listroutes-"),
-		false,
 		false,
 		false,
 		false,

--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -103,7 +103,6 @@ func main() {
 
 	mainnet := flag.Bool("mainnet", false, "switch to mainnet instead of testnet coins")
 	regtest := flag.Bool("regtest", false, "use regtest instead of testnet coins")
-	devmode := flag.Bool("devmode", true, "switch to dev mode")
 	devservers := flag.Bool("devservers", true, "switch to dev servers")
 	gapLimitsReceive := flag.Uint("gapLimitReceive", 0, "gap limit for receive addresses")
 	gapLimitsChange := flag.Uint("gapLimitChange", 0, "gap limit for change addresses")
@@ -135,7 +134,6 @@ func main() {
 			config.AppDir(),
 			!*mainnet,
 			*regtest,
-			*devmode,
 			*devservers,
 			gapLimits,
 		),


### PR DESCRIPTION
`devmode` argument was not actively used in any part of the code. This removes that.