### PR TITLE
frontend: use store.state.active in DefaultCurrencyDropdownSetting (bugfix)

### DIFF
--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -207,7 +207,4 @@ function Conversion({
 
 export const formattedCurrencies = currenciesWithDisplayName.map((fiat) => ({ label: `${fiat.displayName} (${fiat.currency})`, value: fiat.currency }));
 
-const valueLabel = currenciesWithDisplayName.find(fiat => fiat.currency === store.state.active)?.displayName;
-export const defaultValueLabel = valueLabel ? `${valueLabel} (${store.state.active})` : store.state.active;
-
 export const FiatConversion = share<SharedProps, TProvidedProps>(store)(Conversion);

--- a/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/new-settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { defaultValueLabel, formattedCurrencies, selectFiat, setActiveFiat, store } from '../../../../components/rates/rates';
+import { currenciesWithDisplayName, formattedCurrencies, selectFiat, setActiveFiat, store } from '../../../../components/rates/rates';
 import { SingleDropdown } from '../dropdowns/singledropdown';
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { Fiat } from '../../../../api/account';
@@ -22,6 +22,8 @@ import { useTranslation } from 'react-i18next';
 
 export const DefaultCurrencyDropdownSetting = () => {
   const { t } = useTranslation();
+  const valueLabel = currenciesWithDisplayName.find(fiat => fiat.currency === store.state.active)?.displayName;
+  const defaultValueLabel = valueLabel ? `${valueLabel} (${store.state.active})` : store.state.active;
   return (
     <SettingsItem
       settingName={t('newSettings.appearance.defaultCurrency.title')}


### PR DESCRIPTION
When using the `store.state.active` directly from `rates` file, it won't give us the correct value. In our case, this causes invalid value for default currency after refreshing (after loading the component).

We need to use the string that contains `store.active.state` in the component, instead of inside the `rates` file.


[Preview (picking a default value and refreshing)]:

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/b2d94802-5530-4051-9d4c-7b693b67edfc

