### PR TITLE
backend/handlers: add notes to utxo

### DIFF
--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -319,6 +319,7 @@ func (handlers *Handlers) getUTXOs(_ *http.Request) (interface{}, error) {
 				"amount":     handlers.formatBTCAmountAsJSON(btcutil.Amount(output.TxOut.Value), false),
 				"address":    output.Address.EncodeForHumans(),
 				"scriptType": output.Address.Configuration.ScriptType(),
+				"note":       handlers.account.TxNote(output.OutPoint.Hash.String()),
 			})
 	}
 

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -284,6 +284,7 @@ export type TUTXO = {
   txOutput: number;
   address: string;
   amount: IAmount;
+  note: string;
   scriptType: ScriptType;
 };
 

--- a/frontends/web/src/routes/account/send/utxos.module.css
+++ b/frontends/web/src/routes/account/send/utxos.module.css
@@ -21,11 +21,20 @@
     font-size: var(--size-subheader);
 }
 
+.note {
+    color: var(--color-default);
+    font-size: var(--size-subheader);
+    line-height: 1.5;
+    margin-top: -7px;
+    margin-bottom: var(--space-quarter);
+}
+
 .utxoData {
     flex-basis: auto;
     flex-grow: 1;
     flex-shrink: 1;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 .utxoExplorer {
@@ -44,7 +53,6 @@
 }
 
 .amounts {
-    line-height: 1;
     padding-bottom: var(--space-quarter);
 }
 

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -97,6 +97,11 @@ export const UTXOs = ({
                 id={'utxo-' + utxo.outPoint}
                 data-outpoint={utxo.outPoint}
                 onChange={handleUTXOChange}>
+                {utxo.note && (
+                  <div className={style.note}>
+                    <strong>{utxo.note}{' '}</strong>
+                  </div>
+                )}
                 <div className={style.utxoContent}>
                   <div className={style.utxoData}>
                     <div className={style.amounts}>


### PR DESCRIPTION
This adds notes to utxo struct, to be displayed when using coin control feature.