### PR TITLE
frontend: refactor utxo component to functional component

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -280,16 +280,16 @@ export const verifyAddress = (code: AccountCode, addressID: string): Promise<boo
   return apiPost(`account/${code}/verify-address`, addressID);
 };
 
-export interface UTXO {
-    outPoint: string;
-    txId: string;
-    txOutput: number;
-    address: string;
-    amount: IAmount;
-    scriptType: ScriptType;
-}
+export type TUTXO = {
+  outPoint: string;
+  txId: string;
+  txOutput: number;
+  address: string;
+  amount: IAmount;
+  scriptType: ScriptType;
+};
 
-export const getUTXOs = (code: AccountCode): Promise<UTXO[]> => {
+export const getUTXOs = (code: AccountCode): Promise<TUTXO[]> => {
   return apiGet(`account/${code}/utxos`);
 };
 

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { Component, createRef } from 'react';
+import React, { Component } from 'react';
 import { BrowserQRCodeReader } from '@zxing/library';
 import * as accountApi from '../../../api/account';
 import { BtcUnit } from '../../../api/coins';
@@ -42,7 +42,7 @@ import { apiWebsocket } from '../../../utils/websocket';
 import { isBitcoinBased, customFeeUnit, isBitcoinOnly, findAccount } from '../utils';
 import { FeeTargets } from './feetargets';
 import style from './send.module.css';
-import { SelectedUTXO, UTXOs, UTXOsClass } from './utxos';
+import { TSelectedUTXOs, UTXOs } from './utxos';
 import { route } from '../../../utils/route';
 
 interface SendProps {
@@ -95,8 +95,7 @@ interface State {
 }
 
 class Send extends Component<Props, State> {
-  private utxos = createRef<UTXOsClass>();
-  private selectedUTXOs: SelectedUTXO = {};
+  private selectedUTXOs: TSelectedUTXOs = {};
   private unsubscribe!: () => void;
   private qrCodeReader?: BrowserQRCodeReader;
 
@@ -251,9 +250,7 @@ class Send extends Component<Props, State> {
           note: '',
           customFee: '',
         });
-        if (this.utxos.current) {
-          this.utxos.current.clear();
-        }
+        this.selectedUTXOs = {};
         setTimeout(() => this.setState({
           isSent: false,
           isConfirming: false,
@@ -464,7 +461,7 @@ class Send extends Component<Props, State> {
     );
   };
 
-  private onSelectedUTXOsChange = (selectedUTXOs: SelectedUTXO) => {
+  private onSelectedUTXOsChange = (selectedUTXOs: TSelectedUTXOs) => {
     this.selectedUTXOs = selectedUTXOs;
     this.validateAndDisplayFee(true);
   };
@@ -482,8 +479,8 @@ class Send extends Component<Props, State> {
 
   private toggleCoinControl = () => {
     this.setState(({ activeCoinControl }) => {
-      if (activeCoinControl && this.utxos.current) {
-        this.utxos.current.clear();
+      if (activeCoinControl) {
+        this.selectedUTXOs = {};
       }
       return { activeCoinControl: !activeCoinControl };
     });
@@ -623,18 +620,14 @@ class Send extends Component<Props, State> {
                 <label className="labelXLarge">{t('send.availableBalance')}</label>
               </div>
               <Balance balance={balance} noRotateFiat/>
-              {
-                coinControl && (
-                  <UTXOs
-                    accountCode={account.code}
-                    active={activeCoinControl}
-                    explorerURL={account.blockExplorerTxPrefix}
-                    onClose={this.deactivateCoinControl}
-                    onChange={this.onSelectedUTXOsChange}
-                    ref={this.utxos}
-                  />
-                )
-              }
+              { coinControl && (
+                <UTXOs
+                  accountCode={account.code}
+                  active={activeCoinControl}
+                  explorerURL={account.blockExplorerTxPrefix}
+                  onClose={this.deactivateCoinControl}
+                  onChange={this.onSelectedUTXOsChange} />
+              ) }
               <div className={`flex flex-row flex-between ${style.container}`}>
                 <label className="labelXLarge">{t('send.transactionDetails')}</label>
                 { coinControl && (


### PR DESCRIPTION
Slightly changed how the component communicates with send.tsx,
it used a React ref that the parent (send) could clear the child.
Changed to just clear the selectedUTXOs map directly after send
or when the dialog opens (it will set the data again when it's
closed).

tested also that the UTXO list updated after sending which was
fixed in https://github.com/thisconnect/bitbox-wallet-app/commit/582ad7e63e9b8d4ab5a700d4da90d938cfa75276