### PR TITLE
frontend: fix disabled filter buttons on empty summary

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -95,6 +95,11 @@
   border-color: var(--background-quaternary);
   color: var(--color-alt);
 }
+:global(.dark-mode) .filters button[disabled] {
+  background: var(--background-secondary);
+  border-color: var(--background-secondary);
+  color: var(--color-disabled);
+}
 
 .arrow svg {
   margin-right: .25rem;


### PR DESCRIPTION
The chart filter buttons have custom CSS styling which didnt look correct on a new empty account summary view.

Kept lightmode as is and added custom darkmode styling for those buttons in disable state.