### PR TITLE
backend/accounts: de-duplicate account config fields

### DIFF
--- a/backend/accountcodes.go
+++ b/backend/accountcodes.go
@@ -17,7 +17,7 @@ package backend
 import (
 	"fmt"
 
-	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 )
@@ -33,18 +33,18 @@ import (
 
 // regularAccountCode returns an account code based on a keystore root fingerprint, a coin code and
 // an account number.
-func regularAccountCode(rootFingerprint []byte, coinCode coin.Code, accountNumber uint16) accounts.Code {
-	return accounts.Code(fmt.Sprintf("v0-%x-%s-%d", rootFingerprint, coinCode, accountNumber))
+func regularAccountCode(rootFingerprint []byte, coinCode coin.Code, accountNumber uint16) accountsTypes.Code {
+	return accountsTypes.Code(fmt.Sprintf("v0-%x-%s-%d", rootFingerprint, coinCode, accountNumber))
 }
 
 // splitAccountCode returns an account code for split accounts, made by exploding a unified account
 // into one account per signing configuration. This only applies to BTC/LTC.
-func splitAccountCode(parentCode accounts.Code, scriptType signing.ScriptType) accounts.Code {
-	return accounts.Code(fmt.Sprintf("%s-%s", parentCode, scriptType))
+func splitAccountCode(parentCode accountsTypes.Code, scriptType signing.ScriptType) accountsTypes.Code {
+	return accountsTypes.Code(fmt.Sprintf("%s-%s", parentCode, scriptType))
 }
 
 // Erc20AccountCode returns the account code used for an ERC20 token.
 // It is derived from the account code of the parent ETH account and the token code.
-func Erc20AccountCode(ethereumAccountCode accounts.Code, tokenCode string) accounts.Code {
-	return accounts.Code(fmt.Sprintf("%s-%s", ethereumAccountCode, tokenCode))
+func Erc20AccountCode(ethereumAccountCode accountsTypes.Code, tokenCode string) accountsTypes.Code {
+	return accountsTypes.Code(fmt.Sprintf("%s-%s", ethereumAccountCode, tokenCode))
 }

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -168,7 +168,7 @@ func (backend *Backend) createAndPersistAccountConfig(
 	name string,
 	keystore keystore.Keystore,
 	activeTokens []string,
-	accountsConfig *config.AccountsConfig) (accounts.Code, error) {
+	accountsConfig *config.AccountsConfig) (accountsTypes.Code, error) {
 	rootFingerprint, err := keystore.RootFingerprint()
 	if err != nil {
 		return "", err
@@ -296,8 +296,8 @@ func (backend *Backend) CanAddAccount(coinCode coinpkg.Code, keystore keystore.K
 // determined automatically to be the increment of the highest existing account.
 // `name` is the account name, shown to the user. If empty, a default name will be set.
 func (backend *Backend) CreateAndPersistAccountConfig(
-	coinCode coinpkg.Code, name string, keystore keystore.Keystore) (accounts.Code, error) {
-	var accountCode accounts.Code
+	coinCode coinpkg.Code, name string, keystore keystore.Keystore) (accountsTypes.Code, error) {
+	var accountCode accountsTypes.Code
 	err := backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
 		nextAccountNumber, err := nextAccountNumber(coinCode, keystore, accountsConfig)
 		if err != nil {
@@ -315,7 +315,7 @@ func (backend *Backend) CreateAndPersistAccountConfig(
 }
 
 // SetAccountActive activates/deactivates an account.
-func (backend *Backend) SetAccountActive(accountCode accounts.Code, active bool) error {
+func (backend *Backend) SetAccountActive(accountCode accountsTypes.Code, active bool) error {
 	err := backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
 		acct := accountsConfig.Lookup(accountCode)
 		if acct == nil {
@@ -333,7 +333,7 @@ func (backend *Backend) SetAccountActive(accountCode accounts.Code, active bool)
 
 // SetTokenActive activates/deactivates an token on an account. `tokenCode` must be an ERC20 token
 // code, e.g. "eth-erc20-usdt", "eth-erc20-bat", etc.
-func (backend *Backend) SetTokenActive(accountCode accounts.Code, tokenCode string, active bool) error {
+func (backend *Backend) SetTokenActive(accountCode accountsTypes.Code, tokenCode string, active bool) error {
 	err := backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
 		acct := accountsConfig.Lookup(accountCode)
 		if acct == nil {
@@ -349,7 +349,7 @@ func (backend *Backend) SetTokenActive(accountCode accounts.Code, tokenCode stri
 }
 
 // RenameAccount renames an account in the accounts database.
-func (backend *Backend) RenameAccount(accountCode accounts.Code, name string) error {
+func (backend *Backend) RenameAccount(accountCode accountsTypes.Code, name string) error {
 	if name == "" {
 		return errp.New("Name cannot be empty")
 	}
@@ -381,7 +381,7 @@ func (backend *Backend) addAccount(account accounts.Interface) {
 // The accountsAndKeystoreLock must be held when calling this function.
 func (backend *Backend) createAndAddAccount(
 	coin coinpkg.Coin,
-	code accounts.Code,
+	code accountsTypes.Code,
 	name string,
 	signingConfigurations signing.Configurations,
 	active bool,
@@ -493,7 +493,7 @@ type scriptTypeWithKeypath struct {
 func (backend *Backend) persistBTCAccountConfig(
 	keystore keystore.Keystore,
 	coin coinpkg.Coin,
-	code accounts.Code,
+	code accountsTypes.Code,
 	name string,
 	configs []scriptTypeWithKeypath,
 	accountsConfig *config.AccountsConfig,
@@ -569,7 +569,7 @@ func (backend *Backend) persistBTCAccountConfig(
 func (backend *Backend) persistETHAccountConfig(
 	keystore keystore.Keystore,
 	coin coinpkg.Coin,
-	code accounts.Code,
+	code accountsTypes.Code,
 	keypath string,
 	name string,
 	activeTokens []string,

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth"
@@ -394,9 +395,9 @@ func (backend *Backend) createAndAddAccount(
 		DBFolder:    backend.arguments.CacheDirectoryPath(),
 		NotesFolder: backend.arguments.NotesDirectoryPath(),
 		Keystore:    backend.keystore,
-		OnEvent: func(event accounts.Event) {
+		OnEvent: func(event accountsTypes.Event) {
 			backend.events <- AccountEvent{Type: "account", Code: code, Data: string(event)}
-			if account != nil && event == accounts.EventSyncDone {
+			if account != nil && event == accountsTypes.EventSyncDone {
 				backend.notifyNewTxs(account)
 			}
 		},

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -36,17 +36,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Code is a globally unique account code. It is used for example as a name in databases (e.g. cache
-// database, transaction notes database, etc).
-type Code string
-
 // AccountConfig holds account configuration.
 type AccountConfig struct {
 	// Active, if false, does not load the account in the sidebar, portfolio, etc.
 	Active bool
 	// Code is an identifier for the account *type* (part of account database filenames, apis, etc.).
 	// Type as in btc-p2wpkh, eth-erc20-usdt, etc.
-	Code Code
+	Code types.Code
 	// Name returns a human readable long name.
 	Name string
 	// DBFolder is the folder for all accounts. Full path.

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -153,10 +153,10 @@ func (account *BaseAccount) Initialize(accountIdentifier string) error {
 
 	// Append legacy notes (notes stored in files based on obsolete account identifiers). Account
 	// identifiers changed from v4.27.0 to v4.28.0.
-	if len(account.Config().Config.Configurations) == 0 {
+	if len(account.Config().Config.SigningConfigurations) == 0 {
 		return nil
 	}
-	accountNumber, err := account.Config().Config.Configurations[0].AccountNumber()
+	accountNumber, err := account.Config().Config.SigningConfigurations[0].AccountNumber()
 	if err != nil {
 		return nil
 	}
@@ -165,13 +165,13 @@ func (account *BaseAccount) Initialize(accountIdentifier string) error {
 		return nil
 	}
 
-	legacyConfigurations := signing.ConvertToLegacyConfigurations(account.Config().Config.Configurations)
+	legacyConfigurations := signing.ConvertToLegacyConfigurations(account.Config().Config.SigningConfigurations)
 	var legacyAccountIdentifiers []string
 	switch account.coin.Code() {
 	case coin.CodeBTC, coin.CodeTBTC, coin.CodeLTC, coin.CodeTLTC:
 		legacyAccountIdentifiers = []string{fmt.Sprintf("account-%s-%s", legacyConfigurations.Hash(), account.coin.Code())}
 		// Also consider split accounts:
-		for _, cfg := range account.Config().Config.Configurations {
+		for _, cfg := range account.Config().Config.SigningConfigurations {
 			legacyConfigurations := signing.ConvertToLegacyConfigurations(signing.Configurations{cfg})
 			legacyAccountIdentifier := fmt.Sprintf("account-%s-%s-%s", legacyConfigurations.Hash(), account.coin.Code(), cfg.ScriptType())
 			legacyAccountIdentifiers = append(

--- a/backend/accounts/baseaccount_test.go
+++ b/backend/accounts/baseaccount_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin/mocks"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/test"
@@ -53,18 +54,20 @@ func TestBaseAccount(t *testing.T) {
 
 	const accountIdentifier = "test-account-identifier"
 	cfg := &AccountConfig{
-		Code:        "test",
-		Name:        "Test",
-		DBFolder:    test.TstTempDir("baseaccount_test_dbfolder"),
-		NotesFolder: test.TstTempDir("baseaccount_test_notesfolder"),
-		Keystore:    nil,
-		OnEvent:     func(event types.Event) { events <- event },
-		RateUpdater: nil,
-		SigningConfigurations: signing.Configurations{
-			signing.NewBitcoinConfiguration(signing.ScriptTypeP2PKH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
-			signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
-			signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
+		Config: &config.Account{
+			Code: "test",
+			Name: "Test",
+			Configurations: signing.Configurations{
+				signing.NewBitcoinConfiguration(signing.ScriptTypeP2PKH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
+				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
+				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
+			},
 		},
+		DBFolder:        test.TstTempDir("baseaccount_test_dbfolder"),
+		NotesFolder:     test.TstTempDir("baseaccount_test_notesfolder"),
+		Keystore:        nil,
+		OnEvent:         func(event types.Event) { events <- event },
+		RateUpdater:     nil,
 		GetNotifier:     nil,
 		GetSaveFilename: func(suggestedFilename string) string { return suggestedFilename },
 	}

--- a/backend/accounts/baseaccount_test.go
+++ b/backend/accounts/baseaccount_test.go
@@ -57,7 +57,7 @@ func TestBaseAccount(t *testing.T) {
 		Config: &config.Account{
 			Code: "test",
 			Name: "Test",
-			Configurations: signing.Configurations{
+			SigningConfigurations: signing.Configurations{
 				signing.NewBitcoinConfiguration(signing.ScriptTypeP2PKH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
 				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),
 				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, []byte{1, 2, 3, 4}, derivationPath, extendedPublicKey),

--- a/backend/accounts/types/code.go
+++ b/backend/accounts/types/code.go
@@ -1,0 +1,19 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// Code is a globally unique account code. It is used for example as a name in databases (e.g. cache
+// database, transaction notes database, etc).
+type Code string

--- a/backend/accounts/types/event.go
+++ b/backend/accounts/types/event.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accounts
+package types
 
 // Event instances are sent to the onEvent callback of the wallet.
 type Event string

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -718,50 +718,58 @@ func TestCreateAndAddAccount(t *testing.T) {
 	// Add a Bitcoin account.
 	coin, err := b.Coin(coinpkg.CodeBTC)
 	require.NoError(t, err)
-	b.createAndAddAccount(coin, "test-btc-account-code", "Bitcoin account name",
-		signing.Configurations{
-			signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/0'/0'"), mustXKey("xpub6Cxa67Bfe1Aw5VvLM1Ppua9x28CXH1zUYoAuBzFRjR6hWnA6aUcny84KYkeVcZWnWXxKSkxCEyMA8xic54ydBPWm5oziXpsXq6nX8FELMQn")),
+	b.createAndAddAccount(
+		coin,
+		&config.Account{
+			Code: "test-btc-account-code",
+			Name: "Bitcoin account name",
+			Configurations: signing.Configurations{
+				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/0'/0'"), mustXKey("xpub6Cxa67Bfe1Aw5VvLM1Ppua9x28CXH1zUYoAuBzFRjR6hWnA6aUcny84KYkeVcZWnWXxKSkxCEyMA8xic54ydBPWm5oziXpsXq6nX8FELMQn")),
+			},
 		},
-		true,
-		nil,
 	)
 	require.Len(t, b.Accounts(), 1)
 	// Check some properties of the newly added account.
 	acct := b.Accounts()[0]
 	_, ok := acct.(*btc.Account)
 	require.True(t, ok)
-	require.Equal(t, accountsTypes.Code("test-btc-account-code"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-btc-account-code"), acct.Config().Config.Code)
 	require.Equal(t, coin, acct.Coin())
-	require.Equal(t, "Bitcoin account name", acct.Config().Name)
+	require.Equal(t, "Bitcoin account name", acct.Config().Config.Name)
 
 	// Add a Litecoin account.
 	coin, err = b.Coin(coinpkg.CodeLTC)
 	require.NoError(t, err)
-	b.createAndAddAccount(coin, "test-ltc-account-code", "Litecoin account name",
-		signing.Configurations{
-			signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/2'/0'"), mustXKey("xpub6DReBHtKxgeZGBKTaaF1GjeBHa8dZwQpRfgYr3kxt782s8KKqio2pR6piBsiqHEPF7Rg3onMkwt9XrSxNTuW4N1VBjVbn6DQ3GPCBEUgtgP")),
+	b.createAndAddAccount(coin,
+		&config.Account{
+			Code: "test-ltc-account-code",
+			Name: "Litecoin account name",
+			Configurations: signing.Configurations{
+				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/2'/0'"), mustXKey("xpub6DReBHtKxgeZGBKTaaF1GjeBHa8dZwQpRfgYr3kxt782s8KKqio2pR6piBsiqHEPF7Rg3onMkwt9XrSxNTuW4N1VBjVbn6DQ3GPCBEUgtgP")),
+			},
 		},
-		true,
-		nil,
 	)
 	require.Len(t, b.Accounts(), 2)
 	// Check some properties of the newly added account.
 	acct = b.Accounts()[1]
 	_, ok = acct.(*btc.Account)
 	require.True(t, ok)
-	require.Equal(t, accountsTypes.Code("test-ltc-account-code"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-ltc-account-code"), acct.Config().Config.Code)
 	require.Equal(t, coin, acct.Coin())
-	require.Equal(t, "Litecoin account name", acct.Config().Name)
+	require.Equal(t, "Litecoin account name", acct.Config().Config.Name)
 
 	// Add an Ethereum account with some active ERC20 tokens..
 	coin, err = b.Coin(coinpkg.CodeETH)
 	require.NoError(t, err)
-	b.createAndAddAccount(coin, "test-eth-account-code", "Ethereum account name",
-		signing.Configurations{
-			signing.NewEthereumConfiguration(fingerprint, mustKeypath("m/44'/60'/0'/0/0"), mustXKey("xpub6GP83vJASH1kS7dQPWXFjVHDfYajopbG8U3j8peBH67CRCnb8QmDxZJfWpbgCQNHAzCDJ4MyVYjoh7Yv9yo7PQuZ9YyktgrtD9vmeo67Y4E")),
+	b.createAndAddAccount(coin,
+		&config.Account{
+			Code: "test-eth-account-code",
+			Name: "Ethereum account name",
+			Configurations: signing.Configurations{
+				signing.NewEthereumConfiguration(fingerprint, mustKeypath("m/44'/60'/0'/0/0"), mustXKey("xpub6GP83vJASH1kS7dQPWXFjVHDfYajopbG8U3j8peBH67CRCnb8QmDxZJfWpbgCQNHAzCDJ4MyVYjoh7Yv9yo7PQuZ9YyktgrtD9vmeo67Y4E")),
+			},
+			ActiveTokens: []string{"eth-erc20-mkr"},
 		},
-		true,
-		[]string{"eth-erc20-mkr"},
 	)
 	// 2 more accounts: the added ETH account plus the active token for the ETH account.
 	require.Len(t, b.Accounts(), 4)
@@ -770,25 +778,29 @@ func TestCreateAndAddAccount(t *testing.T) {
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.Nil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accountsTypes.Code("test-eth-account-code"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code"), acct.Config().Config.Code)
 	require.Equal(t, coin, acct.Coin())
-	require.Equal(t, "Ethereum account name", acct.Config().Name)
+	require.Equal(t, "Ethereum account name", acct.Config().Config.Name)
 	acct = b.Accounts()[3]
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.NotNil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accountsTypes.Code("test-eth-account-code-eth-erc20-mkr"), acct.Config().Code)
-	require.Equal(t, "Maker", acct.Config().Name)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code-eth-erc20-mkr"), acct.Config().Config.Code)
+	require.Equal(t, "Maker", acct.Config().Config.Name)
 
 	// Add another Ethereum account with some active ERC20 tokens.
 	coin, err = b.Coin(coinpkg.CodeETH)
 	require.NoError(t, err)
-	b.createAndAddAccount(coin, "test-eth-account-code-2", "Ethereum account name 2",
-		signing.Configurations{
-			signing.NewEthereumConfiguration(fingerprint, mustKeypath("m/44'/60'/0'/0/1"), mustXKey("xpub6GP83vJASH1kUpndXSe3e942omyTYSPKaav6shfic7Lc3rFJR9ctA3AXaTf7rX7PuSZNUnaqj4hiqgnRXr26jitBz4jLhmFURtVxDykHbQm")),
+	b.createAndAddAccount(coin,
+		&config.Account{
+			Code: "test-eth-account-code-2",
+			Name: "Ethereum account name 2",
+
+			Configurations: signing.Configurations{
+				signing.NewEthereumConfiguration(fingerprint, mustKeypath("m/44'/60'/0'/0/1"), mustXKey("xpub6GP83vJASH1kUpndXSe3e942omyTYSPKaav6shfic7Lc3rFJR9ctA3AXaTf7rX7PuSZNUnaqj4hiqgnRXr26jitBz4jLhmFURtVxDykHbQm")),
+			},
+			ActiveTokens: []string{"eth-erc20-usdt", "eth-erc20-bat"},
 		},
-		true,
-		[]string{"eth-erc20-usdt", "eth-erc20-bat"},
 	)
 	// 3 more accounts: the added ETH account plus the two active tokens for the ETH account.
 	require.Len(t, b.Accounts(), 7)
@@ -797,21 +809,21 @@ func TestCreateAndAddAccount(t *testing.T) {
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.Nil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accountsTypes.Code("test-eth-account-code-2"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code-2"), acct.Config().Config.Code)
 	require.Equal(t, coin, acct.Coin())
-	require.Equal(t, "Ethereum account name 2", acct.Config().Name)
+	require.Equal(t, "Ethereum account name 2", acct.Config().Config.Name)
 	acct = b.Accounts()[5]
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.NotNil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accountsTypes.Code("test-eth-account-code-2-eth-erc20-usdt"), acct.Config().Code)
-	require.Equal(t, "Tether USD 2", acct.Config().Name)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code-2-eth-erc20-usdt"), acct.Config().Config.Code)
+	require.Equal(t, "Tether USD 2", acct.Config().Config.Name)
 	acct = b.Accounts()[6]
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.NotNil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accountsTypes.Code("test-eth-account-code-2-eth-erc20-bat"), acct.Config().Code)
-	require.Equal(t, "Basic Attention Token 2", acct.Config().Name)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code-2-eth-erc20-bat"), acct.Config().Config.Code)
+	require.Equal(t, "Basic Attention Token 2", acct.Config().Config.Name)
 }
 
 // TestAccountSupported tests that only accounts supported by a keystore are 1) persisted when the
@@ -922,27 +934,27 @@ func TestInactiveAccount(t *testing.T) {
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-55555555-btc-0"))
 	require.False(t, b.Config().AccountsConfig().Lookup("v0-55555555-btc-0").Inactive)
-	require.True(t, lookup(b.Accounts(), "v0-55555555-btc-0").Config().Active)
+	require.True(t, !lookup(b.Accounts(), "v0-55555555-btc-0").Config().Config.Inactive)
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-55555555-ltc-0"))
 	require.False(t, b.Config().AccountsConfig().Lookup("v0-55555555-ltc-0").Inactive)
-	require.True(t, lookup(b.Accounts(), "v0-55555555-ltc-0").Config().Active)
+	require.True(t, !lookup(b.Accounts(), "v0-55555555-ltc-0").Config().Config.Inactive)
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-55555555-eth-0"))
 	require.False(t, b.Config().AccountsConfig().Lookup("v0-55555555-eth-0").Inactive)
-	require.True(t, lookup(b.Accounts(), "v0-55555555-eth-0").Config().Active)
+	require.True(t, !lookup(b.Accounts(), "v0-55555555-eth-0").Config().Config.Inactive)
 
 	// Deactive an account.
 	require.NoError(t, b.SetAccountActive("v0-55555555-btc-0", false))
 	require.Len(t, b.Accounts(), 3)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
 	require.True(t, b.Config().AccountsConfig().Lookup("v0-55555555-btc-0").Inactive)
-	require.False(t, lookup(b.Accounts(), "v0-55555555-btc-0").Config().Active)
+	require.False(t, !lookup(b.Accounts(), "v0-55555555-btc-0").Config().Config.Inactive)
 
 	// Reactivate.
 	require.NoError(t, b.SetAccountActive("v0-55555555-btc-0", true))
 	require.Len(t, b.Accounts(), 3)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
 	require.False(t, b.Config().AccountsConfig().Lookup("v0-55555555-btc-0").Inactive)
-	require.True(t, lookup(b.Accounts(), "v0-55555555-btc-0").Config().Active)
+	require.True(t, !lookup(b.Accounts(), "v0-55555555-btc-0").Config().Config.Inactive)
 
 	// Deactivating an ETH account with tokens also removes the tokens
 	require.NoError(t, b.SetTokenActive("v0-55555555-eth-0", "eth-erc20-usdt", true))
@@ -952,16 +964,16 @@ func TestInactiveAccount(t *testing.T) {
 	require.NoError(t, b.SetAccountActive("v0-55555555-eth-0", false))
 	require.Len(t, b.Accounts(), 5)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
-	require.False(t, lookup(b.Accounts(), "v0-55555555-eth-0").Config().Active)
-	require.False(t, lookup(b.Accounts(), "v0-55555555-eth-0-eth-erc20-usdt").Config().Active)
-	require.False(t, lookup(b.Accounts(), "v0-55555555-eth-0-eth-erc20-bat").Config().Active)
+	require.False(t, !lookup(b.Accounts(), "v0-55555555-eth-0").Config().Config.Inactive)
+	require.False(t, !lookup(b.Accounts(), "v0-55555555-eth-0-eth-erc20-usdt").Config().Config.Inactive)
+	require.False(t, !lookup(b.Accounts(), "v0-55555555-eth-0-eth-erc20-bat").Config().Config.Inactive)
 	// Reactivating restores them again.
 	require.NoError(t, b.SetAccountActive("v0-55555555-eth-0", true))
 	require.Len(t, b.Accounts(), 5)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
-	require.True(t, lookup(b.Accounts(), "v0-55555555-eth-0").Config().Active)
-	require.True(t, lookup(b.Accounts(), "v0-55555555-eth-0-eth-erc20-usdt").Config().Active)
-	require.True(t, lookup(b.Accounts(), "v0-55555555-eth-0-eth-erc20-bat").Config().Active)
+	require.True(t, !lookup(b.Accounts(), "v0-55555555-eth-0").Config().Config.Inactive)
+	require.True(t, !lookup(b.Accounts(), "v0-55555555-eth-0-eth-erc20-usdt").Config().Config.Inactive)
+	require.True(t, !lookup(b.Accounts(), "v0-55555555-eth-0-eth-erc20-bat").Config().Config.Inactive)
 
 	// Deactivate all accounts.
 	require.NoError(t, b.SetAccountActive("v0-55555555-btc-0", false))
@@ -1046,15 +1058,15 @@ func TestTaprootUpgrade(t *testing.T) {
 	ltcAccount := lookup(b.Accounts(), "v0-55555555-ltc-0")
 	require.NotNil(t, ltcAccount)
 	require.Equal(t, coinpkg.CodeBTC, btcAccount.Coin().Code())
-	require.Len(t, btcAccount.Config().SigningConfigurations, 2)
-	require.Len(t, ltcAccount.Config().SigningConfigurations, 2)
+	require.Len(t, btcAccount.Config().Config.Configurations, 2)
+	require.Len(t, ltcAccount.Config().Config.Configurations, 2)
 	require.Equal(t,
-		signing.ScriptTypeP2WPKH, btcAccount.Config().SigningConfigurations[0].ScriptType())
+		signing.ScriptTypeP2WPKH, btcAccount.Config().Config.Configurations[0].ScriptType())
 	require.Equal(t,
-		signing.ScriptTypeP2WPKHP2SH, btcAccount.Config().SigningConfigurations[1].ScriptType())
+		signing.ScriptTypeP2WPKHP2SH, btcAccount.Config().Config.Configurations[1].ScriptType())
 	// Same for the persisted account config.
 	require.Equal(t,
-		btcAccount.Config().SigningConfigurations,
+		btcAccount.Config().Config.Configurations,
 		b.Config().AccountsConfig().Lookup("v0-55555555-btc-0").Configurations)
 
 	// "Unplug", then insert an updated keystore with taproot support.
@@ -1067,17 +1079,17 @@ func TestTaprootUpgrade(t *testing.T) {
 	ltcAccount = lookup(b.Accounts(), "v0-55555555-ltc-0")
 	require.NotNil(t, ltcAccount)
 	require.Equal(t, coinpkg.CodeBTC, b.Accounts()[0].Coin().Code())
-	require.Len(t, btcAccount.Config().SigningConfigurations, 3)
+	require.Len(t, btcAccount.Config().Config.Configurations, 3)
 	// LTC (coin with no taproot support) unchanged.
-	require.Len(t, ltcAccount.Config().SigningConfigurations, 2)
+	require.Len(t, ltcAccount.Config().Config.Configurations, 2)
 	require.Equal(t,
-		signing.ScriptTypeP2WPKH, btcAccount.Config().SigningConfigurations[0].ScriptType())
+		signing.ScriptTypeP2WPKH, btcAccount.Config().Config.Configurations[0].ScriptType())
 	require.Equal(t,
-		signing.ScriptTypeP2WPKHP2SH, btcAccount.Config().SigningConfigurations[1].ScriptType())
+		signing.ScriptTypeP2WPKHP2SH, btcAccount.Config().Config.Configurations[1].ScriptType())
 	require.Equal(t,
-		signing.ScriptTypeP2TR, btcAccount.Config().SigningConfigurations[2].ScriptType())
+		signing.ScriptTypeP2TR, btcAccount.Config().Config.Configurations[2].ScriptType())
 	// Same for the persisted account config.
 	require.Equal(t,
-		btcAccount.Config().SigningConfigurations,
+		btcAccount.Config().Config.Configurations,
 		b.Config().AccountsConfig().Lookup("v0-55555555-btc-0").Configurations)
 }

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -83,11 +83,11 @@ func TestSortAccounts(t *testing.T) {
 	}
 
 	accts := []*config.Account{
-		{Code: "acct-eth-2", CoinCode: coinpkg.CodeETH, Configurations: ethConfig("m/44'/60'/0'/0/1")},
-		{Code: "acct-eth-1", CoinCode: coinpkg.CodeETH, Configurations: ethConfig("m/44'/60'/0'/0/0")},
-		{Code: "acct-btc-1", CoinCode: coinpkg.CodeBTC, Configurations: btcConfig("m/84'/0'/0'")},
-		{Code: "acct-btc-3", CoinCode: coinpkg.CodeBTC, Configurations: btcConfig("m/84'/0'/2'")},
-		{Code: "acct-btc-2", CoinCode: coinpkg.CodeBTC, Configurations: btcConfig("m/84'/0'/1'")},
+		{Code: "acct-eth-2", CoinCode: coinpkg.CodeETH, SigningConfigurations: ethConfig("m/44'/60'/0'/0/1")},
+		{Code: "acct-eth-1", CoinCode: coinpkg.CodeETH, SigningConfigurations: ethConfig("m/44'/60'/0'/0/0")},
+		{Code: "acct-btc-1", CoinCode: coinpkg.CodeBTC, SigningConfigurations: btcConfig("m/84'/0'/0'")},
+		{Code: "acct-btc-3", CoinCode: coinpkg.CodeBTC, SigningConfigurations: btcConfig("m/84'/0'/2'")},
+		{Code: "acct-btc-2", CoinCode: coinpkg.CodeBTC, SigningConfigurations: btcConfig("m/84'/0'/1'")},
 		{Code: "acct-goeth", CoinCode: coinpkg.CodeGOETH},
 		{Code: "acct-ltc", CoinCode: coinpkg.CodeLTC},
 		{Code: "acct-tltc", CoinCode: coinpkg.CodeTLTC},
@@ -134,7 +134,7 @@ func TestNextAccountNumber(t *testing.T) {
 		Accounts: []config.Account{
 			{
 				CoinCode: coinpkg.CodeBTC,
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(
 						signing.ScriptTypeP2WPKH,
 						fingerprint1,
@@ -145,7 +145,7 @@ func TestNextAccountNumber(t *testing.T) {
 			},
 			{
 				CoinCode: coinpkg.CodeBTC,
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(
 						signing.ScriptTypeP2WPKHP2SH,
 						fingerprint1,
@@ -156,7 +156,7 @@ func TestNextAccountNumber(t *testing.T) {
 			},
 			{
 				CoinCode: coinpkg.CodeTBTC,
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(
 						signing.ScriptTypeP2WPKH,
 						fingerprint1,
@@ -167,7 +167,7 @@ func TestNextAccountNumber(t *testing.T) {
 			},
 			{
 				CoinCode: coinpkg.CodeTBTC,
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(
 						signing.ScriptTypeP2WPKH,
 						fingerprint2,
@@ -445,7 +445,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "btc",
 				Name:     "bitcoin 1",
 				Code:     "v0-55555555-btc-0",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/0'/0'"), mustXKey("xpub6Cxa67Bfe1Aw5VvLM1Ppua9x28CXH1zUYoAuBzFRjR6hWnA6aUcny84KYkeVcZWnWXxKSkxCEyMA8xic54ydBPWm5oziXpsXq6nX8FELMQn")),
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2TR, fingerprint, mustKeypath("m/86'/0'/0'"), mustXKey("xpub6CC9Tsi4eJvmRsGuXwKBfHDWUWN66voNeZFmXRJhYZS6yYgXKZmtz5qnxK9WL2FZP8uF3abyFZ29d7RfMks4FjCCu4LMh3edyeCoyEFuZLZ")),
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, fingerprint, mustKeypath("m/49'/0'/0'"), mustXKey("xpub6CUmEcJb7juvnw7fFYybCwvCJuPSEdhTWZCep9X1DBznwB8RRKTYBUidbEPJ9L7ExjrXhem9S759cX3BpzSUSoP2rWh9vqumJ9MPSAbi98F")),
@@ -467,7 +467,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "ltc",
 				Name:     "litecoin 1",
 				Code:     "v0-55555555-ltc-0",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/2'/0'"), mustXKey("xpub6DReBHtKxgeZGBKTaaF1GjeBHa8dZwQpRfgYr3kxt782s8KKqio2pR6piBsiqHEPF7Rg3onMkwt9XrSxNTuW4N1VBjVbn6DQ3GPCBEUgtgP")),
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, fingerprint, mustKeypath("m/49'/2'/0'"), mustXKey("xpub6CrhULuXbYzo7gXNhSNZ6tzgfMWpwRFEisekvFfuWLtpXcV4jfvWf5yCuhRBvhZoisH4JCVp4ddGEi7XF2QE2S4N8pMkirJbp7N2TF5p5qQ")),
 				},
@@ -488,7 +488,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "eth",
 				Name:     "ethereum 1",
 				Code:     "v0-55555555-eth-0",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewEthereumConfiguration(fingerprint, mustKeypath("m/44'/60'/0'/0/0"), mustXKey("xpub6GP83vJASH1kS7dQPWXFjVHDfYajopbG8U3j8peBH67CRCnb8QmDxZJfWpbgCQNHAzCDJ4MyVYjoh7Yv9yo7PQuZ9YyktgrtD9vmeo67Y4E")),
 				},
 			},
@@ -508,7 +508,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "btc",
 				Name:     "bitcoin 2",
 				Code:     "v0-55555555-btc-1",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/0'/1'"), mustXKey("xpub6Cxa67Bfe1Aw7YVtdqKPYLhSkf7omb7WkGXQzof15VXbAZKVct1caHHK55UQN2Fnojbp2okiBCbGXyQSRzMQ6XKJJeeM2jAt6FR8K8ckA88")),
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2TR, fingerprint, mustKeypath("m/86'/0'/1'"), mustXKey("xpub6CC9Tsi4eJvmSBj5xoU4sKnFGF9nF8qwExB3axxu2F7oWKFH5RucWQUfrgVGfnTDr6p5acBGpAqAMKb2A7ek8SbAUvDEXtvj37pM1S9X2km")),
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, fingerprint, mustKeypath("m/49'/0'/1'"), mustXKey("xpub6CUmEcJb7juvpvNs2hKMc9BP1n82ixzUb4jyHUdYzSLmnXru3nb4hhGsfS23WRx8hgJLxMxZ7WcBGzTiYfiANUQZe3TVFghLrxvA2Ls7u4a")),
@@ -530,7 +530,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "ltc",
 				Name:     "litecoin 2",
 				Code:     "v0-55555555-ltc-1",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/2'/1'"), mustXKey("xpub6DReBHtKxgeZJJrrhPEHz9kzEZU1BaQ4kPQ2J1tfjA9DMBKT2bor1ynoAPCsxdyJyZrYK5YsYmkknV5KPtpKeVb2HMX6iQ9wjpAhNSANGiA")),
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, fingerprint, mustKeypath("m/49'/2'/1'"), mustXKey("xpub6CrhULuXbYzo8Lk2iJY5dr6mWjHBKQuohcP99HcioFiouGuEBWEJDMbgLDD89hvJiT1wD94FnuQcSzE4QsxWDv2AQbiitk7EbNvE8mmT17M")),
 				},
@@ -551,7 +551,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "eth",
 				Name:     "ethereum 2",
 				Code:     "v0-55555555-eth-1",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewEthereumConfiguration(fingerprint, mustKeypath("m/44'/60'/0'/0/1"), mustXKey("xpub6GP83vJASH1kUpndXSe3e942omyTYSPKaav6shfic7Lc3rFJR9ctA3AXaTf7rX7PuSZNUnaqj4hiqgnRXr26jitBz4jLhmFURtVxDykHbQm")),
 				},
 			},
@@ -578,7 +578,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "btc",
 				Name:     "bitcoin 1: bech32",
 				Code:     "v0-55555555-btc-0-p2wpkh",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/0'/0'"), mustXKey("xpub6Cxa67Bfe1Aw5VvLM1Ppua9x28CXH1zUYoAuBzFRjR6hWnA6aUcny84KYkeVcZWnWXxKSkxCEyMA8xic54ydBPWm5oziXpsXq6nX8FELMQn")),
 				},
 			},
@@ -589,7 +589,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "btc",
 				Name:     "bitcoin 1",
 				Code:     "v0-55555555-btc-0-p2wpkh-p2sh",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, fingerprint, mustKeypath("m/49'/0'/0'"), mustXKey("xpub6CUmEcJb7juvnw7fFYybCwvCJuPSEdhTWZCep9X1DBznwB8RRKTYBUidbEPJ9L7ExjrXhem9S759cX3BpzSUSoP2rWh9vqumJ9MPSAbi98F")),
 				},
 			},
@@ -600,7 +600,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "btc",
 				Name:     "bitcoin 1: legacy",
 				Code:     "v0-55555555-btc-0-p2pkh",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2PKH, fingerprint, mustKeypath("m/44'/0'/0'"), mustXKey("xpub6D7KuxJsw7N2LtWPQKy6Tqs8vFyKudiDqcx6mtsFXT6FDb8oLcUYRjf7G4Qx8CK4DAQ4kN98n7uDCKmazxaHYLNjwDbJ1nKmDm6QEQCwkGC")),
 				},
 			},
@@ -621,7 +621,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "ltc",
 				Name:     "litecoin 1: bech32",
 				Code:     "v0-55555555-ltc-0-p2wpkh",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/2'/0'"), mustXKey("xpub6DReBHtKxgeZGBKTaaF1GjeBHa8dZwQpRfgYr3kxt782s8KKqio2pR6piBsiqHEPF7Rg3onMkwt9XrSxNTuW4N1VBjVbn6DQ3GPCBEUgtgP")),
 				},
 			},
@@ -632,7 +632,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 				CoinCode: "ltc",
 				Name:     "litecoin 1",
 				Code:     "v0-55555555-ltc-0-p2wpkh-p2sh",
-				Configurations: signing.Configurations{
+				SigningConfigurations: signing.Configurations{
 					signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKHP2SH, fingerprint, mustKeypath("m/49'/2'/0'"), mustXKey("xpub6CrhULuXbYzo7gXNhSNZ6tzgfMWpwRFEisekvFfuWLtpXcV4jfvWf5yCuhRBvhZoisH4JCVp4ddGEi7XF2QE2S4N8pMkirJbp7N2TF5p5qQ")),
 				},
 			},
@@ -723,7 +723,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 		&config.Account{
 			Code: "test-btc-account-code",
 			Name: "Bitcoin account name",
-			Configurations: signing.Configurations{
+			SigningConfigurations: signing.Configurations{
 				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/0'/0'"), mustXKey("xpub6Cxa67Bfe1Aw5VvLM1Ppua9x28CXH1zUYoAuBzFRjR6hWnA6aUcny84KYkeVcZWnWXxKSkxCEyMA8xic54ydBPWm5oziXpsXq6nX8FELMQn")),
 			},
 		},
@@ -744,7 +744,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 		&config.Account{
 			Code: "test-ltc-account-code",
 			Name: "Litecoin account name",
-			Configurations: signing.Configurations{
+			SigningConfigurations: signing.Configurations{
 				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/2'/0'"), mustXKey("xpub6DReBHtKxgeZGBKTaaF1GjeBHa8dZwQpRfgYr3kxt782s8KKqio2pR6piBsiqHEPF7Rg3onMkwt9XrSxNTuW4N1VBjVbn6DQ3GPCBEUgtgP")),
 			},
 		},
@@ -765,7 +765,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 		&config.Account{
 			Code: "test-eth-account-code",
 			Name: "Ethereum account name",
-			Configurations: signing.Configurations{
+			SigningConfigurations: signing.Configurations{
 				signing.NewEthereumConfiguration(fingerprint, mustKeypath("m/44'/60'/0'/0/0"), mustXKey("xpub6GP83vJASH1kS7dQPWXFjVHDfYajopbG8U3j8peBH67CRCnb8QmDxZJfWpbgCQNHAzCDJ4MyVYjoh7Yv9yo7PQuZ9YyktgrtD9vmeo67Y4E")),
 			},
 			ActiveTokens: []string{"eth-erc20-mkr"},
@@ -796,7 +796,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 			Code: "test-eth-account-code-2",
 			Name: "Ethereum account name 2",
 
-			Configurations: signing.Configurations{
+			SigningConfigurations: signing.Configurations{
 				signing.NewEthereumConfiguration(fingerprint, mustKeypath("m/44'/60'/0'/0/1"), mustXKey("xpub6GP83vJASH1kUpndXSe3e942omyTYSPKaav6shfic7Lc3rFJR9ctA3AXaTf7rX7PuSZNUnaqj4hiqgnRXr26jitBz4jLhmFURtVxDykHbQm")),
 			},
 			ActiveTokens: []string{"eth-erc20-usdt", "eth-erc20-bat"},
@@ -1058,16 +1058,16 @@ func TestTaprootUpgrade(t *testing.T) {
 	ltcAccount := lookup(b.Accounts(), "v0-55555555-ltc-0")
 	require.NotNil(t, ltcAccount)
 	require.Equal(t, coinpkg.CodeBTC, btcAccount.Coin().Code())
-	require.Len(t, btcAccount.Config().Config.Configurations, 2)
-	require.Len(t, ltcAccount.Config().Config.Configurations, 2)
+	require.Len(t, btcAccount.Config().Config.SigningConfigurations, 2)
+	require.Len(t, ltcAccount.Config().Config.SigningConfigurations, 2)
 	require.Equal(t,
-		signing.ScriptTypeP2WPKH, btcAccount.Config().Config.Configurations[0].ScriptType())
+		signing.ScriptTypeP2WPKH, btcAccount.Config().Config.SigningConfigurations[0].ScriptType())
 	require.Equal(t,
-		signing.ScriptTypeP2WPKHP2SH, btcAccount.Config().Config.Configurations[1].ScriptType())
+		signing.ScriptTypeP2WPKHP2SH, btcAccount.Config().Config.SigningConfigurations[1].ScriptType())
 	// Same for the persisted account config.
 	require.Equal(t,
-		btcAccount.Config().Config.Configurations,
-		b.Config().AccountsConfig().Lookup("v0-55555555-btc-0").Configurations)
+		btcAccount.Config().Config.SigningConfigurations,
+		b.Config().AccountsConfig().Lookup("v0-55555555-btc-0").SigningConfigurations)
 
 	// "Unplug", then insert an updated keystore with taproot support.
 	b.DeregisterKeystore()
@@ -1079,17 +1079,17 @@ func TestTaprootUpgrade(t *testing.T) {
 	ltcAccount = lookup(b.Accounts(), "v0-55555555-ltc-0")
 	require.NotNil(t, ltcAccount)
 	require.Equal(t, coinpkg.CodeBTC, b.Accounts()[0].Coin().Code())
-	require.Len(t, btcAccount.Config().Config.Configurations, 3)
+	require.Len(t, btcAccount.Config().Config.SigningConfigurations, 3)
 	// LTC (coin with no taproot support) unchanged.
-	require.Len(t, ltcAccount.Config().Config.Configurations, 2)
+	require.Len(t, ltcAccount.Config().Config.SigningConfigurations, 2)
 	require.Equal(t,
-		signing.ScriptTypeP2WPKH, btcAccount.Config().Config.Configurations[0].ScriptType())
+		signing.ScriptTypeP2WPKH, btcAccount.Config().Config.SigningConfigurations[0].ScriptType())
 	require.Equal(t,
-		signing.ScriptTypeP2WPKHP2SH, btcAccount.Config().Config.Configurations[1].ScriptType())
+		signing.ScriptTypeP2WPKHP2SH, btcAccount.Config().Config.SigningConfigurations[1].ScriptType())
 	require.Equal(t,
-		signing.ScriptTypeP2TR, btcAccount.Config().Config.Configurations[2].ScriptType())
+		signing.ScriptTypeP2TR, btcAccount.Config().Config.SigningConfigurations[2].ScriptType())
 	// Same for the persisted account config.
 	require.Equal(t,
-		btcAccount.Config().Config.Configurations,
-		b.Config().AccountsConfig().Lookup("v0-55555555-btc-0").Configurations)
+		btcAccount.Config().Config.SigningConfigurations,
+		b.Config().AccountsConfig().Lookup("v0-55555555-btc-0").SigningConfigurations)
 }

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/arguments"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/blockchain"
@@ -93,7 +94,7 @@ func TestSortAccounts(t *testing.T) {
 		{Code: "acct-tbtc", CoinCode: coinpkg.CodeTBTC},
 	}
 	sortAccounts(accts)
-	expectedOrder := []accounts.Code{
+	expectedOrder := []accountsTypes.Code{
 		"acct-btc-1",
 		"acct-btc-2",
 		"acct-btc-3",
@@ -729,7 +730,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 	acct := b.Accounts()[0]
 	_, ok := acct.(*btc.Account)
 	require.True(t, ok)
-	require.Equal(t, accounts.Code("test-btc-account-code"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-btc-account-code"), acct.Config().Code)
 	require.Equal(t, coin, acct.Coin())
 	require.Equal(t, "Bitcoin account name", acct.Config().Name)
 
@@ -748,7 +749,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 	acct = b.Accounts()[1]
 	_, ok = acct.(*btc.Account)
 	require.True(t, ok)
-	require.Equal(t, accounts.Code("test-ltc-account-code"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-ltc-account-code"), acct.Config().Code)
 	require.Equal(t, coin, acct.Coin())
 	require.Equal(t, "Litecoin account name", acct.Config().Name)
 
@@ -769,14 +770,14 @@ func TestCreateAndAddAccount(t *testing.T) {
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.Nil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accounts.Code("test-eth-account-code"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code"), acct.Config().Code)
 	require.Equal(t, coin, acct.Coin())
 	require.Equal(t, "Ethereum account name", acct.Config().Name)
 	acct = b.Accounts()[3]
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.NotNil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accounts.Code("test-eth-account-code-eth-erc20-mkr"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code-eth-erc20-mkr"), acct.Config().Code)
 	require.Equal(t, "Maker", acct.Config().Name)
 
 	// Add another Ethereum account with some active ERC20 tokens.
@@ -796,20 +797,20 @@ func TestCreateAndAddAccount(t *testing.T) {
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.Nil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accounts.Code("test-eth-account-code-2"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code-2"), acct.Config().Code)
 	require.Equal(t, coin, acct.Coin())
 	require.Equal(t, "Ethereum account name 2", acct.Config().Name)
 	acct = b.Accounts()[5]
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.NotNil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accounts.Code("test-eth-account-code-2-eth-erc20-usdt"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code-2-eth-erc20-usdt"), acct.Config().Code)
 	require.Equal(t, "Tether USD 2", acct.Config().Name)
 	acct = b.Accounts()[6]
 	_, ok = acct.(*eth.Account)
 	require.True(t, ok)
 	require.NotNil(t, acct.Coin().(*eth.Coin).ERC20Token())
-	require.Equal(t, accounts.Code("test-eth-account-code-2-eth-erc20-bat"), acct.Config().Code)
+	require.Equal(t, accountsTypes.Code("test-eth-account-code-2-eth-erc20-bat"), acct.Config().Code)
 	require.Equal(t, "Basic Attention Token 2", acct.Config().Name)
 }
 

--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
@@ -44,8 +45,8 @@ var aoppBTCScriptTypeMap = map[string]signing.ScriptType{
 }
 
 type account struct {
-	Name string        `json:"name"`
-	Code accounts.Code `json:"code"`
+	Name string             `json:"name"`
+	Code accountsTypes.Code `json:"code"`
 }
 
 // aoppState is the current state of an AOPP request. See The values below.
@@ -88,7 +89,7 @@ type AOPP struct {
 	Accounts []account `json:"accounts"`
 	// AccountCode is the code of the chosen account from which an address will be taken. Only
 	// applies for states after (and excluding) `aoppStateChoosingAccount`.
-	AccountCode accounts.Code `json:"accountCode"`
+	AccountCode accountsTypes.Code `json:"accountCode"`
 	// Address that will be delivered to the requesting party via the callback. Only applies if
 	// State == aoppStateSigning or aoppStateSuccess.
 	Address string `json:"address"`
@@ -264,7 +265,7 @@ func (backend *Backend) AOPPApprove() {
 
 // aoppChooseAccount is called when an AOPP request is being processed and an account should be
 // selected. `accountsAndKeystoreLock` must be held when calling this function.
-func (backend *Backend) aoppChooseAccount(code accounts.Code) {
+func (backend *Backend) aoppChooseAccount(code accountsTypes.Code) {
 	if backend.aopp.State != aoppStateChoosingAccount {
 		return
 	}
@@ -394,7 +395,7 @@ func (backend *Backend) aoppChooseAccount(code accounts.Code) {
 
 // AOPPChooseAccount is called when an AOPP request is being processed and the user has chosen an
 // account.
-func (backend *Backend) AOPPChooseAccount(code accounts.Code) {
+func (backend *Backend) AOPPChooseAccount(code accountsTypes.Code) {
 	defer backend.accountsAndKeystoreLock.Lock()()
 	backend.aoppChooseAccount(code)
 }

--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -162,7 +162,7 @@ func (backend *Backend) aoppKeystoreRegistered() {
 		// Filter for the requested script type.
 		if acct.Coin().Code() == coinpkg.CodeBTC && backend.aopp.format != "any" {
 			expectedScriptType, ok := aoppBTCScriptTypeMap[backend.aopp.format]
-			if !ok || acct.Config().Config.Configurations.FindScriptType(expectedScriptType) == -1 {
+			if !ok || acct.Config().Config.SigningConfigurations.FindScriptType(expectedScriptType) == -1 {
 				filteredDueToScriptType = true
 				continue
 			}
@@ -307,7 +307,7 @@ func (backend *Backend) aoppChooseAccount(code accountsTypes.Code) {
 			backend.aoppSetError(errAOPPUnknown)
 			return
 		}
-		signingConfigIdx = account.Config().Config.Configurations.FindScriptType(expectedScriptType)
+		signingConfigIdx = account.Config().Config.SigningConfigurations.FindScriptType(expectedScriptType)
 		if signingConfigIdx == -1 {
 			log.Errorf("Unknown aopp format param %s", backend.aopp.format)
 			backend.aoppSetError(errAOPPUnknown)
@@ -327,7 +327,7 @@ func (backend *Backend) aoppChooseAccount(code accountsTypes.Code) {
 		sig, err := backend.keystore.SignBTCMessage(
 			[]byte(backend.aopp.Message),
 			addr.AbsoluteKeypath(),
-			account.Config().Config.Configurations[signingConfigIdx].ScriptType(),
+			account.Config().Config.SigningConfigurations[signingConfigIdx].ScriptType(),
 		)
 		if err != nil {
 			if firmware.IsErrorAbort(err) {

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	keystoremock "github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/mocks"
@@ -93,7 +93,7 @@ func TestAOPPSuccess(t *testing.T) {
 		scriptType  *signing.ScriptType
 		address     string
 		addressID   string
-		accountCode accounts.Code
+		accountCode accountsTypes.Code
 		accountName string
 	}{
 		{

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -496,7 +496,7 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 			log.WithError(err).Error("Could not retrieve root fingerprint")
 			return false
 		}
-		return account.Configurations.ContainsRootFingerprint(fingerprint)
+		return account.SigningConfigurations.ContainsRootFingerprint(fingerprint)
 	}
 	err := backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
 		accounts := backend.filterAccounts(accountsConfig, belongsToKeystore)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/arguments"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/banners"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
@@ -106,9 +107,9 @@ type deviceEvent struct {
 
 // AccountEvent models an event triggered by an account.
 type AccountEvent struct {
-	Type string        `json:"type"`
-	Code accounts.Code `json:"code"`
-	Data string        `json:"data"`
+	Type string             `json:"type"`
+	Code accountsTypes.Code `json:"code"`
+	Data string             `json:"data"`
 }
 
 // Environment represents functionality where the implementation depends on the environment the app
@@ -705,7 +706,7 @@ func (backend *Backend) HandleURI(uri string) {
 // GetAccountFromCode takes an account code as input and returns the corresponding accounts.Interface object,
 // if found. It also initialize the account before returning it.
 func (backend *Backend) GetAccountFromCode(code string) (accounts.Interface, error) {
-	acctCode := accounts.Code(code)
+	acctCode := accountsTypes.Code(code)
 	// TODO: Refactor to make use of a map.
 	var acct accounts.Interface
 	for _, a := range backend.Accounts() {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -261,7 +261,7 @@ func (backend *Backend) notifyNewTxs(account accounts.Interface) {
 	if unnotifiedCount != 0 {
 		backend.events <- backendEvent{Type: "backend", Data: "newTxs", Meta: map[string]interface{}{
 			"count":       unnotifiedCount,
-			"accountName": account.Config().Name,
+			"accountName": account.Config().Config.Name,
 		}}
 
 		if err := notifier.MarkAllNotified(); err != nil {
@@ -710,10 +710,10 @@ func (backend *Backend) GetAccountFromCode(code string) (accounts.Interface, err
 	// TODO: Refactor to make use of a map.
 	var acct accounts.Interface
 	for _, a := range backend.Accounts() {
-		if !a.Config().Active {
+		if a.Config().Config.Inactive {
 			continue
 		}
-		if a.Config().Code == acctCode {
+		if a.Config().Config.Code == acctCode {
 			acct = a
 			break
 		}

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	keystoremock "github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/mocks"
@@ -113,7 +114,7 @@ func TestRegisterKeystore(t *testing.T) {
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-66666666-eth-0"))
 }
 
-func lookup(accts []accounts.Interface, code accounts.Code) accounts.Interface {
+func lookup(accts []accounts.Interface, code accountsTypes.Code) accounts.Interface {
 	for _, acct := range accts {
 		if acct.Config().Code == code {
 			return acct
@@ -174,7 +175,7 @@ func TestAccounts(t *testing.T) {
 	// 2) Add a second BTC account
 	acctCode, err := b.CreateAndPersistAccountConfig(coinpkg.CodeBTC, "A second Bitcoin account", ks)
 	require.NoError(t, err)
-	require.Equal(t, accounts.Code("v0-55555555-btc-1"), acctCode)
+	require.Equal(t, accountsTypes.Code("v0-55555555-btc-1"), acctCode)
 	require.Len(t, b.Accounts(), 4)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 4)
 
@@ -186,8 +187,8 @@ func TestAccounts(t *testing.T) {
 		b.Config().AccountsConfig().Lookup("v0-55555555-eth-0").ActiveTokens,
 	)
 	require.Len(t, b.Accounts(), 6)
-	require.Equal(t, accounts.Code("v0-55555555-eth-0-eth-erc20-usdt"), b.Accounts()[4].Config().Code)
-	require.Equal(t, accounts.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[5].Config().Code)
+	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-usdt"), b.Accounts()[4].Config().Code)
+	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[5].Config().Code)
 
 	// 4) Deactivate an ETH token
 	require.NoError(t, b.SetTokenActive("v0-55555555-eth-0", "eth-erc20-usdt", false))
@@ -196,7 +197,7 @@ func TestAccounts(t *testing.T) {
 		b.Config().AccountsConfig().Lookup("v0-55555555-eth-0").ActiveTokens,
 	)
 	require.Len(t, b.Accounts(), 5)
-	require.Equal(t, accounts.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[4].Config().Code)
+	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[4].Config().Code)
 
 	// 5) Rename an account
 	require.NoError(t, b.RenameAccount("v0-55555555-eth-0", "My ETH"))

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -116,7 +116,7 @@ func TestRegisterKeystore(t *testing.T) {
 
 func lookup(accts []accounts.Interface, code accountsTypes.Code) accounts.Interface {
 	for _, acct := range accts {
-		if acct.Config().Code == code {
+		if acct.Config().Config.Code == code {
 			return acct
 		}
 	}
@@ -187,8 +187,8 @@ func TestAccounts(t *testing.T) {
 		b.Config().AccountsConfig().Lookup("v0-55555555-eth-0").ActiveTokens,
 	)
 	require.Len(t, b.Accounts(), 6)
-	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-usdt"), b.Accounts()[4].Config().Code)
-	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[5].Config().Code)
+	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-usdt"), b.Accounts()[4].Config().Config.Code)
+	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[5].Config().Config.Code)
 
 	// 4) Deactivate an ETH token
 	require.NoError(t, b.SetTokenActive("v0-55555555-eth-0", "eth-erc20-usdt", false))
@@ -197,19 +197,19 @@ func TestAccounts(t *testing.T) {
 		b.Config().AccountsConfig().Lookup("v0-55555555-eth-0").ActiveTokens,
 	)
 	require.Len(t, b.Accounts(), 5)
-	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[4].Config().Code)
+	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[4].Config().Config.Code)
 
 	// 5) Rename an account
 	require.NoError(t, b.RenameAccount("v0-55555555-eth-0", "My ETH"))
 	require.Equal(t, "My ETH", b.Config().AccountsConfig().Lookup("v0-55555555-eth-0").Name)
-	require.Equal(t, "My ETH", lookup(b.Accounts(), "v0-55555555-eth-0").Config().Name)
+	require.Equal(t, "My ETH", lookup(b.Accounts(), "v0-55555555-eth-0").Config().Config.Name)
 
 	// 6) Deactivate an ETH account - it also deactivates the tokens.
 	require.NoError(t, b.SetAccountActive("v0-55555555-eth-0", false))
-	require.False(t, lookup(b.Accounts(), "v0-55555555-eth-0").Config().Active)
+	require.True(t, lookup(b.Accounts(), "v0-55555555-eth-0").Config().Config.Inactive)
 
 	// 7) Rename an inactive account.
 	require.NoError(t, b.RenameAccount("v0-55555555-eth-0", "My ETH Renamed"))
 	require.Equal(t, "My ETH Renamed", b.Config().AccountsConfig().Lookup("v0-55555555-eth-0").Name)
-	require.Equal(t, "My ETH Renamed", lookup(b.Accounts(), "v0-55555555-eth-0").Config().Name)
+	require.Equal(t, "My ETH Renamed", lookup(b.Accounts(), "v0-55555555-eth-0").Config().Config.Name)
 }

--- a/backend/chart.go
+++ b/backend/chart.go
@@ -30,7 +30,7 @@ import (
 func (backend *Backend) allCoinCodes() []string {
 	allCoinCodes := []string{}
 	for _, account := range backend.Accounts() {
-		if !account.Config().Active {
+		if account.Config().Config.Inactive {
 			continue
 		}
 		if account.FatalError() {
@@ -136,7 +136,7 @@ func (backend *Backend) ChartData() (*Chart, error) {
 	// Total number of transactions across all active accounts.
 	totalNumberOfTransactions := 0
 	for _, account := range backend.Accounts() {
-		if !account.Config().Active {
+		if account.Config().Config.Inactive {
 			continue
 		}
 		if account.FatalError() {

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -128,7 +128,7 @@ func NewAccount(
 	log *logrus.Entry,
 ) *Account {
 	log = log.WithField("group", "btc").
-		WithFields(logrus.Fields{"coin": coin.String(), "code": config.Code, "name": config.Name})
+		WithFields(logrus.Fields{"coin": coin.String(), "code": config.Config.Code, "name": config.Config.Name})
 	log.Debug("Creating new account")
 
 	account := &Account{
@@ -151,7 +151,7 @@ func NewAccount(
 
 // String returns a representation of the account for logging.
 func (account *Account) String() string {
-	return fmt.Sprintf("%s-%s", account.Coin().Code(), account.Config().Code)
+	return fmt.Sprintf("%s-%s", account.Coin().Code(), account.Config().Config.Code)
 }
 
 // FilesFolder implements accounts.Interface.
@@ -285,13 +285,13 @@ func (account *Account) Initialize() error {
 	}
 	account.initialized = true
 
-	signingConfigurations := account.Config().SigningConfigurations
+	signingConfigurations := account.Config().Config.Configurations
 	if len(signingConfigurations) == 0 {
 		return errp.New("There must be a least one signing configuration")
 	}
 	account.notifier = account.Config().GetNotifier(signingConfigurations)
 
-	accountIdentifier := fmt.Sprintf("account-%s", account.Config().Code)
+	accountIdentifier := fmt.Sprintf("account-%s", account.Config().Config.Code)
 	account.dbSubfolder = path.Join(account.Config().DBFolder, accountIdentifier)
 	if err := os.MkdirAll(account.dbSubfolder, 0700); err != nil {
 		return errp.WithStack(err)
@@ -556,7 +556,7 @@ func (account *Account) incAndEmitSyncCounter() {
 	if !account.Synced() {
 		synced := atomic.AddUint32(&account.syncedAddressesCount, 1)
 		account.Notify(observable.Event{
-			Subject: fmt.Sprintf("account/%s/synced-addresses-count", account.Config().Code),
+			Subject: fmt.Sprintf("account/%s/synced-addresses-count", account.Config().Config.Code),
 			Action:  action.Replace,
 			Object:  synced,
 		})

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -28,6 +28,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/addresses"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/blockchain"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/db/transactionsdb"
@@ -325,7 +326,7 @@ func (account *Account) Initialize() error {
 	theHeaders := account.coin.Headers()
 	theHeaders.SubscribeEvent(func(event headers.Event) {
 		if event == headers.EventSynced {
-			account.Config().OnEvent(accounts.EventHeadersSynced)
+			account.Config().OnEvent(accountsTypes.EventHeadersSynced)
 		}
 	})
 	account.transactions = transactions.NewTransactions(
@@ -453,7 +454,7 @@ func (account *Account) Close() {
 		account.log.Info("Closed DB")
 	}
 
-	account.Config().OnEvent(accounts.EventStatusChanged)
+	account.Config().OnEvent(accountsTypes.EventStatusChanged)
 	account.closed = true
 }
 
@@ -497,7 +498,7 @@ func (account *Account) updateFeeTargets() {
 		feeTarget.feeRatePerKb = &feeRatePerKb
 		account.log.WithFields(logrus.Fields{"blocks": feeTarget.blocks,
 			"fee-rate-per-kb": feeRatePerKb}).Debug("Fee estimate per kb")
-		account.Config().OnEvent(accounts.EventFeeTargetsChanged)
+		account.Config().OnEvent(accountsTypes.EventFeeTargetsChanged)
 	}
 }
 
@@ -605,7 +606,7 @@ func (account *Account) onAddressStatus(address *addresses.AccountAddress, statu
 		// We are not closing client.blockchain here, as it is reused per coin with
 		// different accounts.
 		account.fatalError.Store(true)
-		account.Config().OnEvent(accounts.EventStatusChanged)
+		account.Config().OnEvent(accountsTypes.EventStatusChanged)
 		return
 	}
 

--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -285,7 +285,7 @@ func (account *Account) Initialize() error {
 	}
 	account.initialized = true
 
-	signingConfigurations := account.Config().Config.Configurations
+	signingConfigurations := account.Config().Config.SigningConfigurations
 	if len(signingConfigurations) == 0 {
 		return errp.New("There must be a least one signing configuration")
 	}

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/blockchain"
 	blockchainMock "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/blockchain/mocks"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/socksproxy"
@@ -66,15 +67,17 @@ func TestAccount(t *testing.T) {
 
 	account := btc.NewAccount(
 		&accounts.AccountConfig{
-			Code:                  "accountcode",
-			Name:                  "accountname",
-			DBFolder:              dbFolder,
-			Keystore:              nil,
-			OnEvent:               func(accountsTypes.Event) {},
-			RateUpdater:           nil,
-			SigningConfigurations: signingConfigurations,
-			GetNotifier:           func(signing.Configurations) accounts.Notifier { return nil },
-			GetSaveFilename:       func(suggestedFilename string) string { return suggestedFilename },
+			Config: &config.Account{
+				Code:           "accountcode",
+				Name:           "accountname",
+				Configurations: signingConfigurations,
+			},
+			DBFolder:        dbFolder,
+			Keystore:        nil,
+			OnEvent:         func(accountsTypes.Event) {},
+			RateUpdater:     nil,
+			GetNotifier:     func(signing.Configurations) accounts.Notifier { return nil },
+			GetSaveFilename: func(suggestedFilename string) string { return suggestedFilename },
 		},
 		coin, nil,
 		logging.Get().WithGroup("account_test"),

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/blockchain"
 	blockchainMock "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/blockchain/mocks"
@@ -69,7 +70,7 @@ func TestAccount(t *testing.T) {
 			Name:                  "accountname",
 			DBFolder:              dbFolder,
 			Keystore:              nil,
-			OnEvent:               func(accounts.Event) {},
+			OnEvent:               func(accountsTypes.Event) {},
 			RateUpdater:           nil,
 			SigningConfigurations: signingConfigurations,
 			GetNotifier:           func(signing.Configurations) accounts.Notifier { return nil },

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -68,9 +68,9 @@ func TestAccount(t *testing.T) {
 	account := btc.NewAccount(
 		&accounts.AccountConfig{
 			Config: &config.Account{
-				Code:           "accountcode",
-				Name:           "accountname",
-				Configurations: signingConfigurations,
+				Code:                  "accountcode",
+				Name:                  "accountname",
+				SigningConfigurations: signingConfigurations,
 			},
 			DBFolder:        dbFolder,
 			Keystore:        nil,

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -252,7 +252,7 @@ func (handlers *Handlers) postExportTransactions(_ *http.Request) (interface{}, 
 		Success      bool   `json:"success"`
 		ErrorMessage string `json:"errorMessage"`
 	}
-	name := fmt.Sprintf("%s-%s-export.csv", time.Now().Format("2006-01-02-at-15-04-05"), handlers.account.Config().Code)
+	name := fmt.Sprintf("%s-%s-export.csv", time.Now().Format("2006-01-02-at-15-04-05"), handlers.account.Config().Config.Code)
 	downloadsDir, err := config.DownloadsDir()
 	if err != nil {
 		handlers.log.WithError(err).Error("error exporting account")

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -100,7 +100,7 @@ func NewAccount(
 	log *logrus.Entry,
 ) *Account {
 	log = log.WithField("group", "eth").
-		WithFields(logrus.Fields{"coin": accountCoin.String(), "code": config.Code, "name": config.Name})
+		WithFields(logrus.Fields{"coin": accountCoin.String(), "code": config.Config.Code, "name": config.Config.Name})
 	log.Debug("Creating new account")
 
 	account := &Account{
@@ -153,7 +153,7 @@ func (account *Account) Initialize() error {
 	}
 	account.initialized = true
 
-	signingConfigurations := account.Config().SigningConfigurations
+	signingConfigurations := account.Config().Config.Configurations
 	if len(signingConfigurations) != 1 {
 		return errp.New("Ethereum only supports one signing config")
 	}
@@ -162,7 +162,7 @@ func (account *Account) Initialize() error {
 	account.signingConfiguration = signingConfiguration
 	account.notifier = account.Config().GetNotifier(signingConfigurations)
 
-	accountIdentifier := fmt.Sprintf("account-%s", account.Config().Code)
+	accountIdentifier := fmt.Sprintf("account-%s", account.Config().Config.Code)
 	account.dbSubfolder = path.Join(account.Config().DBFolder, accountIdentifier)
 	if err := os.MkdirAll(account.dbSubfolder, 0700); err != nil {
 		return errp.WithStack(err)

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/errors"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/db"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/erc20"
@@ -413,7 +414,7 @@ func (account *Account) Close() {
 		account.log.Info("Closed DB")
 	}
 	close(account.quitChan)
-	account.Config().OnEvent(accounts.EventStatusChanged)
+	account.Config().OnEvent(accountsTypes.EventStatusChanged)
 }
 
 // Notifier implements accounts.Interface.

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -153,7 +153,7 @@ func (account *Account) Initialize() error {
 	}
 	account.initialized = true
 
-	signingConfigurations := account.Config().Config.Configurations
+	signingConfigurations := account.Config().Config.SigningConfigurations
 	if len(signingConfigurations) != 1 {
 		return errp.New("Ethereum only supports one signing config")
 	}

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -83,9 +83,9 @@ func newAccount(t *testing.T) *Account {
 	acct := NewAccount(
 		&accounts.AccountConfig{
 			Config: &config.Account{
-				Code:           "accountcode",
-				Name:           "accountname",
-				Configurations: signingConfigurations,
+				Code:                  "accountcode",
+				Name:                  "accountname",
+				SigningConfigurations: signingConfigurations,
 			},
 			DBFolder:        dbFolder,
 			Keystore:        nil,

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/errors"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/rpcclient/mocks"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
@@ -84,7 +85,7 @@ func newAccount(t *testing.T) *Account {
 			Name:                  "accountname",
 			DBFolder:              dbFolder,
 			Keystore:              nil,
-			OnEvent:               func(accounts.Event) {},
+			OnEvent:               func(accountsTypes.Event) {},
 			RateUpdater:           nil,
 			SigningConfigurations: signingConfigurations,
 			GetNotifier:           func(signing.Configurations) accounts.Notifier { return nil },

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -28,6 +28,7 @@ import (
 	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/rpcclient/mocks"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
@@ -81,15 +82,17 @@ func newAccount(t *testing.T) *Account {
 	coin := NewCoin(client, coin.CodeGOETH, "Goerli", "GOETH", "GOETH", params.GoerliChainConfig, "", nil, nil)
 	acct := NewAccount(
 		&accounts.AccountConfig{
-			Code:                  "accountcode",
-			Name:                  "accountname",
-			DBFolder:              dbFolder,
-			Keystore:              nil,
-			OnEvent:               func(accountsTypes.Event) {},
-			RateUpdater:           nil,
-			SigningConfigurations: signingConfigurations,
-			GetNotifier:           func(signing.Configurations) accounts.Notifier { return nil },
-			GetSaveFilename:       func(suggestedFilename string) string { return suggestedFilename },
+			Config: &config.Account{
+				Code:           "accountcode",
+				Name:           "accountname",
+				Configurations: signingConfigurations,
+			},
+			DBFolder:        dbFolder,
+			Keystore:        nil,
+			OnEvent:         func(accountsTypes.Event) {},
+			RateUpdater:     nil,
+			GetNotifier:     func(signing.Configurations) accounts.Notifier { return nil },
+			GetSaveFilename: func(suggestedFilename string) string { return suggestedFilename },
 		},
 		coin,
 		&http.Client{},

--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -26,11 +26,11 @@ import (
 type Account struct {
 	// Inactive is true if the account should not be loaded in the sidebar and portfolio. It will
 	// still be shown in 'Manage accounts'.
-	Inactive       bool                   `json:"inactive"`
-	CoinCode       coin.Code              `json:"coinCode"`
-	Name           string                 `json:"name"`
-	Code           accountsTypes.Code     `json:"code"`
-	Configurations signing.Configurations `json:"configurations"`
+	Inactive              bool                   `json:"inactive"`
+	CoinCode              coin.Code              `json:"coinCode"`
+	Name                  string                 `json:"name"`
+	Code                  accountsTypes.Code     `json:"code"`
+	SigningConfigurations signing.Configurations `json:"configurations"`
 	// ActiveTokens list the tokens that should be loaded along with the account.  Currently, this
 	// only applies to ETH, and the elements are ERC20 token codes (e.g. "eth-erc20-usdt",
 	// "eth-erc20-bat", etc).

--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -16,7 +16,7 @@
 package config
 
 import (
-	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
@@ -29,7 +29,7 @@ type Account struct {
 	Inactive       bool                   `json:"inactive"`
 	CoinCode       coin.Code              `json:"coinCode"`
 	Name           string                 `json:"name"`
-	Code           accounts.Code          `json:"code"`
+	Code           accountsTypes.Code     `json:"code"`
 	Configurations signing.Configurations `json:"configurations"`
 	// ActiveTokens list the tokens that should be loaded along with the account.  Currently, this
 	// only applies to ETH, and the elements are ERC20 token codes (e.g. "eth-erc20-usdt",
@@ -70,7 +70,7 @@ func newDefaultAccountsonfig() AccountsConfig {
 
 // Lookup returns the account with the given code, or nil if no such account exists.
 // A reference is returned, so the account can be modified by the caller.
-func (cfg AccountsConfig) Lookup(code accounts.Code) *Account {
+func (cfg AccountsConfig) Lookup(code accountsTypes.Code) *Account {
 	for i := range cfg.Accounts {
 		acct := &cfg.Accounts[i]
 		if acct.Code == code {

--- a/backend/exchanges/pocket.go
+++ b/backend/exchanges/pocket.go
@@ -144,7 +144,7 @@ func PocketWidgetSignAddress(account accounts.Interface, message string, format 
 		err := fmt.Errorf("Unknown format:  %s", format)
 		return "", "", err
 	}
-	signingConfigIdx := account.Config().Config.Configurations.FindScriptType(expectedScriptType)
+	signingConfigIdx := account.Config().Config.SigningConfigurations.FindScriptType(expectedScriptType)
 	if signingConfigIdx == -1 {
 		err := fmt.Errorf("Unknown format: %s", format)
 		return "", "", err
@@ -154,7 +154,7 @@ func PocketWidgetSignAddress(account accounts.Interface, message string, format 
 	sig, err := account.Config().Keystore.SignBTCMessage(
 		[]byte(message),
 		addr.AbsoluteKeypath(),
-		account.Config().Config.Configurations[signingConfigIdx].ScriptType(),
+		account.Config().Config.SigningConfigurations[signingConfigIdx].ScriptType(),
 	)
 	if err != nil {
 		return "", "", err

--- a/backend/exchanges/pocket.go
+++ b/backend/exchanges/pocket.go
@@ -144,7 +144,7 @@ func PocketWidgetSignAddress(account accounts.Interface, message string, format 
 		err := fmt.Errorf("Unknown format:  %s", format)
 		return "", "", err
 	}
-	signingConfigIdx := account.Config().SigningConfigurations.FindScriptType(expectedScriptType)
+	signingConfigIdx := account.Config().Config.Configurations.FindScriptType(expectedScriptType)
 	if signingConfigIdx == -1 {
 		err := fmt.Errorf("Unknown format: %s", format)
 		return "", "", err
@@ -154,7 +154,7 @@ func PocketWidgetSignAddress(account accounts.Interface, message string, format 
 	sig, err := account.Config().Keystore.SignBTCMessage(
 		[]byte(message),
 		addr.AbsoluteKeypath(),
-		account.Config().SigningConfigurations[signingConfigIdx].ScriptType(),
+		account.Config().Config.Configurations[signingConfigIdx].ScriptType(),
 	)
 	if err != nil {
 		return "", "", err

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/digitalbitbox/bitbox-wallet-app/backend"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/banners"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
 	accountHandlers "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/handlers"
@@ -96,14 +97,14 @@ type Backend interface {
 	ChartData() (*backend.Chart, error)
 	SupportedCoins(keystore.Keystore) []coinpkg.Code
 	CanAddAccount(coinpkg.Code, keystore.Keystore) (string, bool)
-	CreateAndPersistAccountConfig(coinCode coinpkg.Code, name string, keystore keystore.Keystore) (accounts.Code, error)
-	SetAccountActive(accountCode accounts.Code, active bool) error
-	SetTokenActive(accountCode accounts.Code, tokenCode string, active bool) error
-	RenameAccount(accountCode accounts.Code, name string) error
+	CreateAndPersistAccountConfig(coinCode coinpkg.Code, name string, keystore keystore.Keystore) (accountsTypes.Code, error)
+	SetAccountActive(accountCode accountsTypes.Code, active bool) error
+	SetTokenActive(accountCode accountsTypes.Code, tokenCode string, active bool) error
+	RenameAccount(accountCode accountsTypes.Code, name string) error
 	AOPP() backend.AOPP
 	AOPPCancel()
 	AOPPApprove()
-	AOPPChooseAccount(code accounts.Code)
+	AOPPChooseAccount(code accountsTypes.Code)
 	GetAccountFromCode(code string) (accounts.Interface, error)
 	HTTPClient() *http.Client
 }
@@ -226,8 +227,8 @@ func NewHandlers(
 
 	handlersMapLock := locker.Locker{}
 
-	accountHandlersMap := map[accounts.Code]*accountHandlers.Handlers{}
-	getAccountHandlers := func(accountCode accounts.Code) *accountHandlers.Handlers {
+	accountHandlersMap := map[accountsTypes.Code]*accountHandlers.Handlers{}
+	getAccountHandlers := func(accountCode accountsTypes.Code) *accountHandlers.Handlers {
 		defer handlersMapLock.Lock()()
 		if _, ok := accountHandlersMap[accountCode]; !ok {
 			accountHandlersMap[accountCode] = accountHandlers.NewHandlers(getAPIRouter(
@@ -327,19 +328,19 @@ type activeToken struct {
 	TokenCode string `json:"tokenCode"`
 	// AccountCode is the code of the account, which is not the same as the TokenCode, as there can
 	// be many accounts for the same token.
-	AccountCode accounts.Code `json:"accountCode"`
+	AccountCode accountsTypes.Code `json:"accountCode"`
 }
 
 type accountJSON struct {
-	Active                bool          `json:"active"`
-	CoinCode              coinpkg.Code  `json:"coinCode"`
-	CoinUnit              string        `json:"coinUnit"`
-	CoinName              string        `json:"coinName"`
-	Code                  accounts.Code `json:"code"`
-	Name                  string        `json:"name"`
-	IsToken               bool          `json:"isToken"`
-	ActiveTokens          []activeToken `json:"activeTokens,omitempty"`
-	BlockExplorerTxPrefix string        `json:"blockExplorerTxPrefix"`
+	Active                bool               `json:"active"`
+	CoinCode              coinpkg.Code       `json:"coinCode"`
+	CoinUnit              string             `json:"coinUnit"`
+	CoinName              string             `json:"coinName"`
+	Code                  accountsTypes.Code `json:"code"`
+	Name                  string             `json:"name"`
+	IsToken               bool               `json:"isToken"`
+	ActiveTokens          []activeToken      `json:"activeTokens,omitempty"`
+	BlockExplorerTxPrefix string             `json:"blockExplorerTxPrefix"`
 }
 
 func newAccountJSON(account accounts.Interface, activeTokens []activeToken) *accountJSON {
@@ -453,10 +454,10 @@ func (handlers *Handlers) postAddAccountHandler(r *http.Request) (interface{}, e
 	}
 
 	type response struct {
-		Success      bool          `json:"success"`
-		AccountCode  accounts.Code `json:"accountCode,omitempty"`
-		ErrorMessage string        `json:"errorMessage,omitempty"`
-		ErrorCode    string        `json:"errorCode,omitempty"`
+		Success      bool               `json:"success"`
+		AccountCode  accountsTypes.Code `json:"accountCode,omitempty"`
+		ErrorMessage string             `json:"errorMessage,omitempty"`
+		ErrorCode    string             `json:"errorCode,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&jsonBody); err != nil {
@@ -608,8 +609,8 @@ func (handlers *Handlers) getAccountsTotalBalanceHandler(_ *http.Request) (inter
 
 func (handlers *Handlers) postSetAccountActiveHandler(r *http.Request) (interface{}, error) {
 	var jsonBody struct {
-		AccountCode accounts.Code `json:"accountCode"`
-		Active      bool          `json:"active"`
+		AccountCode accountsTypes.Code `json:"accountCode"`
+		Active      bool               `json:"active"`
 	}
 
 	type response struct {
@@ -628,9 +629,9 @@ func (handlers *Handlers) postSetAccountActiveHandler(r *http.Request) (interfac
 
 func (handlers *Handlers) postSetTokenActiveHandler(r *http.Request) (interface{}, error) {
 	var jsonBody struct {
-		AccountCode accounts.Code `json:"accountCode"`
-		TokenCode   string        `json:"tokenCode"`
-		Active      bool          `json:"active"`
+		AccountCode accountsTypes.Code `json:"accountCode"`
+		TokenCode   string             `json:"tokenCode"`
+		Active      bool               `json:"active"`
 	}
 
 	type response struct {
@@ -649,8 +650,8 @@ func (handlers *Handlers) postSetTokenActiveHandler(r *http.Request) (interface{
 
 func (handlers *Handlers) postRenameAccountHandler(r *http.Request) (interface{}, error) {
 	var jsonBody struct {
-		AccountCode accounts.Code `json:"accountCode"`
-		Name        string        `json:"name"`
+		AccountCode accountsTypes.Code `json:"accountCode"`
+		Name        string             `json:"name"`
 	}
 
 	type response struct {
@@ -1264,7 +1265,7 @@ func (handlers *Handlers) getAOPPHandler(r *http.Request) (interface{}, error) {
 
 func (handlers *Handlers) postAOPPChooseAccountHandler(r *http.Request) (interface{}, error) {
 	var request struct {
-		AccountCode accounts.Code `json:"accountCode"`
+		AccountCode accountsTypes.Code `json:"accountCode"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, errp.WithStack(err)

--- a/backend/notifier.go
+++ b/backend/notifier.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"go.etcd.io/bbolt"
 )
@@ -48,11 +49,11 @@ func (notifier *Notifier) Close() error {
 
 type notifierForAccount struct {
 	db          *bbolt.DB
-	accountCode accounts.Code
+	accountCode accountsTypes.Code
 }
 
 // ForAccount returns a Notifier for a specific account.
-func (notifier *Notifier) ForAccount(accountCode accounts.Code) accounts.Notifier {
+func (notifier *Notifier) ForAccount(accountCode accountsTypes.Code) accounts.Notifier {
 	return &notifierForAccount{db: notifier.db, accountCode: accountCode}
 }
 


### PR DESCRIPTION
accounts.AccountConfig and config.Account have lots of duplicate
fields. Code can be simplifed by reusing the latter in the former.
