### PR TITLE
frontend/exchange: fix back button behavior

### DIFF
--- a/frontends/web/src/routes/buy/exchange.module.css
+++ b/frontends/web/src/routes/buy/exchange.module.css
@@ -21,6 +21,7 @@
 .buttonsContainer {
     display: flex;
     margin-top: var(--space-half);
+    justify-content: center;
 }
 
 .container {

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -18,7 +18,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { route } from '../../utils/route';
 import { IAccount } from '../../api/account';
-import { getExchangeBuySupported } from '../../api/exchanges';
+import { getExchangeSupportedAccounts } from './utils';
 import { getBalance } from '../../api/account';
 import Guide from './guide';
 import { AccountSelector, TOption } from '../../components/accountselector/accountselector';
@@ -40,14 +40,7 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
 
   const checkSupportedCoins = useCallback(async () => {
     try {
-      const accountsWithFalsyValue = await Promise.all(
-        accounts.map(async (account) => {
-          const supported = await getExchangeBuySupported(account.code)();
-          return supported.exchanges.length ? account : false;
-        })
-      );
-      const supportedAccounts =
-        (accountsWithFalsyValue.filter(result => result) as IAccount[]);
+      const supportedAccounts = await getExchangeSupportedAccounts(accounts);
       const options =
         supportedAccounts.map(({ name, code, coinCode }) => ({ label: `${name}`, value: code, coinCode, disabled: false }));
       setOptions(options);

--- a/frontends/web/src/routes/buy/utils.ts
+++ b/frontends/web/src/routes/buy/utils.ts
@@ -15,7 +15,8 @@
  */
 
 import { FrontendExchangeDealsList, Info } from './types';
-
+import { IAccount } from '../../api/account';
+import { getExchangeBuySupported } from '../../api/exchanges';
 /**
  * Finds the lowest fee among all `supported`
  * exchange providers for a given region.
@@ -63,4 +64,17 @@ export function getFormattedName(name: Omit<Info, 'region'>) {
   case 'pocket':
     return 'Pocket';
   }
+}
+
+/**
+ * Filters a given accounts list, keeping only the accounts supported by at least one exchange.
+ */
+export async function getExchangeSupportedAccounts(accounts: IAccount[]): Promise<IAccount[]> {
+  const accountsWithFalsyValue = await Promise.all(
+    accounts.map(async (account) => {
+      const supported = await getExchangeBuySupported(account.code)();
+      return supported.exchanges.length ? account : false;
+    })
+  );
+  return accountsWithFalsyValue.filter(result => result) as IAccount[];
 }


### PR DESCRIPTION
Back button on exchange selection page wasn't working correctly on Android. Also the logic to choose where to land when pressing back was based on the number of total accounts, which is wrong. Now it is based on the number of total accounts with at least one available exchange.