### PR TITLE
frontend: fix globe icon in lightmode

### DIFF
--- a/frontends/web/src/routes/buy/components/countryselect.tsx
+++ b/frontends/web/src/routes/buy/components/countryselect.tsx
@@ -34,8 +34,8 @@ type TProps = {
 }
 
 const SelectedRegionIcon = ({ regionCode }: { regionCode: string }) => {
-  const darkmode = useDarkmode();
-  const globe = darkmode ? <GlobeLight className={styles.globe} /> : <GlobeDark className={styles.globe} />;
+  const { isDarkMode } = useDarkmode();
+  const globe = isDarkMode ? <GlobeLight className={styles.globe} /> : <GlobeDark className={styles.globe} />;
   return (
     <span>
       {regionCode === '' ? globe : <span className={`fi fi-${regionCode} ${styles.flag}`}></span>}


### PR DESCRIPTION
in 393344428732250e7066456a04b8d4a4cec82848 the useDarkmode hook changed, it now returns an object with isDarkMode and a function to toggle. This object was always truthy and so the globe always used light icon.