### PR TITLE
backend/usb: run all hidapi API calls in a dedicated OS thread

### DIFF
--- a/backend/devices/usb/hid.go
+++ b/backend/devices/usb/hid.go
@@ -17,10 +17,33 @@ package usb
 import (
 	"encoding/hex"
 	"io"
+	"runtime"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
 	hid "github.com/digitalbitbox/usb"
 )
+
+// Run functions sent to this channel in a goroutine fixed to an OS thread. We will run all hidapi
+// API calls in that thread. This is needed for hidapi to work properly on macOS. The reason for
+// this is not entirely clear - maybe something in the macOS SDK relies on thread-local variables
+// between HID API calls. See also https://github.com/libusb/hidapi/issues/503.
+var funcCalls chan func()
+
+func init() {
+	funcCalls = make(chan func())
+	go func() {
+		runtime.LockOSThread()
+		for {
+			f := <-funcCalls
+			f()
+		}
+	}()
+}
+
+type funcCallResult[T any] struct {
+	value T
+	err   error
+}
 
 type hidDeviceInfo struct {
 	hid.DeviceInfo
@@ -66,28 +89,76 @@ func (info hidDeviceInfo) Identifier() string {
 	return hex.EncodeToString([]byte(info.DeviceInfo.Path))
 }
 
+// singleThreadedDevice runs all hidapi functions in the same OS thread. See the docs of the
+// `funcCalls` variable for more info. Implements io.ReadWriteCloser, like `hid.Device`.
+type singleThreadedDevice struct {
+	device hid.Device
+}
+
+// Write wraps hid.Device.Write to run in a dedicated OS thread.
+func (s singleThreadedDevice) Write(b []byte) (int, error) {
+	ch := make(chan funcCallResult[int])
+	funcCalls <- func() {
+		written, err := s.device.Write(b)
+		ch <- funcCallResult[int]{written, err}
+	}
+	result := <-ch
+	return result.value, result.err
+}
+
+// Read wraps hid.Device.Write to run in a dedicated OS thread.
+func (s singleThreadedDevice) Read(b []byte) (int, error) {
+	ch := make(chan funcCallResult[int])
+	funcCalls <- func() {
+		read, err := s.device.Read(b)
+		ch <- funcCallResult[int]{read, err}
+	}
+	result := <-ch
+	return result.value, result.err
+}
+
+// Close wraps hid.Device.Write to run in a dedicated OS thread.
+func (s singleThreadedDevice) Close() error {
+	ch := make(chan error)
+	funcCalls <- func() {
+		ch <- s.device.Close()
+	}
+	return <-ch
+}
+
 // Open implements DeviceInfo.
 func (info hidDeviceInfo) Open() (io.ReadWriteCloser, error) {
-	device, err := info.DeviceInfo.Open()
-	if err != nil {
-		return nil, err
+	ch := make(chan funcCallResult[hid.Device])
+	funcCalls <- func() {
+		device, err := info.DeviceInfo.Open()
+		ch <- funcCallResult[hid.Device]{device, err}
 	}
-	return device, nil
+	result := <-ch
+	if result.err != nil {
+		return nil, result.err
+	}
+
+	return singleThreadedDevice{device: result.value}, nil
 }
 
 // DeviceInfos returns a slice of all recognized devices.
 func DeviceInfos() []DeviceInfo {
 	deviceInfosFiltered := []DeviceInfo{}
 
-	// The library never actually returns an error in this function.
-	deviceInfos, err := hid.EnumerateHid(0, 0)
-	if err != nil {
-		logging.Get().WithError(err).Error("EnumerateHid() returned an error")
+	ch := make(chan funcCallResult[[]hid.DeviceInfo])
+	funcCalls <- func() {
+		di, err := hid.EnumerateHid(0, 0)
+		ch <- funcCallResult[[]hid.DeviceInfo]{di, err}
+	}
+	result := <-ch
+	// The library never actually returns an error in this functions.
+	if result.err != nil {
+		logging.Get().WithError(result.err).Error("EnumerateHid() returned an error")
 		return deviceInfosFiltered
 	}
 
-	for idx := range deviceInfos {
-		di := hidDeviceInfo{deviceInfos[idx]}
+	for idx := range result.value {
+		di := hidDeviceInfo{result.value[idx]}
 		// If Enumerate() is called too quickly after a device is inserted, the HID device input
 		// report is not yet ready.
 		if di.Serial() == "" || di.Product() == "" {


### PR DESCRIPTION
For unknown reasons, on macOS, there are intermittent errors during hid.Device.Write():

`IOHIDLibUserClient:0x100002065 setReport failed: 0xe00002bc` In the BitBoxApp, the issue appears most frequently in the loop polling the device for a API call status in query.go/rawQueryV7.

Running all calls in the same OS thread seems to resolve the issue, even though it is not clear why that is. Maybe something in the macOS SDK relies on thread-local variables, or there is a memory-bug that does not get triggered this way.

After a long time debugging this, I am still not sure what causes it, especially because it also happens in a test program without any goroutines of this sort:

`main() { for { C.hid_write(...); C.hid_read(...) }`.

The issue disappears however if there is a `runtime.Gosched()` in every loop iteration in this test program, which is perplexing, as there are no other goroutines to yield to. Further investigation is needed to figure out what is going on under the hood - for now we apply the fix to run all calls in the same thread. `runtime.Gosched()`
is not needed in our case as the scheduler is automatically invoked
when sending to and reading from the `funcCalls` channel.