### PR TITLE
frontend: send button spacing css regression

### DIFF
--- a/frontends/web/src/components/layout/grid.module.css
+++ b/frontends/web/src/components/layout/grid.module.css
@@ -18,7 +18,10 @@
 .columnButtonsInline {
     display: flex;
     flex-direction: row-reverse;
-    gap: var(--space-half);
+}
+
+.columnButtonsInline > *:not(:first-child) {
+    margin-right: var(--space-half);
 }
 
 @media (min-width: 769px) {


### PR DESCRIPTION
The send and back button had no more spacing. CSS regression introduced in:
- 7e49d89fb8ed97184a756b11701c21c83128abe1

Reason: on older chrome versions (before 84) gap did not work with flexbox, gap only works with dislpay: grid. See also:
- https://developer.mozilla.org/en-US/docs/Web/CSS/gap