### PR TITLE
frontend: fix `ExchangeSelectionRadio`'s outline-overlap issue

### DIFF
--- a/frontends/web/src/routes/buy/components/exchangeselectionradio.module.css
+++ b/frontends/web/src/routes/buy/components/exchangeselectionradio.module.css
@@ -132,6 +132,11 @@
     background-color: var(--background-focus);
 }
 
+.radio:focus {
+    position: relative;
+    z-index: 2;
+}
+
 .radio input:checked + label::before {
     background-color: var(--background-secondary);
 }


### PR DESCRIPTION
Our current implementation causing the outline of the `ExchangeSelectionRadio` to be overlapping with another radio component.

To fix this, we're modifying the radio when `:focus` to have `z-index: 2` and `position: relative`.