### PR TITLE
backend: fix ETH balance update including pending txs

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -379,21 +379,44 @@ func (account *Account) update() error {
 		}
 	}
 
+	var balance *big.Int
 	if account.coin.erc20Token != nil {
-		balance, err := account.coin.client.ERC20Balance(account.address.Address, account.coin.erc20Token)
+		balance, err = account.coin.client.ERC20Balance(account.address.Address, account.coin.erc20Token)
 		if err != nil {
 			return errp.WithStack(err)
 		}
-		account.balance = coin.NewAmount(balance)
 	} else {
-		balance, err := account.coin.client.Balance(context.TODO(), account.address.Address)
+		balance, err = account.coin.client.Balance(context.TODO(), account.address.Address)
 		if err != nil {
 			return errp.WithStack(err)
 		}
-		account.balance = coin.NewAmount(balance)
 	}
 
+	pendingAmount := pendingTxsAmount(outgoingTransactionsData, account.coin.erc20Token != nil)
+	account.balance = coin.NewAmount(balance.Sub(balance, pendingAmount))
+
 	return nil
+}
+
+// pendingTxsAmount returns the total amount of pending transactions. Fees are not included for erc20 txs.
+func pendingTxsAmount(outgoingTransactionsData []*accounts.TransactionData, isErc20 bool) *big.Int {
+	pendingTxAmount := big.NewInt(0)
+	for _, tx := range outgoingTransactionsData {
+		if tx.Status == accounts.TxStatusPending {
+			// Skip sendSelf txs
+			if tx.Type == accounts.TxTypeSend {
+				pendingTxAmount = pendingTxAmount.Add(pendingTxAmount, tx.Amount.BigInt())
+			}
+			if !isErc20 {
+				// tx Fee is considered only for ETH transactions. For ERC20 tokens it should
+				// be subtracted to the balance of the related ETH account. This is not done at
+				// the moment, could be possibly fixed in the future migrating to BlockBook.
+				pendingTxAmount = pendingTxAmount.Add(pendingTxAmount, tx.Fee.BigInt())
+			}
+		}
+	}
+
+	return pendingTxAmount
 }
 
 // FatalError implements accounts.Interface.


### PR DESCRIPTION
ETH accounts update fetches the balance from etherscan. This amount does not consider possible pending outgoing transactions and this means that after sending a txs the balance is not correctly updated, until the txs gets confirmed.

With this, the balance fetched from etherscan is decresed considering the amounts and fees of pending outgoing transactions.

NOTES: The fees are only considered when computing the balance for ETH accounts, since for ERC20-tokens they should be subtracted from the related ETH account. This is not implemented yet, as it would require a link between the ETH main account and the ERC20 derived account. It could be possibly solved with a future migration to blockbook chain explorer, that could allow to list the ERC20 pending transactions within the main ETH account transactions fetched.