### PR TITLE
frontend: rephrase sd card warning when creating a new wallet

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -240,7 +240,7 @@
       "nameLabel": "BitBox02 name",
       "namePlaceholder": "My BitBox02",
       "title": "Choose BitBox02 name",
-      "toastMicroSD": "Please make sure your microSD card is inserted in your BitBox02."
+      "toastMicroSD": "Please insert your microSD card into your BitBox02 which will be used to store a backup of the wallet."
     },
     "stepCreateSuccess": {
       "removeMicroSD": "Please remove the microSD card from your BitBox02 and store it in a secure location.",

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -573,12 +573,12 @@ class BitBox02 extends Component<Props, State> {
               verticallyCentered
               width="600px">
               <ViewHeader title={t('bitbox02Wizard.stepCreate.title')}>
+                <p>{t('bitbox02Wizard.stepCreate.description')}</p>
                 {!sdCardInserted && (
                   <Status type="warning">
                     <span>{t('bitbox02Wizard.stepCreate.toastMicroSD')}</span>
                   </Status>
                 )}
-                <p>{t('bitbox02Wizard.stepCreate.description')}</p>
               </ViewHeader>
               <ViewContent>
                 <Input


### PR DESCRIPTION
There was no exlpanation of why the microSD card should be inserted when creating a new wallet during the set wallet name step.

Moved step description next to the title followed by the warning and added minimal information about what the SD Card will be used for, i.e.  to create a backup of the wallet.