### PR TITLE
frontend: revert attestation warning regression

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -463,7 +463,7 @@ class BitBox02 extends Component<Props, State> {
               <p>{t('bitbox02Wizard.stepConnected.unlock')}</p>
             </ViewHeader>
             <ViewContent fullWidth>
-              {attestationResult === true ? (
+              {attestationResult === false ? (
                 <Status>
                   {t('bitbox02Wizard.attestationFailed')}
                 </Status>


### PR DESCRIPTION
In e34ddc8450fbb6596375ed5655bbbc4f84f1fa93 the attestation error was changed for debuggin purpose and accidentally commited. Changed back to show the warning if attestation fails