### PR TITLE
backend/handlers: skip 0txs to mitigate address poisoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for Czech Crown (CZK) and add Czech translation
 - Add support for Zloty (PLN)
 - Add advanced setup with skip microSD card or 12-word seed options
+- Hide 0 amount ERC20 transactions to partially mitigate Address Poisoning Attack
 
 ## 4.37.0
 - Bundle BitBox02 firmware version v9.14.0

--- a/backend/accounts/transaction.go
+++ b/backend/accounts/transaction.go
@@ -119,8 +119,9 @@ type TransactionData struct {
 
 	// --- Fields only used for ETH follow
 
-	Gas   uint64
-	Nonce *uint64
+	Gas     uint64
+	Nonce   *uint64
+	IsErc20 bool
 }
 
 // isConfirmed returns true if the transaction has at least one confirmation.

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -18,6 +18,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -230,6 +231,10 @@ func (handlers *Handlers) getAccountTransactions(_ *http.Request) (interface{}, 
 	}
 	result.Transactions = []Transaction{}
 	for _, txInfo := range txs {
+		if txInfo.IsErc20 && big.NewInt(0).Cmp(txInfo.Amount.BigInt()) == 0 {
+			// skipping 0 amount erc20 txs to mitigate Address Poisoning attack
+			continue
+		}
 		result.Transactions = append(result.Transactions, handlers.getTxInfoJSON(txInfo, false))
 	}
 	result.Success = true

--- a/backend/coins/btc/transactions/transactions.go
+++ b/backend/coins/btc/transactions/transactions.go
@@ -492,6 +492,7 @@ func (transactions *Transactions) txInfo(
 		Size:             int64(txInfo.Tx.SerializeSize()),
 		Weight:           btcdBlockchain.GetTransactionWeight(btcutilTx),
 		CreatedTimestamp: txInfo.CreatedTimestamp,
+		IsErc20:          false,
 	}
 }
 

--- a/backend/coins/eth/etherscan/etherscan.go
+++ b/backend/coins/eth/etherscan/etherscan.go
@@ -167,6 +167,7 @@ func (tx *Transaction) TransactionData(isERC20 bool) *accounts.TransactionData {
 		Addresses:                tx.addresses(),
 		Gas:                      tx.jsonTransaction.GasUsed.BigInt().Uint64(),
 		Nonce:                    &nonce,
+		IsErc20:                  isERC20,
 	}
 }
 

--- a/backend/coins/eth/types/types.go
+++ b/backend/coins/eth/types/types.go
@@ -125,6 +125,7 @@ func (txh *TransactionWithMetadata) TransactionData(
 		Fee: txh.fee(),
 		// ERC20 token transaction pay fees in Ether.
 		FeeIsDifferentUnit:       erc20Token != nil,
+		IsErc20:                  erc20Token != nil,
 		Timestamp:                nil,
 		TxID:                     txh.TxID(),
 		InternalID:               txh.TxID(),


### PR DESCRIPTION
Address Poisoning attack consists of an attacker creating empty (0 amount) txs to/from vanity addresses, hoping that the possible victim will copy/paste the wrong address from the transaction history when sending/receiving coins. This can happen in some ERC20 tokens, depending on the implementation of the `transfer` function inside the token contract (see
https://mirror.xyz/x-explore.eth/cL3d_CyNujXq8XY7ueP4omNXx_IY1EG5Dz0FD0vJ90M for details).

This hide 0 amount erc20 txs from the `transactions` endpoint, to mitigate the effects of this attack.