### PR TITLE
frontend: convert gotostartupsettings.tsx into a functional component

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/gotostartupsettings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/gotostartupsettings.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2021 Shift Crypto AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,55 +15,40 @@
  * limitations under the License.
  */
 
-import { Component } from 'react';
-import { translate, TranslateProps } from '../../../decorators/translate';
+import { useState } from 'react';
 import { apiPost } from '../../../utils/request';
 import { SettingsButton } from '../../../components/settingsButton/settingsButton';
 import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
+import { useTranslation } from 'react-i18next';
 
-interface GotoStartupSettingsProps {
-    apiPrefix: string;
+type TProps = {
+    deviceID: string;
 }
 
-type Props = GotoStartupSettingsProps & TranslateProps;
+export const GotoStartupSettings = ({ deviceID }: TProps) => {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const { t } = useTranslation();
 
-interface State {
-    isConfirming: boolean;
-}
-
-class GotoStartupSettings extends Component<Props, State> {
-  public readonly state: State = {
-    isConfirming: false,
+  const gotoStartupSettings = async () => {
+    setIsConfirming(true);
+    await apiPost(`devices/bitbox02/${deviceID}/goto-startup-settings`).catch(console.error);
+    setIsConfirming(false);
   };
 
-  private gotoStartupSettings = (): void => {
-    this.setState({ isConfirming: true });
-    apiPost(this.props.apiPrefix + '/goto-startup-settings').then(() => {
-      this.setState({ isConfirming: false });
-    });
-  };
-
-  public render() {
-    const { t } = this.props;
-    const { isConfirming } = this.state;
-    return (
-      <div>
-        <SettingsButton
-          onClick={this.gotoStartupSettings}>
-          {t('bitbox02Settings.gotoStartupSettings.title')}
-        </SettingsButton>
-        {
-          isConfirming && (
-            <WaitDialog
-              title={t('bitbox02Settings.gotoStartupSettings.title')} >
-              {t('bitbox02Settings.gotoStartupSettings.description')}
-            </WaitDialog>
-          )
-        }
-      </div>
-    );
-  }
-}
-
-const HOC = translate()(GotoStartupSettings);
-export { HOC as GotoStartupSettings };
+  return (
+    <div>
+      <SettingsButton
+        onClick={gotoStartupSettings}>
+        {t('bitbox02Settings.gotoStartupSettings.title')}
+      </SettingsButton>
+      {
+        isConfirming && (
+          <WaitDialog
+            title={t('bitbox02Settings.gotoStartupSettings.title')} >
+            {t('bitbox02Settings.gotoStartupSettings.description')}
+          </WaitDialog>
+        )
+      }
+    </div>
+  );
+};

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -122,7 +122,7 @@ export const Settings = ({ deviceID }: TProps) => {
                     </SettingsButton>
                   ) : <Skeleton fontSize="var(--item-height)" /> }
                   { versionInfo && versionInfo.canGotoStartupSettings ? (
-                    <GotoStartupSettings apiPrefix={apiPrefix} />
+                    <GotoStartupSettings deviceID={deviceID} />
                   ) : <Skeleton fontSize="var(--item-height)" /> }
                 </Column>
               </Grid>


### PR DESCRIPTION
To follow the latest conventions and best practices of React, we'd like to convert our class components into functional ones.

Here, we're converting `gotostartupsettings.tsx` into a functional component.