### PR TITLE
frontend: single dropdown styling and refactoring

### DIFF
--- a/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -1,32 +1,6 @@
+import { setActiveFiat, store } from '../../../../components/rates/rates';
+import { SingleDropdown } from '../singledropdown/singledropdown';
 import { SettingsItem } from '../settingsItem/settingsItem';
-import Select from 'react-select';
-import { store, setActiveFiat } from '../../../../components/rates/rates';
-import { Fiat } from '../../../../api/account';
-import styles from './defaultCurrencySetting.module.css';
-
-type SelectOption = {
-  label: Fiat;
-  value: Fiat;
-}
-
-type TSelectProps = {
-  options: SelectOption[];
-  handleChange: (fiat: Fiat) => void;
-}
-
-const ReactSelect = ({ options, handleChange }: TSelectProps) => <Select
-  className={styles.select}
-  classNamePrefix="react-select"
-  defaultValue={{ label: store.state.active, value: store.state.active }}
-  isSearchable={true}
-  onChange={(selected) => {
-    if (selected) {
-      handleChange(selected.value as Fiat);
-    }
-  }
-  }
-  options={options}
-/>;
 
 export const DefaultCurrencyDropdownSetting = () => {
   const formattedCurrencies = store.state.selected.map((currency) => ({ label: currency, value: currency }));
@@ -35,7 +9,13 @@ export const DefaultCurrencyDropdownSetting = () => {
     <SettingsItem
       settingName="Default Currency"
       secondaryText="Select your default currency."
-      extraComponent={<ReactSelect options={formattedCurrencies} handleChange={setActiveFiat}/>}
+      extraComponent={
+        <SingleDropdown
+          options={formattedCurrencies}
+          handleChange={setActiveFiat}
+          defaultValue={{ label: store.state.active, value: store.state.active }}
+        />
+      }
     />
   );
 };

--- a/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencySetting.module.css
+++ b/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencySetting.module.css
@@ -1,3 +1,0 @@
-.select {
-    width: 280px;
-}

--- a/frontends/web/src/routes/new-settings/components/appearance/languageDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/languageDropdownSetting.tsx
@@ -1,20 +1,8 @@
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { useTranslation } from 'react-i18next';
-import { TActiveLanguageCodes, TLanguage, TLanguagesList } from '../../../../components/language/types';
-import Select from 'react-select';
-import styles from './defaultCurrencySetting.module.css';
+import { TLanguagesList } from '../../../../components/language/types';
 import { getSelectedIndex } from '../../../../utils/language';
-
-type SelectOption = {
-  label: string;
-  value: TActiveLanguageCodes;
-}
-
-type TSelectProps = {
-  options: SelectOption[];
-  handleChange: (langCode: TActiveLanguageCodes) => void;
-  selectedLanguage: TLanguage;
-}
+import { SingleDropdown } from '../singledropdown/singledropdown';
 
 const defaultLanguages: TLanguagesList = [
   { code: 'ar', display: 'العربية' },
@@ -37,21 +25,6 @@ const defaultLanguages: TLanguagesList = [
   { code: 'zh', display: '中文' },
 ];
 
-
-const ReactSelect = ({ options, handleChange, selectedLanguage }: TSelectProps) => <Select
-  className={styles.select}
-  classNamePrefix="react-select"
-  isSearchable={true}
-  defaultValue={{ label: selectedLanguage.display, value: selectedLanguage.code }}
-  onChange={(selected) => {
-    if (selected) {
-      handleChange(selected.value as TActiveLanguageCodes);
-    }
-  }
-  }
-  options={options}
-/>;
-
 export const LanguageDropdownSetting = () => {
   const { i18n } = useTranslation();
   const selectedLanguage = defaultLanguages[getSelectedIndex(defaultLanguages, i18n)];
@@ -60,7 +33,13 @@ export const LanguageDropdownSetting = () => {
     <SettingsItem
       settingName="Language"
       secondaryText="Which language you want the BitBoxApp to use."
-      extraComponent={<ReactSelect options={formattedLanguages} handleChange={i18n.changeLanguage} selectedLanguage={selectedLanguage} />}
+      extraComponent={
+        <SingleDropdown
+          options={formattedLanguages}
+          handleChange={i18n.changeLanguage}
+          defaultValue={{ label: selectedLanguage.display, value: selectedLanguage.code }}
+        />
+      }
     />
   );
 };

--- a/frontends/web/src/routes/new-settings/components/singledropdown/singledropdown.module.css
+++ b/frontends/web/src/routes/new-settings/components/singledropdown/singledropdown.module.css
@@ -1,0 +1,50 @@
+.dropdown {
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23777' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-labelledby='chevron down' color='%23777'%3E%3Cdefs/%3E%3Cpolyline points='6 10 12 16 18 10'/%3E%3C/svg%3E%0A");
+    background-repeat: no-repeat;
+    font-weight: 400;
+    height: calc(var(--space-quarter) * 3);
+    padding: 0 calc(var(--space-quarter) + var(--space-eight));
+}
+
+.select {
+    width: 280px;
+}
+
+.select :global(.react-select__menu) {
+    background-color: var(--background-secondary);
+}
+
+.select :global(.react-select__option) {
+    background-color: var(--background-secondary);
+}
+
+.select :global(.react-select__option):hover {
+    background-color: var(--background-custom-select-hover);
+}
+
+.select :global(.react-select__option--is-selected),
+.select :global(.react-select__option--is-selected):hover {
+    background-color: var(--background-custom-select-selected);
+}
+
+.select :global(.react-select__control) {
+    background-color: var(--background-secondary);
+    border: 2px solid var(--color-custom-select-border);
+    border-radius: 0;
+    padding: 0 var(--space-eight);
+}
+
+.select :global(.react-select__control):hover {
+    cursor: pointer;
+}
+
+.valueContainer {
+    font-size: var(--size-default);
+    color: var(--color-default);
+    padding: 8px 0;
+}
+
+.select :global(.react-select__option--is-selected) .optionValue {
+    color: var(--color-alt);
+}

--- a/frontends/web/src/routes/new-settings/components/singledropdown/singledropdown.tsx
+++ b/frontends/web/src/routes/new-settings/components/singledropdown/singledropdown.tsx
@@ -1,0 +1,66 @@
+import { FC } from 'react';
+import Select, { components, DropdownIndicatorProps, SingleValue as SingleValueType, SingleValueProps, OptionProps } from 'react-select';
+import styles from './singledropdown.module.css';
+
+type TOption = {
+    label: string;
+    value: string;
+}
+
+type TSelectProps = {
+    options: TOption[];
+    handleChange: (param?: any) => void;
+    defaultValue: TOption;
+}
+
+const DropdownIndicator: FC<DropdownIndicatorProps<TOption>> = (props) => {
+  return (
+    <components.DropdownIndicator {...props}>
+      <div className={styles.dropdown} />
+    </components.DropdownIndicator>
+  );
+};
+
+
+const Option: FC<OptionProps<TOption>> = (props) => {
+  const { label } = props.data;
+  return (
+    <components.Option {...props}>
+      <div className={styles.valueContainer}>
+        <span className={styles.optionValue}>{label}</span>
+      </div>
+    </components.Option>
+  );
+};
+
+const SingleValue: FC<SingleValueProps<TOption>> = (props) => {
+  const { label } = props.data;
+  return (
+    <components.SingleValue {...props}>
+      <div className={styles.valueContainer}>
+        <span className={styles.singleValue}>{label}</span>
+      </div>
+    </components.SingleValue>
+  );
+};
+
+
+export const SingleDropdown = ({ options, handleChange, defaultValue }: TSelectProps) => {
+  return (
+    <Select
+      className={styles.select}
+      classNamePrefix="react-select"
+      isSearchable={true}
+      defaultValue={defaultValue}
+      components={{ IndicatorSeparator: () => null, DropdownIndicator, SingleValue, Option }}
+      onChange={(selected) => {
+        if (selected) {
+          const value = (selected as SingleValueType<TOption>)?.value || '';
+          handleChange(value);
+        }
+      }
+      }
+      options={options}
+    />
+  );
+};

--- a/frontends/web/src/style/variables.css
+++ b/frontends/web/src/style/variables.css
@@ -106,6 +106,7 @@
     --color-light: var(--color-mediumgray);
     --color-alt: var(--color-white);
     --color-tertiary: var(--color-gray-alt);
+    --color-custom-select-border: var(--color-lightgray);
 
     /* background colors */
     /* all backgrounds should use these colors and not from the main colors directly */
@@ -132,6 +133,7 @@
         --color-light: var(--color-mediumgray);
         --color-alt: var(--color-white);
         --color-tertiary: var(--color-gray-alt);
+        --color-custom-select-border: var(--color-gray);
 
         /* background colors */
         --background: var(--color-dark);
@@ -157,6 +159,7 @@
         --color-light: var(--color-mediumgray);
         --color-alt: var(--color-white);
         --color-tertiary: var(--color-gray-alt);
+        --color-custom-select-border: var(--color-gray);
 
         /* background colors */
         --background: var(--color-dark);


### PR DESCRIPTION
Refactored and re-styled the **single dropdown** component for the newly redesigned / revamped settings. This is so that we can re-use and already are re-using the this **single dropdown** component in this PR. 

We'll do the same for multi dropdown component (which is used for selecting active currencies) **in another PR.**

For detailed changes, please refer to the commit history.

Preview (light):
<img width="1482" alt="Screenshot 2023-05-01 at 17 44 48" src="https://user-images.githubusercontent.com/28676406/235481514-3b220f40-fa44-482b-b7c2-ca9661a9acc0.png">

Preview (dark):
<img width="1482" alt="Screenshot 2023-05-01 at 17 44 42" src="https://user-images.githubusercontent.com/28676406/235481531-219af338-df0c-45fc-a367-b334bd310ff2.png">
