### PR TITLE
qt: fix @media prefers-color-scheme rule in Qt 5.15.2

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -170,6 +170,11 @@ int main(int argc, char *argv[])
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
+    // Make `@media (prefers-color-scheme: light/dark)` CSS rules work.
+    // See https://github.com/qutebrowser/qutebrowser/issues/5915#issuecomment-737115530
+    // This might only be needed for Qt 5.15.2, should revisit this when updating Qt.
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--blink-settings=preferredColorScheme=1");
+
 // QT configuration parameters which change the attack surface for memory
 // corruption vulnerabilities
 #if QT_VERSION >= QT_VERSION_CHECK(5,8,0)


### PR DESCRIPTION
Darkmode did not work on linux/Windows/macOS as the `@media (prefers-color-scheme: light/dark)` seemed to be ignored. Defining this env var seems to fix it. I did not investigate further about why that is.