### PR TITLE
backend/usb: only force single thread on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 - Enable auto HiDPI scaling to correctly manage scale factor on high density screens
 
+## 4.36.1
+- Fix USB communication issue on Windows
+
 ## 4.36.0
 - Re-style header for a better space utilisation
 - Re-style sidebar navigation on mobile (portrait) to be full-screen for better space utilisation and a more modern look

--- a/backend/devices/usb/hid.go
+++ b/backend/devices/usb/hid.go
@@ -23,6 +23,8 @@ import (
 	hid "github.com/digitalbitbox/usb"
 )
 
+const darwin = "darwin"
+
 // Run functions sent to this channel in a goroutine fixed to an OS thread. We will run all hidapi
 // API calls in that thread. This is needed for hidapi to work properly on macOS. The reason for
 // this is not entirely clear - maybe something in the macOS SDK relies on thread-local variables
@@ -30,14 +32,16 @@ import (
 var funcCalls chan func()
 
 func init() {
-	funcCalls = make(chan func())
-	go func() {
-		runtime.LockOSThread()
-		for {
-			f := <-funcCalls
-			f()
-		}
-	}()
+	if runtime.GOOS == darwin {
+		funcCalls = make(chan func())
+		go func() {
+			runtime.LockOSThread()
+			for {
+				f := <-funcCalls
+				f()
+			}
+		}()
+	}
 }
 
 type funcCallResult[T any] struct {
@@ -128,29 +132,37 @@ func (s singleThreadedDevice) Close() error {
 
 // Open implements DeviceInfo.
 func (info hidDeviceInfo) Open() (io.ReadWriteCloser, error) {
-	ch := make(chan funcCallResult[hid.Device])
-	funcCalls <- func() {
-		device, err := info.DeviceInfo.Open()
-		ch <- funcCallResult[hid.Device]{device, err}
+	if runtime.GOOS == darwin {
+		ch := make(chan funcCallResult[hid.Device])
+		funcCalls <- func() {
+			device, err := info.DeviceInfo.Open()
+			ch <- funcCallResult[hid.Device]{device, err}
+		}
+		result := <-ch
+		if result.err != nil {
+			return nil, result.err
+		}
+		return singleThreadedDevice{device: result.value}, nil
 	}
-	result := <-ch
-	if result.err != nil {
-		return nil, result.err
-	}
-
-	return singleThreadedDevice{device: result.value}, nil
+	return info.DeviceInfo.Open()
 }
 
 // DeviceInfos returns a slice of all recognized devices.
 func DeviceInfos() []DeviceInfo {
 	deviceInfosFiltered := []DeviceInfo{}
 
+	var result funcCallResult[[]hid.DeviceInfo]
 	ch := make(chan funcCallResult[[]hid.DeviceInfo])
-	funcCalls <- func() {
+	if runtime.GOOS == darwin {
+		funcCalls <- func() {
+			di, err := hid.EnumerateHid(0, 0)
+			ch <- funcCallResult[[]hid.DeviceInfo]{di, err}
+		}
+		result = <-ch
+	} else {
 		di, err := hid.EnumerateHid(0, 0)
-		ch <- funcCallResult[[]hid.DeviceInfo]{di, err}
+		result = funcCallResult[[]hid.DeviceInfo]{di, err}
 	}
-	result := <-ch
 	// The library never actually returns an error in this functions.
 	if result.err != nil {
 		logging.Get().WithError(result.err).Error("EnumerateHid() returned an error")

--- a/backend/update.go
+++ b/backend/update.go
@@ -27,7 +27,7 @@ const updateFileURL = "https://shiftcrypto.ch/updates/desktop.json"
 
 var (
 	// Version of the backend as displayed to the user.
-	Version = semver.NewSemVer(4, 36, 0)
+	Version = semver.NewSemVer(4, 36, 1)
 )
 
 // UpdateFile is retrieved from the server.

--- a/frontends/qt/setup.nsi
+++ b/frontends/qt/setup.nsi
@@ -22,7 +22,7 @@ SetCompressor /SOLID lzma
 
 # General Symbol Definitions
 !define REGKEY "SOFTWARE\$(^Name)"
-!define VERSION 4.36.0.0
+!define VERSION 4.36.1.0
 !define COMPANY "Shift Crypto AG"
 !define URL https://github.com/digitalbitbox/bitbox-wallet-app/releases/
 !define BINDIR "build\windows"


### PR DESCRIPTION
In a35e009b we forced all USB communication to happen in a single thread because macOS otherwise fails with obscure errors (see commit msg).

For simplicity we applied this to all platforms. At least on Windows, users ar experiencing issues where the BitBox02 would timeout during password entry. It is not clear why, but since this was the only change related to USB communication, we revert it for all platforms except macOS.