### PR TITLE
Btc amount spacing

### DIFF
--- a/frontends/web/src/components/amount/amount.test.tsx
+++ b/frontends/web/src/components/amount/amount.test.tsx
@@ -100,27 +100,46 @@ describe('Amount formatting', () => {
         const { container } = render(<Amount amount="10.00000000" unit={coin} removeBtcTrailingZeroes/>);
         expect(container).toHaveTextContent('10');
       });
-      it('10.12300000 ' + coin + ' with removeBtcTrailingZeroes enabled becomes 10.123', () => {
-        const { container } = render(<Amount amount="10.12300000" unit={coin} removeBtcTrailingZeroes/>);
-        expect(container).toHaveTextContent('10.123');
+      it('12345.12300000 ' + coin + ' with removeBtcTrailingZeroes enabled becomes 12345.123', () => {
+        const { container } = render(<Amount amount="12345.12300000" unit={coin} removeBtcTrailingZeroes/>);
+        expect(container).toHaveTextContent('12345.123');
       });
       it('42 ' + coin + ' with removeBtcTrailingZeroes enabled stays 42', () => {
         const { container } = render(<Amount amount="42" unit={coin} removeBtcTrailingZeroes/>);
         expect(container).toHaveTextContent('42');
       });
-      it('10.00000000 ' + coin + ' with removeBtcTrailingZeroes disabled stays 10.00000000', () => {
-        const { container } = render(<Amount amount="10.00000000" unit={coin}/>);
-        expect(container).toHaveTextContent('10.00000000');
+      it('0.12345678 ' + coin + ' with removeBtcTrailingZeroes enabled stays 0.12345678', () => {
+        const { container } = render(<Amount amount="0.12345678" unit={coin} removeBtcTrailingZeroes/>);
+        expect(container).toHaveTextContent('0.12345678');
       });
-      it('10.12300000 ' + coin + ' with removeBtcTrailingZeroes disabled stays 10.12300000', () => {
-        const { container } = render(<Amount amount="10.12300000" unit={coin}/>);
-        expect(container).toHaveTextContent('10.12300000');
+      it('10.00000000 ' + coin + ' with removeBtcTrailingZeroes disabled gets spaced', () => {
+        const { getByTestId } = render(<Amount amount="10.00000000" unit={coin}/>);
+        const blocks = getByTestId('amountBlocks');
+        expect(blocks.innerHTML).toBe(
+          '<span>10.00</span>' +
+          '<span class="space">000</span>' +
+          '<span class="space">000</span>');
+      });
+      it('12345.12300000 ' + coin + ' with removeBtcTrailingZeroes disabled gets spaced', () => {
+        const { getByTestId } = render(<Amount amount="12345.12300000" unit={coin}/>);
+        const blocks = getByTestId('amountBlocks');
+        expect(blocks.innerHTML).toBe(
+          '<span>12345.12</span>' +
+          '<span class="space">300</span>' +
+          '<span class="space">000</span>');
       });
       it('42 ' + coin + ' with removeBtcTrailingZeroes disabled stays 42', () => {
         const { container } = render(<Amount amount="42" unit={coin}/>);
         expect(container).toHaveTextContent('42');
       });
-
+      it('0.12345678 ' + coin + ' with removeBtcTrailingZeroes disabled gets spaced', () => {
+        const { getByTestId } = render(<Amount amount="0.12345678" unit={coin}/>);
+        const blocks = getByTestId('amountBlocks');
+        expect(blocks.innerHTML).toBe(
+          '<span>0.12</span>' +
+          '<span class="space">345</span>' +
+          '<span class="space">678</span>');
+      });
     });
   });
 

--- a/frontends/web/src/components/amount/amount.tsx
+++ b/frontends/web/src/components/amount/amount.tsx
@@ -40,6 +40,18 @@ export const Amount = ({ amount, unit, removeBtcTrailingZeroes }: TProps) => {
     return <span data-testid={'amountBlocks'}>{blocks.reverse()}</span>;
   };
 
+  const formatBtc = (amount: string): JSX.Element => {
+    const dot = amount.indexOf('.');
+    if (dot === -1) {
+      return <>{amount}</>;
+    }
+    return <span data-testid={'amountBlocks'}>
+      <span>{amount.slice(0, dot + 3)}</span>
+      <span className={style.space}>{amount.slice(dot + 3, dot + 6)}</span>
+      <span className={style.space}>{amount.slice(dot + 6, dot + 9)}</span>
+    </span>;
+  };
+
   switch (unit) {
   case 'BTC':
   case 'TBTC':
@@ -47,8 +59,9 @@ export const Amount = ({ amount, unit, removeBtcTrailingZeroes }: TProps) => {
   case 'TLTC':
     if (removeBtcTrailingZeroes && amount.includes('.')) {
       return <>{amount.replace(/\.?0+$/, '')}</>;
+    } else {
+      return formatBtc(amount);
     }
-    break;
   case 'sat':
   case 'tsat':
     return formatSats(amount);


### PR DESCRIPTION
Current proposal: using spacing for BTC/LTC fractional part everywhere except for balance and chart, since the trailing zeroes are removed there (see pics).

![image](https://user-images.githubusercontent.com/11994448/234587325-fd375abd-f16e-474b-b44f-a6c07b15829a.png)

![image](https://user-images.githubusercontent.com/11994448/234587339-1ff63fd5-defc-4023-8916-1ce5760158ea.png)

![immagine](https://user-images.githubusercontent.com/11994448/234800143-fb5bbe74-faa1-498f-8c0e-0514bcefa6f9.png)

