### PR TITLE
frontend: use CSS var for legacy dialog's background

### DIFF
--- a/frontends/web/src/components/dialog/dialog-legacy.module.css
+++ b/frontends/web/src/components/dialog/dialog-legacy.module.css
@@ -18,7 +18,7 @@
 }
 
 .modal {
-    background-color: white;
+    background-color: var(--background-secondary);
     width: 100%;
     max-width: 420px;
     border-radius: 2px;


### PR DESCRIPTION
As legacy dialog is still used in some parts of the app, we need
to use proper CSS variables for the component so its styling
will be appropriate for both dark and light mode.

(`<Confirm/>`) before:
<img width="776" alt="Screenshot 2023-03-21 at 10 30 45" src="https://user-images.githubusercontent.com/28676406/226567229-d70f0349-59cd-4f14-8299-195d3e9dec2a.png">


after:
<img width="776" alt="Screenshot 2023-03-21 at 10 47 30" src="https://user-images.githubusercontent.com/28676406/226570286-ec7b066c-96a7-4a6d-810e-e301ab5a6811.png">

