### PR TITLE
backend/bitbox02: allow creation of 16 byte seeds (12 words)

### DIFF
--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -76,6 +76,7 @@ export type VersionInfo = {
     // This has no influence over whether one can display the recovery words after the initial
     // setup - that is always possible regardless of this value.
     canBackupWithRecoveryWords: boolean;
+    canCreate12Words: boolean;
 }
 
 export const getVersion = (
@@ -165,6 +166,7 @@ export const verifyChannelHash = (
 
 export const setPassword = (
   deviceID: string,
+  seedLen: 16 | 32,
 ): Promise<SuccessResponse | FailResponse> => {
-  return apiPost(`devices/bitbox02/${deviceID}/set-password`);
+  return apiPost(`devices/bitbox02/${deviceID}/set-password`, seedLen);
 };

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -180,7 +180,7 @@ class BitBox02 extends Component<Props, State> {
 
   private setPassword = () => {
     this.setState({ createWalletStatus: 'setPassword' });
-    setPassword(this.props.deviceID).then((response) => {
+    setPassword(this.props.deviceID, 32).then((response) => {
       if (!response.success) {
         if (response.code === errUserAbort) {
           // On user abort, just go back to the first screen. This is a bit lazy, as we should show

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/btcutil v1.1.2
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
-	github.com/digitalbitbox/bitbox02-api-go v0.0.0-20230421031421-e7f12bcd9a9a
+	github.com/digitalbitbox/bitbox02-api-go v0.0.0-20230603085322-9cc89fdf484b
 	github.com/digitalbitbox/block-client-go v0.0.0-20230103135723-d8eaf468753d
 	github.com/digitalbitbox/usb v0.0.0-20230208083750-001c519abaff
 	github.com/ethereum/go-ethereum v1.10.21

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalbitbox/bitbox02-api-go v0.0.0-20230421031421-e7f12bcd9a9a h1:OvlfoDTni2yXk+6YvoNT2KkJU6bp45fUBgN11aGlzeY=
-github.com/digitalbitbox/bitbox02-api-go v0.0.0-20230421031421-e7f12bcd9a9a/go.mod h1:FA63g3SOdHI8nPAJjKP7owPicmaav83FE0kCNvizVWk=
+github.com/digitalbitbox/bitbox02-api-go v0.0.0-20230603085322-9cc89fdf484b h1:t5jQZlBkEngRjHiyRvJT/ysbVLChF7zx+thdbkmINi0=
+github.com/digitalbitbox/bitbox02-api-go v0.0.0-20230603085322-9cc89fdf484b/go.mod h1:FA63g3SOdHI8nPAJjKP7owPicmaav83FE0kCNvizVWk=
 github.com/digitalbitbox/block-client-go v0.0.0-20230103135723-d8eaf468753d h1:hRjtOvL6k8Ie08XVUwzDNCSlP4wbwboVh1lkEtv0R40=
 github.com/digitalbitbox/block-client-go v0.0.0-20230103135723-d8eaf468753d/go.mod h1:GvmItOHUQJD0Dx0o2ZPgKpwI9XP9JGAo5bTV0B2kbN8=
 github.com/digitalbitbox/usb v0.0.0-20230208083750-001c519abaff h1:2SjR45Wi7pjTnfEE1HEqVN0o+nxeyf9hvMLbI7aEEuM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,7 +51,7 @@ github.com/decred/dcrd/crypto/blake256
 github.com/decred/dcrd/dcrec/secp256k1/v4
 github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa
 github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr
-# github.com/digitalbitbox/bitbox02-api-go v0.0.0-20230421031421-e7f12bcd9a9a
+# github.com/digitalbitbox/bitbox02-api-go v0.0.0-20230603085322-9cc89fdf484b
 ## explicit; go 1.13
 github.com/digitalbitbox/bitbox02-api-go/api/bootloader
 github.com/digitalbitbox/bitbox02-api-go/api/common


### PR DESCRIPTION
This is supported since firmware v9.6.0.

api-go is updated to the latest version which exposes this functionality.

```
go get github.com/digitalbitbox/bitbox02-api-go@9cc89fd
go mod vendor
go mod tidy
```