### PR TITLE
frontend: fix removing darkmode from config

### DIFF
--- a/frontends/web/src/contexts/DarkmodeProvider.tsx
+++ b/frontends/web/src/contexts/DarkmodeProvider.tsx
@@ -76,7 +76,6 @@ export const DarkModeProvider = ({ children }: TProps) => {
           // remove darkmode from config, so it use the same mode as the OS
           const { darkmode, ...frontend } = config.frontend;
           setConfig({
-            backend: config.backend,
             frontend: {
               ...frontend,
               darkmode: undefined,
@@ -85,7 +84,6 @@ export const DarkModeProvider = ({ children }: TProps) => {
         } else {
           // darkmode is different from OS, save to config
           setConfig({
-            backend: config.backend,
             frontend: {
               ...config.frontend,
               darkmode,

--- a/frontends/web/src/contexts/DarkmodeProvider.tsx
+++ b/frontends/web/src/contexts/DarkmodeProvider.tsx
@@ -77,7 +77,10 @@ export const DarkModeProvider = ({ children }: TProps) => {
           const { darkmode, ...frontend } = config.frontend;
           setConfig({
             backend: config.backend,
-            frontend,
+            frontend: {
+              ...frontend,
+              darkmode: undefined,
+            },
           });
         } else {
           // darkmode is different from OS, save to config


### PR DESCRIPTION
When user changes darkmode settings to the same setting that the OS prefers the config should be just removed, so it uses same as OS.

This broke in:
- e91c84a517cfe81fbdaac228ed58ef1cef8ae687

setConfig now merged with current config and ensures nothing gets lost, but this broke removing the config by omitting.