### PR TITLE
docker: update ubuntu base image to 20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Improve sats amount readability adding thousands separator
+- Update minimum supported buntu version to 20.04+
 
 ## 4.37.0
 - Bundle BitBox02 firmware version v9.14.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 FROM thyrlian/android-sdk:4.0 as android
 
-FROM shiftcrypto/qt5:5.15.2
+FROM shiftcrypto/qt5:4
 
 # Android
 COPY --from=android /opt/android-sdk /opt/android-sdk

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -4,7 +4,7 @@ platforms should be viable for development, building, and use of the BitBox
 Wallet application.
 
 * Debian GNU/Linux: Stretch and Buster or newer
-* Ubuntu: 18.04+
+* Ubuntu: 20.04+
 * Fedora: 26+
 * MacOS: 10.13+
 * Windows: Windows 7+

--- a/frontends/qt/docker-qt5base/Dockerfile
+++ b/frontends/qt/docker-qt5base/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:18.04 as qt5base
+FROM ubuntu:20.04 as qt5base
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -56,7 +56,7 @@ RUN apt-get -y install --no-install-recommends \
     libfontconfig1-dev \
     libcap-dev \
     libbz2-dev \
-    libgcrypt11-dev \
+    libgcrypt20-dev \
     libpci-dev \
     libnss3-dev \
     libxcursor-dev \
@@ -77,6 +77,7 @@ RUN apt-get -y install --no-install-recommends \
     libxss-dev \
     libasound2-dev \
     libgstreamer1.0-dev \
+    libwayland-dev \
     libgstreamer-plugins-base1.0-dev
 
 # Get the source code
@@ -108,11 +109,13 @@ RUN cd /tmp/qt5 && make -j1
 
 RUN cd /tmp/qt5 && make install
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
 
 COPY --from=qt5base /opt/qt5 /opt/qt5
 
 Run apt-get update
 
 # This is needed for compiling apps depending on the qt5 libs.
-RUN apt-get -y install --no-install-recommends libxcb-xinerama0 libxcb-xkb-dev libxcb-render-util0 libxcb-image0 libxcb-keysyms1 libxcb-icccm4 libcups2 libgl1-mesa-dev libegl1-mesa-dev libfontconfig1-dev libfreetype6-dev libxi-dev libxcursor-dev libxrender-dev libxss-dev libxcomposite-dev libasound2-dev libxtst-dev libxslt-dev libnss3-dev libicu-dev
+RUN apt-get -y install --no-install-recommends libxcb-xinerama0 libxcb-xkb-dev libxcb-render-util0 libxcb-image0 libxcb-keysyms1 libxcb-icccm4 libxcb-randr0 libxcb-shape0 libxcb-xinput0 libcups2 libgl1-mesa-dev libegl1-mesa-dev libfontconfig1-dev libfreetype6-dev libxi-dev libxcursor-dev libxrender-dev libxss-dev libxcomposite-dev libasound2-dev libxtst-dev libxslt-dev libnss3-dev libicu-dev libpcre2-16-0

--- a/scripts/docker_install.sh
+++ b/scripts/docker_install.sh
@@ -58,7 +58,7 @@ cd /opt && \
 # Install fpm to create deb/rpm packages
 apt-get install -y --no-install-recommends \
         ruby ruby-dev build-essential rpm
-gem install --no-ri --no-rdoc fpm
+gem install --no-document fpm
 
 # Needed for Android.
 apt-get install -y --no-install-recommends default-jdk


### PR DESCRIPTION
We would like to update nodejs to v18.16.0, which requires libc6 with a higher version than that available on ubuntu 18.04 (which reached end of life on 30/04/2023). This commit updates shiftcrypto/qt5 and shiftcripto/bitbox-wallet-app docker images to be based upon ubuntu 20.04 and allows updating nodejs.