### PR TITLE
frontend: fix default & active currencies selection

### DIFF
--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -30,7 +30,7 @@ export interface SharedProps {
     active: Fiat;
     // eslint-disable-next-line react/no-unused-prop-types
     selected: Fiat[];
-    btcUnit: BtcUnit;
+    btcUnit?: BtcUnit;
 }
 
 export const currencies: Fiat[] = ['AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'EUR', 'GBP', 'HKD', 'ILS', 'JPY', 'KRW', 'NOK', 'RUB', 'SEK', 'SGD', 'USD', 'BTC'];

--- a/frontends/web/src/routes/new-settings/appearance.tsx
+++ b/frontends/web/src/routes/new-settings/appearance.tsx
@@ -4,7 +4,7 @@ import { DarkmodeToggleSetting } from './components/appearance/darkmodeToggleSet
 import { DefaultCurrencyDropdownSetting } from './components/appearance/defaultCurrencyDropdownSetting';
 import { DisplaySatsToggleSetting } from './components/appearance/displaySatsToggleSetting';
 import { LanguageDropdownSetting } from './components/appearance/languageDropdownSetting';
-import { ActiveCurrenciesDropdownSetting } from './components/appearance/activeCurrenciesDropdownSetting';
+import { ActiveCurrenciesDropdownSettingWithStore } from './components/appearance/activeCurrenciesDropdownSetting';
 
 export const Appearance = () => {
   return (
@@ -13,7 +13,7 @@ export const Appearance = () => {
       <View fullscreen={false}>
         <ViewContent>
           <DefaultCurrencyDropdownSetting />
-          <ActiveCurrenciesDropdownSetting />
+          <ActiveCurrenciesDropdownSettingWithStore />
           <LanguageDropdownSetting />
           <DarkmodeToggleSetting />
           <DisplaySatsToggleSetting />

--- a/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
@@ -1,8 +1,9 @@
 import Select, { ActionMeta, MultiValue, MultiValueRemoveProps, components } from 'react-select';
 import { SettingsItemContainer } from '../settingsItemContainer/settingsItemContainer';
-import { currencies, store, selectFiat, unselectFiat } from '../../../../components/rates/rates';
+import { currencies, store, selectFiat, unselectFiat, SharedProps } from '../../../../components/rates/rates';
 import { Fiat } from '../../../../api/account';
 import styles from './defaultCurrencySetting.module.css';
+import { share } from '../../../../decorators/share';
 
 type SelectOption = {
   label: Fiat;
@@ -11,13 +12,15 @@ type SelectOption = {
 
 type TSelectProps = {
   options: SelectOption[];
-  selectedCurrencies: SelectOption[];
-}
+} & Omit<SharedProps, 'btcUnit'>
 
-const ReactSelect = ({ options, selectedCurrencies }: TSelectProps) => {
+const ReactSelect = ({ options, active, selected }: TSelectProps) => {
+  const selectedCurrencies = selected.length > 0 ? selected?.map(currency => ({ label: currency, value: currency })) : [];
+
   const MultiValueRemove = (props: MultiValueRemoveProps<SelectOption>) => {
+    const currency = props.data.value;
     return (
-      selectedCurrencies.length > 1 ?
+      currency !== active ?
         <components.MultiValueRemove {...props}>
           {'X'}
         </components.MultiValueRemove>
@@ -51,15 +54,16 @@ const ReactSelect = ({ options, selectedCurrencies }: TSelectProps) => {
     />);
 };
 
-export const ActiveCurrenciesDropdownSetting = () => {
-  const selectedCurrencies = store.state.selected.length > 0 ? store.state.selected.map(currency => ({ label: currency, value: currency, isFixed: true })) : [];
+export const ActiveCurrenciesDropdownSetting = ({ selected, active }: SharedProps) => {
   const formattedCurrencies = currencies.map((currency) => ({ label: currency, value: currency }));
 
   return (
     <SettingsItemContainer
       settingName="Active Currencies"
-      secondaryText="Which language you want the BitBoxApp to use."
-      extraComponent={<ReactSelect options={formattedCurrencies} selectedCurrencies={selectedCurrencies} />}
+      secondaryText="These additional currencies can be toggled through on your account page."
+      extraComponent={<ReactSelect options={formattedCurrencies} active={active} selected={selected} />}
     />
   );
 };
+
+export const ActiveCurrenciesDropdownSettingWithStore = share<SharedProps>(store)(ActiveCurrenciesDropdownSetting);

--- a/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
@@ -12,7 +12,7 @@ type SelectOption = {
 
 type TSelectProps = {
   options: SelectOption[];
-} & Omit<SharedProps, 'btcUnit'>
+} & SharedProps;
 
 const ReactSelect = ({ options, active, selected }: TSelectProps) => {
   const selectedCurrencies = selected.length > 0 ? selected?.map(currency => ({ label: currency, value: currency })) : [];

--- a/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -1,7 +1,7 @@
 import { SettingsItemContainer } from '../settingsItemContainer/settingsItemContainer';
 import Select from 'react-select';
 import { store } from '../../../../components/rates/rates';
-import { currencies, setActiveFiat } from '../../../../components/rates/rates';
+import { setActiveFiat } from '../../../../components/rates/rates';
 import { Fiat } from '../../../../api/account';
 import styles from './defaultCurrencySetting.module.css';
 
@@ -30,7 +30,8 @@ const ReactSelect = ({ options, handleChange }: TSelectProps) => <Select
 />;
 
 export const DefaultCurrencyDropdownSetting = () => {
-  const formattedCurrencies = currencies.map((currency) => ({ label: currency, value: currency }));
+  const formattedCurrencies = store.state.selected.map((currency) => ({ label: currency, value: currency }));
+
   return (
     <SettingsItemContainer
       settingName="Default Currency"

--- a/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -1,7 +1,6 @@
 import { SettingsItemContainer } from '../settingsItemContainer/settingsItemContainer';
 import Select from 'react-select';
-import { store } from '../../../../components/rates/rates';
-import { setActiveFiat } from '../../../../components/rates/rates';
+import { store, setActiveFiat } from '../../../../components/rates/rates';
 import { Fiat } from '../../../../api/account';
 import styles from './defaultCurrencySetting.module.css';
 


### PR DESCRIPTION
Previously, in the newly created appearance (`new-settings/appearance`) we could:

1. set a default currency that's not even in our active currencies list.

2. remove our default currency from our active currencies list. So our default currency
won't be among the active currencies, which doesn't make sense.

**These are bugs and aren't the intended behaviours.** This could be verified by the fact that in the old settings, these aren't allowed.
 
The root cause is because we needed to add the checks. After adding the checks though, it's still not fixed because we can't get the updated values of the store once these values change, except by refreshing it (which isn't what we want).

**To fix this, we unfortunately still need to use our "old" `share` decorator. It's because these values are currently stored within our own `store` implementation. We can't listen to changes in this store simply by using `useEffect` since it's not a react state.**

Thus, we need to wrap the component, in this case `activeCurrenciesDropdown` using the `share` decorator to be able to subscribe to these currencies changes and get the update immediately once the `store` values get updated.

Preview:

https://user-images.githubusercontent.com/28676406/234286169-19eb186a-2a3b-4cef-8478-93f3ae74a0f1.mov


