### PR TITLE
frontend/android: update targetSdkVersion to 33

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   # https://docs.github.com/en/packages/guides/pushing-and-pulling-docker-images
   #
   # Keep this in sync with default in scripts/github-ci.sh.
-  CI_IMAGE: ghcr.io/digitalbitbox/bitbox-wallet-app-ci:17
+  CI_IMAGE: ghcr.io/digitalbitbox/bitbox-wallet-app-ci:18
   GITHUB_BUILD_DIR: ${{github.workspace}}
 
 jobs:

--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    buildToolsVersion "29.0.0"
-    compileSdkVersion 29
+    buildToolsVersion "33.0.0"
+    compileSdkVersion 33
     defaultConfig {
         applicationId "ch.shiftcrypto.bitboxapp"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 42
         versionName "android-4.37.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/scripts/docker_install.sh
+++ b/scripts/docker_install.sh
@@ -63,4 +63,4 @@ gem install --no-ri --no-rdoc fpm
 # Needed for Android.
 apt-get install -y --no-install-recommends default-jdk
 # Keep versions in sync with build.gradle and frontends/android/Makefile.
-/opt/android-sdk/cmdline-tools/tools/bin/sdkmanager "ndk;21.2.6472646" "platforms;android-29" "build-tools;29.0.0" "platform-tools"
+/opt/android-sdk/cmdline-tools/tools/bin/sdkmanager "ndk;21.2.6472646" "platforms;android-33" "build-tools;33.0.0" "platform-tools"

--- a/scripts/github-ci.sh
+++ b/scripts/github-ci.sh
@@ -12,7 +12,7 @@ if [ "$OS_NAME" == "linux" ]; then
     # Which docker image to use to run the CI. Defaults to Docker Hub.
     # Overwrite with CI_IMAGE=docker/image/path environment variable.
     # Keep this in sync with .github/workflows/ci.yml.
-    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:17}"
+    : "${CI_IMAGE:=shiftcrypto/bitbox-wallet-app:18}"
     # Time image pull to compare in the future.
     time docker pull "$CI_IMAGE"
 


### PR DESCRIPTION
We need to update target SDK version because of this:

```
Starting August 31, 2023:

    New apps and app updates must target API level 33 to be submitted to Google Play (Wear OS must target API 30).
    Existing apps must target API level 31 or above to remain discoverable by all users on Google Play. Apps that target API level 30 or below (target API level 29 or below for Wear OS), will only be discoverable on devices running Android OS same or lower than your apps’ target API level.
```