### PR TITLE
golanci-lint: disable deprecated tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,6 +135,9 @@ linters:
     - interfacebloat
     - revive
     - musttag
+    - structcheck
+    - deadcode
+    - varcheck
   disable-all: false
 
 issues:


### PR DESCRIPTION
Some golanci-lint default tests are deprecated because unmantained. This update disables them:
- `varcheck`
- `structcheck`
- `deadcode`

Ref: https://github.com/golangci/golangci-lint/issues/1841