### PR TITLE
frontend: improve spacing of exchange radio

### DIFF
--- a/frontends/web/src/routes/buy/components/exchangeselectionradio.module.css
+++ b/frontends/web/src/routes/buy/components/exchangeselectionradio.module.css
@@ -50,7 +50,9 @@
     font-weight: 400;
     line-height: 22px;
     margin: 0;
-    margin-left: var(--space-quarter);
+}
+.paymentMethodName img {
+    margin-right: var(--space-quarter);
 }
 
 .paymentMethodContainer:not(:first-child) {
@@ -58,7 +60,8 @@
 }
 
 .paymentMethodContainer > span {
-    width: 124px;
+    flex-basis: 124px;
+    flex-grow: 1;
 }
 
 .radio {

--- a/frontends/web/src/routes/buy/components/exchangeselectionradio.tsx
+++ b/frontends/web/src/routes/buy/components/exchangeselectionradio.tsx
@@ -40,16 +40,16 @@ const PaymentMethod = ({ methodName }: TPaymentMethodProps) => {
   switch (methodName) {
   case 'bank-transfer':
     return (
-      <span>
+      <span className={style.paymentMethodName}>
         {isDarkMode ? <Bank /> : <BankDark />}
-        <p className={style.paymentMethodName}>{t('buy.exchange.bankTransfer')}</p>
+        {t('buy.exchange.bankTransfer')}
       </span>
     );
   case 'card':
     return (
-      <span>
+      <span className={style.paymentMethodName}>
         {isDarkMode ? <CreditCard /> : <CreditCardDark />}
-        <p className={style.paymentMethodName}>{t('buy.exchange.creditCard')}</p>
+        {t('buy.exchange.creditCard')}
       </span>
     );
   default:


### PR DESCRIPTION
Long label after the bank/card icon broke weirdly to a new line in some languages. This change is not perfect but improves that the word break nicer when needed and not rightaway after the icon.

