### PR TITLE
frontend: use CSS variables country selector

### DIFF
--- a/frontends/web/src/routes/buy/components/countryselect.module.css
+++ b/frontends/web/src/routes/buy/components/countryselect.module.css
@@ -22,12 +22,12 @@
     display: flex;
 }
 
-.select :global(.react-select__input-container){
-    color: var(--color-alt);
+.select :global(.react-select__input-container) {
+    color: var(--color-default);
 }
 
 .select :global(.react-select__single-value) {
-    color: var(--color-alt);
+    color: var(--color-default);
 }
 
 .select :global(.react-select__menu) {
@@ -38,13 +38,17 @@
     background-color: var(--background-secondary);
 }
 
-.select :global(.react-select__option):hover, 
-.select :global(.react-select__option--is-selected) {
-    background-color: var(--background);
+.select :global(.react-select__option):hover {
+    background-color: var(--background-custom-select-hover);
+}
+
+.select :global(.react-select__option--is-selected),
+.select :global(.react-select__option--is-selected):hover {
+    background-color: var(--background-custom-select-selected);
 }
 
 .select :global(.react-select__control) {
-    background-color: var(--background);
+    background-color: var(--background-secondary);
     padding: var(--space-quarter) var(--space-eight);
 }
 
@@ -53,7 +57,12 @@
 }
 
 .selectLabelText {
+    color: var(--color-default);
     margin-left: 6px;
+}
+
+.select :global(.react-select__option--is-selected) .selectLabelText {
+    color: var(--color-alt);
 }
 
 .singleValueContainer {


### PR DESCRIPTION
we need to use proper CSS variables for the component so its styling will be appropriate for both dark and light mode.

Before:
<img width="776" alt="Screenshot 2023-03-21 at 12 56 27" src="https://user-images.githubusercontent.com/28676406/226709604-7495d55c-4552-4c44-a244-93e193fd7df2.png">


After:
<img width="771" alt="Screenshot 2023-03-22 at 13 42 50" src="https://user-images.githubusercontent.com/28676406/226908056-e4c7b5bf-a82a-40f1-a5bc-20ac444d28e9.png">
<img width="660" alt="Screenshot 2023-03-22 at 13 43 07" src="https://user-images.githubusercontent.com/28676406/226908070-44d0cc0e-e92c-4326-b435-8bb9e70f8d4f.png">
