### PR TITLE
backend/btc: avoid some panics

### DIFF
--- a/backend/coins/btc/account.go
+++ b/backend/coins/btc/account.go
@@ -587,8 +587,12 @@ func (account *Account) onAddressStatus(address *addresses.AccountAddress, statu
 	}
 	addressHistory, err := account.getAddressHistory(address)
 	if err != nil {
+		if account.isClosed() {
+			account.log.WithError(err).Error("stopping sync because account was closed")
+			return
+		}
 		// TODO
-		panic(err)
+		account.log.WithError(err).Panic("getAddressHistory failed")
 	}
 	if status == addressHistory.Status() {
 		account.incAndEmitSyncCounter()
@@ -631,8 +635,12 @@ func (account *Account) ensureAddresses() {
 		for {
 			newAddresses, err := addressChain.EnsureAddresses()
 			if err != nil {
+				if account.isClosed() {
+					account.log.WithError(err).Error("stopping sync because account was closed")
+					return
+				}
 				// TODO
-				panic(err)
+				account.log.WithError(err).Panic("EnsureAddresses failed")
 			}
 			if len(newAddresses) == 0 {
 				break


### PR DESCRIPTION
When the account and db closes, DB operations subsequently fail. The panics should be handled better anyway, but in the case that the account was closed, we can just abort there and prevent a crash.