### PR TITLE
frontend: small settings styling/spacing improvement

### DIFF
--- a/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.module.css
+++ b/frontends/web/src/routes/new-settings/components/settingsItem/settingsItem.module.css
@@ -50,7 +50,7 @@
     color: var(--color-secondary);
     font-size: 14px;
     margin: 0;
-    margin-top: 16px;
+    margin-top: var(--space-quarter);
     overflow: hidden;
     text-overflow: ellipsis;
 }
@@ -58,12 +58,8 @@
 @media (max-width: 768px) { 
     .container {
          height: auto;
-         margin-bottom: 2px;
+         margin-bottom: 5px;
          min-width: 100%;
-    }
-
-    .rightContentContainer {
-        margin-top: var(--space-quarter);
     }
 
     .secondaryText {

--- a/frontends/web/src/routes/new-settings/components/singledropdown/singledropdown.module.css
+++ b/frontends/web/src/routes/new-settings/components/singledropdown/singledropdown.module.css
@@ -51,6 +51,7 @@
 
 @media (max-width: 560px) {
     .select {
+        margin-top: var(--space-quarter);
         width: 100%;
     }
 }

--- a/frontends/web/src/routes/new-settings/components/tabs.module.css
+++ b/frontends/web/src/routes/new-settings/components/tabs.module.css
@@ -1,6 +1,5 @@
 .container {
     display: flex;
-    padding-left: var(--space-half);
     margin-bottom: var(--space-default);
 }
 
@@ -11,7 +10,7 @@
 }
 
 .container a.active {
-    padding-bottom: var(--space-half);
+    padding-bottom: var(--space-quarter);
     border-bottom: 2px solid var(--color-blue);
 }
 


### PR DESCRIPTION
small spacing/aligning improvement, will paste screenshots in comments.

- decrease space between active tab and underline
- decrease space between setting config label and description
- align tabs on the left with content/main-title
- center setting toggle vertically on mobile

cc @jadzeidan 