### PR TITLE
frontend: make manage account tab functional for the new settings

### DIFF
--- a/frontends/web/src/routes/new-settings/about.tsx
+++ b/frontends/web/src/routes/new-settings/about.tsx
@@ -3,19 +3,17 @@ import { Main, Header } from '../../components/layout';
 import { View, ViewContent } from '../../components/view/view';
 import { WithSettingsTabs } from './components/tabs';
 import { AppVersion } from './components/about/app-version-setting';
+import { TPagePropsWithSettingsTabs } from './type';
 
-type TProps = {
-  deviceIDs: string[]
-}
 
-export const About = ({ deviceIDs }: TProps) => {
+export const About = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
   return (
     <Main>
       <div className="hide-on-small"><Header title={<h2>{t('sidebar.settings')}</h2>} /></div>
       <View fullscreen={false}>
         <ViewContent>
-          <WithSettingsTabs subPageTitle={t('settings.about')} hideMobileMenu deviceIDs={deviceIDs}>
+          <WithSettingsTabs deviceIDs={deviceIDs} hideMobileMenu hasAccounts={hasAccounts} subPageTitle={t('settings.about')}>
             <AppVersion />
           </WithSettingsTabs>
         </ViewContent>

--- a/frontends/web/src/routes/new-settings/appearance.tsx
+++ b/frontends/web/src/routes/new-settings/appearance.tsx
@@ -7,19 +7,16 @@ import { DisplaySatsToggleSetting } from './components/appearance/displaySatsTog
 import { LanguageDropdownSetting } from './components/appearance/languageDropdownSetting';
 import { ActiveCurrenciesDropdownSettingWithStore } from './components/appearance/activeCurrenciesDropdownSetting';
 import { WithSettingsTabs } from './components/tabs';
+import { TPagePropsWithSettingsTabs } from './type';
 
-type TProps = {
-  deviceIDs: string[]
-}
-
-export const Appearance = ({ deviceIDs }: TProps) => {
+export const Appearance = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
   return (
     <Main>
       <div className="hide-on-small"><Header title={<h2>{t('sidebar.settings')}</h2>} /></div>
       <View fullscreen={false}>
         <ViewContent>
-          <WithSettingsTabs subPageTitle={t('settings.appearance')} hideMobileMenu deviceIDs={deviceIDs}>
+          <WithSettingsTabs subPageTitle={t('settings.appearance')} hasAccounts={hasAccounts} hideMobileMenu deviceIDs={deviceIDs}>
             <DefaultCurrencyDropdownSetting />
             <ActiveCurrenciesDropdownSettingWithStore />
             <LanguageDropdownSetting />

--- a/frontends/web/src/routes/new-settings/components/tabs.tsx
+++ b/frontends/web/src/routes/new-settings/components/tabs.tsx
@@ -10,6 +10,7 @@ import styles from './tabs.module.css';
 type TWithSettingsTabsProps = {
   children: ReactNode
   deviceIDs: string[]
+  hasAccounts: boolean;
   hideMobileMenu?: boolean;
   subPageTitle: string;
 }
@@ -22,17 +23,24 @@ type TTab = {
 
 type TTabs = {
   deviceIDs: string[];
+  hasAccounts: boolean;
   hideMobileMenu?: boolean;
 }
 
-export const WithSettingsTabs = ({ children, deviceIDs, hideMobileMenu, subPageTitle }: TWithSettingsTabsProps) => {
+export const WithSettingsTabs = ({
+  children,
+  deviceIDs,
+  hideMobileMenu,
+  hasAccounts,
+  subPageTitle
+}: TWithSettingsTabsProps) => {
   return (
     <>
       <div className="show-on-small">
         <MobileHeader subPageTitle={subPageTitle} />
       </div>
       <div className="hide-on-small">
-        <Tabs hideMobileMenu={hideMobileMenu} deviceIDs={deviceIDs} />
+        <Tabs hideMobileMenu={hideMobileMenu} deviceIDs={deviceIDs} hasAccounts={hasAccounts} />
       </div>
       {children}
     </>
@@ -63,17 +71,17 @@ export const Tab = ({ name, url, hideMobileMenu }: TTab) => {
   );
 };
 
-export const Tabs = ({ deviceIDs, hideMobileMenu }: TTabs) => {
+export const Tabs = ({ deviceIDs, hideMobileMenu, hasAccounts }: TTabs) => {
   const { t } = useTranslation();
   return (
     <div className={styles.container}>
-      <Tab hideMobileMenu={hideMobileMenu} name={t('settings.appearance')} url="/new-settings/appearance" />
-      <Tab hideMobileMenu={hideMobileMenu} name={'Manage accounts'} url="/new-settings/manage-accounts"/>
+      <Tab key="appearance" hideMobileMenu={hideMobileMenu} name={t('settings.appearance')} url="/new-settings/appearance" />
+      {hasAccounts ? <Tab key="manage-accounts" hideMobileMenu={hideMobileMenu} name={'Manage accounts'} url="/settings/manage-accounts" /> : null}
       {deviceIDs.map(id => (
-        <Tab hideMobileMenu={hideMobileMenu} name={'Device settings'} key={id} url={`/device/${id}`} />
+        <Tab hideMobileMenu={hideMobileMenu} name={'Device settings'} key={`device-${id}`} url={`/device/${id}`} />
       )) }
-      <Tab hideMobileMenu={hideMobileMenu} name={'Advanced settings'} url="/new-settings/advanced-settings" />
-      <Tab hideMobileMenu={hideMobileMenu} name={t('settings.about')} url="/new-settings/about" />
+      <Tab key="advanced-settings" hideMobileMenu={hideMobileMenu} name={'Advanced settings'} url="/new-settings/advanced-settings" />
+      <Tab key="about" hideMobileMenu={hideMobileMenu} name={'About'} url="/new-settings/about" />
     </div>
   );
 };

--- a/frontends/web/src/routes/new-settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/new-settings/mobile-settings.tsx
@@ -4,10 +4,7 @@ import { Header, Main } from '../../components/layout';
 import { route } from '../../utils/route';
 import { useMediaQuery } from '../../hooks/mediaquery';
 import { Tabs } from './components/tabs';
-
-type TProps = {
-  deviceIDs: string[]
-}
+import { TPagePropsWithSettingsTabs } from './type';
 
 /**
  * The "index" page of the settings
@@ -17,7 +14,7 @@ type TProps = {
  * we see on Desktop, as it's the equivalent
  * of "tabs" on Mobile.
  **/
-export const MobileSettings = ({ deviceIDs }: TProps) => {
+export const MobileSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const isMobile = useMediaQuery('(max-width: 768px)');
   useEffect(() => {
     if (!isMobile) {
@@ -29,7 +26,7 @@ export const MobileSettings = ({ deviceIDs }: TProps) => {
       <Header title={<h2>Settings</h2>} />
       <View fullscreen={false}>
         <ViewContent>
-          <Tabs deviceIDs={deviceIDs} />
+          <Tabs deviceIDs={deviceIDs} hasAccounts={hasAccounts} />
         </ViewContent>
       </View>
     </Main>

--- a/frontends/web/src/routes/new-settings/type.ts
+++ b/frontends/web/src/routes/new-settings/type.ts
@@ -1,0 +1,4 @@
+export type TPagePropsWithSettingsTabs = {
+    deviceIDs: string[];
+    hasAccounts: boolean;
+}

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -41,6 +41,7 @@ const InjectParams = ({ children }: TInjectParamsProps) => {
 };
 
 export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAccounts }: TAppRouterProps) => {
+  const hasAccounts = accounts.length > 0;
   const Homepage = <DeviceSwitch
     key={devicesKey('device-switch-default')}
     deviceID={null}
@@ -115,18 +116,22 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
   const MobileSettingsEl = <InjectParams>
     <MobileSettings
       deviceIDs={deviceIDs}
+      hasAccounts={hasAccounts}
+
     />
   </InjectParams>;
 
   const AppearanceEl = <InjectParams>
     <Appearance
       deviceIDs={deviceIDs}
+      hasAccounts={hasAccounts}
     />
   </InjectParams>;
 
   const AboutEl = <InjectParams>
     <About
       deviceIDs={deviceIDs}
+      hasAccounts={hasAccounts}
     />
   </InjectParams>;
 


### PR DESCRIPTION
We pass a condition `hasAccounts` (bool) to each page that uses tabs, and based on this condition the settings tab render "Manage Accounts" tab (if `true`) and vice versa (when `false`).

When user has no account (Manage Account tab isn't visible):
<img width="1480" alt="Screenshot 2023-05-08 at 09 29 30" src="https://user-images.githubusercontent.com/28676406/236762631-eb045442-b0d8-4f8b-8e1d-85a1cef0d645.png">

When user has at least 1 account (Manage Account tab visible):
<img width="1480" alt="Screenshot 2023-05-08 at 09 24 40" src="https://user-images.githubusercontent.com/28676406/236762602-cbb485df-8df6-4646-84a4-2e52784125f7.png">
