### PR TITLE
frontend: fix scanning qr code with amount in sats mode

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -501,6 +501,10 @@ class Send extends Component<Props, State> {
       address = url.pathname;
       if (this.isBitcoinBased()) {
         amount = url.searchParams.get('amount') || '';
+        if (amount && this.state.btcUnit === 'sat') {
+          // convert expected amount in BTC to sat
+          amount = `${Number(amount) * 100_000_000}`;
+        }
       }
     } catch {
       address = uri;


### PR DESCRIPTION
The send interface shows an error when scanning a QR code with amount when in sats mode. Reason: sats cannot have decimals on L1.

Added a check to see if amount is specified and app in sats mode, in which case it tires to parse the amount and multiply with 100m.

100m is written with numeric separation for better readability https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#numeric_separators
