### PR TITLE
backend/btc: do not panic when retrieving transactions

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -665,7 +665,7 @@ func (account *Account) Transactions() (accounts.OrderedTransactions, error) {
 	if account.fatalError.Load() {
 		return nil, errp.New("can't call Transactions() after a fatal error")
 	}
-	txs, err := account.transactions.Transactions(
+	return account.transactions.Transactions(
 		func(scriptHashHex blockchain.ScriptHashHex) bool {
 			for _, subacc := range account.subaccounts {
 				if subacc.changeAddresses.LookupByScriptHashHex(scriptHashHex) != nil {
@@ -674,11 +674,6 @@ func (account *Account) Transactions() (accounts.OrderedTransactions, error) {
 			}
 			return false
 		})
-	if err != nil {
-		// TODO
-		panic(err)
-	}
-	return txs, nil
 }
 
 // GetUnusedReceiveAddresses returns a number of unused addresses. Returns nil if the account is not initialized.

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -220,14 +220,19 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 }
 
 func (handlers *Handlers) getAccountTransactions(_ *http.Request) (interface{}, error) {
-	result := []Transaction{}
+	var result struct {
+		Success      bool          `json:"success"`
+		Transactions []Transaction `json:"list"`
+	}
 	txs, err := handlers.account.Transactions()
 	if err != nil {
-		return nil, err
+		return result, nil
 	}
+	result.Transactions = []Transaction{}
 	for _, txInfo := range txs {
-		result = append(result, handlers.getTxInfoJSON(txInfo, false))
+		result.Transactions = append(result.Transactions, handlers.getTxInfoJSON(txInfo, false))
 	}
+	result.Success = true
 	return result, nil
 }
 

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -176,6 +176,8 @@ export interface ITransaction {
     weight: number;
 }
 
+export type TTransactions = { success: false } | { success: true; list: ITransaction[]; };
+
 export interface INoteTx {
     internalTxID: string;
     note: string;
@@ -188,7 +190,7 @@ export const postNotesTx = (code: AccountCode, {
   return apiPost(`account/${code}/notes/tx`, { internalTxID, note });
 };
 
-export const getTransactionList = (code: AccountCode): Promise<ITransaction[]> => {
+export const getTransactionList = (code: AccountCode): Promise<TTransactions> => {
   return apiGet(`account/${code}/transactions`);
 };
 

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { ITransaction } from '../../api/account';
+import { TTransactions } from '../../api/account';
 import A from '../../components/anchor/anchor';
 import { runningInAndroid } from '../../utils/env';
 import { Transaction } from './transaction';
@@ -25,7 +25,7 @@ import style from './transactions.module.css';
 type TProps = {
     accountCode: string;
     explorerURL: string;
-    transactions?: ITransaction[];
+    transactions?: TTransactions;
     handleExport: () => void;
 };
 
@@ -62,8 +62,8 @@ export const Transactions = ({
         <div className={style.currency}>{t('transaction.details.amount')}</div>
         <div className={style.action}>&nbsp;</div>
       </div>
-      { (transactions && transactions.length > 0)
-        ? transactions.map((props, index) => (
+      { (transactions && transactions.success && transactions.list.length > 0)
+        ? transactions.list.map((props, index) => (
           <Transaction
             accountCode={accountCode}
             key={props.internalID}
@@ -72,7 +72,11 @@ export const Transactions = ({
             {...props} />
         )) : (
           <div className={`flex flex-row flex-center ${style.empty}`}>
-            <p>{t('transactions.placeholder')}</p>
+            { transactions && !transactions.success ? (
+              <p>{t('transactions.errorLoadTransactions')}</p>
+            ) : (
+              <p>{t('transactions.placeholder')}</p>
+            ) }
           </div>
         ) }
     </div>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1407,6 +1407,7 @@
     "weight": "Weight"
   },
   "transactions": {
+    "errorLoadTransactions": "There was an error loading the transactions",
     "placeholder": "No transactions yet."
   },
   "unknownError": "An unknown error occurred: {{errorMessage}}",

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -57,7 +57,7 @@ export function Account({
   const [balance, setBalance] = useState<accountApi.IBalance>();
   const [status, setStatus] = useState<accountApi.IStatus>();
   const [syncedAddressesCount, setSyncedAddressesCount] = useState<number>();
-  const [transactions, setTransactions] = useState<accountApi.ITransaction[]>();
+  const [transactions, setTransactions] = useState<accountApi.TTransactions>();
   const [usesProxy, setUsesProxy] = useState<boolean>();
   const [stateCode, setStateCode] = useState<string>();
   const supportedExchanges = useLoad<SupportedExchanges>(getExchangeBuySupported(code), [code]);
@@ -191,7 +191,8 @@ export function Account({
     && !balance.hasAvailable
     && !balance.hasIncoming
     && transactions
-    && transactions.length === 0;
+    && transactions.success
+    && transactions.list.length === 0;
 
   const showBuyButton = exchangeBuySupported && isAccountEmpty;
 
@@ -266,7 +267,7 @@ export function Account({
         account={account}
         unit={balance?.available.unit}
         hasIncomingBalance={balance && balance.hasIncoming}
-        hasTransactions={transactions !== undefined && transactions.length > 0}
+        hasTransactions={transactions !== undefined && transactions.success && transactions.list.length > 0}
         hasNoBalance={balance && balance.available.amount === '0'} />
     </div>
   );

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -161,7 +161,11 @@ export const Pocket = ({ code }: TProps) => {
 
   const handleRequestXpub = () => {
     getTransactionList(code).then(txs => {
-      if (txs.length > 0) {
+      if (!txs.success) {
+        alertUser(t('transactions.errorLoadTransactions'));
+        return;
+      }
+      if (txs.list.length > 0) {
         confirmation(t('buy.pocket.previousTransactions'), result => {
           if (result) {
             sendXpub();


### PR DESCRIPTION
Fixes one panic TODO. All call sites deal with the error now. An error here is usually a database access for a database that was already closed (e.g. transactions endpoint called at the same time as a bitbox02 is unplugged or the account is closed for some other reason).