### PR TITLE
frontend: remove additional styling on buttons in exchange page

### DIFF
--- a/frontends/web/src/routes/buy/exchange.module.css
+++ b/frontends/web/src/routes/buy/exchange.module.css
@@ -20,13 +20,7 @@
 
 .buttonsContainer {
     display: flex;
-    margin-top: var(--space-default);
-}
-
-.buttonsContainer a, .buttonsContainer button{
-    height: 0px;
-    min-width: 0 !important;
-    padding: 18px 24px;
+    margin-top: var(--space-half);
 }
 
 .container {


### PR DESCRIPTION
To match our app's styling and to maintain uniformity throughout our app's UI, we should remove the additional/custom css applied to the "back" and "next" button in the exchange page.

Also altered the buttons' container margin to match the previous page's  button (the "next"  button) spacing, for the same reason as the above.

Before:
![Screenshot 2023-02-13 at 08 48 04](https://user-images.githubusercontent.com/28676406/218400094-d3ef6f0f-5c1a-4183-a913-55e5b2498593.png)


After:
![Screenshot 2023-02-13 at 08 47 55](https://user-images.githubusercontent.com/28676406/218400108-8fe705e6-d7e2-4572-8ceb-3e6df45ffe7e.png)

![Screenshot 2023-02-13 at 11 25 10](https://user-images.githubusercontent.com/28676406/218433122-c44b6ec6-080f-454b-9663-8f9a2d421bed.png)

