### PR TITLE
backend/chart: add latest rates timestamps in chart data

### DIFF
--- a/backend/chart.go
+++ b/backend/chart.go
@@ -72,6 +72,8 @@ type Chart struct {
 	FormattedTotal string `json:"formattedChartTotal"`
 	// Only valid if DataMissing is false
 	IsUpToDate bool `json:"chartIsUpToDate"`
+	// Latest rate timestamp available among all enabled coins.
+	LastTimestamp int64 `json:"lastTimestamp"`
 }
 
 func (backend *Backend) addChartData(
@@ -125,6 +127,7 @@ func (backend *Backend) ChartData() (*Chart, error) {
 		backend.log.Info("ChartDataMissing, until is zero")
 	}
 	isUpToDate := time.Since(until) < 2*time.Hour
+	lastTimestamp := until.UnixMilli()
 
 	formatBtcAsSat := util.FormatBtcAsSat(backend.Config().AppConfig().Backend.BtcUnit)
 
@@ -316,5 +319,6 @@ func (backend *Backend) ChartData() (*Chart, error) {
 		Total:          chartTotal,
 		FormattedTotal: formattedChartTotal,
 		IsUpToDate:     isUpToDate,
+		LastTimestamp:  lastTimestamp,
 	}, nil
 }

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -123,6 +123,7 @@ export interface ISummary {
     chartTotal: number | null;
     formattedChartTotal: string | null;
     chartIsUpToDate: boolean; // only valid if chartDataMissing is false
+    lastTimestamp: number;
 }
 
 export const getSummary = (): Promise<ISummary> => {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -446,6 +446,7 @@
   },
   "chart": {
     "dataMissing": "Gathering historical data... stay tuned.",
+    "dataOldTimestamp": "Historical exchange rates updating. The chart is not displaying data after {{time}}.",
     "dataUpdating": "updating data…",
     "filter": {
       "all": "All",

--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -12,11 +12,11 @@
   align-items: center;
   color: var(--color-tertiary);
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: center;
+  padding: 0 var(--space-half);
   text-align: center;
 }
-
 
 .chart header {
   display: flex;

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -75,6 +75,7 @@ class Chart extends Component<Props, State> {
       chartTotal: null,
       formattedChartTotal: null,
       chartIsUpToDate: false,
+      lastTimestamp: 0,
     }
   };
 
@@ -139,9 +140,9 @@ class Chart extends Component<Props, State> {
   };
 
   private createChart = () => {
-    const { data: { chartIsUpToDate, chartDataMissing } } = this.props;
+    const { data: { chartDataMissing } } = this.props;
     const darkmode = getDarkmode();
-    if (this.ref.current && this.hasData() && (chartIsUpToDate && !chartDataMissing)) {
+    if (this.ref.current && this.hasData() && !chartDataMissing) {
       if (!this.chart) {
         const chartWidth = !this.state.isMobile ? this.ref.current.offsetWidth : document.body.clientWidth;
         const chartHeight = !this.state.isMobile ? this.height : this.mobileHeight;
@@ -411,8 +412,6 @@ class Chart extends Component<Props, State> {
     });
   };
 
-
-
   private renderDate = (date: number) => {
     return new Date(date).toLocaleString(
       this.props.i18n.language,
@@ -432,7 +431,7 @@ class Chart extends Component<Props, State> {
     const {
       t,
       data: {
-        chartDataDaily,
+        lastTimestamp,
         chartDataMissing,
         chartFiat,
         chartIsUpToDate,
@@ -505,13 +504,15 @@ class Chart extends Component<Props, State> {
           {!isMobile && <Filters {...chartFiltersProps} />}
         </header>
         <div className={styles.chartCanvas} style={{ minHeight: chartHeight }}>
-          {(!chartIsUpToDate || chartDataMissing) ? (
+          {chartDataMissing ? (
             <div className={styles.chartUpdatingMessage} style={{ height: chartHeight }}>
-              {chartDataDaily === undefined
-                ? t('chart.dataMissing')
-                : t('chart.dataUpdating')}
+              {t('chart.dataMissing')}
             </div>
-          ) : hasData ? null : noDataPlaceholder}
+          ) : hasData ? !chartIsUpToDate && (
+            <div className={styles.chartUpdatingMessage}>
+              {t('chart.dataOldTimestamp', { time: new Date(lastTimestamp).toLocaleString(this.props.i18n.language), })}
+            </div>
+          ) : noDataPlaceholder}
           <div ref={this.ref} className={styles.invisible}></div>
           <span
             ref={this.refToolTip}


### PR DESCRIPTION
If one of the coin/rates pairs is older than 2hs the backend set the `chartIsUpToDate` flag to false inside the `account-summary` return struct. This adds a map to the struct that list the latest update timestamp for each coin. This will allow the frontend to show a meaningful message in the future instead of just keep loading the chart.