### PR TITLE
frontend/skipfortesting: fix bug on `registerTestingDevice`

### DIFF
--- a/frontends/web/src/routes/device/components/skipfortesting.tsx
+++ b/frontends/web/src/routes/device/components/skipfortesting.tsx
@@ -22,8 +22,8 @@ import { PasswordSingleInput } from '../../../components/password';
 export const SkipForTesting = () => {
   const [testPIN, setTestPIN] = useState('');
   const registerTestingDevice = async (e: React.SyntheticEvent) => {
-    await testRegister(testPIN);
     e.preventDefault();
+    await testRegister(testPIN);
   };
   const handleFormChange = (value: string) => {
     setTestPIN(value);


### PR DESCRIPTION
Recent commit 8a20585 refactored `SkipForTesting` component into functional. This introduced a regression caused by the calling of `preventDefault` method of a `React.SyntheticEvent` after awaiting a post call. This on Firefox seems to cause the component to refresh before the conclusion of the call, causing a regression that blocks the use of test wallets. Moving the `preventDefault` call before the `await` fixes it.