### PR TITLE
frontend: fix dialog open on mount

### DIFF
--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -49,13 +49,17 @@ class Dialog extends Component<Props, State> {
     renderDialog: false,
   };
 
+  public componentDidMount(): void {
+    if (this.props.open) {
+      this.activate();
+    }
+  }
+
   public componentDidUpdate(prevProps: Readonly<Props>): void {
     const { open } = this.props;
 
     if (open && !prevProps.open) {
-      this.setState({ renderDialog: true }, () => {
-        this.activate();
-      });
+      this.activate();
       return;
     }
 


### PR DESCRIPTION
Currently dialog only checks on component did change if the prop is open, but ignores if the open prop is already set to true when the component mounts.

This was the reason why sdcard warning did not show when microSD card was missing on the manage-backups view.

Added on component did mount method that checks if the open prop is already set to true and if so calls this activate.

Changed the existing on props did update and removed setState, as this.activate will do setState anyway.