### PR TITLE
frontend/Qt: enable autoscaling for high density screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Enable auto HiDPI scaling to correctly manage scale factor on high density screens
+
 ## 4.36.0
 - Re-style header for a better space utilisation
 - Re-style sidebar navigation on mobile (portrait) to be full-screen for better space utilisation and a more modern look

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -165,10 +165,8 @@ public:
 
 int main(int argc, char *argv[])
 {
-// Enable auto HiDPI scaling on Windows only for now.
-#if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5,6,0)
+    // Enable auto HiDPI scaling to correctly manage scale factor on bigger screens
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
 
 // QT configuration parameters which change the attack surface for memory
 // corruption vulnerabilities


### PR DESCRIPTION
Autoscaling was only enabled for windows, because with Qt < v5.14 it didn't look nice on Linux and Mac OS. Now that we are compiling with Qt v5.15 we can enable it on all OSs.