### PR TITLE
backend: remove ext.shiftcrypto.ch and guids.shiftcrypot.ch

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -62,9 +62,7 @@ func init() {
 var fixedURLWhitelist = []string{
 	// Shift Crypto owned domains.
 	"https://shiftcrypto.ch/",
-	"https://ext.shiftcrypto.ch/",
 	"https://shiftcrypto.shop/",
-	"https://guides.shiftcrypto.ch/",
 	"https://shiftcrypto.support/",
 	// Exchange rates.
 	"https://www.coingecko.com/",


### PR DESCRIPTION
Not used anywhere in the app or in the banner notifications.