### PR TITLE
backend/accounts: make distinction between testnet and mainnet

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1021,11 +1021,14 @@ func (backend *Backend) maybeAddHiddenUnusedAccounts() {
 	}
 
 	// Enable accounts discovery for these coins.
-	coinCodes := []coinpkg.Code{
-		coinpkg.CodeBTC,
-		coinpkg.CodeTBTC,
-		coinpkg.CodeLTC,
-		coinpkg.CodeTLTC,
+	var coinCodes []coinpkg.Code
+	switch {
+	case backend.arguments.Regtest():
+		coinCodes = []coinpkg.Code{coinpkg.CodeRBTC}
+	case backend.arguments.Testing():
+		coinCodes = []coinpkg.Code{coinpkg.CodeTBTC, coinpkg.CodeTLTC}
+	default:
+		coinCodes = []coinpkg.Code{coinpkg.CodeBTC, coinpkg.CodeLTC}
 	}
 	for _, coinCode := range coinCodes {
 		var newAccountCode *accountsTypes.Code


### PR DESCRIPTION
If there is a testnet account stored (from a testnet run) and the app is then run in mainnet, the accounts scan would also scan testnet accounts. This commit fixes it to only look at the right coins depending on testnet or mainnet.