### PR TITLE
btc: enable custom fees w/ info text if fee targets are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Enable auto HiDPI scaling to correctly manage scale factor on high density screens
+- Bitcoin: enable setting a custom fee if the fee rate estimations are unavailable
 
 ## 4.36.0
 - Re-style header for a better space utilisation

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -526,9 +526,14 @@ outer:
 		feeTargets = append(feeTargets, feeTarget)
 	}
 	// If the default fee level was dropped, use the cheapest.
+	// If no fee targets are available, use custom (the user can manually enter a fee rate).
 	defaultFee := accounts.DefaultFeeTarget
-	if !defaultAvailable && len(feeTargets) != 0 {
-		defaultFee = feeTargets[0].Code()
+	if !defaultAvailable {
+		if len(feeTargets) != 0 {
+			defaultFee = feeTargets[0].Code()
+		} else {
+			defaultFee = accounts.FeeTargetCodeCustom
+		}
 	}
 	return feeTargets, defaultFee
 }

--- a/frontends/web/src/components/message/__snapshots__/message.test.tsx.snap
+++ b/frontends/web/src/components/message/__snapshots__/message.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`components/message/message should have child nodes 1`] = `
 <div
-  class="message"
+  class="message "
 >
   <span>
     hello

--- a/frontends/web/src/components/message/message.module.css
+++ b/frontends/web/src/components/message/message.module.css
@@ -12,6 +12,11 @@
     overflow: hidden;
 }
 
+.message.small {
+    flex-shrink: 1;
+    font-size: var(--size-default);
+}
+
 .message img {
     margin-right: var(--spacing-default);
 }

--- a/frontends/web/src/components/message/message.tsx
+++ b/frontends/web/src/components/message/message.tsx
@@ -19,12 +19,14 @@ import styles from './message.module.css';
 
 export interface Props {
     hidden?: boolean;
+    small?: boolean;
     type?: 'message' | 'success' | 'info' | 'warning' | 'error';
     children: ReactNode;
 }
 
 export function Message({
   hidden,
+  small,
   type = 'message',
   children,
 }: Props) {
@@ -32,7 +34,7 @@ export function Message({
     return null;
   }
   return (
-    <div className={styles[type]}>
+    <div className={`${styles[type]} ${small ? styles.small : ''}`}>
       {children}
     </div>
   );

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1316,6 +1316,7 @@
     },
     "maximum": "Send all",
     "maximumSelectedCoins": "Send selected coins",
+    "noFeeTargets": "Fee rate estimations are currently unavailable. Please try again later or enter a custom fee.",
     "priority": "Priority",
     "scanQR": "Scan QR code",
     "signprogress": {


### PR DESCRIPTION
In case the fee estimations were missing for any reason (e.g. download too slow or some error), the send screen was unusable, as the transaction proposal could not be made due to missing fee. The error was not propagated to the user, and a transaction could not be made.

This patch enables custom fees as a fallback in that case, even if custom fees are otherwise disabled in the settings. It is not great (probably confusing for most users), but better than not being able to transact at all. Luckily this should not happen often - the only instance we know of so far has been with a user that used a custom Electrs node on a slow connection, going into the send screen immediately after sync.

Alternatives considered:
- try downloading the fee rates on the fly if they are missing. Didn't do this as we currently don't have custom Electrum request timeouts. In case the fee rates were missing due to the server or connection being slow, this would block loading the send screen. Doing this approach in a good way would take much more time, and since it is a rare problem, I opted for the quick fix.