### PR TITLE
frontend: limit success icon min and max size

### DIFF
--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -214,6 +214,8 @@
 .content .largeIcon {
     margin: var(--space-half) auto;
     max-height: 100%;
+    max-width: 280px;
+    min-width: 80px;
     width: 50%;
 }
 @media (max-width: 768px) {


### PR DESCRIPTION
Success icon is sometimes rendered too big, this seems to be a regression from View component refactoring.

Changed to limit the max size of large icons in the view component.