### PR TITLE
frontend: differ `--color-disabled` for lightmode and darkmode

### DIFF
--- a/frontends/web/src/style/variables.css
+++ b/frontends/web/src/style/variables.css
@@ -34,7 +34,6 @@
     --color-warning: var(--color-softred);
     --color-error: var(--color-swissred);
     --color-danger: var(--color-error);
-    --color-disabled: var(--color-gray);
 
     /* font sizes */
     --size-extra-large: 2.2rem;
@@ -95,6 +94,10 @@
 
 :root,
 .light-mode {
+
+    /* status colors*/
+    --color-disabled: var(--color-mediumgray);
+
     /* font colors */
     /* all fonts should use these colors and not from the main colors directly */
     --color-default: var(--color-dark);
@@ -119,6 +122,9 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
+        /* status colors*/
+        --color-disabled: var(--color-gray);
+        
         /* font colors */
         --color-default: var(--color-lightgray);
         --color-primary: var(--color-blue);
@@ -141,6 +147,9 @@
 }
 @media (prefers-color-scheme: light) {
     .dark-mode {
+        /* status colors*/
+        --color-disabled: var(--color-gray);
+
         /* font colors */
         --color-default: var(--color-lightgray);
         --color-primary: var(--color-blue);


### PR DESCRIPTION
`--color-disabled` should have different values depending on the theme (dark or light).

Previews

1. disabled toggle bgcolor:
<img width="365" alt="Screenshot 2023-03-22 at 06 57 49" src="https://user-images.githubusercontent.com/28676406/226815786-27c3b0fe-f099-428c-b84c-b2b9e6de38db.png">

<img width="326" alt="Screenshot 2023-03-22 at 06 56 34" src="https://user-images.githubusercontent.com/28676406/226815808-b08447cd-ab2d-4a03-a5b3-ac234d574baa.png">

2. buttons in the "connect your own full node" screen:

<img width="970" alt="Screenshot 2023-03-22 at 06 57 39" src="https://user-images.githubusercontent.com/28676406/226815790-63019ab0-344b-4ad0-8f0b-db877a62b0fa.png">

<img width="1002" alt="Screenshot 2023-03-22 at 06 57 27" src="https://user-images.githubusercontent.com/28676406/226815776-78f6b2b4-8d0b-455d-a58f-b79f22f2f644.png">

