### PR TITLE
frontend: fix language button regression

### DIFF
--- a/frontends/web/src/components/language/language.tsx
+++ b/frontends/web/src/components/language/language.tsx
@@ -94,6 +94,7 @@ const LanguageSwitch = ({ languages }: TLanguageSwitchProps) => {
   return (
     <div>
       <button
+        type="button"
         title="Select Language"
         className={style.link}
         onClick={() => setActiveDialog(true)}>
@@ -119,6 +120,7 @@ const LanguageSwitch = ({ languages }: TLanguageSwitchProps) => {
             const selected = selectedIndex === i;
             return (
               <button
+                type="button"
                 key={language.code}
                 className={[style.language, selected ? style.selected : ''].join(' ')}
                 onClick={() => changeLanguage(language.code, i)}


### PR DESCRIPTION
The language button didn't work in some views that have a form around the view.

regression introduced in 77fd86e40491d0af98578b2015f0fe194d609390

test:
1) create new wallet
2) on enter-name click on langauge button
3) invalid input

reason was that buttons by default are type submit, so if there is a form wrapping the whole view, clicking the button fires the onsubmit event that propagates all up the the form wrapping the view.