### PR TITLE
api/bitbox02: allow backups using recovery words, skipping sdcard

### DIFF
--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -68,6 +68,14 @@ export type VersionInfo = {
     currentVersion: string;
     canUpgrade: boolean;
     canGotoStartupSettings: boolean;
+    // If true, creating a backup using the mnemonic recovery words instead of the microSD card
+    // is supported in the initial setup.
+    //
+    // If false, the backup must be performed using the microSD card in the initial setup.
+    //
+    // This has no influence over whether one can display the recovery words after the initial
+    // setup - that is always possible regardless of this value.
+    canBackupWithRecoveryWords: boolean;
 }
 
 export const getVersion = (
@@ -96,10 +104,13 @@ export const checkBackup = (
   return apiPost(`devices/bitbox02/${deviceID}/backups/check`, { silent });
 };
 
+// The 'recovery-words' method is only allowed if `canBackupWithRecoveryWords` returned by
+// `getVersion()` is true.
 export const createBackup = (
   deviceID: string,
+  method: 'sdcard' | 'recovery-words',
 ): Promise<FailResponse | SuccessResponse> => {
-  return apiPost(`devices/bitbox02/${deviceID}/backups/create`);
+  return apiPost(`devices/bitbox02/${deviceID}/backups/create`, method);
 };
 
 export const restoreBackup = (

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -309,8 +309,7 @@ class BitBox02 extends Component<Props, State> {
         title: this.props.t('bitbox02Interact.confirmDate'),
         text: this.props.t('bitbox02Interact.confirmDateText'),
       } });
-
-      createBackup(this.props.deviceID)
+      createBackup(this.props.deviceID, 'sdcard')
         .then(() => this.setState({ creatingBackup: false, waitDialog: undefined }))
         .catch(() => {
           alertUser(this.props.t('bitbox02Wizard.createBackupFailed'), { asDialog: false });

--- a/frontends/web/src/routes/device/bitbox02/createbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/createbackup.tsx
@@ -34,7 +34,7 @@ export const Create = ({ deviceID }: TProps) => {
 
   const createBackup = () => {
     setCreatingBackup(true);
-    createBackupAPI(deviceID)
+    createBackupAPI(deviceID, 'sdcard')
       .then((result) => {
         setCreatingBackup(false);
         setDisabled(false);


### PR DESCRIPTION
This adds a parameter to the createBackup endpoint to choose the sdcard backup or the recovery words backup. This can be then used later to allow skipping the sdcard backup in favor of the recovery words backup in the BitBox02 setup wizard.

Since this feature is only possible since firmware v9.13.0, one must first check if `versionInfo.canBackupWithRecoveryWords` is true before using the recovery words method.