### PR TITLE
frontend: use CSS variables for account selector

### DIFF
--- a/frontends/web/src/components/accountselector/accountselector.module.css
+++ b/frontends/web/src/components/accountselector/accountselector.module.css
@@ -28,13 +28,21 @@
     background-color: var(--background-secondary);
 }
 
-.select :global(.react-select__option):hover, 
-.select :global(.react-select__option--is-selected) {
-    background-color: var(--background);
+.select :global(.react-select__option):hover {
+    background-color: var(--background-custom-select-hover);
+}
+
+.select :global(.react-select__option--is-selected),
+.select :global(.react-select__option--is-selected):hover {
+    background-color: var(--background-custom-select-selected);
 }
 
 .select :global(.react-select__option--is-disabled) span {
     color: var(--color-secondary);
+}
+
+.select :global(.react-select__option--is-disabled.react-select__option--is-selected):hover {
+    background-color: var(--background-custom-select-selected);
 }
 
 .select :global(.react-select__option--is-disabled):hover {
@@ -46,7 +54,7 @@
 }
 
 .select :global(.react-select__control) {
-    background-color: var(--background);
+    background-color: var(--background-secondary);
     padding: var(--space-quarter) var(--space-eight);
 }
 
@@ -66,11 +74,14 @@
     width: 100%;
 }
 
-
 .valueContainer {
     align-items: center;
-    color: var(--color-alt);
+    color: var(--color-default);
     display: flex;
+}
+
+.select :global(.react-select__option--is-selected) .selectLabelText {
+    color: var(--color-alt);
 }
 
 .valueContainer > img {

--- a/frontends/web/src/style/variables.css
+++ b/frontends/web/src/style/variables.css
@@ -21,6 +21,8 @@
     --color-blue: #5E94BF;
     --color-lightblue: #73A5CD;
     --color-light-skyblue: #ECF7FF;
+    --color-electric-blue: #2684FF;
+    --color-powder-blue: #DEEBFF;
     --color-blue-alt: #91BFCF;
     --color-orange: #F5A04C;
     --color-olive: #908B00;
@@ -111,6 +113,8 @@
     --background-focus: var(--color-light-skyblue);
     --background-tertiary: var(--color-gray-alt);
     --background-quaternary: var(--color-mediumgray);
+    --background-custom-select-hover: var(--color-powder-blue);
+    --background-custom-select-selected: var(--color-electric-blue);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -131,6 +135,8 @@
         --background-focus: var(--color-softblack);
         --background-tertiary: var(--color-dark);
         --background-quaternary: var(--color-dark);
+        --background-custom-select-hover: var(--color-dark);
+        --background-custom-select-selected: var(--color-dark);
     }
 }
 @media (prefers-color-scheme: light) {
@@ -151,6 +157,8 @@
         --background-focus: var(--color-softblack);
         --background-tertiary: var(--color-dark);
         --background-quaternary: var(--color-dark);
+        --background-custom-select-hover: var(--color-dark);
+        --background-custom-select-selected: var(--color-dark);
     }
 }
 


### PR DESCRIPTION
We need to use proper CSS variables for the component so its styling will be appropriate for both dark and light mode.

Before:
<img width="776" alt="Screenshot 2023-03-21 at 12 59 22" src="https://user-images.githubusercontent.com/28676406/226611868-9fcb4cb9-d27e-4e7a-aa74-1f7d80405a30.png">


After:

<img width="1480" alt="Screenshot 2023-03-22 at 06 34 23" src="https://user-images.githubusercontent.com/28676406/226812305-77d04906-6dcd-4c30-8b60-2a8ffeb41b2a.png">
<img width="1480" alt="Screenshot 2023-03-22 at 06 34 30" src="https://user-images.githubusercontent.com/28676406/226812310-c2a1fa6e-382d-44dc-90a5-2b5e7ea66a15.png">
