### PR TITLE
frontend: update bitboxapp logo to support darkmode

### DIFF
--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -18,7 +18,7 @@ import { FunctionComponent, ReactNode } from 'react';
 import { useDarkmode } from '../../hooks/darkmode';
 import { LanguageSwitch } from '../language/language';
 import { Version } from '../layout/version';
-import { AppLogo, SwissMadeOpenSource, SwissMadeOpenSourceDark } from '../icon/logo';
+import { AppLogo, AppLogoInverted, SwissMadeOpenSource, SwissMadeOpenSourceDark } from '../icon/logo';
 import { AnimatedChecked, Close } from '../icon/icon';
 import style from './view.module.css';
 
@@ -162,10 +162,13 @@ export const ViewHeader: FunctionComponent<THeaderProps> = ({
   title,
   withAppLogo,
 }) => {
+  const { isDarkMode } = useDarkmode();
   const headerStyles = small ? `${style.header} ${style.smallHeader}` : style.header;
   return (
     <header className={headerStyles}>
-      {withAppLogo && <AppLogo />}
+      {withAppLogo && (
+        isDarkMode ? <AppLogoInverted /> : <AppLogo />
+      )}
       <h1 className={style.title}>{title}</h1>
       {children}
     </header>


### PR DESCRIPTION
Modified the App logo in the view component to dynamically switch between light and dark mode versions based on the current theme.

![Screen Shot 2023-04-12 at 13 56 07](https://user-images.githubusercontent.com/546900/231456645-9994e4d9-d614-4e69-8fd8-7cb927fe5418.png)
