### PR TITLE
frontend: use skeleton when rendering DeviceNameSetting

### DIFF
--- a/frontends/web/src/routes/settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/settings/bb02-settings.tsx
@@ -114,7 +114,13 @@ const Content = ({ deviceID }: TProps) => {
       {/*"Device information" section*/}
       <div className={styles.section}>
         <h3 className="subTitle">{t('deviceSettings.deviceInformation.title')}</h3>
-        {deviceInfo ? <DeviceNameSetting deviceName={deviceInfo.name} deviceID={deviceID} /> : null }
+        {deviceInfo ?
+          <DeviceNameSetting
+            deviceName={deviceInfo.name}
+            deviceID={deviceID}
+          /> :
+          <StyledSkeleton />
+        }
         <AttestationCheckSetting deviceID={deviceID} />
         {
           versionInfo ?


### PR DESCRIPTION
Without skeleton, there will be a slight jump in the layout of "Manage Device" settings, (under Device Information) due to `null` being rendered when `deviceinfo` is still undefined.


Before:

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/3d454c93-e355-40e9-a583-4673706d0a47



After:

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/0fd0a8a6-c187-407a-98f6-6ce29106ef99

