### PR TITLE
frontend: added new settings styling for mobile and small bugfix

### DIFF
--- a/frontends/web/src/routes/new-settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/new-settings/bb02-settings.tsx
@@ -106,7 +106,6 @@ const Content = ({ deviceID }: TProps) => {
         {
           versionInfo ?
             <FirmwareSetting
-              asButton
               deviceID={deviceID}
               versionInfo={versionInfo}
             /> :

--- a/frontends/web/src/routes/new-settings/components/about/app-version-setting.tsx
+++ b/frontends/web/src/routes/new-settings/components/about/app-version-setting.tsx
@@ -19,6 +19,9 @@ import { useTranslation } from 'react-i18next';
 import { getUpdate, getVersion } from '../../../../api/version';
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { Checked, RedDot } from '../../../../components/icon';
+import { StyledSkeleton } from '../../bb02-settings';
+import { apiPost } from '../../../../utils/request';
+import { downloadLinkByLanguage } from '../../../../components/appdownloadlink/appdownloadlink';
 
 export const AppVersion = () => {
   const { t } = useTranslation();
@@ -27,11 +30,20 @@ export const AppVersion = () => {
   const update = useLoad(getUpdate);
 
   const secondaryText = !!update ? t('settings.info.out-of-date') : t('settings.info.up-to-date');
-
   const icon = !!update ? <RedDot width={18} height={18} /> : <Checked />;
   const versionNumber = !!version ? version : '-';
 
+  if (update === undefined) {
+    return <StyledSkeleton />;
+  }
+
   return (
-    <SettingsItem settingName="App version" secondaryText={secondaryText} displayedValue={versionNumber} extraComponent={icon} />
+    <SettingsItem
+      settingName="App version"
+      secondaryText={secondaryText}
+      displayedValue={versionNumber}
+      extraComponent={icon}
+      onClick={update ? () => apiPost('open', downloadLinkByLanguage()) : undefined}
+    />
   );
 };

--- a/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
@@ -80,6 +80,7 @@ const ActiveCurrenciesDropdownSetting = ({ selected, active }: SharedProps) => {
   const formattedCurrencies = currencies.map((currency) => ({ label: currency, value: currency }));
   return (
     <SettingsItem
+      collapseOnSmall
       settingName="Active Currencies"
       secondaryText="These additional currencies can be toggled through on your account page."
       extraComponent={
@@ -87,7 +88,8 @@ const ActiveCurrenciesDropdownSetting = ({ selected, active }: SharedProps) => {
           options={formattedCurrencies}
           active={active}
           selected={selected}
-        />}
+        />
+      }
     />
   );
 };

--- a/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -26,6 +26,7 @@ export const DefaultCurrencyDropdownSetting = () => {
     <SettingsItem
       settingName="Default Currency"
       secondaryText="Select your default currency."
+      collapseOnSmall
       extraComponent={
         <SingleDropdown
           options={formattedCurrencies}

--- a/frontends/web/src/routes/new-settings/components/appearance/languageDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/languageDropdownSetting.tsx
@@ -49,6 +49,7 @@ export const LanguageDropdownSetting = () => {
     <SettingsItem
       settingName="Language"
       secondaryText="Which language you want the BitBoxApp to use."
+      collapseOnSmall
       extraComponent={
         <SingleDropdown
           options={formattedLanguages}

--- a/frontends/web/src/routes/new-settings/components/device-settings/attestation-check-setting.tsx
+++ b/frontends/web/src/routes/new-settings/components/device-settings/attestation-check-setting.tsx
@@ -45,6 +45,7 @@ const AttestationCheckSetting = ({ deviceID }: TProps) => {
       secondaryText={t('deviceSettings.deviceInformation.attestation.description')}
       extraComponent={icon}
       displayedValue={t(`deviceSettings.hardware.attestation.${attestation}`)}
+      hideDisplayedValueOnSmall
     />
   );
 };

--- a/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.module.css
+++ b/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.module.css
@@ -59,5 +59,35 @@
     .container {
          height: auto;
          margin-bottom: 2px;
+         min-width: 100%;
     }
+
+    .rightContentContainer {
+        margin-top: var(--space-quarter);
+    }
+
+    .secondaryText {
+        display: none;
+    }
+}
+
+@media (max-width: 560px) {
+    
+    .container.collapse {
+        align-items: start;
+        flex-direction: column;
+    }
+
+    .container.collapse .displayedValue.withMargin {
+        margin-right: 0;
+    }
+
+    .container.collapse .rightContentContainer {
+        width: 100%
+    }
+
+    .hideDisplayedValueOnSmall {
+        display: none;
+    }
+    
 }

--- a/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.tsx
+++ b/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.tsx
@@ -18,27 +18,37 @@ import { ReactNode } from 'react';
 import styles from './settingsItem.module.css';
 
 type TProps = {
-    className?: string
-    onClick?: () => void;
-    settingName: string | ReactNode;
-    secondaryText?: string;
-    displayedValue?: string;
-    extraComponent?: ReactNode;
+  className?: string
+  collapseOnSmall?: boolean;
+  displayedValue?: string;
+  extraComponent?: ReactNode;
+  hideDisplayedValueOnSmall?: boolean;
+  onClick?: () => void;
+  secondaryText?: string;
+  settingName: string | ReactNode;
 }
 
 export const SettingsItem = ({
   className = '',
-  onClick,
-  settingName,
-  secondaryText,
+  collapseOnSmall = false,
   displayedValue = '',
   extraComponent,
+  hideDisplayedValueOnSmall = false,
+  onClick,
+  secondaryText,
+  settingName,
 }: TProps) => {
   const notButton = onClick === undefined;
 
   const rightContent = (
     <div className={styles.rightContentContainer}>
-      <p className={`${styles.displayedValue} ${extraComponent ? `${styles.withMargin}` : ''}`}>{displayedValue}</p>
+      <p className={
+        `
+        ${styles.displayedValue}
+        ${extraComponent ? styles.withMargin : ''}
+        ${hideDisplayedValueOnSmall ? styles.hideDisplayedValueOnSmall : ''}
+       `}
+      >{displayedValue}</p>
       {extraComponent ? extraComponent : null }
     </div>
   );
@@ -60,7 +70,10 @@ export const SettingsItem = ({
   return (
     <>
       {notButton ?
-        <div className={`${styles.container} ${className}`} >
+        <div className={
+          `${styles.container} ${className} 
+          ${collapseOnSmall ? styles.collapse : ''}`
+        } >
           {content}
         </div> :
         <button

--- a/frontends/web/src/routes/new-settings/components/singledropdown/singledropdown.module.css
+++ b/frontends/web/src/routes/new-settings/components/singledropdown/singledropdown.module.css
@@ -48,3 +48,9 @@
 .select :global(.react-select__option--is-selected) .optionValue {
     color: var(--color-alt);
 }
+
+@media (max-width: 560px) {
+    .select {
+        width: 100%;
+    }
+}

--- a/frontends/web/src/routes/new-settings/components/tabs.tsx
+++ b/frontends/web/src/routes/new-settings/components/tabs.tsx
@@ -94,7 +94,7 @@ export const Tabs = ({ deviceIDs, hideMobileMenu, hasAccounts }: TTabs) => {
       <Tab key="appearance" hideMobileMenu={hideMobileMenu} name={t('settings.appearance')} url="/new-settings/appearance" />
       {hasAccounts ? <Tab key="manage-accounts" hideMobileMenu={hideMobileMenu} name={'Manage accounts'} url="/settings/manage-accounts" /> : null}
       {deviceIDs.map(id => (
-        <Tab hideMobileMenu={hideMobileMenu} name={'Device settings'} key={`device-${id}`} url={`/new-settings/device-settings/${id}`} />
+        <Tab hideMobileMenu={hideMobileMenu} name={t('sidebar.device')} key={`device-${id}`} url={`/new-settings/device-settings/${id}`} />
       )) }
       <Tab key="advanced-settings" hideMobileMenu={hideMobileMenu} name={'Advanced settings'} url="/new-settings/advanced-settings" />
       <Tab key="about" hideMobileMenu={hideMobileMenu} name={'About'} url="/new-settings/about" />


### PR DESCRIPTION
To have optimal UI & UX we slightly change the styling of the new settings SettingItem  on mobile by hiding the secondary text and optionally collapsing elements & hiding displayed value.

With this PR, the new settings now should be fully responsive. 

Preview:

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/7e38eb99-54ec-4ed2-8ff3-5d12a615e678

