### PR TITLE
backend: rename account without reinitializing all accounts

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -42,6 +42,17 @@ const hardenedKeystart uint32 = hdkeychain.HardenedKeyStart
 // limit, but simply use a hard limit for simplicity.
 const accountsHardLimit = 5
 
+type accountsList []accounts.Interface
+
+func (a accountsList) lookup(code accountsTypes.Code) accounts.Interface {
+	for _, acct := range a {
+		if acct.Config().Config.Code == code {
+			return acct
+		}
+	}
+	return nil
+}
+
 // sortAccounts sorts the accounts in-place by 1) coin 2) account number.
 func sortAccounts(accounts []*config.Account) {
 	compareCoin := func(coin1, coin2 coinpkg.Code) int {
@@ -364,7 +375,11 @@ func (backend *Backend) RenameAccount(accountCode accountsTypes.Code, name strin
 	if err != nil {
 		return err
 	}
-	backend.ReinitializeAccounts()
+	acct := backend.accounts.lookup(accountCode)
+	if acct != nil {
+		acct.Config().Config.Name = name
+		backend.emitAccountsStatusChanged()
+	}
 	return nil
 }
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -161,8 +161,8 @@ type Backend struct {
 	devices map[string]device.Interface
 
 	accountsAndKeystoreLock locker.Locker
+	accounts                accountsList
 	// keystore is nil if no keystore is connected.
-	accounts []accounts.Interface
 	keystore keystore.Keystore
 	aopp     AOPP
 


### PR DESCRIPTION
Closing and rescanning all accounts is overkill.
