### PR TITLE
frontend: fix regression api create-backup

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -206,6 +206,7 @@
       "point3": "Create a backup",
       "text": "Ok, let's create a new wallet!"
     },
+    "createBackupAborted": "Creating backup aborted.",
     "createBackupFailed": "Creating backup failed, try again.",
     "initialize": {
       "passwordText": "Now let's set a password for your device. Use the controls on your BitBox to enter and choose a password.",

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -310,10 +310,13 @@ class BitBox02 extends Component<Props, State> {
         text: this.props.t('bitbox02Interact.confirmDateText'),
       } });
       createBackup(this.props.deviceID, 'sdcard')
-        .then(() => this.setState({ creatingBackup: false, waitDialog: undefined }))
-        .catch(() => {
-          alertUser(this.props.t('bitbox02Wizard.createBackupFailed'), { asDialog: false });
-        });
+        .then(({ success }) => {
+          if (!success) {
+            alertUser(this.props.t('bitbox02Wizard.createBackupFailed'), { asDialog: false });
+          }
+          this.setState({ creatingBackup: false, waitDialog: undefined });
+        })
+        .catch(console.error);
     });
   };
 

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -310,9 +310,13 @@ class BitBox02 extends Component<Props, State> {
         text: this.props.t('bitbox02Interact.confirmDateText'),
       } });
       createBackup(this.props.deviceID, 'sdcard')
-        .then(({ success }) => {
-          if (!success) {
-            alertUser(this.props.t('bitbox02Wizard.createBackupFailed'), { asDialog: false });
+        .then((result) => {
+          if (!result.success) {
+            if (result.code === 104) {
+              alertUser(this.props.t('bitbox02Wizard.createBackupAborted'), { asDialog: false });
+            } else {
+              alertUser(this.props.t('bitbox02Wizard.createBackupFailed'), { asDialog: false });
+            }
           }
           this.setState({ creatingBackup: false, waitDialog: undefined });
         })


### PR DESCRIPTION
createBackup was still using catch in case of success false, this should have been part of 374bd5377b0021ab23f452657e1ddaf721524f63

This also fixes an issue when continuing the workflow after the user aborted is-date-correct on the device. After canceling the app showed confirm date on device but the device did not continue.