### PR TITLE
frontend: create general settings page for mobile

### DIFF
--- a/frontends/web/src/components/icon/assets/icons/right-chevron.svg
+++ b/frontends/web/src/components/icon/assets/icons/right-chevron.svg
@@ -1,0 +1,3 @@
+ <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#777777" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="9 18 15 12 9 6"></polyline>
+</svg>

--- a/frontends/web/src/components/icon/icon.tsx
+++ b/frontends/web/src/components/icon/icon.tsx
@@ -45,6 +45,7 @@ import guideSVG from './assets/icons/guide.svg';
 import menuDarkSVG from './assets/icons/menu-dark.svg';
 import menuLightSVG from './assets/icons/menu-light.svg';
 import warningPNG from './assets/icons/warning.png';
+import rightChevronSVG from './assets/icons/right-chevron.svg';
 import saveSVG from './assets/icons/save.svg';
 import saveLightSVG from './assets/icons/save-light.svg';
 import starSVG from './assets/icons/star.svg';
@@ -146,6 +147,7 @@ export const GuideActive = (props: ImgProps) => (<img src={guideSVG} draggable={
 export const MenuDark = (props: ImgProps) => (<img src={menuDarkSVG} draggable={false} {...props} />);
 export const MenuLight = (props: ImgProps) => (<img src={menuLightSVG} draggable={false} {...props} />);
 export const Warning = (props: ImgProps) => (<img src={warningPNG} draggable={false} {...props} />);
+export const RightChevron = (props: ImgProps) => (<img src={rightChevronSVG} draggable={false} {...props} />);
 export const Save = (props: ImgProps) => (<img src={saveSVG} draggable={false} {...props} />);
 export const SaveLight = (props: ImgProps) => (<img src={saveLightSVG} draggable={false} {...props} />);
 export const Star = (props: ImgProps) => (<img src={starSVG} draggable={false} {...props} />);

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -239,7 +239,7 @@ class Sidebar extends Component<Props> {
           <div key="settings-new" className={style.sidebarItem}>
             <NavLink
               className={({ isActive }) => isActive ? style.sidebarActive : ''}
-              to={'/new-settings/appearance'}
+              to={'/new-settings'}
               title={t('sidebar.settings')}
               onClick={this.handleSidebarItemClick}>
               <div className="stacked">

--- a/frontends/web/src/routes/new-settings/components/settingsItemContainer/settingsItemContainer.module.css
+++ b/frontends/web/src/routes/new-settings/components/settingsItemContainer/settingsItemContainer.module.css
@@ -39,3 +39,9 @@
 .notButton:focus {
     outline: none;
 }
+
+@media (max-width: 768px) { 
+   .container {
+        margin-bottom: 0;
+   }
+}

--- a/frontends/web/src/routes/new-settings/components/settingsItemContainer/settingsItemContainer.tsx
+++ b/frontends/web/src/routes/new-settings/components/settingsItemContainer/settingsItemContainer.tsx
@@ -1,21 +1,24 @@
 import { ReactNode } from 'react';
+import { RightChevron } from '../../../../components/icon';
 import styles from './settingsItemContainer.module.css';
 
 type TProps = {
     onClick?: () => void;
     settingName: string;
     secondaryText?: string | JSX.Element;
-    extraComponent?: ReactNode;
+  extraComponent?: ReactNode;
+  showRightChevron?: boolean;
 }
 
 export const SettingsItemContainer = ({
   onClick,
   settingName,
   secondaryText,
-  extraComponent
+  extraComponent,
+  showRightChevron
+
 }: TProps) => {
   const notButton = onClick === undefined;
-
   const content =
     (<>
       <span>
@@ -24,7 +27,8 @@ export const SettingsItemContainer = ({
           <p className={styles.secondaryText}>{secondaryText}</p>
         ) : null }
       </span>
-      {extraComponent ? extraComponent : null }
+      {extraComponent ? extraComponent : null}
+      {showRightChevron ? <RightChevron style={{ fontSize: '2px' }} /> : null}
     </>
     );
 

--- a/frontends/web/src/routes/new-settings/general.tsx
+++ b/frontends/web/src/routes/new-settings/general.tsx
@@ -1,10 +1,17 @@
+import { useEffect } from 'react';
 import { View, ViewContent } from '../../components/view/view';
 import { Header, Main } from '../../components/layout';
 import { SettingsItemContainer } from './components/settingsItemContainer/settingsItemContainer';
 import { route } from '../../utils/route';
+import { useMediaQuery } from '../../hooks/mediaquery';
 
 export const GeneralSettings = () => {
-
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  useEffect(() => {
+    if (!isMobile) {
+      route('/new-settings/appearance');
+    }
+  }, [isMobile]);
   return (
     <Main>
       <Header title={<h2>Settings</h2>} />

--- a/frontends/web/src/routes/new-settings/general.tsx
+++ b/frontends/web/src/routes/new-settings/general.tsx
@@ -1,0 +1,39 @@
+import { View, ViewContent } from '../../components/view/view';
+import { Header, Main } from '../../components/layout';
+import { SettingsItemContainer } from './components/settingsItemContainer/settingsItemContainer';
+import { route } from '../../utils/route';
+
+export const GeneralSettings = () => {
+
+  return (
+    <Main>
+      <Header title={<h2>Settings</h2>} />
+      <View fullscreen={false}>
+        <ViewContent>
+
+          <SettingsItemContainer
+            settingName="Appearance"
+            onClick={() => route('/new-settings/appearance')}
+          />
+          <SettingsItemContainer
+            settingName="Manage Accounts"
+            onClick={() => route('/new-settings/manage-accounts')}
+          />
+          <SettingsItemContainer
+            settingName="Device Settings"
+            onClick={() => route('/new-settings/device-settings')}
+          />
+          <SettingsItemContainer
+            settingName="Advanced Settings"
+            onClick={() => route('/new-settings/advanced-settings')}
+          />
+          <SettingsItemContainer
+            settingName="About"
+            onClick={() => route('/new-settings/about')}
+          />
+        </ViewContent>
+
+      </View>
+    </Main>
+  );
+};

--- a/frontends/web/src/routes/new-settings/general.tsx
+++ b/frontends/web/src/routes/new-settings/general.tsx
@@ -21,22 +21,27 @@ export const GeneralSettings = () => {
           <SettingsItemContainer
             settingName="Appearance"
             onClick={() => route('/new-settings/appearance')}
+            showRightChevron
           />
           <SettingsItemContainer
             settingName="Manage Accounts"
             onClick={() => route('/new-settings/manage-accounts')}
+            showRightChevron
           />
           <SettingsItemContainer
             settingName="Device Settings"
             onClick={() => route('/new-settings/device-settings')}
+            showRightChevron
           />
           <SettingsItemContainer
             settingName="Advanced Settings"
             onClick={() => route('/new-settings/advanced-settings')}
+            showRightChevron
           />
           <SettingsItemContainer
             settingName="About"
             onClick={() => route('/new-settings/about')}
+            showRightChevron
           />
         </ViewContent>
 

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -20,6 +20,7 @@ import { Passphrase } from './device/bitbox02/passphrase';
 import { Account } from './account/account';
 import { ReceiveAccountsSelector } from './accounts/select-receive';
 import { Appearance } from './new-settings/appearance';
+import { GeneralSettings } from './new-settings/general';
 
 type TAppRouterProps = {
     devices: TDevices;
@@ -142,6 +143,7 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
         <Route path="manage-accounts" element={<ManageAccounts key={'manage-accounts'} />} />
       </Route>
       <Route path="new-settings">
+        <Route index element={<GeneralSettings />} />
         <Route path="appearance" element={<Appearance />} />
       </Route>
     </Route>


### PR DESCRIPTION
For the settings revamp, we want to have a dedicated screen for settings menu for mobile - which is used in place of tabs (since tabs are only available on Desktop).  Users on desktop will automatically be redirected to the `appearance` page once they open this page, whereas for mobile they can visit this page since it serves the purpose of being a "menu" for them.

**We'll call this menu page the "general settings" page.** Please feel free to give suggestions to name the page, bc there was no name before so had to come up w/ one - otherwise it's tricky to reference it 😉 .

Please see commit messages to see detailed changes.

Preview (darkmode):
<img width="329" alt="Screenshot 2023-04-26 at 19 08 02" src="https://user-images.githubusercontent.com/28676406/234650812-14e6bd3e-c0a8-4a92-af7e-806eda6c8682.png">


Preview (lightmode):
<img width="333" alt="Screenshot 2023-04-26 at 19 03 43" src="https://user-images.githubusercontent.com/28676406/234650702-c38a262a-cc0f-4f23-a331-3ea83e881336.png">

