### PR TITLE
backend: comply with new golangci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   # https://docs.github.com/en/packages/guides/pushing-and-pulling-docker-images
   #
   # Keep this in sync with default in scripts/travis-ci.sh.
-  CI_IMAGE: ghcr.io/digitalbitbox/bitbox-wallet-app-ci:15
+  CI_IMAGE: ghcr.io/digitalbitbox/bitbox-wallet-app-ci:16
   TRAVIS_BUILD_DIR: ${{github.workspace}}
 
 jobs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,6 +131,9 @@ linters:
     - makezero
     - nolintlint
     - gocyclo
+    - nosnakecase
+    - interfacebloat
+    - revive
   disable-all: false
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ catch:
 	@echo "Choose a make target."
 envinit:
 	# Keep golangci-lint version in sync with what's in .github/workflows/ci.yml.
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.46.1
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.50.1
 	go install github.com/vektra/mockery/v2@latest
 	go install github.com/matryer/moq@latest
 	go install golang.org/x/tools/cmd/goimports@latest

--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -83,7 +83,7 @@ type Interface interface {
 	VerifyAddress(addressID string) (bool, error)
 
 	TxNote(txID string) string
-	// ProposeTxnote stores a note. The note is is persisted in the notes database upon calling
+	// ProposeTxnote stores a note. The note is persisted in the notes database upon calling
 	// SendTx(). This function must be called before `SendTx()`.
 	ProposeTxNote(string)
 	// SetTxNote sets a tx note and refreshes the account.

--- a/backend/accounts/notifier.go
+++ b/backend/accounts/notifier.go
@@ -15,6 +15,7 @@
 package accounts
 
 // Notifier juggles transaction IDs for the purpose of notifications and unread counts.
+//
 //go:generate mockery -name Notifier
 type Notifier interface {
 	// Put adds the id to the 'unnotified' set, unless it is already in the 'seen' set.

--- a/backend/accounts/transaction.go
+++ b/backend/accounts/transaction.go
@@ -38,7 +38,7 @@ const (
 	TxTypeSendSelf TxType = "sendSelf"
 )
 
-// TxStatus is the the status of the tx and helps the frontend show the appropriate information.
+// TxStatus is the status of the tx and helps the frontend show the appropriate information.
 type TxStatus string
 
 const (
@@ -123,7 +123,7 @@ type TransactionData struct {
 	Nonce *uint64
 }
 
-// isConfirmed returns true if the transaction has has at least one confirmation.
+// isConfirmed returns true if the transaction has at least one confirmation.
 func (tx *TransactionData) isConfirmed() bool {
 	return tx.Height > 0
 }

--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -61,7 +61,7 @@ const (
 	// Nothing is happening, we are waiting for an AOPP request.
 	aoppStateInactive aoppState = "inactive"
 	// The user is prompted to continue or cancel a new AOPP request. This is always the first state
-	// when a new AOPP request is is handled.
+	// when a new AOPP request is handled.
 	aoppStateUserApproval aoppState = "user-approval"
 	// No keystore is connected, so we are waiting for the user to insert and unlock their
 	// device. This state is skipped if a keystore already exists.

--- a/backend/coins/btc/addresses/addresschain.go
+++ b/backend/coins/btc/addresses/addresschain.go
@@ -112,7 +112,7 @@ func (addresses *AddressChain) LookupByScriptHashHex(hashHex blockchain.ScriptHa
 	return addresses.addressesLookup[hashHex]
 }
 
-// EnsureAddresses appends addresses to the address chain until there are `gapLimit` unused unused
+// EnsureAddresses appends addresses to the address chain until there are `gapLimit` unused
 // ones, and returns the new addresses.
 func (addresses *AddressChain) EnsureAddresses() ([]*AccountAddress, error) {
 	defer addresses.addressesLock.Lock()()

--- a/backend/coins/btc/coin.go
+++ b/backend/coins/btc/coin.go
@@ -243,7 +243,7 @@ func (coin *Coin) SmallestUnit() string {
 	}
 }
 
-// DecodeAddress decodes a btc/ltc address, checking that that the format matches the account coin
+// DecodeAddress decodes a btc/ltc address, checking that the format matches the account coin
 // type.
 func (coin *Coin) DecodeAddress(address string) (btcutil.Address, error) {
 	btcAddress, err := btcutil.DecodeAddress(address, coin.Net())

--- a/backend/coins/coin/amount.go
+++ b/backend/coins/coin/amount.go
@@ -38,7 +38,7 @@ func NewAmountFromInt64(amount int64) Amount {
 }
 
 // NewAmountFromString parses a user given coin amount, converting it from the default coin unit to
-// the the smallest unit.
+// the smallest unit.
 func NewAmountFromString(s string, unit *big.Int) (Amount, error) {
 	// big.Rat parsing accepts rationals like "2/3". Exclude those, we only want decimals.
 	if strings.ContainsRune(s, '/') {

--- a/backend/coins/coin/coin.go
+++ b/backend/coins/coin/coin.go
@@ -22,6 +22,7 @@ import (
 )
 
 // Coin models the currency of a blockchain.
+//
 //go:generate moq -pkg mocks -out mocks/coin.go . Coin
 type Coin interface {
 	observable.Interface

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -499,7 +499,7 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (*TxProposal, error
 			From: account.address.Address,
 			To:   &contractAddress,
 			Gas:  0,
-			// Gas price has to be 0 for the the Etherscan EstimateGas call to succeed.
+			// Gas price has to be 0 for the Etherscan EstimateGas call to succeed.
 			GasPrice: big.NewInt(0),
 			Value:    big.NewInt(0),
 			Data:     erc20ContractData,

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -59,7 +59,7 @@ type Coin struct {
 }
 
 // NewCoin creates a new coin with the given parameters.
-// transactionsSource: can be nil, in which case transactions will not be be processed (in other
+// transactionsSource: can be nil, in which case transactions will not be processed (in other
 // words, account.Transactions() will always be empty apart from the outgoing transactions which //
 // are stored in the local database).
 // For erc20 tokens, provide erc20Token using NewERC20Token() (otherwise keep nil).

--- a/backend/coins/eth/rpcclient/rpcclient.go
+++ b/backend/coins/eth/rpcclient/rpcclient.go
@@ -25,6 +25,7 @@ import (
 )
 
 // Interface can be implemented to provide an Ethereum rpc client.
+//
 //go:generate moq -pkg mocks -out mocks/rpcclient.go . Interface
 type Interface interface {
 	TransactionReceiptWithBlockNumber(

--- a/backend/devices/bitbox/device.go
+++ b/backend/devices/bitbox/device.go
@@ -86,6 +86,7 @@ const (
 )
 
 // CommunicationInterface contains functions needed to communicate with the device.
+//
 //go:generate mockery -name CommunicationInterface
 type CommunicationInterface interface {
 	SendPlain(string) (map[string]interface{}, error)
@@ -588,7 +589,7 @@ func (dbb *Device) seed(pin, backupPassword, source, filename string) error {
 }
 
 // CheckBackup uses the provided backup file and recovery password to check if they correspond to
-//the current wallet. Returns true if it matches, false if not.
+// the current wallet. Returns true if it matches, false if not.
 func (dbb *Device) CheckBackup(backupPassword, filename string) (bool, error) {
 	if backupPassword == "" {
 		return false, errp.New("invalid password")

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -32,19 +32,20 @@ import (
 // backendEnv is a backend environment implementation for testing.
 //
 // TODO: Move this to the test pkg. Unfortunately, there's imports cycle:
-//   $ go vet ./backend/...
-//   import cycle not allowed in test
-//   package github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/db/transactionsdb (test)
-//           imports github.com/digitalbitbox/bitbox-wallet-app/util/test
-//           imports github.com/digitalbitbox/bitbox-wallet-app/backend/devices/usb
-//           imports github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox
-//           imports github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc
-//           imports github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/db/transactionsdb
-//   import cycle not allowed in test
-//   package github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox (test)
-//           imports github.com/digitalbitbox/bitbox-wallet-app/util/test
-//           imports github.com/digitalbitbox/bitbox-wallet-app/backend/devices/usb
-//           imports github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox
+//
+//	$ go vet ./backend/...
+//	import cycle not allowed in test
+//	package github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/db/transactionsdb (test)
+//	        imports github.com/digitalbitbox/bitbox-wallet-app/util/test
+//	        imports github.com/digitalbitbox/bitbox-wallet-app/backend/devices/usb
+//	        imports github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox
+//	        imports github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc
+//	        imports github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/db/transactionsdb
+//	import cycle not allowed in test
+//	package github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox (test)
+//	        imports github.com/digitalbitbox/bitbox-wallet-app/util/test
+//	        imports github.com/digitalbitbox/bitbox-wallet-app/backend/devices/usb
+//	        imports github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox
 type backendEnv struct {
 	Locale string // returned by NativeLocale
 }
@@ -74,7 +75,7 @@ func TestGetNativeLocale(t *testing.T) {
 	defer back.Close()
 
 	h := handlers.NewHandlers(back, handlers.NewConnectionData(0, ""))
-	r := httptest.NewRequest("GET", "/api/native-locale", nil)
+	r := httptest.NewRequest(http.MethodGet, "/api/native-locale", nil)
 	w := httptest.NewRecorder()
 	h.Router.ServeHTTP(w, r)
 	res := w.Result()

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -38,6 +38,7 @@ const (
 var ErrSigningAborted = errors.New("signing aborted by user")
 
 // Keystore supports hardened key derivation according to BIP32 and signing of transactions.
+//
 //go:generate moq -pkg mocks -out mocks/keystore.go . Keystore
 type Keystore interface {
 	// Type denotes the type of the keystore.

--- a/backend/rates/history.go
+++ b/backend/rates/history.go
@@ -264,7 +264,7 @@ func (updater *RateUpdater) fetchGeckoMarketRange(ctx context.Context, coin, fia
 			"vs_currency": {gfiat},
 		}
 		endpoint := fmt.Sprintf("%s/coins/%s/market_chart/range?%s", updater.coingeckoURL, gcoin, param.Encode())
-		req, err := http.NewRequest("GET", endpoint, nil)
+		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 		if err != nil {
 			return err
 		}

--- a/backend/rates/rates.go
+++ b/backend/rates/rates.go
@@ -177,7 +177,7 @@ func (updater *RateUpdater) LatestPriceForPair(coinUnit, fiat string) (float64, 
 // The returned value may be imprecise if at arg matches no timestamp exactly.
 // In this case, linear interpolation is used as an approximation.
 // If no data is available with the given args, HistoricalPriceAt returns 0.
-// The latest rates can lag behind by many minutes (5-30min). Use `LatestPrice` get get the latest
+// The latest rates can lag behind by many minutes (5-30min). Use `LatestPrice` get the latest
 // rates.
 func (updater *RateUpdater) HistoricalPriceAt(coin, fiat string, at time.Time) float64 {
 	updater.historyMu.RLock()
@@ -257,7 +257,7 @@ func (updater *RateUpdater) updateLast(ctx context.Context) {
 		"vs_currencies": {simplePriceAllCurrencies},
 	}
 	endpoint := fmt.Sprintf("%s/simple/price?%s", updater.coingeckoURL, param.Encode())
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
 		updater.log.WithError(err).Error("could not create request")
 		updater.last = nil

--- a/backend/signing/configuration.go
+++ b/backend/signing/configuration.go
@@ -241,7 +241,7 @@ func (configs Configurations) ContainsRootFingerprint(rootFingerprint []byte) bo
 	return false
 }
 
-// FindScriptType returns the index of the the first configuration that is a Bitcoin configuration
+// FindScriptType returns the index of the first configuration that is a Bitcoin configuration
 // and uses the provided script type. Returns -1 if none is found.
 func (configs Configurations) FindScriptType(scriptType ScriptType) int {
 	for idx, config := range configs {

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -14,7 +14,7 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     # Which docker image to use to run the CI. Defaults to Docker Hub.
     # Overwrite with CI_IMAGE=docker/image/path environment variable.
     # Keep this in sync with .github/workflows/ci.yml.
-    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:15}"
+    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:16}"
     # Time image pull to compare in the future.
     time docker pull "$CI_IMAGE"
 

--- a/util/jsonp/jsonp.go
+++ b/util/jsonp/jsonp.go
@@ -25,7 +25,7 @@ func MustMarshal(value interface{}) []byte {
 	return jsonBytes
 }
 
-// MustUnmarshal decodes json that that cannot fail. Panics on a decoding error.
+// MustUnmarshal decodes json that cannot fail. Panics on a decoding error.
 func MustUnmarshal(jsonBytes []byte, value interface{}) {
 	if err := json.Unmarshal(jsonBytes, value); err != nil {
 		panic(err)

--- a/util/test/tcp.go
+++ b/util/test/tcp.go
@@ -25,7 +25,8 @@ import (
 
 // TCPServerCertKey is the private key of TCPServerCert in PEM encoding.
 // It was generated with:
-//     openssl ecparam -out key.pem -name secp256r1 -genkey; cat key.pem
+//
+//	openssl ecparam -out key.pem -name secp256r1 -genkey; cat key.pem
 const TCPServerCertKey = `
 -----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIFlVUmHt+140ZsJz0i2QlFd9m3zLNKQ0FmadLADGWKJvoAoGCCqGSM49
@@ -36,9 +37,10 @@ jXbEaVL0nhsoi2DbNJbGzMaIBhyYrtaFAw==
 
 // TCPServerCertPub is the TCPServerCert in PEM encoding.
 // It was generated with:
-//     openssl req -new -key key.pem -x509 -nodes -days 10000 \
-//       -subj '/CN=node.example.org' \
-//       -addext 'subjectAltName=DNS:node.example.org'
+//
+//	openssl req -new -key key.pem -x509 -nodes -days 10000 \
+//	  -subj '/CN=node.example.org' \
+//	  -addext 'subjectAltName=DNS:node.example.org'
 const TCPServerCertPub = `
 -----BEGIN CERTIFICATE-----
 MIIBTDCB8qADAgECAgkAqux29iMFU0UwCgYIKoZIzj0EAwIwGzEZMBcGA1UEAwwQ


### PR DESCRIPTION
Upgrading `golanci-lint` to v1.50 showed several nits in the code. With this I updated the code where possible and skipped three new tests.