### PR TITLE
frontend: refactor api calls should not throw on failed result

### DIFF
--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -37,15 +37,9 @@ export const resetDevice = (deviceID: string): Promise<SuccessResponse | FailRes
 };
 
 export const getDeviceInfo = (
-  deviceID: string
-): Promise<DeviceInfo> => {
-  return apiGet(`devices/bitbox02/${deviceID}/info`)
-    .then((response: DeviceInfoResponse | FailResponse) => {
-      if (!response.success) {
-        return Promise.reject(response);
-      }
-      return Promise.resolve(response.deviceInfo);
-    });
+  deviceID: string,
+): Promise<DeviceInfoResponse | FailResponse> => {
+  return apiGet(`devices/bitbox02/${deviceID}/info`);
 };
 
 export const checkSDCard = (
@@ -63,16 +57,10 @@ export const insertSDCard = (
 export const setDeviceName = (
   deviceID: string,
   newDeviceName: string,
-): Promise<void> => {
+): Promise<SuccessResponse | FailResponse> => {
   return apiPost(`devices/bitbox02/${deviceID}/set-device-name`, {
     name: newDeviceName
-  })
-    .then((response: SuccessResponse | FailResponse) => {
-      if (!response.success) {
-        return Promise.reject(response);
-      }
-      return Promise.resolve();
-    });
+  });
 };
 
 export type VersionInfo = {
@@ -91,14 +79,8 @@ export const getVersion = (
 export const setMnemonicPassphraseEnabled = (
   deviceID: string,
   enabled: boolean,
-): Promise<void | FailResponse> => {
-  return apiPost(`devices/bitbox02/${deviceID}/set-mnemonic-passphrase-enabled`, enabled)
-    .then((response: SuccessResponse | FailResponse) => {
-      if (!response.success) {
-        return Promise.reject(response);
-      }
-      return Promise.resolve();
-    });
+): Promise<SuccessResponse | FailResponse> => {
+  return apiPost(`devices/bitbox02/${deviceID}/set-mnemonic-passphrase-enabled`, enabled);
 };
 
 export const verifyAttestation = (
@@ -110,24 +92,14 @@ export const verifyAttestation = (
 export const checkBackup = (
   deviceID: string,
   silent: boolean,
-): Promise<string> => {
-  return apiPost(`devices/bitbox02/${deviceID}/backups/check`, { silent })
-    .then((response: FailResponse | (SuccessResponse & { backupID: string; })) => {
-      if (response.success) {
-        return response.backupID;
-      }
-      throw response;
-    });
+): Promise<FailResponse | (SuccessResponse & { backupID: string; })> => {
+  return apiPost(`devices/bitbox02/${deviceID}/backups/check`, { silent });
 };
 
-export const createBackup = (deviceID: string): Promise<void> => {
-  return apiPost(`devices/bitbox02/${deviceID}/backups/create`)
-    .then((response: FailResponse | SuccessResponse) => {
-      if (!response.success) {
-        return Promise.reject(response);
-      }
-      return Promise.resolve();
-    });
+export const createBackup = (
+  deviceID: string,
+): Promise<FailResponse | SuccessResponse> => {
+  return apiPost(`devices/bitbox02/${deviceID}/backups/create`);
 };
 
 export const restoreBackup = (
@@ -145,14 +117,10 @@ export const showMnemonic = (deviceID: string): Promise<void> => {
   return apiPost(`devices/bitbox02/${deviceID}/show-mnemonic`);
 };
 
-export const restoreFromMnemonic = (deviceID: string): Promise<void> => {
-  return apiPost(`devices/bitbox02/${deviceID}/restore-from-mnemonic`)
-    .then((response: FailResponse | SuccessResponse) => {
-      if (!response.success) {
-        return Promise.reject(response);
-      }
-      return Promise.resolve();
-    });
+export const restoreFromMnemonic = (
+  deviceID: string,
+): Promise<FailResponse | SuccessResponse> => {
+  return apiPost(`devices/bitbox02/${deviceID}/restore-from-mnemonic`);
 };
 
 export type TStatus = 'connected'

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -172,6 +172,7 @@
   "bitbox02Settings": {
     "deviceName": {
       "current": "Current device name",
+      "error": "Device name could not be set",
       "input": "BitBox02 name",
       "placeholder": "New device name",
       "title": "Set BitBox02 name"

--- a/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
@@ -38,21 +38,28 @@ export const Check = ({ deviceID, backups, disabled }: TProps) => {
   const checkBackup = async () => {
     setMessage(t('backup.check.confirmTitle'));
     try {
-      const backupID = await bitbox02API.checkBackup(deviceID, true);
-      const foundBackup = backups.find((backup: Backup) => backup.id === backupID);
-      if (!foundBackup) {
-        alertUser(t('unknownError', { errorMessage: 'Not found' }));
+      const result = await bitbox02API.checkBackup(deviceID, true);
+      if (result.success) {
+        const { backupID } = result;
+        const foundBackup = backups.find((backup: Backup) => backup.id === backupID);
+        if (!foundBackup) {
+          alertUser(t('unknownError', { errorMessage: 'Not found' }));
+          return;
+        }
+        setActiveDialog(true);
+        setFoundBackup(foundBackup);
+      }
+      const check = await bitbox02API.checkBackup(deviceID, false);
+      if (!check.success) {
+        setActiveDialog(true);
+        setMessage(t('backup.check.notOK'));
+        setUserVerified(true);
         return;
       }
-      setActiveDialog(true);
-      setFoundBackup(foundBackup);
-      await bitbox02API.checkBackup(deviceID, false);
       setMessage(t('backup.check.success'));
       setUserVerified(true);
-    } catch {
-      setActiveDialog(true);
-      setMessage(t('backup.check.notOK'));
-      setUserVerified(true);
+    } catch (error) {
+      console.error(error);
     }
   };
 

--- a/frontends/web/src/routes/device/bitbox02/createbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/createbackup.tsx
@@ -35,31 +35,34 @@ export const Create = ({ deviceID }: TProps) => {
   const createBackup = () => {
     setCreatingBackup(true);
     createBackupAPI(deviceID)
-      .then(() => {
+      .then((result) => {
         setCreatingBackup(false);
         setDisabled(false);
+        if (!result.success) {
+          alertUser(t('backup.create.fail'));
+        }
       })
-      .catch(() => {
-        setCreatingBackup(false);
-        setDisabled(false);
-        alertUser(t('backup.create.fail'));
-      });
+      .catch(console.error);
   };
 
   const maybeCreateBackup = async () => {
     setDisabled(true);
-    const check = await checkBackup(deviceID, true).catch(console.error);
-    if (check) {
-      confirmation(t('backup.create.alreadyExists'), result => {
-        if (result) {
-          createBackup();
-        } else {
-          setDisabled(false);
-        }
-      });
-      return;
+    try {
+      const check = await checkBackup(deviceID, true);
+      if (check.success) {
+        confirmation(t('backup.create.alreadyExists'), result => {
+          if (result) {
+            createBackup();
+          } else {
+            setDisabled(false);
+          }
+        });
+        return;
+      }
+      createBackup();
+    } catch (error) {
+      console.error(error);
     }
-    createBackup();
   };
 
   return (

--- a/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
@@ -45,11 +45,18 @@ export const SetDeviceName = ({
   const updateName = async () => {
     setInProgress(true);
     try {
-      await setDeviceName(deviceID, name);
-      const { name: newDeviceName } = await getDeviceInfo(deviceID);
-      setCurrentName(newDeviceName);
-    } catch (e) {
+      const setNameResult = await setDeviceName(deviceID, name);
+      if (!setNameResult.success) {
+        throw new Error(setNameResult.message);
+      }
+      const deviceInfoResult = await getDeviceInfo(deviceID);
+      if (!deviceInfoResult.success) {
+        throw new Error(deviceInfoResult.message);
+      }
+      setCurrentName(deviceInfoResult.deviceInfo.name);
+    } catch (error) {
       alertUser('Device name could not be set');
+      console.error(error);
     } finally {
       setActive(false);
       setInProgress(false);

--- a/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setdevicename.tsx
@@ -55,7 +55,7 @@ export const SetDeviceName = ({
       }
       setCurrentName(deviceInfoResult.deviceInfo.name);
     } catch (error) {
-      alertUser('Device name could not be set');
+      alertUser(t('bitbox02Settings.deviceName.error'));
       console.error(error);
     } finally {
       setActive(false);

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -43,10 +43,15 @@ export const Settings = ({ deviceID }: TProps) => {
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo>();
   const [attestation, setAttestation] = useState<boolean | null>(null);
   useEffect(() => {
-    getDeviceInfo(deviceID).then(setDeviceInfo).catch(error => {
-      console.error(error);
-      alertUser(t('genericError'));
-    });
+    getDeviceInfo(deviceID)
+      .then(result => {
+        if (!result.success) {
+          alertUser(t('genericError'));
+          return;
+        }
+        setDeviceInfo(result.deviceInfo);
+      })
+      .catch(console.error);
     verifyAttestation(deviceID).then(setAttestation);
   }, [deviceID, t]);
 


### PR DESCRIPTION
api calls that throw if success is false, have few disadvantages:

- rejecting the promise on failed success mixes failed response with real errors, so catch gets either an error or a failed response
- data passed to promise reject cannot be typed
- throwing error in the api call must be caught, either try/catch or .catch else the whole script just stops with uncaught promise error

Refcatored api calls and removed the success handling, always resolving the promise now with response data.