### PR TITLE
backend: sort accounts in Accounts()

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -31,6 +31,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable/action"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // hardenedKeystart is the BIP44 offset to make a keypath element hardened.
@@ -43,36 +44,67 @@ const hardenedKeystart uint32 = hdkeychain.HardenedKeyStart
 const accountsHardLimit = 5
 
 // sortAccounts sorts the accounts in-place by 1) coin 2) account number.
-func sortAccounts(accounts []*config.Account) {
-	compareCoin := func(coin1, coin2 coinpkg.Code) int {
-		order := map[coinpkg.Code]int{
-			coinpkg.CodeBTC:   0,
-			coinpkg.CodeTBTC:  1,
-			coinpkg.CodeLTC:   2,
-			coinpkg.CodeTLTC:  3,
-			coinpkg.CodeETH:   4,
-			coinpkg.CodeGOETH: 6,
+func sortAccounts(accounts []accounts.Interface) {
+	compareCoin := func(coin1, coin2 coinpkg.Coin) int {
+		getOrder := func(c coinpkg.Coin) (int, bool) {
+			order, ok := map[coinpkg.Code]int{
+				coinpkg.CodeBTC:  0,
+				coinpkg.CodeTBTC: 1,
+				coinpkg.CodeLTC:  2,
+				coinpkg.CodeTLTC: 3,
+			}[c.Code()]
+			if ok {
+				return order, true
+			}
+			// We want to sort ETH and ERC20 tokens with the same priority even though they have
+			// different coin codes, so we use the chain ID.
+			ethCoin, ok := c.(*eth.Coin)
+			if ok {
+				switch ethCoin.ChainID() {
+				case params.MainnetChainConfig.ChainID.Uint64():
+					return 4, true
+				case params.GoerliChainConfig.ChainID.Uint64():
+					return 5, true
+				}
+			}
+			return 0, false
 		}
-		order1, ok1 := order[coin1]
-		order2, ok2 := order[coin2]
+		order1, ok1 := getOrder(coin1)
+		order2, ok2 := getOrder(coin2)
 		if !ok1 || !ok2 {
 			// In case we deal with a coin we didn't specify, we fallback to ordering by coin code.
-			return strings.Compare(string(coin1), string(coin2))
+			return strings.Compare(string(coin1.Code()), string(coin2.Code()))
 		}
 		return order1 - order2
 	}
 	less := func(i, j int) bool {
 		acct1 := accounts[i]
 		acct2 := accounts[j]
-		coinCmp := compareCoin(acct1.CoinCode, acct2.CoinCode)
-		if coinCmp == 0 && len(acct1.SigningConfigurations) > 0 && len(acct2.SigningConfigurations) > 0 {
-			signingCfg1 := acct1.SigningConfigurations[0]
-			signingCfg2 := acct2.SigningConfigurations[0]
+		coinCmp := compareCoin(acct1.Coin(), acct2.Coin())
+		if coinCmp == 0 && len(acct1.Config().Config.SigningConfigurations) > 0 && len(acct2.Config().Config.SigningConfigurations) > 0 {
+			signingCfg1 := acct1.Config().Config.SigningConfigurations[0]
+			signingCfg2 := acct2.Config().Config.SigningConfigurations[0]
 			// An error should never happen here, but if it does, we just sort as if it was account
 			// number 0.
 			accountNumber1, _ := signingCfg1.AccountNumber()
 			accountNumber2, _ := signingCfg2.AccountNumber()
-			return accountNumber1 < accountNumber2
+			if accountNumber1 != accountNumber2 {
+				return accountNumber1 < accountNumber2
+			}
+			// Same coin, same account number: for ETH coins, put regular account first, followed by
+			// its children ERC20 token accounts.
+			ethCoin1, ok1 := acct1.Coin().(*eth.Coin)
+			ethCoin2, ok2 := acct2.Coin().(*eth.Coin)
+			if ok1 && ok2 {
+				if ethCoin1.ERC20Token() != nil && ethCoin2.ERC20Token() != nil {
+					// ERC20 tokens sorted by code.
+					return acct1.Config().Config.Code < acct2.Config().Config.Code
+				}
+				// ETH parent account comes before its ERC20 tokens.
+				return ethCoin2.ERC20Token() != nil
+			}
+			// Unspecified account ordering: default to ordering by code.
+			return acct1.Config().Config.Code < acct2.Config().Config.Code
 		}
 		return coinCmp < 0
 	}
@@ -109,7 +141,6 @@ func (backend *Backend) filterAccounts(accountsConfig *config.AccountsConfig, fi
 		}
 		accounts = append(accounts, account)
 	}
-	sortAccounts(accounts)
 	return accounts
 }
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -410,6 +410,7 @@ func (backend *Backend) Testing() bool {
 // Accounts returns the current accounts of the backend.
 func (backend *Backend) Accounts() []accounts.Interface {
 	defer backend.accountsAndKeystoreLock.RLock()()
+	sortAccounts(backend.accounts)
 	return backend.accounts
 }
 

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -187,8 +187,8 @@ func TestAccounts(t *testing.T) {
 		b.Config().AccountsConfig().Lookup("v0-55555555-eth-0").ActiveTokens,
 	)
 	require.Len(t, b.Accounts(), 6)
-	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-usdt"), b.Accounts()[4].Config().Config.Code)
-	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[5].Config().Config.Code)
+	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-bat"), b.Accounts()[4].Config().Config.Code)
+	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0-eth-erc20-usdt"), b.Accounts()[5].Config().Config.Code)
 
 	// 4) Deactivate an ETH token
 	require.NoError(t, b.SetTokenActive("v0-55555555-eth-0", "eth-erc20-usdt", false))


### PR DESCRIPTION
We have persisted accounts in accounts.json and load them into live
accounts.

We want the accounts sorted by coin, account number for the
frontend (sidebar, manage accounts). Until now we sorted the accounts
while loading them from accounts.json.

It is preferable to sort the accounts only when serving them to the
frontend - then we could easily modify the backend.accounts list on
the fly and add accounts without having to call `Reinitialize()`,
which closes all accounts and reloads all of them, just so that the
sorting is correct. When we add automatic accounts discovery, we don't
want to Reinitialize() repeatedly for every account that is found, but
just add it to the list.

The sorting function is now a bit more complicated because it needs to
also sort ETH with their ERC20 tokens explicitly (before, they were
correctly ordered implicitly by the order in which they were loaded
from accounts.json).
