### PR TITLE
backend/btc: fix error propagation in TransactionBroadcast

### DIFF
--- a/backend/coins/btc/electrum/client.go
+++ b/backend/coins/btc/electrum/client.go
@@ -119,10 +119,13 @@ func (c *client) TransactionBroadcast(transaction *wire.MsgTx) error {
 	_ = transaction.BtcEncode(rawTx, 0, wire.WitnessEncoding)
 	rawTxHex := hex.EncodeToString(rawTx.Bytes())
 	txID, err := c.client.TransactionBroadcast(context.Background(), rawTxHex)
-	if txID != transaction.TxHash().String() {
-		return errp.New("Response is unexpected (expected TX hash)")
+	if err != nil {
+		return err
 	}
-	return err
+	if txID != transaction.TxHash().String() {
+		return errp.New("Response is unexpected (transaction hash mismatch)")
+	}
+	return nil
 }
 
 func (c *client) TransactionGet(txHash chainhash.Hash) (*wire.MsgTx, error) {

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -384,6 +384,7 @@ func (handlers *Handlers) postAccountSendTx(r *http.Request) (interface{}, error
 		return map[string]interface{}{"success": false, "aborted": true}, nil
 	}
 	if err != nil {
+		handlers.log.WithError(err).Error("Failed to send transaction")
 		result := map[string]interface{}{"success": false, "errorMessage": err.Error()}
 		if err.Error() == etherscan.ERC20GasErr {
 			result["errorCode"] = errors.ERC20InsufficientGasFunds.Error()


### PR DESCRIPTION
If there was any error, the user would see 'Response is unexpected (expected TX hash)' instead of the real error, which could be something different.