### PR TITLE
Frontend revamp settings tabs

### DIFF
--- a/frontends/web/src/components/icon/assets/icons/chevron-left-dark.svg
+++ b/frontends/web/src/components/icon/assets/icons/chevron-left-dark.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.25 4.5L6.75 9L11.25 13.5" stroke="#777777" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontends/web/src/components/icon/assets/icons/chevron-right-dark.svg
+++ b/frontends/web/src/components/icon/assets/icons/chevron-right-dark.svg
@@ -1,0 +1,3 @@
+ <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#777777" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="9 18 15 12 9 6"></polyline>
+</svg>

--- a/frontends/web/src/components/icon/icon.tsx
+++ b/frontends/web/src/components/icon/icon.tsx
@@ -29,6 +29,8 @@ import bankLightSVG from './assets/icons/bank-light.svg';
 import buyInfoSVG from './assets/icons/buy-info.svg';
 import checkedSmallSVG from './assets/icons/checked-small.svg';
 import checkSVG from './assets/icons/check.svg';
+import chevronRightDark from './assets/icons/chevron-right-dark.svg';
+import chevronLeftDark from './assets/icons/chevron-left-dark.svg';
 import cancelSVG from './assets/icons/cancel.svg';
 import creditCardDarkSVG from './assets/icons/credit-card.svg';
 import creditCardLightSVG from './assets/icons/credit-card-light.svg';
@@ -130,6 +132,8 @@ export const BuyInfo = (props: ImgProps) => (<img src={buyInfoSVG} draggable={fa
 export const Checked = (props: ImgProps) => (<img src={checkedSmallSVG} draggable={false} {...props} />);
 // simple check for copy component
 export const Check = (props: ImgProps) => (<img src={checkSVG} draggable={false} {...props} />);
+export const ChevronLeftDark = (props: ImgProps) => (<img src={chevronLeftDark} draggable={false} {...props} />);
+export const ChevronRightDark = (props: ImgProps) => (<img src={chevronRightDark} draggable={false} {...props} />);
 export const Cancel = (props: ImgProps) => (<img src={cancelSVG} draggable={false} {...props} />);
 export const CreditCardDark = (props: ImgProps) => (<img src={creditCardDarkSVG} draggable={false} {...props} />);
 export const CreditCard = (props: ImgProps) => (<img src={creditCardLightSVG} draggable={false} {...props} />);

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -239,7 +239,7 @@ class Sidebar extends Component<Props> {
           <div key="settings-new" className={style.sidebarItem}>
             <NavLink
               className={({ isActive }) => isActive ? style.sidebarActive : ''}
-              to={'/new-settings/appearance'}
+              to={'/new-settings'}
               title={t('sidebar.settings')}
               onClick={this.handleSidebarItemClick}>
               <div className="stacked">

--- a/frontends/web/src/routes/new-settings/appearance.tsx
+++ b/frontends/web/src/routes/new-settings/appearance.tsx
@@ -1,22 +1,31 @@
+import { Main, Header } from '../../components/layout';
 import { View, ViewContent } from '../../components/view/view';
-import { Header, Main } from '../../components/layout';
+import { useTranslation } from 'react-i18next';
 import { DarkmodeToggleSetting } from './components/appearance/darkmodeToggleSetting';
 import { DefaultCurrencyDropdownSetting } from './components/appearance/defaultCurrencyDropdownSetting';
 import { DisplaySatsToggleSetting } from './components/appearance/displaySatsToggleSetting';
 import { LanguageDropdownSetting } from './components/appearance/languageDropdownSetting';
 import { ActiveCurrenciesDropdownSettingWithStore } from './components/appearance/activeCurrenciesDropdownSetting';
+import { WithSettingsTabs } from './components/tabs';
 
-export const Appearance = () => {
+type TProps = {
+  deviceIDs: string[]
+}
+
+export const Appearance = ({ deviceIDs }: TProps) => {
+  const { t } = useTranslation();
   return (
     <Main>
-      <Header title={<h2>Settings</h2>} />
+      <div className="hide-on-small"><Header title={<h2>{t('sidebar.settings')}</h2>} /></div>
       <View fullscreen={false}>
         <ViewContent>
-          <DefaultCurrencyDropdownSetting />
-          <ActiveCurrenciesDropdownSettingWithStore />
-          <LanguageDropdownSetting />
-          <DarkmodeToggleSetting />
-          <DisplaySatsToggleSetting />
+          <WithSettingsTabs subPageTitle={'Appearance'} hideMobileMenu deviceIDs={deviceIDs}>
+            <DefaultCurrencyDropdownSetting />
+            <ActiveCurrenciesDropdownSettingWithStore />
+            <LanguageDropdownSetting />
+            <DarkmodeToggleSetting />
+            <DisplaySatsToggleSetting />
+          </WithSettingsTabs>
         </ViewContent>
       </View>
     </Main>

--- a/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
@@ -1,6 +1,6 @@
 import Select, { ActionMeta, MultiValue, MultiValueRemoveProps, components } from 'react-select';
-import { SettingsItemContainer } from '../settingsItemContainer/settingsItemContainer';
 import { currencies, store, selectFiat, unselectFiat, SharedProps } from '../../../../components/rates/rates';
+import { SettingsItem } from '../settingsItem/settingsItem';
 import { Fiat } from '../../../../api/account';
 import styles from './defaultCurrencySetting.module.css';
 import { share } from '../../../../decorators/share';
@@ -54,11 +54,11 @@ const ReactSelect = ({ options, active, selected }: TSelectProps) => {
     />);
 };
 
-export const ActiveCurrenciesDropdownSetting = ({ selected, active }: SharedProps) => {
+const ActiveCurrenciesDropdownSetting = ({ selected, active }: SharedProps) => {
   const formattedCurrencies = currencies.map((currency) => ({ label: currency, value: currency }));
 
   return (
-    <SettingsItemContainer
+    <SettingsItem
       settingName="Active Currencies"
       secondaryText="These additional currencies can be toggled through on your account page."
       extraComponent={<ReactSelect options={formattedCurrencies} active={active} selected={selected} />}

--- a/frontends/web/src/routes/new-settings/components/appearance/darkmodeToggleSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/darkmodeToggleSetting.tsx
@@ -1,13 +1,13 @@
 import { useTranslation } from 'react-i18next';
 import { useDarkmode } from '../../../../hooks/darkmode';
 import { Toggle } from '../../../../components/toggle/toggle';
-import { SettingsItemContainer } from '../settingsItemContainer/settingsItemContainer';
+import { SettingsItem } from '../settingsItem/settingsItem';
 
 export const DarkmodeToggleSetting = () => {
   const { t } = useTranslation();
   const { toggleDarkmode, isDarkMode } = useDarkmode();
   return (
-    <SettingsItemContainer
+    <SettingsItem
       settingName={t('darkmode.toggle')}
       secondaryText="See the BitBoxApp in dark mode."
       extraComponent={<Toggle checked={isDarkMode} onChange={() => toggleDarkmode(!isDarkMode)} />}

--- a/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -1,4 +1,4 @@
-import { SettingsItemContainer } from '../settingsItemContainer/settingsItemContainer';
+import { SettingsItem } from '../settingsItem/settingsItem';
 import Select from 'react-select';
 import { store, setActiveFiat } from '../../../../components/rates/rates';
 import { Fiat } from '../../../../api/account';
@@ -32,7 +32,7 @@ export const DefaultCurrencyDropdownSetting = () => {
   const formattedCurrencies = store.state.selected.map((currency) => ({ label: currency, value: currency }));
 
   return (
-    <SettingsItemContainer
+    <SettingsItem
       settingName="Default Currency"
       secondaryText="Select your default currency."
       extraComponent={<ReactSelect options={formattedCurrencies} handleChange={setActiveFiat}/>}

--- a/frontends/web/src/routes/new-settings/components/appearance/displaySatsToggleSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/displaySatsToggleSetting.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Toggle } from '../../../../components/toggle/toggle';
-import { SettingsItemContainer } from '../settingsItemContainer/settingsItemContainer';
+import { SettingsItem } from '../settingsItem/settingsItem';
 import { useLoad } from '../../../../hooks/api';
 import { getConfig } from '../../../../api/backend';
 import { setConfig } from '../../../../utils/config';
@@ -41,7 +41,7 @@ export const DisplaySatsToggleSetting = () => {
 
   return (
     <>
-      <SettingsItemContainer
+      <SettingsItem
         settingName={t('settings.expert.useSats')}
         secondaryText="Enable or disable Satoshis."
         extraComponent={

--- a/frontends/web/src/routes/new-settings/components/appearance/languageDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/languageDropdownSetting.tsx
@@ -1,4 +1,4 @@
-import { SettingsItemContainer } from '../settingsItemContainer/settingsItemContainer';
+import { SettingsItem } from '../settingsItem/settingsItem';
 import { useTranslation } from 'react-i18next';
 import { TActiveLanguageCodes, TLanguage, TLanguagesList } from '../../../../components/language/types';
 import Select from 'react-select';
@@ -57,7 +57,7 @@ export const LanguageDropdownSetting = () => {
   const selectedLanguage = defaultLanguages[getSelectedIndex(defaultLanguages, i18n)];
   const formattedLanguages = defaultLanguages.map(lang => ({ label: lang.display, value: lang.code }));
   return (
-    <SettingsItemContainer
+    <SettingsItem
       settingName="Language"
       secondaryText="Which language you want the BitBoxApp to use."
       extraComponent={<ReactSelect options={formattedLanguages} handleChange={i18n.changeLanguage} selectedLanguage={selectedLanguage} />}

--- a/frontends/web/src/routes/new-settings/components/mobile-header.module.css
+++ b/frontends/web/src/routes/new-settings/components/mobile-header.module.css
@@ -1,0 +1,39 @@
+.container {
+    align-items: center;
+    display: flex;
+    margin-bottom: var(--space-default);
+    position: relative;
+}
+
+.backButton {
+    background-color: transparent;
+    border: none;
+    color: var(--color-default);
+    display: flex;
+    align-items: center;
+    font-size: var(--size-title);
+    padding: var(--space-quarter);
+    padding-left: 0;
+    text-decoration: none;
+}
+
+.backButton:focus {
+    outline: none;
+}
+
+.backButton:hover {
+    cursor: pointer;
+}
+
+.backButton img {
+    margin-right: var(--space-eight);
+}
+
+.headerText {
+    font-size: var(--size-title);
+    font-weight: 400;
+    margin: 0 auto;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+}

--- a/frontends/web/src/routes/new-settings/components/mobile-header.tsx
+++ b/frontends/web/src/routes/new-settings/components/mobile-header.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next';
+import { ChevronLeftDark } from '../../../components/icon';
+import { route } from '../../../utils/route';
+import styles from './mobile-header.module.css';
+
+type TProps = {
+  subPageTitle: string;
+}
+
+export const MobileHeader = ({ subPageTitle }: TProps) => {
+  const { t } = useTranslation();
+  const handleClick = () => {
+    //goes to the 'general settings' page
+    route('/new-settings');
+  };
+  return (
+    <div className={styles.container}>
+      <button onClick={handleClick} className={styles.backButton}><ChevronLeftDark /> {t('button.back')}</button>
+      <h1 className={styles.headerText}>{subPageTitle}</h1>
+    </div>
+  );
+};

--- a/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.module.css
+++ b/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.module.css
@@ -39,3 +39,9 @@
 .notButton:focus {
     outline: none;
 }
+
+@media (max-width: 768px) { 
+    .container {
+         margin-bottom: 0;
+    }
+}

--- a/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.tsx
+++ b/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.tsx
@@ -1,18 +1,21 @@
 import { ReactNode } from 'react';
-import styles from './settingsItemContainer.module.css';
+import styles from './settingsItem.module.css';
 
 type TProps = {
+  className?: string
     onClick?: () => void;
     settingName: string;
     secondaryText?: string | JSX.Element;
-    extraComponent?: ReactNode;
+  extraComponent?: ReactNode;
+
 }
 
-export const SettingsItemContainer = ({
+export const SettingsItem = ({
+  className,
   onClick,
   settingName,
   secondaryText,
-  extraComponent
+  extraComponent,
 }: TProps) => {
   const notButton = onClick === undefined;
 
@@ -33,11 +36,11 @@ export const SettingsItemContainer = ({
   return (
     <>
       {notButton ?
-        <div className={`${styles.container} ${styles.notButton}`} >
+        <div className={`${styles.container} ${styles.notButton} ${className}`} >
           {content}
         </div> :
         <button
-          className={styles.container}
+          className={`${styles.container} ${className}`}
           onClick={onClick}>
           {content}
         </button> }

--- a/frontends/web/src/routes/new-settings/components/tabs.module.css
+++ b/frontends/web/src/routes/new-settings/components/tabs.module.css
@@ -1,0 +1,25 @@
+.container {
+    display: flex;
+    padding-left: var(--space-half);
+    margin-bottom: var(--space-default);
+}
+
+.container a {
+    margin-right: var(--space-default);
+    font-size: var(--size-subheader);
+    text-decoration: none;
+}
+
+.container a.active {
+    padding-bottom: var(--space-half);
+    border-bottom: 2px solid var(--color-blue);
+}
+
+@media (max-width: 768px) {
+    .container,
+    .container a,
+    .container a.active {
+        all: unset;
+    }
+}
+

--- a/frontends/web/src/routes/new-settings/components/tabs.tsx
+++ b/frontends/web/src/routes/new-settings/components/tabs.tsx
@@ -1,0 +1,79 @@
+import { ReactNode } from 'react';
+import { MobileHeader } from './mobile-header';
+import { NavLink } from 'react-router-dom';
+import { route } from '../../../utils/route';
+import { SettingsItem } from './settingsItem/settingsItem';
+import { ChevronRightDark } from '../../../components/icon';
+import { useTranslation } from 'react-i18next';
+import styles from './tabs.module.css';
+
+type TWithSettingsTabsProps = {
+  children: ReactNode
+  deviceIDs: string[]
+  hideMobileMenu?: boolean;
+  subPageTitle: string;
+}
+
+type TTab = {
+  name: string;
+  url: string;
+  hideMobileMenu?: boolean;
+}
+
+type TTabs = {
+  deviceIDs: string[];
+  hideMobileMenu?: boolean;
+}
+
+export const WithSettingsTabs = ({ children, deviceIDs, hideMobileMenu, subPageTitle }: TWithSettingsTabsProps) => {
+  return (
+    <>
+      <div className="show-on-small">
+        <MobileHeader subPageTitle={subPageTitle} />
+      </div>
+      <div className="hide-on-small">
+        <Tabs hideMobileMenu={hideMobileMenu} deviceIDs={deviceIDs} />
+      </div>
+      {children}
+    </>
+  );
+};
+
+export const Tab = ({ name, url, hideMobileMenu }: TTab) => {
+
+  if (!hideMobileMenu) {
+    // Will only be shown on mobile (index/general settings page)
+    return (
+      <div key={url} className="show-on-small">
+        <SettingsItem
+          settingName={name}
+          onClick={() => route(url)}
+          extraComponent={<ChevronRightDark/>} />
+      </div>
+    );
+  }
+
+  return (
+    <NavLink
+      className={({ isActive }) => isActive ? `${styles.active} hide-on-small` : 'hide-on-small'}
+      to={url}
+      key={url}>
+      {name}
+    </NavLink>
+  );
+};
+
+export const Tabs = ({ deviceIDs, hideMobileMenu }: TTabs) => {
+  const { t } = useTranslation();
+  return (
+    <div className={styles.container}>
+      <Tab hideMobileMenu={hideMobileMenu} name={t('settings.appearance')} url="/new-settings/appearance" />
+      <Tab hideMobileMenu={hideMobileMenu} name={'Manage accounts'} url="/new-settings/manage-accounts"/>
+      {deviceIDs.map(id => (
+        <Tab hideMobileMenu={hideMobileMenu} name={'Device settings'} key={id} url={`/device/${id}`} />
+      )) }
+      <Tab hideMobileMenu={hideMobileMenu} name={'Advanced settings'} url="/new-settings/advanced-settings" />
+      <Tab hideMobileMenu={hideMobileMenu} name={'About'} url="/new-settings/about" />
+    </div>
+  );
+};

--- a/frontends/web/src/routes/new-settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/new-settings/mobile-settings.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { View, ViewContent } from '../../components/view/view';
+import { Header, Main } from '../../components/layout';
+import { route } from '../../utils/route';
+import { useMediaQuery } from '../../hooks/mediaquery';
+import { Tabs } from './components/tabs';
+
+type TProps = {
+  deviceIDs: string[]
+}
+
+/**
+ * The "index" page of the settings
+ * that will only be shown on Mobile.
+ *
+ * The data will be the same as the "tabs"
+ * we see on Desktop, as it's the equivalent
+ * of "tabs" on Mobile.
+ **/
+export const MobileSettings = ({ deviceIDs }: TProps) => {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  useEffect(() => {
+    if (!isMobile) {
+      route('/new-settings/appearance');
+    }
+  }, [isMobile]);
+  return (
+    <Main>
+      <Header title={<h2>Settings</h2>} />
+      <View fullscreen={false}>
+        <ViewContent>
+          <Tabs deviceIDs={deviceIDs} />
+        </ViewContent>
+      </View>
+    </Main>
+  );
+};

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -20,6 +20,7 @@ import { Passphrase } from './device/bitbox02/passphrase';
 import { Account } from './account/account';
 import { ReceiveAccountsSelector } from './accounts/select-receive';
 import { Appearance } from './new-settings/appearance';
+import { MobileSettings } from './new-settings/mobile-settings';
 
 type TAppRouterProps = {
     devices: TDevices;
@@ -110,6 +111,18 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
     devices={devices}
   /></InjectParams>;
 
+  const MobileSettingsEl = <InjectParams>
+    <MobileSettings
+      deviceIDs={deviceIDs}
+    />
+  </InjectParams>;
+
+  const AppearanceEl = <InjectParams>
+    <Appearance
+      deviceIDs={deviceIDs}
+    />
+  </InjectParams>;
+
   const ReceiveAccountsSelectorEl = <InjectParams><ReceiveAccountsSelector activeAccounts={activeAccounts}/></InjectParams>;
 
   return <Routes>
@@ -142,7 +155,8 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
         <Route path="manage-accounts" element={<ManageAccounts key={'manage-accounts'} />} />
       </Route>
       <Route path="new-settings">
-        <Route path="appearance" element={<Appearance />} />
+        <Route index element={MobileSettingsEl} />
+        <Route path="appearance" element={AppearanceEl} />
       </Route>
     </Route>
   </Routes>;


### PR DESCRIPTION
This PR is mainly to set-up the Tabs view that we have on Desktop, as well as the "Back" button when on mobile.

For each changes, please see the commits history.

Preview (desktop):
<img width="1490" alt="Screenshot 2023-04-24 at 18 44 53" src="https://user-images.githubusercontent.com/28676406/234063185-36f4d3d9-c135-48f3-bb21-a10db020bcc1.png">

Preview (mobile) _(still missing the "arrow left" / "chevron left" icon to be put on the left of the "Back" button):_
<img width="333" alt="Screenshot 2023-04-24 at 18 45 29" src="https://user-images.githubusercontent.com/28676406/234063197-df29786a-3c83-4303-b52b-d329c33a2e55.png">
