### PR TITLE
frontend: fix exchange selection color in lightmode

### DIFF
--- a/frontends/web/src/routes/buy/components/exchangeselectionradio.module.css
+++ b/frontends/web/src/routes/buy/components/exchangeselectionradio.module.css
@@ -63,8 +63,8 @@
 
 .radio {
     --size-default: 14px;
-    background-color: var(--background);
-    border: 1px solid var(--color-secondary);
+    background-color: var(--background-secondary);
+    border: 1px solid var(--background-quaternary);
     display: block;
     padding: 8px;
 }


### PR DESCRIPTION
Background should be white and border lightgray, was using wrong CSS variables.