### PR TITLE
backend: fix external BTC value parsing when sats mode is enabled

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -197,8 +197,8 @@ func NewHandlers(
 	getAPIRouter(apiRouter)("/test/register", handlers.postRegisterTestKeystoreHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/test/deregister", handlers.postDeregisterTestKeystoreHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/rates", handlers.getRatesHandler).Methods("GET")
-	getAPIRouter(apiRouter)("/coins/convertToPlainFiat", handlers.getConvertToPlainFiatHandler).Methods("GET")
-	getAPIRouter(apiRouter)("/coins/convertFromFiat", handlers.getConvertFromFiatHandler).Methods("GET")
+	getAPIRouter(apiRouter)("/coins/convert-to-plain-fiat", handlers.getConvertToPlainFiatHandler).Methods("GET")
+	getAPIRouter(apiRouter)("/coins/convert-from-fiat", handlers.getConvertFromFiatHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/coins/tltc/headers/status", handlers.getHeadersStatus(coinpkg.CodeTLTC)).Methods("GET")
 	getAPIRouter(apiRouter)("/coins/tbtc/headers/status", handlers.getHeadersStatus(coinpkg.CodeTBTC)).Methods("GET")
 	getAPIRouter(apiRouter)("/coins/ltc/headers/status", handlers.getHeadersStatus(coinpkg.CodeLTC)).Methods("GET")
@@ -737,7 +737,7 @@ func (handlers *Handlers) getConvertToPlainFiatHandler(r *http.Request) (interfa
 
 	currentCoin, err := handlers.backend.Coin(coinpkg.Code(from))
 	if err != nil {
-		logrus.Error(err.Error())
+		handlers.log.WithError(err).Error("Could not get coin " + from)
 		return map[string]interface{}{
 			"success": false,
 		}, nil
@@ -745,7 +745,7 @@ func (handlers *Handlers) getConvertToPlainFiatHandler(r *http.Request) (interfa
 
 	coinAmount, err := currentCoin.ParseAmount(amount)
 	if err != nil {
-		logrus.Error(err.Error())
+		handlers.log.WithError(err).Error("Error parsing amount " + amount)
 		return map[string]interface{}{
 			"success": false,
 		}, nil

--- a/frontends/web/src/api/coins.ts
+++ b/frontends/web/src/api/coins.ts
@@ -17,7 +17,7 @@
 import { subscribeEndpoint, TSubscriptionCallback } from './subscribe';
 import { CoinCode } from './account';
 import { ISuccess } from './backend';
-import { apiPost } from '../utils/request';
+import { apiPost, apiGet } from '../utils/request';
 
 export type BtcUnit = 'default' | 'sat';
 
@@ -36,4 +36,13 @@ export const subscribeCoinHeaders = (coinCode: CoinCode) => (
 
 export const setBtcUnit = (unit: BtcUnit): Promise<ISuccess> => {
   return apiPost('coins/btc/set-unit', { unit });
+};
+
+export type TAmount = {
+  success: boolean;
+  amount: string;
+}
+
+export const parseExternalBtcAmount = (amount: string): Promise<TAmount> => {
+  return apiGet(`coins/btc/parse-external-amount?amount=${amount}`);
 };

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -414,7 +414,7 @@ class Send extends Component<Props, State> {
   private convertToFiat = (value?: string | boolean) => {
     if (value) {
       const coinCode = this.getAccount()!.coinCode;
-      apiGet(`coins/convertToPlainFiat?from=${coinCode}&to=${this.state.fiatUnit}&amount=${value}`)
+      apiGet(`coins/convert-to-plain-fiat?from=${coinCode}&to=${this.state.fiatUnit}&amount=${value}`)
         .then(data => {
           if (data.success) {
             this.setState({ fiatAmount: data.fiatAmount });
@@ -430,7 +430,7 @@ class Send extends Component<Props, State> {
   private convertFromFiat = (value: string) => {
     if (value) {
       const coinCode = this.getAccount()!.coinCode;
-      apiGet(`coins/convertFromFiat?from=${this.state.fiatUnit}&to=${coinCode}&amount=${value}`)
+      apiGet(`coins/convert-from-fiat?from=${this.state.fiatUnit}&to=${coinCode}&amount=${value}`)
         .then(data => {
           if (data.success) {
             this.setState({ amount: data.amount });


### PR DESCRIPTION
Parsing external BTC values (e.g. amount scanned through QR scanning feature) did not properly convert BTC values to sats in case sats mode was enabled. This fixes adding a backend endpoint that allows to parse an external BTC value, converting to sats if needed.