### PR TITLE
frontend: move create-wallet workflow to its own component

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -17,7 +17,7 @@
 
 import { Component } from 'react';
 import { Backup } from '../components/backup';
-import { checkSDCard, errUserAbort, getStatus, getVersion, insertSDCard, restoreFromMnemonic, setDeviceName, setPassword, VersionInfo, verifyAttestation, TStatus, createBackup } from '../../../api/bitbox02';
+import { checkSDCard, getStatus, getVersion, insertSDCard, restoreFromMnemonic, VersionInfo, verifyAttestation, TStatus } from '../../../api/bitbox02';
 import { attestationCheckDone, statusChanged } from '../../../api/devicessync';
 import { UnsubscribeList, unsubscribe } from '../../../utils/subscriptions';
 import { route } from '../../../utils/route';
@@ -31,11 +31,10 @@ import { UpgradeButton } from './upgradebutton';
 import { Unlock } from './unlock';
 import { Pairing } from './setup/pairing';
 import { Wait } from './setup/wait';
-import { SetPassword, SetPasswordWithBackup } from './setup/password';
+import { SetPasswordWithBackup } from './setup/password';
 import { SetupOptions } from './setup/choose';
-import { SetDeviceName } from './setup/name';
 import { RestoreFromSDCardBackup } from './setup/restore';
-import { ChecklistWalletCreate } from './setup/checklist';
+import { CreateWallet } from './setup/wallet-create';
 import { CreateWalletSuccess, RestoreFromMnemonicSuccess, RestoreFromSDCardSuccess } from './setup/success';
 
 interface BitBox02Props {
@@ -48,11 +47,8 @@ interface State {
     versionInfo?: VersionInfo;
     attestation: boolean | null;
     status: '' | TStatus;
-    appStatus: 'createWallet' | 'restoreBackup' | 'restoreFromMnemonic' | 'agreement' | 'complete' | '';
-    createWalletStatus: 'intro' | 'setPassword' | 'createBackup';
+    appStatus: 'createWallet' | 'restoreBackup' | 'restoreFromMnemonic' | '';
     restoreBackupStatus: 'intro' | 'restore' | 'setPassword';
-    sdCardInserted?: boolean;
-    errorText?: string;
     // if true, we just pair and unlock, so we can hide some steps.
     unlockOnly: boolean;
     showWizard: boolean;
@@ -69,9 +65,7 @@ class BitBox02 extends Component<Props, State> {
     this.state = {
       attestation: null,
       status: '',
-      sdCardInserted: undefined,
       appStatus: '',
-      createWalletStatus: 'intro',
       restoreBackupStatus: 'intro',
       unlockOnly: true,
       showWizard: false,
@@ -116,10 +110,7 @@ class BitBox02 extends Component<Props, State> {
       if (status === 'seeded') {
         this.setState({ appStatus: 'createWallet' });
       }
-      this.setState({
-        status,
-        errorText: undefined,
-      });
+      this.setState({ status });
       if (status === 'initialized' && unlockOnly && showWizard) {
         // bitbox is unlocked, now route to / and wait for incoming accounts
         route('/', true);
@@ -132,13 +123,7 @@ class BitBox02 extends Component<Props, State> {
   }
 
   private createWallet = () => {
-    checkSDCard(this.props.deviceID).then(sdCardInserted => {
-      this.setState({ sdCardInserted });
-    });
-    this.setState({
-      appStatus: 'createWallet',
-      createWalletStatus: 'intro',
-    });
+    this.setState({ appStatus: 'createWallet' });
   };
 
   private restoreBackup = () => {
@@ -154,7 +139,6 @@ class BitBox02 extends Component<Props, State> {
 
   private insertSDCard = () => {
     return checkSDCard(this.props.deviceID).then(sdCardInserted => {
-      this.setState({ sdCardInserted });
       if (sdCardInserted) {
         return true;
       }
@@ -164,7 +148,6 @@ class BitBox02 extends Component<Props, State> {
       } });
       return insertSDCard(this.props.deviceID).then((response) => {
         this.setState({
-          sdCardInserted: response.success,
           waitDialog: undefined,
         });
         if (response.success) {
@@ -175,31 +158,6 @@ class BitBox02 extends Component<Props, State> {
         }
         return false;
       });
-    });
-  };
-
-  private setPassword = () => {
-    this.setState({ createWalletStatus: 'setPassword' });
-    setPassword(this.props.deviceID).then((response) => {
-      if (!response.success) {
-        if (response.code === errUserAbort) {
-          // On user abort, just go back to the first screen. This is a bit lazy, as we should show
-          // a screen to ask the user to go back or try again.
-          this.setState({
-            appStatus: '',
-            errorText: undefined,
-          });
-        } else {
-          this.setState({
-            errorText: this.props.t('bitbox02Wizard.noPasswordMatch'),
-          }, () => {
-            this.setPassword();
-          });
-        }
-        // show noPasswordMatch error and do NOT continue to createBackup
-        return;
-      }
-      this.setState({ createWalletStatus: 'createBackup' });
     });
   };
 
@@ -218,57 +176,6 @@ class BitBox02 extends Component<Props, State> {
       });
     }
     this.setState({ selectedBackup: undefined });
-  };
-
-  private createBackup = () => {
-    this.insertSDCard().then(success1 => {
-      if (!success1) {
-        alertUser(this.props.t('bitbox02Wizard.createBackupFailed'), { asDialog: false });
-        return;
-      }
-      this.setState({
-        waitDialog: {
-          title: this.props.t('bitbox02Interact.confirmDate'),
-          text: this.props.t('bitbox02Interact.confirmDateText'),
-        }
-      });
-      createBackup(this.props.deviceID, 'sdcard')
-        .then((result) => {
-          if (!result.success) {
-            if (result.code === 104) {
-              alertUser(this.props.t('bitbox02Wizard.createBackupAborted'), { asDialog: false });
-            } else {
-              alertUser(this.props.t('bitbox02Wizard.createBackupFailed'), { asDialog: false });
-            }
-          }
-          this.setState({ waitDialog: undefined });
-        })
-        .catch(console.error);
-    });
-  };
-
-  private setDeviceName = (deviceName: string) => {
-    const { deviceID, t } = this.props;
-    this.setState({
-      waitDialog: { title: t('bitbox02Interact.confirmName') }
-    }, async () => {
-      try {
-        const result = await setDeviceName(deviceID, deviceName);
-        if (!result.success) {
-          alertUser(result.message || t('genericError'), {
-            asDialog: false,
-            callback: () => this.setState({ waitDialog: undefined }),
-          });
-          return;
-        }
-        this.setState(
-          { waitDialog: undefined },
-          () => this.setPassword(),
-        );
-      } catch (error) {
-        console.error(error);
-      }
-    });
   };
 
   private restoreFromMnemonic = async () => {
@@ -296,12 +203,9 @@ class BitBox02 extends Component<Props, State> {
       versionInfo,
       status,
       appStatus,
-      createWalletStatus,
       restoreBackupStatus,
-      errorText,
       unlockOnly,
       showWizard,
-      sdCardInserted,
       waitDialog,
       selectedBackup,
     } = this.state;
@@ -377,18 +281,11 @@ class BitBox02 extends Component<Props, State> {
             }} />
         )}
 
-        { (!unlockOnly && appStatus === 'createWallet' && createWalletStatus === 'intro') && (
-          <SetDeviceName
-            key="set-devicename"
-            sdCardInserted={sdCardInserted}
-            onDeviceName={this.setDeviceName}
-            onBack={() => this.setState({ appStatus: '' })} />
-        )}
-        { (!unlockOnly && appStatus === 'createWallet' && createWalletStatus === 'setPassword') && (
-          <SetPassword key="create-wallet" errorText={errorText} />
-        )}
-        { (!unlockOnly && appStatus === 'createWallet' && status === 'seeded' && createWalletStatus === 'createBackup') && (
-          <ChecklistWalletCreate key="create-backup" onContinue={this.createBackup} />
+        { (!unlockOnly && appStatus === 'createWallet') && (
+          <CreateWallet
+            deviceID={deviceID}
+            isSeeded={status === 'seeded'}
+            onAbort={() => this.setState({ appStatus: '' })} />
         )}
 
         {/* keeping the backups mounted even restoreBackupStatus === 'restore' is not true so it catches potential errors */}
@@ -401,10 +298,7 @@ class BitBox02 extends Component<Props, State> {
             onBack={() => this.setState({ appStatus: '' })} />
         )}
         { (!unlockOnly && appStatus === 'restoreBackup' && status !== 'initialized' && restoreBackupStatus === 'setPassword') && (
-          <SetPasswordWithBackup
-            key="set-password"
-            errorText={errorText}
-            forBackup={selectedBackup} />
+          <SetPasswordWithBackup key="set-password" forBackup={selectedBackup} />
         )}
 
         { (appStatus === 'createWallet' && status === 'initialized') && (

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -263,7 +263,7 @@ class BitBox02 extends Component<Props, State> {
             pairingFailed={status === 'pairingFailed'} />
         )}
 
-        { (!unlockOnly && status === 'uninitialized' && appStatus === '') && (
+        { (!unlockOnly && appStatus === '') && (
           <SetupOptions
             key="choose-setup"
             onSelectSetup={(option) => {

--- a/frontends/web/src/routes/device/bitbox02/setup/password.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/password.tsx
@@ -50,12 +50,11 @@ export const SetPassword = ({ errorText }: Props) => {
   );
 };
 
-type PropsWithBackup = Props & {
+type PropsWithBackup = {
   forBackup?: Backup;
 }
 
 export const SetPasswordWithBackup = ({
-  errorText,
   forBackup,
 }: PropsWithBackup) => {
   const { i18n, t } = useTranslation();
@@ -67,25 +66,19 @@ export const SetPasswordWithBackup = ({
       withBottomBar
       width="700px">
       <ViewHeader title={t('backup.restore.confirmTitle')}>
-        {errorText ? (
-          <Status type="warning">
-            <span>{errorText}</span>
-          </Status>
-        ) : (
-          forBackup ? (
-            <div>
-              <MultilineMarkup tagName="div" markup={t('backup.restore.selectedBackup', {
-                backupName: forBackup.name,
-                createdDateTime: convertDateToLocaleString(forBackup.date, i18n.language),
-              })}/>
-              <p className="text-small text-ellipsis">
-                ID:
-                {' '}
-                {forBackup.id}
-              </p>
-            </div>
-          ) : null
-        )}
+        { forBackup ? (
+          <div>
+            <MultilineMarkup tagName="div" markup={t('backup.restore.selectedBackup', {
+              backupName: forBackup.name,
+              createdDateTime: convertDateToLocaleString(forBackup.date, i18n.language),
+            })}/>
+            <p className="text-small text-ellipsis">
+              ID:
+              {' '}
+              {forBackup.id}
+            </p>
+          </div>
+        ) : null }
       </ViewHeader>
       <ViewContent>
         <p>{t('bitbox02Wizard.stepPassword.useControls')}</p>

--- a/frontends/web/src/routes/device/bitbox02/setup/wallet-create.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/wallet-create.tsx
@@ -135,7 +135,10 @@ export const CreateWallet = ({
       const result2 = await bitbox02.createBackup(deviceID, 'sdcard');
       if (!result2.success) {
         if (result2.code === bitbox02.errUserAbort) {
-          alertUser(t('bitbox02Wizard.createBackupAborted'), { asDialog: false });
+          alertUser(t('bitbox02Wizard.createBackupAborted'), {
+            asDialog: false,
+            callback: () => onAbort(),
+          });
         } else {
           alertUser(t('bitbox02Wizard.createBackupFailed'), { asDialog: false });
         }

--- a/frontends/web/src/routes/device/bitbox02/setup/wallet-create.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/wallet-create.tsx
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import * as bitbox02 from '../../../../api/bitbox02';
+import { alertUser } from '../../../../components/alert/Alert';
+import { Wait } from './wait';
+import { ChecklistWalletCreate } from './checklist';
+import { SetDeviceName } from './name';
+import { SetPassword } from './password';
+
+type TCreateWalletStatus = 'intro' | 'setPassword' | 'createBackup';
+
+type TWait = {
+  title: string;
+  text?: string;
+};
+
+type Props = {
+  deviceID: string;
+  isSeeded: boolean;
+  onAbort: () => void;
+};
+
+export const CreateWallet = ({
+  deviceID,
+  isSeeded,
+  onAbort,
+}: Props) => {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<TCreateWalletStatus>('intro');
+  const [errorText, setErrorText] = useState('');
+  const [waitView, setWaitView] = useState<TWait>();
+  const [hasSDCard, setSDCard] = useState<boolean>();
+
+  useEffect(() => {
+    bitbox02.checkSDCard(deviceID).then(setSDCard);
+  }, [deviceID]);
+
+  const ensurePassword = async () => {
+    setStatus('setPassword');
+    try {
+      const result = await bitbox02.setPassword(deviceID);
+      if (!result.success) {
+        if (result.code === bitbox02.errUserAbort) {
+          // On user abort, just go back to the first screen. This is a bit lazy, as we should show
+          // a screen to ask the user to go back or try again.
+          setErrorText('');
+          onAbort();
+        } else {
+          setErrorText(t('bitbox02Wizard.noPasswordMatch'));
+          ensurePassword();
+        }
+        // show error and do NOT continue to createBackup
+        return;
+      }
+      setErrorText('');
+      setStatus('createBackup');
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const setDeviceName = async (deviceName: string) => {
+    setWaitView({ title: t('bitbox02Interact.confirmName') });
+    try {
+      const result = await bitbox02.setDeviceName(deviceID, deviceName);
+      if (!result.success) {
+        alertUser(result.message || t('genericError'), {
+          asDialog: false,
+          callback: () => setWaitView(undefined),
+        });
+        return;
+      }
+      setWaitView(undefined);
+      ensurePassword();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const ensureSDCard = async () => {
+    try {
+      const sdCardInserted = await bitbox02.checkSDCard(deviceID);
+      if (sdCardInserted) {
+        return true;
+      }
+      setWaitView({
+        title: t('bitbox02Wizard.stepInsertSD.insertSDcardTitle'),
+        text: t('bitbox02Wizard.stepInsertSD.insertSDCard'),
+      });
+      const result = await bitbox02.insertSDCard(deviceID);
+      setWaitView(undefined);
+      if (result.success) {
+        return true;
+      }
+      if (result.message) {
+        alertUser(result.message, { asDialog: false });
+      }
+      return false;
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const createBackup = async () => {
+    try {
+      const result1 = await ensureSDCard();
+      if (!result1) {
+        alertUser(t('bitbox02Wizard.createBackupFailed'), { asDialog: false });
+        return;
+      }
+      setWaitView({
+        title: t('bitbox02Interact.confirmDate'),
+        text: t('bitbox02Interact.confirmDateText'),
+      });
+      const result2 = await bitbox02.createBackup(deviceID, 'sdcard');
+      if (!result2.success) {
+        if (result2.code === bitbox02.errUserAbort) {
+          alertUser(t('bitbox02Wizard.createBackupAborted'), { asDialog: false });
+        } else {
+          alertUser(t('bitbox02Wizard.createBackupFailed'), { asDialog: false });
+        }
+      }
+      setWaitView(undefined);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  if (waitView) {
+    return (
+      <Wait
+        key="wait-view"
+        title={waitView.title}
+        text={waitView.text} />
+    );
+  }
+
+  if (status === 'createBackup' && isSeeded) {
+    return (
+      <ChecklistWalletCreate key="create-backup" onContinue={createBackup} />
+    );
+  }
+
+  switch (status) {
+  case 'intro':
+    return (
+      <SetDeviceName
+        key="set-devicename"
+        sdCardInserted={hasSDCard}
+        onDeviceName={setDeviceName}
+        onBack={onAbort} />
+    );
+  case 'setPassword':
+    return (
+      <SetPassword key="create-wallet" errorText={errorText} />
+    );
+  default:
+    return null;
+  }
+};

--- a/frontends/web/src/routes/device/bitbox02/setup/wallet-create.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/wallet-create.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as bitbox02 from '../../../../api/bitbox02';
+import { useMountedRef } from '../../../../hooks/mount';
 import { alertUser } from '../../../../components/alert/Alert';
 import { Wait } from './wait';
 import { ChecklistWalletCreate } from './checklist';
@@ -42,6 +43,7 @@ export const CreateWallet = ({
   onAbort,
 }: Props) => {
   const { t } = useTranslation();
+  const isMounted = useMountedRef();
   const [status, setStatus] = useState<TCreateWalletStatus>('intro');
   const [errorText, setErrorText] = useState('');
   const [waitView, setWaitView] = useState<TWait>();
@@ -63,7 +65,9 @@ export const CreateWallet = ({
           onAbort();
         } else {
           setErrorText(t('bitbox02Wizard.noPasswordMatch'));
-          ensurePassword();
+          if (isMounted.current) {
+            ensurePassword();
+          }
         }
         // show error and do NOT continue to createBackup
         return;


### PR DESCRIPTION
Move createWalletStatus and everything related to creating a new wallet into its own component.

Next step is to do the same with restore backup.