### PR TITLE
frontend: fix translation keys

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -189,9 +189,9 @@
     "advanced": {
       "button": "Advanced options",
       "outOfDate": "Firmware out of date for this feature",
+      "seed12WordInfo": "Please note that the number of words cannot be changed after creating the wallet.",
       "seed12WordLabel": "Create 12-word instead of 24-word seed",
-      "seed12WordText_1": "By default the BitBox02 uses a 24-word seed. Both seed lengths are secure against brute forcing in practice. Some users may prefer the convenience of the 12-word seed instead.",
-      "seed12WordText_2": "Please note that the number of words cannot be changed after creating the wallet.",
+      "seed12WordText": "By default the BitBox02 uses a 24-word seed. Both seed lengths are secure against brute forcing in practice. Some users may prefer the convenience of the 12-word seed instead.",
       "skipSDCardLabel": "Skip microSD card backup and write down recovery words instead",
       "skipSDCardText": "You always have the option to create a microSD card backup and write your recovery words after setup. This can be done from settings.",
       "title": "Advanced backup options"

--- a/frontends/web/src/routes/device/bitbox02/setup/choose.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/choose.tsx
@@ -126,13 +126,13 @@ export const SetupOptions = ({
                 </div>
                 <p className="m-top-quarter m-bottom-default">
                   <small>
-                    {t('bitbox02Wizard.advanced.seed12WordText_1')}
+                    {t('bitbox02Wizard.advanced.seed12WordText')}
                   </small>
                 </p>
                 <p className="m-top-quarter m-bottom-default">
                   <small>
                     <Info className={style.textIcon} />
-                    {t('bitbox02Wizard.advanced.seed12WordText_2')}
+                    {t('bitbox02Wizard.advanced.seed12WordInfo')}
                   </small>
                 </p>
               </div>


### PR DESCRIPTION
Locize recognized keys ending with _1 and _2 as plural, this was not intended, fixed by renaming the keys.

https://www.i18next.com/translation-function/plurals