### PR TITLE
Export btc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Update transactions export feature to use preferred BTC amount unit
+
+
 ## 4.37.0
 - Bundle BitBox02 firmware version v9.14.0
 - Enable auto HiDPI scaling to correctly manage scale factor on high density screens

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -286,9 +286,9 @@ func (account *BaseAccount) ExportCSV(w io.Writer, transactions []*TransactionDa
 		feeString := ""
 		fee := transaction.Fee
 		if fee != nil {
-			feeString = fee.BigInt().String()
+			feeString = account.Coin().FormatAmount(*fee, true)
 		}
-		unit := account.Coin().SmallestUnit()
+		unit := account.Coin().GetFormatUnit(false)
 		timeString := ""
 		if transaction.Timestamp != nil {
 			timeString = transaction.Timestamp.Format(time.RFC3339)
@@ -300,7 +300,7 @@ func (account *BaseAccount) ExportCSV(w io.Writer, transactions []*TransactionDa
 			err := writer.Write([]string{
 				timeString,
 				transactionType,
-				addressAndAmount.Amount.BigInt().String(),
+				account.Coin().FormatAmount(addressAndAmount.Amount, false),
 				unit,
 				feeString,
 				addressAndAmount.Address,

--- a/backend/accounts/baseaccount_test.go
+++ b/backend/accounts/baseaccount_test.go
@@ -106,8 +106,11 @@ func TestBaseAccount(t *testing.T) {
 		CodeFunc: func() coin.Code {
 			return coin.CodeTBTC
 		},
-		SmallestUnitFunc: func() string {
-			return "satoshi"
+		GetFormatUnitFunc: func(bool) string {
+			return "sat"
+		},
+		FormatAmountFunc: func(amount coin.Amount, isFee bool) string {
+			return amount.BigInt().String()
 		},
 	}
 	account := NewBaseAccount(cfg, mockCoin, logging.Get().WithGroup("baseaccount_test"))
@@ -195,8 +198,8 @@ func TestBaseAccount(t *testing.T) {
 		timestamp := time.Date(2020, 2, 30, 16, 44, 20, 0, time.UTC)
 		require.Equal(t,
 			header+
-				`2020-03-01T16:44:20Z,sent,123,satoshi,101,some-address,some-tx-id,"some note, with a comma"
-2020-03-01T16:44:20Z,sent_to_yourself,456,satoshi,,another-address,some-tx-id,"some note, with a comma"
+				`2020-03-01T16:44:20Z,sent,123,sat,101,some-address,some-tx-id,"some note, with a comma"
+2020-03-01T16:44:20Z,sent_to_yourself,456,sat,,another-address,some-tx-id,"some note, with a comma"
 `,
 			export([]*TransactionData{
 				{

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -728,7 +728,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 	defer b.Close()
 	fingerprint := []byte{0x55, 0x55, 0x55, 0x55}
 
-	require.Equal(t, []accounts.Interface{}, b.accounts)
+	require.Equal(t, accountsList{}, b.accounts)
 
 	// Add a Bitcoin account.
 	coin, err := b.Coin(coinpkg.CodeBTC)


### PR DESCRIPTION
This updates `ExportCSV` function to follow user preference for BTC
amount unit, instead of always using sats.