### PR TITLE
backend/accounts_test: fix bug in accounts test

### DIFF
--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -728,7 +728,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 	defer b.Close()
 	fingerprint := []byte{0x55, 0x55, 0x55, 0x55}
 
-	require.Equal(t, []accounts.Interface{}, b.accounts)
+	require.Equal(t, accountsList{}, b.accounts)
 
 	// Add a Bitcoin account.
 	coin, err := b.Coin(coinpkg.CodeBTC)


### PR DESCRIPTION
Recent commits
3b2c46eaf308c9034dd6f7e2de4092c6310474e2
ans
1d98d661a2d4b2878895c381c919fe341a664785
updated accounts_test using different versions of the `Backend` struct. This caused the merge of the two commits into master to introduce an inconsistency which makes the CI flow fail.