### PR TITLE
frontend: convert `reset.tsx` into a functional component

### DIFF
--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -32,6 +32,10 @@ type DeviceInfoResponse = SuccessResponse & {
     deviceInfo: DeviceInfo;
 };
 
+export const resetDevice = (deviceID: string): Promise<SuccessResponse | FailResponse> => {
+  return apiPost(`devices/bitbox02/${deviceID}/reset`);
+};
+
 export const getDeviceInfo = (
   deviceID: string
 ): Promise<DeviceInfo> => {

--- a/frontends/web/src/routes/device/bitbox02/settings.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings.tsx
@@ -51,7 +51,6 @@ export const Settings = ({ deviceID }: TProps) => {
   }, [deviceID, t]);
 
   const versionInfo = useLoad(() => getVersion(deviceID), [deviceID]);
-  const apiPrefix = 'devices/bitbox02/' + deviceID;
 
   const routeToPassphrase = () => {
     route(`/passphrase/${deviceID}`);
@@ -74,7 +73,7 @@ export const Settings = ({ deviceID }: TProps) => {
                     {t('deviceSettings.secrets.manageBackups')}
                   </SettingsButton>
                   <ShowMnemonic deviceID={deviceID} />
-                  <Reset apiPrefix={apiPrefix} />
+                  <Reset deviceID={deviceID} />
                 </Column>
                 <Column className="m-bottom-default">
                   <h3 className="subTitle">{t('deviceSettings.hardware.title')}</h3>


### PR DESCRIPTION
To follow the latest conventions and best practices of React, 
we'd like to convert our class components into functional ones.

Here, we're converting `reset.tsx` into a functional component.