### PR TITLE
frontend: remove custom disabled button styling

### DIFF
--- a/frontends/web/src/routes/settings/electrum.module.css
+++ b/frontends/web/src/routes/settings/electrum.module.css
@@ -54,7 +54,7 @@
     word-break: normal;
 }
 
-.servers .server > div button[disabled], textarea[name="electrumCert"] ~ div button[disabled] {
+.servers .server > div button[disabled] {
     background-color: var(--color-disabled);
     color: var(--color-secondary);
 }


### PR DESCRIPTION
Removing custom disabled button styling on connect-your-own-node view. There is no reason to use different disabled button styles.

