### PR TITLE
frontend: added guides for relevant settings pages & modified header

### DIFF
--- a/frontends/web/src/components/layout/header.module.css
+++ b/frontends/web/src/components/layout/header.module.css
@@ -115,6 +115,11 @@
 }
 
 @media (max-width: 768px) {
+
+    .sidebarToggler.hideSidebarToggler {
+        display: none;
+    }
+
     .container .header {
         padding: 0 var(--space-half);
     }

--- a/frontends/web/src/components/layout/header.tsx
+++ b/frontends/web/src/components/layout/header.tsx
@@ -25,6 +25,7 @@ import style from './header.module.css';
 interface HeaderProps {
     title?: string | JSX.Element | JSX.Element[];
     narrow?: boolean;
+    hideSidebarToggler?: boolean;
 }
 type Props = HeaderProps & SharedPanelProps & TranslateProps;
 
@@ -38,11 +39,11 @@ class Header extends Component<Props> {
   };
 
   public render() {
-    const { t, title, narrow, children, guideExists, shown, sidebarStatus } = this.props;
+    const { t, title, narrow, children, guideExists, shown, sidebarStatus, hideSidebarToggler } = this.props;
     return (
       <div className={[style.container, sidebarStatus ? style[sidebarStatus] : ''].join(' ')}>
         <div className={[style.header, narrow ? style.narrow : ''].join(' ')}>
-          <div className={style.sidebarToggler} onClick={toggleSidebar}>
+          <div className={`${style.sidebarToggler} ${hideSidebarToggler ? style.hideSidebarToggler : ''}`} onClick={toggleSidebar}>
             <MenuDark className="show-in-lightmode" />
             <MenuLight className="show-in-darkmode" />
           </div>

--- a/frontends/web/src/routes/new-settings/about.tsx
+++ b/frontends/web/src/routes/new-settings/about.tsx
@@ -15,25 +15,50 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { Main, Header } from '../../components/layout';
+import { Main, Header, GuideWrapper, GuidedContent } from '../../components/layout';
 import { View, ViewContent } from '../../components/view/view';
 import { WithSettingsTabs } from './components/tabs';
 import { AppVersion } from './components/about/app-version-setting';
 import { TPagePropsWithSettingsTabs } from './type';
+import { MobileHeader } from './components/mobile-header';
+import { Guide } from '../../components/guide/guide';
+import { Entry } from '../../components/guide/entry';
 
 
 export const About = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
   return (
-    <Main>
-      <div className="hide-on-small"><Header title={<h2>{t('sidebar.settings')}</h2>} /></div>
-      <View fullscreen={false}>
-        <ViewContent>
-          <WithSettingsTabs deviceIDs={deviceIDs} hideMobileMenu hasAccounts={hasAccounts} subPageTitle={t('settings.about')}>
-            <AppVersion />
-          </WithSettingsTabs>
-        </ViewContent>
-      </View>
-    </Main>
+    <GuideWrapper>
+      <GuidedContent>
+        <Main>
+          <Header
+            hideSidebarToggler
+            title={
+              <>
+                <h2 className="hide-on-small">{t('sidebar.settings')}</h2>
+                <MobileHeader withGuide title={t('settings.about')} />
+              </>
+            } />
+          <View fullscreen={false}>
+            <ViewContent>
+              <WithSettingsTabs deviceIDs={deviceIDs} hideMobileMenu hasAccounts={hasAccounts}>
+                <AppVersion />
+              </WithSettingsTabs>
+            </ViewContent>
+          </View>
+        </Main>
+      </GuidedContent>
+      <AboutGuide />
+    </GuideWrapper>
+  );
+};
+
+
+const AboutGuide = () => {
+  const { t } = useTranslation();
+  return (
+    <Guide>
+      <Entry key="guide.settings.servers" entry={t('guide.settings.servers')} />
+    </Guide>
   );
 };

--- a/frontends/web/src/routes/new-settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/new-settings/advanced-settings.tsx
@@ -17,7 +17,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../hooks/api';
-import { Main, Header } from '../../components/layout';
+import { Main, Header, GuideWrapper, GuidedContent } from '../../components/layout';
 import { View, ViewContent } from '../../components/view/view';
 import { WithSettingsTabs } from './components/tabs';
 import { TPagePropsWithSettingsTabs } from './type';
@@ -26,6 +26,9 @@ import { EnableCoinControlSetting } from './components/advanced-settings/enable-
 import { ConnectFullNodeSetting } from './components/advanced-settings/connect-full-node-setting';
 import { EnableTorProxySetting } from './components/advanced-settings/enable-tor-proxy-setting';
 import { getConfig } from '../../utils/config';
+import { MobileHeader } from './components/mobile-header';
+import { Guide } from '../../components/guide/guide';
+import { Entry } from '../../components/guide/entry';
 
 export type TProxyConfig = {
   proxyAddress: string;
@@ -59,23 +62,47 @@ export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetti
   }, [fetchedConfig]);
 
   return (
-    <Main>
-      <div className="hide-on-small"><Header title={<h2>{t('sidebar.settings')}</h2>} /></div>
-      <View fullscreen={false}>
-        <ViewContent>
-          <WithSettingsTabs
-            deviceIDs={deviceIDs}
-            hideMobileMenu
-            hasAccounts={hasAccounts}
-            subPageTitle={t('settings.advancedSettings')}
-          >
-            <EnableCustomFeesToggleSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
-            <EnableCoinControlSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
-            <EnableTorProxySetting proxyConfig={proxyConfig} onChangeConfig={setConfig} />
-            <ConnectFullNodeSetting />
-          </WithSettingsTabs>
-        </ViewContent>
-      </View>
-    </Main>
+    <GuideWrapper>
+      <GuidedContent>
+        <Main>
+          <Header
+            hideSidebarToggler
+            title={
+              <>
+                <h2 className="hide-on-small">{t('sidebar.settings')}</h2>
+                <MobileHeader withGuide title={t('settings.advancedSettings')} />
+              </>
+            } />
+          <View fullscreen={false}>
+            <ViewContent>
+              <WithSettingsTabs
+                deviceIDs={deviceIDs}
+                hideMobileMenu
+                hasAccounts={hasAccounts}
+              >
+                <EnableCustomFeesToggleSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
+                <EnableCoinControlSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
+                <EnableTorProxySetting proxyConfig={proxyConfig} onChangeConfig={setConfig} />
+                <ConnectFullNodeSetting />
+              </WithSettingsTabs>
+            </ViewContent>
+          </View>
+        </Main>
+      </GuidedContent>
+      <AdvancedSettingsGuide />
+    </GuideWrapper>
+
+  );
+};
+
+
+const AdvancedSettingsGuide = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Guide>
+      <Entry key="guide.settings-electrum.why" entry={t('guide.settings-electrum.why')} />
+      <Entry key="guide.settings-electrum.tor" entry={t('guide.settings-electrum.tor')} />
+    </Guide>
   );
 };

--- a/frontends/web/src/routes/new-settings/appearance.tsx
+++ b/frontends/web/src/routes/new-settings/appearance.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Main, Header } from '../../components/layout';
+import { Main, Header, GuideWrapper, GuidedContent } from '../../components/layout';
 import { View, ViewContent } from '../../components/view/view';
 import { useTranslation } from 'react-i18next';
 import { DarkmodeToggleSetting } from './components/appearance/darkmodeToggleSetting';
@@ -24,23 +24,58 @@ import { LanguageDropdownSetting } from './components/appearance/languageDropdow
 import { ActiveCurrenciesDropdownSettingWithStore } from './components/appearance/activeCurrenciesDropdownSetting';
 import { WithSettingsTabs } from './components/tabs';
 import { TPagePropsWithSettingsTabs } from './type';
+import { MobileHeader } from './components/mobile-header';
+import { Guide } from '../../components/guide/guide';
+import { Entry } from '../../components/guide/entry';
 
 export const Appearance = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
   return (
-    <Main>
-      <div className="hide-on-small"><Header title={<h2>{t('sidebar.settings')}</h2>} /></div>
-      <View fullscreen={false}>
-        <ViewContent>
-          <WithSettingsTabs subPageTitle={t('settings.appearance')} hasAccounts={hasAccounts} hideMobileMenu deviceIDs={deviceIDs}>
-            <DefaultCurrencyDropdownSetting />
-            <ActiveCurrenciesDropdownSettingWithStore />
-            <LanguageDropdownSetting />
-            <DarkmodeToggleSetting />
-            <DisplaySatsToggleSetting />
-          </WithSettingsTabs>
-        </ViewContent>
-      </View>
-    </Main>
+    <GuideWrapper>
+      <GuidedContent>
+        <Main>
+          <Header
+            hideSidebarToggler
+            title={
+              <>
+                <h2 className="hide-on-small">{t('sidebar.settings')}</h2>
+                <MobileHeader withGuide title={t('settings.appearance')} />
+              </>
+            } />
+          <View fullscreen={false}>
+            <ViewContent>
+              <WithSettingsTabs hasAccounts={hasAccounts} hideMobileMenu deviceIDs={deviceIDs}>
+                <DefaultCurrencyDropdownSetting />
+                <ActiveCurrenciesDropdownSettingWithStore />
+                <LanguageDropdownSetting />
+                <DarkmodeToggleSetting />
+                <DisplaySatsToggleSetting />
+              </WithSettingsTabs>
+            </ViewContent>
+          </View>
+        </Main>
+      </GuidedContent>
+      <AppearanceGuide />
+    </GuideWrapper>
+
+  );
+};
+
+const AppearanceGuide = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Guide>
+      <Entry key="guide.settings.sats" entry={t('guide.settings.sats')} />
+      <Entry key="guide.accountRates" entry={{
+        link: {
+          text: 'www.coingecko.com',
+          url: 'https://www.coingecko.com/'
+        },
+        text: t('guide.accountRates.text'),
+        title: t('guide.accountRates.title')
+      }} />
+
+    </Guide>
   );
 };

--- a/frontends/web/src/routes/new-settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/new-settings/bb02-settings.tsx
@@ -17,7 +17,7 @@
 import { useState, useEffect } from 'react';
 import { useLoad } from '../../hooks/api';
 import { useTranslation } from 'react-i18next';
-import { Header, Main } from '../../components/layout';
+import { GuideWrapper, GuidedContent, Header, Main } from '../../components/layout';
 import { ViewContent, View } from '../../components/view/view';
 import { WithSettingsTabs } from './components/tabs';
 import { TPagePropsWithSettingsTabs } from './type';
@@ -34,6 +34,8 @@ import { SecureChipSetting } from './components/device-settings/secure-chip-sett
 import { DeviceNameSetting } from './components/device-settings/device-name-setting';
 import { FactoryResetSetting } from './components/device-settings/factory-reset-setting';
 import styles from './bb02-settings.module.css';
+import { ManageDeviceGuide } from '../device/bitbox02/settings-guide';
+import { MobileHeader } from './components/mobile-header';
 
 
 type TProps = {
@@ -54,19 +56,30 @@ const BB02Settings = ({ deviceID, deviceIDs, hasAccounts }: TWrapperProps) => {
   const { t } = useTranslation();
   return (
     <Main>
-      <div className="hide-on-small"><Header title={<h2>{t('sidebar.settings')}</h2>} /></div>
-      <View fullscreen={false}>
-        <ViewContent>
-          <WithSettingsTabs
-            deviceIDs={deviceIDs}
-            hideMobileMenu
-            hasAccounts={hasAccounts}
-            subPageTitle={t('settings.about')}
-          >
-            <Content deviceID={deviceID} />
-          </WithSettingsTabs>
-        </ViewContent>
-      </View>
+      <GuideWrapper>
+        <GuidedContent>
+          <Header
+            hideSidebarToggler
+            title={
+              <>
+                <h2 className="hide-on-small">{t('sidebar.settings')}</h2>
+                <MobileHeader withGuide title={t('sidebar.device')} />
+              </>
+            }/>
+          <View fullscreen={false}>
+            <ViewContent>
+              <WithSettingsTabs
+                deviceIDs={deviceIDs}
+                hideMobileMenu
+                hasAccounts={hasAccounts}
+              >
+                <Content deviceID={deviceID} />
+              </WithSettingsTabs>
+            </ViewContent>
+          </View>
+        </GuidedContent>
+        <ManageDeviceGuide />
+      </GuideWrapper>
     </Main>
   );
 };

--- a/frontends/web/src/routes/new-settings/components/mobile-header.module.css
+++ b/frontends/web/src/routes/new-settings/components/mobile-header.module.css
@@ -1,7 +1,6 @@
 .container {
     align-items: center;
-    display: flex;
-    margin-bottom: var(--space-default);
+    display: none;
     position: relative;
 }
 
@@ -36,4 +35,14 @@
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
+}
+
+.withGuide .headerText {
+    left: calc(50% + 37px);
+}
+
+@media (max-width: 768px) {
+    .container {
+        display: flex;
+    }
 }

--- a/frontends/web/src/routes/new-settings/components/mobile-header.tsx
+++ b/frontends/web/src/routes/new-settings/components/mobile-header.tsx
@@ -20,19 +20,20 @@ import { route } from '../../../utils/route';
 import styles from './mobile-header.module.css';
 
 type TProps = {
-  subPageTitle: string;
+  title: string;
+  withGuide?: boolean;
 }
 
-export const MobileHeader = ({ subPageTitle }: TProps) => {
+export const MobileHeader = ({ title, withGuide = false }: TProps) => {
   const { t } = useTranslation();
   const handleClick = () => {
     //goes to the 'general settings' page
     route('/new-settings');
   };
   return (
-    <div className={styles.container}>
+    <div className={`${styles.container} ${withGuide ? `${styles.withGuide}` : ''}`}>
       <button onClick={handleClick} className={styles.backButton}><ChevronLeftDark /> {t('button.back')}</button>
-      <h1 className={styles.headerText}>{subPageTitle}</h1>
+      <h1 className={styles.headerText}>{title}</h1>
     </div>
   );
 };

--- a/frontends/web/src/routes/new-settings/components/tabs.tsx
+++ b/frontends/web/src/routes/new-settings/components/tabs.tsx
@@ -15,7 +15,6 @@
  */
 
 import { ReactNode } from 'react';
-import { MobileHeader } from './mobile-header';
 import { NavLink } from 'react-router-dom';
 import { route } from '../../../utils/route';
 import { SettingsItem } from './settingsItem/settingsItem';
@@ -28,7 +27,6 @@ type TWithSettingsTabsProps = {
   deviceIDs: string[]
   hasAccounts: boolean;
   hideMobileMenu?: boolean;
-  subPageTitle: string;
 }
 
 type TTab = {
@@ -48,13 +46,9 @@ export const WithSettingsTabs = ({
   deviceIDs,
   hideMobileMenu,
   hasAccounts,
-  subPageTitle
 }: TWithSettingsTabsProps) => {
   return (
     <>
-      <div className="show-on-small">
-        <MobileHeader subPageTitle={subPageTitle} />
-      </div>
       <div className="hide-on-small">
         <Tabs hideMobileMenu={hideMobileMenu} deviceIDs={deviceIDs} hasAccounts={hasAccounts} />
       </div>
@@ -92,12 +86,12 @@ export const Tabs = ({ deviceIDs, hideMobileMenu, hasAccounts }: TTabs) => {
   return (
     <div className={styles.container}>
       <Tab key="appearance" hideMobileMenu={hideMobileMenu} name={t('settings.appearance')} url="/new-settings/appearance" />
-      {hasAccounts ? <Tab key="manage-accounts" hideMobileMenu={hideMobileMenu} name={'Manage accounts'} url="/settings/manage-accounts" /> : null}
+      {hasAccounts ? <Tab key="manage-accounts" hideMobileMenu={hideMobileMenu} name={t('manageAccounts.title')} url="/settings/manage-accounts" /> : null}
       {deviceIDs.map(id => (
         <Tab hideMobileMenu={hideMobileMenu} name={t('sidebar.device')} key={`device-${id}`} url={`/new-settings/device-settings/${id}`} />
       )) }
-      <Tab key="advanced-settings" hideMobileMenu={hideMobileMenu} name={'Advanced settings'} url="/new-settings/advanced-settings" />
-      <Tab key="about" hideMobileMenu={hideMobileMenu} name={'About'} url="/new-settings/about" />
+      <Tab key="advanced-settings" hideMobileMenu={hideMobileMenu} name={t('settings.advancedSettings')} url="/new-settings/advanced-settings" />
+      <Tab key="about" hideMobileMenu={hideMobileMenu} name={t('settings.about')} url="/new-settings/about" />
     </div>
   );
 };

--- a/frontends/web/src/routes/new-settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/new-settings/mobile-settings.tsx
@@ -21,6 +21,7 @@ import { route } from '../../utils/route';
 import { useMediaQuery } from '../../hooks/mediaquery';
 import { Tabs } from './components/tabs';
 import { TPagePropsWithSettingsTabs } from './type';
+import { useTranslation } from 'react-i18next';
 
 /**
  * The "index" page of the settings
@@ -32,6 +33,7 @@ import { TPagePropsWithSettingsTabs } from './type';
  **/
 export const MobileSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const isMobile = useMediaQuery('(max-width: 768px)');
+  const { t } = useTranslation();
   useEffect(() => {
     if (!isMobile) {
       route('/new-settings/appearance');
@@ -39,7 +41,7 @@ export const MobileSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetting
   }, [isMobile]);
   return (
     <Main>
-      <Header title={<h2>Settings</h2>} />
+      <Header guideExists={false} title={<h2>{t('settings.title')}</h2>} />
       <View fullscreen={false}>
         <ViewContent>
           <Tabs deviceIDs={deviceIDs} hasAccounts={hasAccounts} />

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -28,6 +28,7 @@ import { Message } from '../../components/message/message';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { WithSettingsTabs } from '../new-settings/components/tabs';
 import { View, ViewContent } from '../../components/view/view';
+import { MobileHeader } from '../new-settings/components/mobile-header';
 import style from './manage-accounts.module.css';
 
 interface ManageAccountsProps {
@@ -212,10 +213,17 @@ class ManageAccounts extends Component<Props, State> {
     const accountList = this.renderAccounts();
     return (
       <Main>
-        <div className="hide-on-small"><Header title={<h2>{t('settings.title')}</h2>} /></div>
+        <Header
+          hideSidebarToggler
+          title={
+            <>
+              <h2 className="hide-on-small">{t('settings.title')}</h2>
+              <MobileHeader title={t('manageAccounts.title')} />
+            </>
+          } />
         <View fullscreen={false}>
           <ViewContent>
-            <WithSettingsTabs deviceIDs={deviceIDs} hideMobileMenu hasAccounts={hasAccounts} subPageTitle={t('manageAccounts.title')}>
+            <WithSettingsTabs deviceIDs={deviceIDs} hideMobileMenu hasAccounts={hasAccounts}>
               <>
                 <Button
                   className={style.addAccountBtn}


### PR DESCRIPTION
There were several changes to make the guide works with our tabbed settings.

1. We now use the `Header` component's prop `title` for showing both setting page name for both desktop & mobile.

e.g "Settings" on Desktop and "Appearance" on mobile (when on `/new-settings/appearance`). Previously, to display the page name on mobile we use `WithSettingsTabs`

2. Modified `WithSettingsTab` to not receive the page title anymore due to the point above.

3. Modified `Header` to be able to hide sidebarToggler also due to point 1.

We need to be able to hide `sidebarToggler` because on an individual setting page on mobile (for example `Appearance`), we already have a back button which is inside `MobileHeader`.

So we don't need the `sidebarToggler` anymore.


Preview:

![Screenshot 2023-06-13 at 17 36 29](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/c14d7245-409e-40b0-ad4e-9e800aeda202)
<img width="1488" alt="Screenshot 2023-06-13 at 17 36 38" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/7510d072-7fd8-4485-9ee4-f57f6faee43f">
<img width="1488" alt="Screenshot 2023-06-13 at 17 36 46" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/f79e2d8f-8006-4988-afef-c415535ab6ff">
