### PR TITLE
frontend: fix "back btn" behaviour on country selector (buy page).

### DIFF
--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -15,9 +15,10 @@
  */
 import 'flag-icons';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import i18n from '../../i18n/i18n';
 import { useTranslation } from 'react-i18next';
-import { Button, ButtonLink } from '../../components/forms';
+import { Button } from '../../components/forms';
 import * as exchangesAPI from '../../api/exchanges';
 import { IAccount } from '../../api/account';
 import { Header } from '../../components/layout';
@@ -61,6 +62,7 @@ export const Exchange = ({ code, accounts }: TProps) => {
   const nativeLocale = useLoad(getNativeLocale);
   const supportedExchanges = useLoad<exchangesAPI.SupportedExchanges>(exchangesAPI.getExchangeBuySupported(code));
   const config = useLoad(getConfig);
+  const navigate = useNavigate();
 
   const account = findAccount(accounts, code);
   const name = getCryptoName(t('buy.info.crypto'), account);
@@ -175,6 +177,17 @@ export const Exchange = ({ code, accounts }: TProps) => {
   const cardFee = infoFeesDetail && infoFeesDetail.find(feeDetail => feeDetail.payment === 'card')?.fee;
   const bankTransferFee = infoFeesDetail && infoFeesDetail.find(feeDetail => feeDetail.payment === 'bank-transfer')?.fee;
 
+  const handleGoBack = () => {
+    if (accounts.length > 1) {
+      return navigate(-1);
+    }
+
+    // Has to navigate 2 pages back.
+    // Otherwise, users with only 1 account
+    // will be redireted back to this page.
+    navigate(-2);
+  };
+
   return (
     <div className="contentWithGuide">
       <div className="container">
@@ -216,12 +229,12 @@ export const Exchange = ({ code, accounts }: TProps) => {
                   </div>
 
                   {!noExchangeAvailable && <div className={style.buttonsContainer}>
-                    <ButtonLink
+                    <Button
                       className={style.buttonBack}
                       secondary
-                      to={'/buy/info'}>
+                      onClick={handleGoBack}>
                       {t('button.back')}
-                    </ButtonLink>
+                    </Button>
                     <Button
                       primary
                       disabled={!selectedExchange}


### PR DESCRIPTION
Back button in the country selector (`/buy/exchange/`) page doesn't work as expected when there's only one account. 

This is due to the back button is trying to go back to `/buy/info`, but that page redirects the user back to the `/buy/exchange/` page again. Therefore no "going back" action is actually happening for the user.

We fix this by going back 2 pages when there's only one account, and only going back once when there's more than one account. `useNavigate()` is utilised for this approach.