### PR TITLE
frontend: set dark mode colour scheme for account dropdown/selector

### DIFF
--- a/frontends/web/src/components/accountselector/accountselector.module.css
+++ b/frontends/web/src/components/accountselector/accountselector.module.css
@@ -1,6 +1,6 @@
 .balance, .balanceSingleValue{
     margin-left: auto;
-    color: var(--color-gray);
+    color: var(--color-secondary);
 }
 
 .balanceSingleValue {
@@ -20,11 +20,33 @@
     margin-bottom: var(--space-half);
 }
 
+.select :global(.react-select__menu) {
+    background-color: var(--background-dark);
+}
+
+.select :global(.react-select__option) {
+    background-color: var(--background-dark);
+}
+
+.select :global(.react-select__option):hover, 
+.select :global(.react-select__option--is-selected) {
+    background-color: var(--background);
+}
+
+.select :global(.react-select__option--is-disabled) span {
+    color: var(--color-secondary);
+}
+
+.select :global(.react-select__option--is-disabled):hover {
+    background-color: transparent;
+}
+
 .select :global(.react-select__option--is-selected) .balance {
     color: var(--color-white);
 }
 
 .select :global(.react-select__control) {
+    background-color: var(--background);
     padding: var(--space-quarter) var(--space-eight);
 }
 
@@ -45,9 +67,10 @@
 }
 
 
-.valueContainer{
-    display: flex;
+.valueContainer {
     align-items: center;
+    color: var(--color-alt);
+    display: flex;
 }
 
 .valueContainer > img {


### PR DESCRIPTION
Hardcoded CSS values to display the account dropdown in dark mode. We added some new selectors in the css file, where previously weren't needed.

This is because most of react-select's default styles suit our light mode. However, it's not the case for dark mode. Thus, we need to grab ahold of more selectors to be customised for them to work with our dark mode (hence adding more selectors in the css).

Preview:
<img width="776" alt="Screenshot 2023-03-13 at 09 08 05" src="https://user-images.githubusercontent.com/28676406/224642592-ab1b5780-fb6c-402a-84c8-eb3cb5b345ac.png">

<img width="776" alt="Screenshot 2023-03-13 at 09 08 02" src="https://user-images.githubusercontent.com/28676406/224642610-13f98863-86d3-4628-ba36-99f81f8263ed.png">

