### PR TITLE
frontend: use Context for Darkmode

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -37,6 +37,7 @@ import { apiPost } from './utils/request';
 import { apiWebsocket } from './utils/websocket';
 import { route, RouterWatcher } from './utils/route';
 import { Darkmode } from './components/darkmode/darkmode';
+import { DarkModeProvider } from './contexts/DarkmodeProvider';
 
  interface State {
      accounts: IAccount[];
@@ -184,28 +185,30 @@ class App extends Component<Props, State> {
     const activeAccounts = this.activeAccounts();
     return (
       <ConnectedApp>
-        <Darkmode />
-        <div className={['app', i18nEditorActive ? 'i18nEditor' : ''].join(' ')}>
-          <Sidebar
-            accounts={activeAccounts}
-            deviceIDs={deviceIDs} />
-          <div className="appContent flex flex-column flex-1" style={{ minWidth: 0 }}>
-            <Update />
-            <Banner msgKey="bitbox01" />
-            <MobileDataWarning />
-            <Aopp />
-            <AppRouter
-              accounts={accounts}
-              activeAccounts={activeAccounts}
-              deviceIDs={deviceIDs}
-              devices={devices}
-              devicesKey={this.devicesKey}
-            />
-            <RouterWatcher onChange={this.handleRoute} />
+        <DarkModeProvider>
+          <Darkmode />
+          <div className={['app', i18nEditorActive ? 'i18nEditor' : ''].join(' ')}>
+            <Sidebar
+              accounts={activeAccounts}
+              deviceIDs={deviceIDs} />
+            <div className="appContent flex flex-column flex-1" style={{ minWidth: 0 }}>
+              <Update />
+              <Banner msgKey="bitbox01" />
+              <MobileDataWarning />
+              <Aopp />
+              <AppRouter
+                accounts={accounts}
+                activeAccounts={activeAccounts}
+                deviceIDs={deviceIDs}
+                devices={devices}
+                devicesKey={this.devicesKey}
+              />
+              <RouterWatcher onChange={this.handleRoute} />
+            </div>
+            <Alert />
+            <Confirm />
           </div>
-          <Alert />
-          <Confirm />
-        </div>
+        </DarkModeProvider>
       </ConnectedApp>
     );
   }

--- a/frontends/web/src/components/darkmode/darkmode.tsx
+++ b/frontends/web/src/components/darkmode/darkmode.tsx
@@ -15,30 +15,19 @@
  */
 
 import { useDarkmode } from '../../hooks/darkmode';
-import { setDarkTheme } from '../../api/darktheme';
 
 let darkmode: boolean | undefined;
 
-export const setDarkmode = (dark: boolean) => {
-  setDarkTheme(dark);
-  if (dark) {
-    document.body.classList.add('dark-mode');
-    document.body.classList.remove('light-mode');
-  } else {
-    document.body.classList.remove('dark-mode');
-    document.body.classList.add('light-mode');
-  }
-  darkmode = dark;
-};
-
 export const Darkmode = () => {
-  const mode = useDarkmode();
-  setDarkmode(mode);
+  const { isDarkMode } = useDarkmode();
+  darkmode = isDarkMode;
   return null;
 };
-
 /**
- * get darkmode, only usefull for conditional rendering
+ * Retrieve dark mode state for
+ * conditional rendering in class
+ * components. Use `useDarkmode`
+ * hook for functional components.
  * @returns {boolean} darkmode
  */
 export const getDarkmode = () => darkmode;

--- a/frontends/web/src/components/darkmode/darkmodetoggle.tsx
+++ b/frontends/web/src/components/darkmode/darkmodetoggle.tsx
@@ -14,67 +14,19 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLoad } from '../../hooks/api';
-import { useMediaQuery } from '../../hooks/mediaquery';
-import { getConfig, setConfig } from '../../api/backend';
 import { SettingsToggle } from '../../components/settingsButton/settingsToggle';
-import { setDarkmode as setGlobalDarkmode } from './darkmode';
+import { useDarkmode } from '../../hooks/darkmode';
 
 export const DarkModeToggle = () => {
-  const [darkmode, setDarkmode] = useState(false);
   const { t } = useTranslation();
-  const config = useLoad(getConfig);
-  const osPrefersDarkmode = useMediaQuery('(prefers-color-scheme: dark)');
-
-  useEffect(() => {
-    getConfig()
-      .then(config => {
-        // use config if it exists
-        if ('darkmode' in config.frontend) {
-          setDarkmode(config.frontend.darkmode);
-          return;
-        }
-        // else use mode from OS
-        setDarkmode(osPrefersDarkmode);
-      })
-      .catch(console.error);
-  }, [config, osPrefersDarkmode]);
-
-  useEffect(() => setGlobalDarkmode(darkmode), [darkmode]);
-
-  const handleDarkmodeChange = (event: React.SyntheticEvent) => {
-    const target = event.target as HTMLInputElement;
-    setDarkmode(target.checked);
-    getConfig()
-      .then(config => {
-        if (osPrefersDarkmode === target.checked) {
-          // remove darkmode from config, so it use the same mode as the OS
-          const { darkmode, ...frontend } = config.frontend;
-          setConfig({
-            backend: config.backend,
-            frontend,
-          });
-        } else {
-          // darkmode is different from OS, save to config
-          setConfig({
-            backend: config.backend,
-            frontend: {
-              ...config.frontend,
-              darkmode: target.checked,
-            }
-          });
-        }
-      })
-      .catch(console.error);
-  };
+  const { isDarkMode, toggleDarkmode } = useDarkmode();
 
   return (
     <SettingsToggle
-      checked={darkmode}
+      checked={isDarkMode}
       id="darkMode"
-      onChange={handleDarkmodeChange}>
+      onChange={() => toggleDarkmode(!isDarkMode)}>
       {t('darkmode.toggle')}
     </SettingsToggle>
   );

--- a/frontends/web/src/components/icon/combined.tsx
+++ b/frontends/web/src/components/icon/combined.tsx
@@ -19,11 +19,11 @@ import { BitBox02StylizedDark, BitBox02StylizedLight, CaretDown } from './icon';
 import style from './combined.module.css';
 
 export const PointToBitBox02 = () => {
-  const darkmode = useDarkmode();
+  const { isDarkMode } = useDarkmode();
   return (
     <div className={style.point2bitbox02}>
       <CaretDown className={style.caret} />
-      { darkmode
+      { isDarkMode
         ? (<BitBox02StylizedLight className={style.bitbox02} />)
         : (<BitBox02StylizedDark className={style.bitbox02} />)
       }

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -59,7 +59,7 @@ export const View = ({
   width,
   withBottomBar,
 }: TViewProps) => {
-  const darkmode = useDarkmode();
+  const { isDarkMode } = useDarkmode();
   const containerClasses = `${
     style[fullscreen ? 'fullscreen' : 'fill']
   } ${
@@ -93,7 +93,7 @@ export const View = ({
       {withBottomBar && (
         <div style={{ marginTop: 'auto' }}>
           <footer className={style.footer}>
-            {darkmode ? (<SwissMadeOpenSourceDark />) : (<SwissMadeOpenSource />)}
+            {isDarkMode ? (<SwissMadeOpenSourceDark />) : (<SwissMadeOpenSource />)}
             <div className="m-right-half hide-on-small">
               <Version />
             </div>

--- a/frontends/web/src/contexts/DarkmodeContext.ts
+++ b/frontends/web/src/contexts/DarkmodeContext.ts
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-import { useContext } from 'react';
-import DarkModeContext from '../contexts/DarkmodeContext';
+import { createContext } from 'react';
 
-/**
-Hook that manages the app's dark mode state.
-For class components, use `getDarkmode()`.
-@return {Object} An object with a boolean `isDarkMode`
-which is the dark mode state of the app, and
-`toggleDarkMode` function to toggle the state.
-*/
-export const useDarkmode = () => {
-  const { isDarkMode, toggleDarkmode } = useContext(DarkModeContext);
-  return { isDarkMode, toggleDarkmode };
-};
+type DarkModeContextProps = {
+  isDarkMode: boolean;
+  toggleDarkmode: (darkmode: boolean) => void;
+}
+
+const DarkModeContext = createContext<DarkModeContextProps>({} as DarkModeContextProps);
+
+export default DarkModeContext;

--- a/frontends/web/src/contexts/DarkmodeProvider.tsx
+++ b/frontends/web/src/contexts/DarkmodeProvider.tsx
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect, ReactNode, useCallback } from 'react';
+import { getConfig, setConfig } from '../api/backend';
+import { setDarkTheme } from '../api/darktheme';
+import { useMediaQuery } from '../hooks/mediaquery';
+import DarkModeContext from './DarkmodeContext';
+
+type TProps = {
+  children: ReactNode;
+}
+
+export const DarkModeProvider = ({ children }: TProps) => {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  const osPrefersDarkmode = useMediaQuery('(prefers-color-scheme: dark)');
+
+  const setAppTheme = useCallback(() => {
+    setDarkTheme(isDarkMode);
+    if (isDarkMode) {
+      document.body.classList.add('dark-mode');
+      document.body.classList.remove('light-mode');
+    } else {
+      document.body.classList.remove('dark-mode');
+      document.body.classList.add('light-mode');
+    }
+  }, [isDarkMode]);
+
+  useEffect(() => {
+    getConfig()
+      .then(config => {
+        // use config if it exists
+        if ('darkmode' in config.frontend) {
+          setIsDarkMode(config.frontend.darkmode);
+          return;
+        }
+        // else use mode from OS
+        setIsDarkMode(osPrefersDarkmode);
+
+      })
+      .catch(console.error);
+  }, [osPrefersDarkmode]);
+
+  useEffect(() => {
+    setAppTheme();
+  }, [isDarkMode, setAppTheme]);
+
+  const toggleDarkmode = (darkmode: boolean) => {
+    setIsDarkMode(!isDarkMode);
+    getConfig()
+      .then(config => {
+        if (osPrefersDarkmode === darkmode) {
+          // remove darkmode from config, so it use the same mode as the OS
+          const { darkmode, ...frontend } = config.frontend;
+          setConfig({
+            backend: config.backend,
+            frontend,
+          });
+        } else {
+          // darkmode is different from OS, save to config
+          setConfig({
+            backend: config.backend,
+            frontend: {
+              ...config.frontend,
+              darkmode,
+            }
+          });
+        }
+      });
+  };
+
+  return (
+    <DarkModeContext.Provider value={{ isDarkMode, toggleDarkmode }}>
+      {children}
+    </DarkModeContext.Provider>
+  );
+};
+
+

--- a/frontends/web/src/routes/buy/components/exchangeselectionradio.tsx
+++ b/frontends/web/src/routes/buy/components/exchangeselectionradio.tsx
@@ -36,19 +36,19 @@ type TPaymentMethodProps = { methodName: ExchangeDealWithBestDeal['payment'] };
 
 const PaymentMethod = ({ methodName }: TPaymentMethodProps) => {
   const { t } = useTranslation();
-  const darkmode = useDarkmode();
+  const { isDarkMode } = useDarkmode();
   switch (methodName) {
   case 'bank-transfer':
     return (
       <span>
-        {darkmode ? <Bank /> : <BankDark />}
+        {isDarkMode ? <Bank /> : <BankDark />}
         <p className={style.paymentMethodName}>{t('buy.exchange.bankTransfer')}</p>
       </span>
     );
   case 'card':
     return (
       <span>
-        {darkmode ? <CreditCard /> : <CreditCardDark />}
+        {isDarkMode ? <CreditCard /> : <CreditCardDark />}
         <p className={style.paymentMethodName}>{t('buy.exchange.creditCard')}</p>
       </span>
     );

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -32,7 +32,7 @@ import style from './bitbox01/bitbox01.module.css';
 export const Waiting = () => {
   const { t } = useTranslation();
   const testing = useLoad(debug ? getTesting : () => Promise.resolve(false));
-  const darkmode = useDarkmode();
+  const { isDarkMode } = useDarkmode();
 
   useEffect(() => {
     const { sidebarStatus } = panelStore.state;
@@ -47,7 +47,7 @@ export const Waiting = () => {
         <Header title={<h2>{t('welcome.title')}</h2>} />
         <div className="content padded narrow isVerticallyCentered">
           <div>
-            {darkmode ? (<AppLogoInverted />) : (<AppLogo />)}
+            {isDarkMode ? (<AppLogoInverted />) : (<AppLogo />)}
             <div className="box large">
               <h3 className={style.waitingText}>{t('welcome.insertDevice')}</h3>
               <p className={style.waitingDescription}>{t('welcome.insertBitBox02')}</p>
@@ -62,7 +62,7 @@ export const Waiting = () => {
           </div>
         </div>
         <Footer>
-          {darkmode ? (<SwissMadeOpenSourceDark />) : (<SwissMadeOpenSource />)}
+          {isDarkMode ? (<SwissMadeOpenSourceDark />) : (<SwissMadeOpenSource />)}
         </Footer>
       </div>
       <Guide>


### PR DESCRIPTION
Using context for Darkmode allows us to get and set the darkmode state easier across component (globally). We used our own `useDarkmode` hook to wrap the dark mode context.

Keeping `getDarkmode()` as it's still required by class components.