### PR TITLE
frontend: fix buy CTA redirect & balance loading (account dropdown)

### DIFF
--- a/frontends/web/src/components/accountselector/accountselector.tsx
+++ b/frontends/web/src/components/accountselector/accountselector.tsx
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { FunctionComponent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AccountCode, IAccount } from '../../api/account';
 import { Button } from '../forms';
 import Select, { components, SingleValueProps, OptionProps, SingleValue, DropdownIndicatorProps } from 'react-select';
-import { FunctionComponent } from 'react';
 import Logo from '../icon/logo';
 import styles from './accountselector.module.css';
 
@@ -80,6 +79,12 @@ const DropdownIndicator: FunctionComponent<DropdownIndicatorProps<TOption>> = (p
 
 export const AccountSelector = ({ title, options, selected, onChange, onProceed }: TAccountSelector) => {
   const { t } = useTranslation();
+  const [selectedAccount, setSelectedAccount] = useState<TOption>();
+
+  useEffect(() => {
+    setSelectedAccount(options.find(opt => opt.value === selected));
+  }, [options, selected]);
+
   return (
     <>
       <h1 className="title text-center">{title}</h1>
@@ -87,14 +92,11 @@ export const AccountSelector = ({ title, options, selected, onChange, onProceed 
         className={styles.select}
         classNamePrefix="react-select"
         components={{ DropdownIndicator, SingleValue: SelectSingleValue, Option: SelectOption, IndicatorSeparator: () => null }}
-        defaultValue={selected === '' ?
-          {
-            label: t('buy.info.selectLabel'),
-            value: 'choose',
-            disabled: true
-          } :
-          options.find(opt => opt.value === selected)
-        }
+        value={selected === '' ? {
+          label: t('buy.info.selectLabel'),
+          value: 'choose',
+          disabled: true
+        } : selectedAccount}
         isSearchable={false}
         onChange={(e) => {
           const value = (e as SingleValue<TOption>)?.value || '';

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -31,7 +31,7 @@ type TBuyReceiveCTAProps = {
 export const BuyReceiveCTA = ({ code, unit, balanceList }: TBuyReceiveCTAProps) => {
   const formattedUnit = isBitcoinCoin(unit as CoinWithSAT) ? 'BTC' : unit;
   const { t } = useTranslation();
-  const onBuyCTA = () => route(code ? `/buy/exchange/${code}` : '/buy/info');
+  const onBuyCTA = () => route(code ? `/buy/info/${code}` : '/buy/info');
   const onReceiveCTA = () => {
     if (balanceList) {
       if (balanceList.length > 1) {


### PR DESCRIPTION
1. Buy CTA for an empty account in the `/account/${code}` page redirects user straight into the country selector (`/buy/exchange/${code}`). We'd like it to redirect to the account selector first (`/buy/info/${code}`) so user will be able to see the account they selected. The selected account is displayed in a dropdown.

2. The said dropdown is also supposed to  display the selected account's  balance which gets fetched asyncly. The balance was fetched asyncly, but it's not yet displayed. This PR also fixes this bug; to actually display the fetched balance in the dropdown.

Preview for an empty account:

https://user-images.githubusercontent.com/28676406/223382842-aae6e8f5-e91d-4f19-95dd-5b8aa3b596ca.mov


Preview for a non-empty account:

https://user-images.githubusercontent.com/28676406/223385266-044cb8c2-7c98-45bb-b884-dd58944fb961.mov


