### PR TITLE
frontend: using locize keys for texts in the new settings

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -508,11 +508,11 @@
     },
     "expert": {
       "factoryReset": {
-        "description": "Reset your device to factory settings. This deletes your wallet!",
+        "description": "Reset your device to factory settings. This deletes the wallet on your BitBox02!",
         "title": "Factory reset"
       },
       "goToStartupSettings": {
-        "description": "Enters the bootloader of the BitBox02. Can enable firmware hash from here."
+        "description": "Enter the bootloader of the BitBox02. You can enable the firmware the hash from here."
       },
       "passphrase": {
         "description": "Enable or disable the passphrase feature.",
@@ -1026,6 +1026,44 @@
   "mobile": {
     "usingMobileDataWarning": "Mobile data usage: this app may download up to a few hundred megabytes of blockchain header data after unlocking an account. Please connect to Wi-Fi to avoid using mobile data. After dismissing it, this message won't be shown again."
   },
+  "newSettings": {
+    "about": {
+      "appVersion": {
+        "title": "App version"
+      }
+    },
+    "advancedSettings": {
+      "coinControl": {
+        "description": "Select which UTXOs are part of a transaction to help improve privacy."
+      },
+      "customFees": {
+        "description": "Lets you enter your own fee when sending."
+      },
+      "torProxy": {
+        "description": "Connect over Tor for better privacy."
+      }
+    },
+    "appearance": {
+      "activeCurrencies": {
+        "description": "These additional currencies can be toggled through on your account page.",
+        "title": "Active currencies"
+      },
+      "darkmode": {
+        "description": "See the BitBoxApp in dark mode."
+      },
+      "defaultCurrency": {
+        "description": "Select your default currency",
+        "title": "Default currency"
+      },
+      "language": {
+        "description": "Which language you want the BitBoxApp to use.",
+        "title": "Language"
+      },
+      "toggleSats": {
+        "description": "Enable or disable Satoshis."
+      }
+    }
+  },
   "note": {
     "input": {
       "description": "(optional)",
@@ -1367,7 +1405,6 @@
         "title": "Connect your own full node"
       },
       "fee": "Enable custom fees",
-      "feeDescription": "Lets you enter your own fee when sending.",
       "setProxyAddress": "Set proxy address",
       "title": "Expert settings",
       "useProxy": "Enable tor proxy",

--- a/frontends/web/src/routes/new-settings/components/about/app-version-setting.tsx
+++ b/frontends/web/src/routes/new-settings/components/about/app-version-setting.tsx
@@ -18,8 +18,8 @@ import { useLoad } from '../../../../hooks/api';
 import { useTranslation } from 'react-i18next';
 import { getUpdate, getVersion } from '../../../../api/version';
 import { SettingsItem } from '../settingsItem/settingsItem';
-import { Checked, RedDot } from '../../../../components/icon';
 import { StyledSkeleton } from '../../bb02-settings';
+import { Checked, RedDot } from '../../../../components/icon';
 import { apiPost } from '../../../../utils/request';
 import { downloadLinkByLanguage } from '../../../../components/appdownloadlink/appdownloadlink';
 
@@ -39,7 +39,7 @@ export const AppVersion = () => {
 
   return (
     <SettingsItem
-      settingName="App version"
+      settingName={t('newSettings.about.appVersion.title')}
       secondaryText={secondaryText}
       displayedValue={versionNumber}
       extraComponent={icon}

--- a/frontends/web/src/routes/new-settings/components/advanced-settings/enable-coin-control-setting.tsx
+++ b/frontends/web/src/routes/new-settings/components/advanced-settings/enable-coin-control-setting.tsx
@@ -41,7 +41,7 @@ export const EnableCoinControlSetting = ({ frontendConfig, onChangeConfig }: TPr
   return (
     <SettingsItem
       settingName={t('settings.expert.coinControl')}
-      secondaryText={t('settings.expert.coinControl')}
+      secondaryText={t('newSettings.advancedSettings.coinControl.description')}
       extraComponent={
         frontendConfig !== undefined ?
           <Toggle

--- a/frontends/web/src/routes/new-settings/components/advanced-settings/enable-custom-fees-toggle-setting.tsx
+++ b/frontends/web/src/routes/new-settings/components/advanced-settings/enable-custom-fees-toggle-setting.tsx
@@ -41,7 +41,7 @@ export const EnableCustomFeesToggleSetting = ({ frontendConfig, onChangeConfig }
   return (
     <SettingsItem
       settingName={t('settings.expert.fee')}
-      secondaryText={t('settings.expert.feeDescription')}
+      secondaryText={t('newSettings.advancedSettings.customFees.description')}
       extraComponent={
         frontendConfig !== undefined ?
           <Toggle

--- a/frontends/web/src/routes/new-settings/components/advanced-settings/enable-tor-proxy-setting.tsx
+++ b/frontends/web/src/routes/new-settings/components/advanced-settings/enable-tor-proxy-setting.tsx
@@ -50,7 +50,7 @@ export const EnableTorProxySetting = ({ proxyConfig, onChangeConfig }: TProps) =
         className={styles.settingItem}
         settingName={t('settings.expert.useProxy')}
         onClick={() => setShowTorProxyDialog(true)}
-        secondaryText={t('settings.expert.useProxy')}
+        secondaryText={t('newSettings.advancedSettings.torProxy.description')}
         displayedValue={proxyEnabled ? t('generic.enabled_true') : t('generic.enabled_false')}
         extraComponent={<ChevronRightDark width={24} height={24} />}
       />

--- a/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/activeCurrenciesDropdownSetting.tsx
@@ -18,13 +18,15 @@ import { store, SharedProps, formattedCurrencies } from '../../../../components/
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { share } from '../../../../decorators/share';
 import { ActiveCurrenciesDropdown } from '../dropdowns/activecurrenciesdropdown';
+import { useTranslation } from 'react-i18next';
 
 const ActiveCurrenciesDropdownSetting = ({ selected, active }: SharedProps) => {
+  const { t } = useTranslation();
   return (
     <SettingsItem
       collapseOnSmall
-      settingName="Active Currencies"
-      secondaryText="These additional currencies can be toggled through on your account page."
+      settingName={t('newSettings.appearance.activeCurrencies.title')}
+      secondaryText={t('newSettings.appearance.activeCurrencies.description')}
       extraComponent={
         <ActiveCurrenciesDropdown
           options={formattedCurrencies}

--- a/frontends/web/src/routes/new-settings/components/appearance/darkmodeToggleSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/darkmodeToggleSetting.tsx
@@ -25,7 +25,7 @@ export const DarkmodeToggleSetting = () => {
   return (
     <SettingsItem
       settingName={t('darkmode.toggle')}
-      secondaryText="See the BitBoxApp in dark mode."
+      secondaryText={t('newSettings.appearance.darkmode.description')}
       extraComponent={<Toggle checked={isDarkMode} onChange={() => toggleDarkmode(!isDarkMode)} />}
     />
   );

--- a/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -18,12 +18,14 @@ import { defaultValueLabel, formattedCurrencies, selectFiat, setActiveFiat, stor
 import { SingleDropdown } from '../dropdowns/singledropdown';
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { Fiat } from '../../../../api/account';
+import { useTranslation } from 'react-i18next';
 
 export const DefaultCurrencyDropdownSetting = () => {
+  const { t } = useTranslation();
   return (
     <SettingsItem
-      settingName="Default Currency"
-      secondaryText="Select your default currency."
+      settingName={t('newSettings.appearance.defaultCurrency.title')}
+      secondaryText={t('newSettings.appearance.defaultCurrency.description')}
       collapseOnSmall
       extraComponent={
         <SingleDropdown

--- a/frontends/web/src/routes/new-settings/components/appearance/displaySatsToggleSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/displaySatsToggleSetting.tsx
@@ -58,7 +58,7 @@ export const DisplaySatsToggleSetting = () => {
     <>
       <SettingsItem
         settingName={t('settings.expert.useSats')}
-        secondaryText="Enable or disable Satoshis."
+        secondaryText={t('newSettings.appearance.toggleSats.description')}
         extraComponent={
           <>
             {

--- a/frontends/web/src/routes/new-settings/components/appearance/languageDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/languageDropdownSetting.tsx
@@ -42,13 +42,13 @@ const defaultLanguages: TLanguagesList = [
 ];
 
 export const LanguageDropdownSetting = () => {
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation();
   const selectedLanguage = defaultLanguages[getSelectedIndex(defaultLanguages, i18n)];
   const formattedLanguages = defaultLanguages.map(lang => ({ label: lang.display, value: lang.code }));
   return (
     <SettingsItem
-      settingName="Language"
-      secondaryText="Which language you want the BitBoxApp to use."
+      settingName={t('newSettings.appearance.language.title')}
+      secondaryText={t('newSettings.appearance.language.description')}
       collapseOnSmall
       extraComponent={
         <SingleDropdown

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -212,7 +212,7 @@ class ManageAccounts extends Component<Props, State> {
     const accountList = this.renderAccounts();
     return (
       <Main>
-        <div className="hide-on-small"><Header title={<h2>{t('manageAccounts.title')}</h2>} /></div>
+        <div className="hide-on-small"><Header title={<h2>{t('settings.title')}</h2>} /></div>
         <View fullscreen={false}>
           <ViewContent>
             <WithSettingsTabs deviceIDs={deviceIDs} hideMobileMenu hasAccounts={hasAccounts} subPageTitle={t('manageAccounts.title')}>


### PR DESCRIPTION
To be able to provide translated texts to the users, we must use locize keys.

In this commit, when the exact word we want to use is already available in locize, we're using them. Otherwise, we created new entries.

Edited & deleted some keys in-place as well as they're not yet "live" on locize.