### PR TITLE
.github/workflows/ci.yml: update to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   test-lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone the repo
         with:
@@ -39,7 +39,7 @@ jobs:
         env:
           OS_NAME: linux
   android:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
           path: frontends/android/BitBoxApp/app/build/outputs/apk/debug/app-debug.apk
           name: BitBoxApp-android-${{github.sha}}.apk
   qt-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
This is only for the CI base image. Our actual CI runs in a docker image that has an independent base image, which is stil 18.04.

This change is needed as GitHub deprecated ubuntu-18.04:

>  The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04 or ubuntu-22.04 (ubuntu-latest). For more details, see https://github.com/actions/runner-images/issues/6002