### PR TITLE
backend: fix unit test

### DIFF
--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -728,7 +728,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 	defer b.Close()
 	fingerprint := []byte{0x55, 0x55, 0x55, 0x55}
 
-	require.Equal(t, []accounts.Interface{}, b.accounts)
+	require.Equal(t, accountsList{}, b.accounts)
 
 	// Add a Bitcoin account.
 	coin, err := b.Coin(coinpkg.CodeBTC)


### PR DESCRIPTION
Unit test broke as a result of a semantic merge conflict when merging 27a5da070f791c79ba67e8e170f0fe7f842c97d4 (conflict with ca8fa91dfd3c436b141804d8582d7a4f23277865).