### PR TITLE
frontend/android: change App style to autoswitch darkmode

### DIFF
--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -243,6 +243,10 @@ func (m *mockTransactionsSource) Transactions(
 	return []*accounts.TransactionData{}, nil
 }
 
+func (e environment) SetDarkTheme(bool) {
+	// nothing to do here.
+}
+
 func newBackend(t *testing.T, testing, regtest bool) *Backend {
 	t.Helper()
 	b, err := NewBackend(

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -137,6 +137,9 @@ type Environment interface {
 	// `suggestedFilename` is the proposed/default destination.
 	// The function should return the empty string if the user aborted the process.
 	GetSaveFilename(suggestedFilename string) string
+	// SetDarkTheme allows to handle theme setting change at environment level. Can be used e.g. to
+	// update status bar color on Mobile.
+	SetDarkTheme(bool)
 }
 
 // Backend ties everything together and is the main starting point to use the BitBox wallet library.

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -145,6 +145,7 @@ type BackendEnvironment struct {
 	// preferred UI language.
 	NativeLocaleFunc    func() string
 	GetSaveFilenameFunc func(string) string
+	SetDarkThemeFunc    func(bool)
 }
 
 // NotifyUser implements backend.Environment.
@@ -192,6 +193,12 @@ func (env *BackendEnvironment) GetSaveFilename(suggestedFilename string) string 
 		return env.GetSaveFilenameFunc(suggestedFilename)
 	}
 	return ""
+}
+
+func (env *BackendEnvironment) SetDarkTheme(isDark bool) {
+	if env.SetDarkThemeFunc != nil {
+		env.SetDarkThemeFunc(isDark)
+	}
 }
 
 // Serve serves the BitBox API for use in a native client.

--- a/backend/bridgecommon/bridgecommon_test.go
+++ b/backend/bridgecommon/bridgecommon_test.go
@@ -61,6 +61,10 @@ func (e environment) GetSaveFilename(string) string {
 	return ""
 }
 
+func (e environment) SetDarkTheme(bool) {
+	// nothing to do here.
+}
+
 // TestServeShutdownServe checks that you can call Serve twice in a row.
 func TestServeShutdownServe(t *testing.T) {
 	bridgecommon.Serve(

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -180,6 +180,7 @@ func NewHandlers(
 	getAPIRouter(apiRouter)("/update", handlers.getUpdateHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/banners/{key}", handlers.getBannersHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/using-mobile-data", handlers.getUsingMobileDataHandler).Methods("GET")
+	getAPIRouter(apiRouter)("/set-dark-theme", handlers.postDarkThemeHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/version", handlers.getVersionHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/testing", handlers.getTestingHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/account-add", handlers.postAddAccountHandler).Methods("POST")
@@ -420,6 +421,15 @@ func (handlers *Handlers) getBannersHandler(r *http.Request) (interface{}, error
 
 func (handlers *Handlers) getUsingMobileDataHandler(r *http.Request) (interface{}, error) {
 	return handlers.backend.Environment().UsingMobileData(), nil
+}
+
+func (handlers *Handlers) postDarkThemeHandler(r *http.Request) (interface{}, error) {
+	var isDark bool
+	if err := json.NewDecoder(r.Body).Decode(&isDark); err != nil {
+		return nil, errp.WithStack(err)
+	}
+	handlers.backend.Environment().SetDarkTheme(isDark)
+	return nil, nil
 }
 
 func (handlers *Handlers) getVersionHandler(_ *http.Request) (interface{}, error) {

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -56,6 +56,7 @@ func (e *backendEnv) DeviceInfos() []usb.DeviceInfo { return nil }
 func (e *backendEnv) UsingMobileData() bool         { return false }
 func (e *backendEnv) NativeLocale() string          { return e.Locale }
 func (e *backendEnv) GetSaveFilename(string) string { return "" }
+func (e *backendEnv) SetDarkTheme(bool)             {}
 
 func TestGetNativeLocale(t *testing.T) {
 	const ptLocale = "pt"

--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -98,6 +98,11 @@ func (webdevEnvironment) GetSaveFilename(suggestedFilename string) string {
 	return suggestedFilename
 }
 
+// SetDarkTheme implements backend.Environment.
+func (webdevEnvironment) SetDarkTheme(isDark bool) {
+	// nothing to do here.
+}
+
 func main() {
 	config.SetAppDir("appfolder.dev")
 

--- a/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
+++ b/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
             android:name=".MainActivity"
             android:launchMode="singleTop"
             android:taskAffinity=""
-            android:configChanges="orientation|screenSize|keyboardHidden|keyboard"
+            android:configChanges="orientation|screenSize|keyboardHidden|keyboard|uiMode"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
@@ -16,6 +16,7 @@ import android.os.Handler;
 import android.os.Message;
 
 import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.MutableLiveData;
 
 import java.util.Locale;
 
@@ -26,7 +27,7 @@ import goserver.GoReadWriteCloserInterface;
 
 public class GoViewModel extends AndroidViewModel {
 
-    private class GoDeviceInfo implements GoDeviceInfoInterface {
+      private class GoDeviceInfo implements GoDeviceInfoInterface {
         private UsbDevice device;
         public GoDeviceInfo(UsbDevice device) {
             this.device = device;
@@ -148,6 +149,11 @@ public class GoViewModel extends AndroidViewModel {
             }
             return locale.toString();
         }
+
+        public void setDarkTheme(boolean isDark) {
+            Util.log("Set Dark Theme GoViewModel - isdark: " + isDark);
+            GoViewModel.this.isDarkTheme.postValue(isDark);
+        }
     }
 
     public class Response {
@@ -176,6 +182,15 @@ public class GoViewModel extends AndroidViewModel {
         }
     }
 
+     private MutableLiveData<Boolean> isDarkTheme = new MutableLiveData<>();
+
+     public MutableLiveData<Boolean> getIsDarkTheme() {
+         return isDarkTheme;
+     }
+
+     public void setIsDarkTheme(Boolean isDark) {
+         this.isDarkTheme.postValue(isDark);
+    }
     private GoEnvironment goEnvironment;
     private GoAPI goAPI;
 

--- a/frontends/android/BitBoxApp/app/src/main/res/values-v23/styles.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/values-v23/styles.xml
@@ -1,7 +1,7 @@
 <resources>
     <!-- extend the base theme to add styles available only with API level 23+ -->
     <style name="AppTheme" parent="BaseAppTheme">
-        <item name="android:statusBarColor">@color/colorPrimary</item>
-        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:statusBarColor">@color/colorPrimaryDark</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>

--- a/frontends/android/BitBoxApp/app/src/main/res/values-v23/styles.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/values-v23/styles.xml
@@ -1,7 +1,7 @@
 <resources>
     <!-- extend the base theme to add styles available only with API level 23+ -->
     <style name="AppTheme" parent="BaseAppTheme">
-        <item name="android:statusBarColor">@color/colorPrimaryDark</item>
-        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:statusBarColor">@color/colorPrimary</item>
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 </resources>

--- a/frontends/android/BitBoxApp/app/src/main/res/values/colors.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorPrimary">#F5F5F5</color>
-    <color name="colorPrimaryDark">#E5E5E5</color>
+    <color name="colorPrimaryDark">#000000</color>
     <color name="colorAccent">#D81B60</color>
 </resources>

--- a/frontends/android/BitBoxApp/app/src/main/res/values/colors.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorPrimary">#F5F5F5</color>
-    <color name="colorPrimaryDark">#000000</color>
+    <color name="colorPrimaryDark">#1D1D1B</color>
     <color name="colorAccent">#D81B60</color>
 </resources>

--- a/frontends/android/BitBoxApp/app/src/main/res/values/styles.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
   <!-- Base application theme. -->
-    <style name="BaseAppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="BaseAppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/frontends/android/goserver/goserver.go
+++ b/frontends/android/goserver/goserver.go
@@ -90,6 +90,7 @@ type GoEnvironmentInterface interface {
 	SystemOpen(string) error
 	UsingMobileData() bool
 	NativeLocale() string
+	SetDarkTheme(bool)
 }
 
 // readWriteCloser implements io.ReadWriteCloser, translating from GoReadWriteCloserInterface. All methods
@@ -196,6 +197,7 @@ func Serve(dataDir string, environment GoEnvironmentInterface, goAPI GoAPIInterf
 				// On Android, we don't yet support exporting files. Implement this once needed.
 				return ""
 			},
+			SetDarkThemeFunc: environment.SetDarkTheme,
 		},
 	)
 }

--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -168,6 +168,7 @@ func serve(
 				filename := C.GoString(cFilename)
 				return filename
 			},
+			SetDarkThemeFunc: func(bool) {},
 		},
 	)
 }

--- a/frontends/web/src/api/darktheme.ts
+++ b/frontends/web/src/api/darktheme.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apiPost } from '../utils/request';
+
+export const setDarkTheme = (isDark: boolean): Promise<null> => {
+  return apiPost('set-dark-theme', isDark);
+};

--- a/frontends/web/src/components/darkmode/darkmode.tsx
+++ b/frontends/web/src/components/darkmode/darkmode.tsx
@@ -15,10 +15,12 @@
  */
 
 import { useDarkmode } from '../../hooks/darkmode';
+import { setDarkTheme } from '../../api/darktheme';
 
 let darkmode: boolean | undefined;
 
 export const setDarkmode = (dark: boolean) => {
+  setDarkTheme(dark);
   if (dark) {
     document.body.classList.add('dark-mode');
     document.body.classList.remove('light-mode');


### PR DESCRIPTION
App style parent is changed to `Theme.AppCompat.DayNight.DarkActionBar` as this allows to automatically enable dark mode following system setting (e.g. when on power saving).