### PR TITLE
frontend: change behaviour of active & default currencies

### DIFF
--- a/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import { useEffect, useState } from 'react';
 import Select, { ActionMeta, MultiValue, MultiValueRemoveProps, components } from 'react-select';
 import { currencies, store, selectFiat, unselectFiat, SharedProps } from '../../../../components/rates/rates';
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { Fiat } from '../../../../api/account';
-import styles from './defaultCurrencySetting.module.css';
 import { share } from '../../../../decorators/share';
 
 type SelectOption = {
@@ -31,7 +31,14 @@ type TSelectProps = {
 } & SharedProps;
 
 const ReactSelect = ({ options, active, selected }: TSelectProps) => {
-  const selectedCurrencies = selected.length > 0 ? selected?.map(currency => ({ label: currency, value: currency })) : [];
+  const [selectedCurrencies, setSelectedCurrencies] = useState<SelectOption[]>([]);
+
+  useEffect(() => {
+    if (selected.length > 0) {
+      const formattedSelectedCurrencies = selected.map(currency => ({ label: currency, value: currency }));
+      setSelectedCurrencies(formattedSelectedCurrencies);
+    }
+  }, [selected]);
 
   const MultiValueRemove = (props: MultiValueRemoveProps<SelectOption>) => {
     const currency = props.data.value;
@@ -46,13 +53,12 @@ const ReactSelect = ({ options, active, selected }: TSelectProps) => {
 
   return (
     <Select
-      className={styles.select}
       classNamePrefix="react-select"
       isSearchable
       isClearable={false}
       components={{ MultiValueRemove }}
       isMulti
-      defaultValue={selectedCurrencies}
+      value={selectedCurrencies}
       onChange={(selectedFiats: MultiValue<SelectOption>, meta: ActionMeta<SelectOption>) => {
         switch (meta.action) {
         case 'remove-value':
@@ -72,12 +78,16 @@ const ReactSelect = ({ options, active, selected }: TSelectProps) => {
 
 const ActiveCurrenciesDropdownSetting = ({ selected, active }: SharedProps) => {
   const formattedCurrencies = currencies.map((currency) => ({ label: currency, value: currency }));
-
   return (
     <SettingsItem
       settingName="Active Currencies"
       secondaryText="These additional currencies can be toggled through on your account page."
-      extraComponent={<ReactSelect options={formattedCurrencies} active={active} selected={selected} />}
+      extraComponent={
+        <ReactSelect
+          options={formattedCurrencies}
+          active={active}
+          selected={selected}
+        />}
     />
   );
 };

--- a/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { setActiveFiat, store } from '../../../../components/rates/rates';
+import { currencies, selectFiat, setActiveFiat, store } from '../../../../components/rates/rates';
 import { SingleDropdown } from '../singledropdown/singledropdown';
 import { SettingsItem } from '../settingsItem/settingsItem';
+import { Fiat } from '../../../../api/account';
 
 export const DefaultCurrencyDropdownSetting = () => {
-  const formattedCurrencies = store.state.selected.map((currency) => ({ label: currency, value: currency }));
+  const formattedCurrencies = currencies.map((currency) => ({ label: currency, value: currency }));
 
   return (
     <SettingsItem
@@ -28,7 +29,12 @@ export const DefaultCurrencyDropdownSetting = () => {
       extraComponent={
         <SingleDropdown
           options={formattedCurrencies}
-          handleChange={setActiveFiat}
+          handleChange={(fiat: Fiat) => {
+            setActiveFiat(fiat);
+            if (!store.state.selected.includes(fiat)) {
+              selectFiat(fiat);
+            }
+          }}
           defaultValue={{ label: store.state.active, value: store.state.active }}
         />
       }


### PR DESCRIPTION
To improve intuitiveness of our default & currencies settings, we are changing its behaviour.

The default currencies dropdown now shows all the currencies, and when selecting a currency from the dropdown, that currency will be the active currency.

(also removed unused / empty style file)

Preview: 

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/06a04a46-75cd-4944-9111-3ec03352775c

