### PR TITLE
frontend: hide hamburger on large screen

### DIFF
--- a/frontends/web/src/components/layout/header.module.css
+++ b/frontends/web/src/components/layout/header.module.css
@@ -108,6 +108,12 @@
     opacity: 0.4;    
 }
 
+@media (min-width: 1200px) {
+    .sidebarToggler {
+        display: none;
+    }
+}
+
 @media (max-width: 768px) {
     .container .header {
         padding: 0 var(--space-half);


### PR DESCRIPTION
Hamber should not be shown on large screen as the sidebar is always visible, for example on waiting view.

CSS regression introduced in b169a1439