### PR TITLE
frontend: display bitbox01 serial number for customer support

### DIFF
--- a/frontends/web/src/components/settingsButton/settingsButton.module.css
+++ b/frontends/web/src/components/settingsButton/settingsButton.module.css
@@ -38,7 +38,7 @@
     font-size: var(--size-small);
     color: var(--color-secondary);
     white-space: nowrap;
-    max-width: 150px;
+    max-width: 300px;
     text-overflow: ellipsis;
     overflow: hidden;
 }

--- a/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/settings.jsx
@@ -45,6 +45,7 @@ class Settings extends Component {
     name: null,
     spinner: true,
     sdcard: false,
+    serial: '',
     pairing: false,
     mobileChannel: false,
     connected: false,
@@ -59,6 +60,7 @@ class Settings extends Component {
         new_hidden_wallet,
         pairing,
         sdcard,
+        serial,
         version,
       }) => {
         this.setState({
@@ -68,6 +70,7 @@ class Settings extends Component {
           newHiddenWallet: new_hidden_wallet,
           pairing,
           sdcard,
+          serial,
           spinner: false,
         });
       });
@@ -124,6 +127,7 @@ class Settings extends Component {
       name,
       spinner,
       sdcard,
+      serial,
       pairing,
       mobileChannel,
       connected,
@@ -200,6 +204,9 @@ class Settings extends Component {
                   <div className="column column-1-2">
                     <h3 className="subTitle">{t('deviceSettings.hardware.title')}</h3>
                     <div className="box slim divide">
+                      <SettingsItem optionalText={serial}>
+                        Serial number
+                      </SettingsItem>
                       <SettingsItem optionalText={t(`deviceSettings.hardware.sdcard.${sdcard}`)}>
                         {t('deviceSettings.hardware.sdcard.label')}
                       </SettingsItem>


### PR DESCRIPTION
Added BitBox01 serial number for customer support purposes.

![Screen Shot 2023-05-17 at 14 33 03](https://github.com/digitalbitbox/bitbox-wallet-app/assets/546900/ac670afa-906c-4384-a8b6-cdf38a8ddf2c)
