### PR TITLE
qt/windows: hide CMD window when queriyng for darkmode

### DIFF
--- a/frontends/qt/server/detectdarktheme_darwin.go
+++ b/frontends/qt/server/detectdarktheme_darwin.go
@@ -1,0 +1,39 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+// +build darwin
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
+)
+
+// detect theme used by OS and return true if it's dark
+func detectDarkTheme() bool {
+	log := logging.Get().WithGroup("server")
+	cmd := exec.Command("defaults", "read", "-g", "AppleInterfaceStyle")
+	out, err := cmd.Output()
+	if err == nil {
+		log.Info("MacOS theme: " + string(out))
+		if strings.TrimSpace(string(out)) == "Dark" {
+			return true
+		}
+	}
+	return false
+}

--- a/frontends/qt/server/detectdarktheme_linux.go
+++ b/frontends/qt/server/detectdarktheme_linux.go
@@ -1,0 +1,69 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
+)
+
+func detectDarkTheme() bool {
+	log := logging.Get().WithGroup("server")
+	// Try KDE first, since Kubuntu can also have `gsettings` and that can lead to wrong results
+	cmd := exec.Command("kreadconfig5", "--file", os.ExpandEnv("$HOME/.config/kdeglobals"), "--group", "General", "--key", "ColorScheme")
+	out, err := cmd.Output()
+	if err == nil {
+		log.Info("kde theme: " + string(out))
+		if matchDarkTheme(string(out)) {
+			return true
+		}
+	}
+
+	// Try Gnome/Ubuntu
+	cmd = exec.Command("gsettings", "get", "org.gnome.desktop.interface", "color-scheme")
+	out, err = cmd.Output()
+	if err == nil {
+		log.Info("Gnome/Ubuntu theme: " + string(out))
+		if matchDarkTheme(string(out)) {
+			return true
+		}
+	}
+
+	// Try Cinnamon
+	cmd = exec.Command("gsettings", "get", "org.cinnamon.desktop.interface", "gtk-theme")
+	out, err = cmd.Output()
+	if err == nil {
+		log.Info("Cinnamon theme: " + string(out))
+		if matchDarkTheme(string(out)) {
+			return true
+		}
+	}
+
+	// Try XFCE4
+	cmd = exec.Command("xfconf-query", "-c", "xsettings", "-p", "/Net/ThemeName")
+	out, err = cmd.Output()
+	if err == nil {
+		log.Info("xfce theme: " + string(out))
+		if matchDarkTheme(string(out)) {
+			return true
+		}
+	}
+	return false
+}

--- a/frontends/qt/server/detectdarktheme_windows.go
+++ b/frontends/qt/server/detectdarktheme_windows.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
+)
+
+// detect theme used by OS and return true if it's dark
+func detectDarkTheme() bool {
+	log := logging.Get().WithGroup("server")
+	const regKey = `HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`
+	const regName = `AppsUseLightTheme`
+	cmd := exec.Command("reg", "query", regKey, "/v", regName)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	out, err := cmd.Output()
+	if err == nil {
+		log.Info("windows theme: " + string(out))
+		if strings.Contains(string(out), "0x0") {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
When starting the app and when toggling darkmode, a CMD window would pop up on Windows very quickly during the execution of `reg query ...`.