### PR TITLE
frontend: fix country dropdown search text colour

### DIFF
--- a/frontends/web/src/routes/buy/components/countryselect.module.css
+++ b/frontends/web/src/routes/buy/components/countryselect.module.css
@@ -22,6 +22,10 @@
     display: flex;
 }
 
+.select :global(.react-select__input-container){
+    color: var(--color-alt);
+}
+
 .select :global(.react-select__single-value) {
     color: var(--color-alt);
 }


### PR DESCRIPTION
The dropdown text previously has a dark colour. This is now changed to a light colour so it's visible (in the darkmode).

Preview (before):
![Screenshot 2023-03-14 at 13 27 45](https://user-images.githubusercontent.com/28676406/225001662-94261a73-0a18-4818-8d7e-72e36a7a366d.png)

Preview (after):
![Screenshot 2023-03-14 at 13 27 32](https://user-images.githubusercontent.com/28676406/225001733-a2de4abc-16ed-4cd7-aa2d-46fc6adf449a.png)
