### PR TITLE
frontend/banner: add banner support for bitbox02

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -37,6 +37,7 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/ltc"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/bitbox02"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/device"
 	deviceevent "github.com/digitalbitbox/bitbox-wallet-app/backend/devices/device/event"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/devices/usb"
@@ -598,6 +599,8 @@ func (backend *Backend) Register(theDevice device.Interface) error {
 	switch theDevice.ProductName() {
 	case bitbox.ProductName:
 		backend.banners.Activate(banners.KeyBitBox01)
+	case bitbox02.ProductName:
+		backend.banners.Activate(banners.KeyBitBox02)
 	}
 	return nil
 }

--- a/backend/banners/banners.go
+++ b/backend/banners/banners.go
@@ -30,6 +30,14 @@ const bannersURL = "https://bitbox.swiss/updates/banners.json"
 // MessageKey enumerates the possible keys in the banners json.
 type MessageKey string
 
+type TypeCode string
+
+const (
+	TypeWarning TypeCode = "warning"
+	TypeSuccess TypeCode = "success"
+	TypeInfo    TypeCode = "info"
+)
+
 const (
 	// KeyBitBox01 is the message key for the event when a BitBox01 gets connected.
 	KeyBitBox01 MessageKey = "bitbox01"
@@ -49,7 +57,8 @@ type Message struct {
 	} `json:"link"`
 	// Dismissible: if true the ID field will be the key of config.frontend map to keep
 	// trace of dismissed banners (see status.tsx for details).
-	Dismissible *bool `json:"dismissible"`
+	Dismissible *bool     `json:"dismissible"`
+	Type        *TypeCode `json:"type"`
 }
 
 // Banners fetches banner information from remote.

--- a/backend/banners/banners.go
+++ b/backend/banners/banners.go
@@ -33,6 +33,7 @@ type MessageKey string
 const (
 	// KeyBitBox01 is the message key for the event when a BitBox01 gets connected.
 	KeyBitBox01 MessageKey = "bitbox01"
+	KeyBitBox02 MessageKey = "bitbox02"
 )
 
 // Message is one entry in the banners json.
@@ -43,8 +44,12 @@ type Message struct {
 	ID string `json:"id"`
 	// Link, if present, will be appended to the message.
 	Link *struct {
-		Href string `json:"href"`
+		Href string  `json:"href"`
+		Text *string `json:"text"`
 	} `json:"link"`
+	// Dismissible: if true the ID field will be the key of config.frontend map to keep
+	// trace of dismissed banners (see status.tsx for details).
+	Dismissible *bool `json:"dismissible"`
 }
 
 // Banners fetches banner information from remote.
@@ -54,6 +59,7 @@ type Banners struct {
 	url     string
 	banners struct {
 		BitBox01 *Message `json:"bitbox01"`
+		BitBox02 *Message `json:"bitbox02"`
 	}
 
 	active map[MessageKey]struct{}
@@ -113,6 +119,8 @@ func (banners *Banners) GetMessage(key MessageKey) *Message {
 	switch key {
 	case KeyBitBox01:
 		return banners.banners.BitBox01
+	case KeyBitBox02:
+		return banners.banners.BitBox02
 	default:
 		banners.log.Errorf("unrecognized key: %s", key)
 		return nil

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -193,6 +193,7 @@ class App extends Component<Props, State> {
             <div className="appContent flex flex-column flex-1" style={{ minWidth: 0 }}>
               <Update />
               <Banner msgKey="bitbox01" />
+              <Banner msgKey="bitbox02" />
               <MobileDataWarning />
               <Aopp />
               <AppRouter

--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -24,8 +24,9 @@ type TBannerInfo = {
     message: { [key: string]: string; };
     link?: {
         href: string;
-        text: string;
+        text?: string;
     };
+    dismissible?: boolean;
 }
 
 type TLoadedProps = {
@@ -34,21 +35,21 @@ type TLoadedProps = {
 
 type TBannerProps = {
     // eslint-disable-next-line react/no-unused-prop-types
-    msgKey: 'bitbox01';
+    msgKey: 'bitbox01' | 'bitbox02';
 }
 
 type TProps = TLoadedProps & TBannerProps & TranslateProps;
 
-function Banner({ banner, i18n, t }: TProps) {
+function Banner({ msgKey, banner, i18n, t }: TProps) {
   if (!i18n.options.fallbackLng) {
     return null;
   }
   return banner && (
-    <Status dismissible="" type="warning">
+    <Status dismissible={banner.dismissible ? `banner-${msgKey}-${banner.id}` : ''} type="warning">
       { banner.message[i18n.language] || banner.message[(i18n.options.fallbackLng as string[])[0]] }&nbsp;
       { banner.link && (
         <A href={banner.link.href}>
-          {t('clickHere')}
+          { banner.link.text || t('clickHere') }
         </A>
       )}
     </Status>

--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -17,7 +17,7 @@
 import { subscribe } from '../../decorators/subscribe';
 import { translate, TranslateProps } from '../../decorators/translate';
 import A from '../anchor/anchor';
-import { Status } from '../status/status';
+import { Status, statusType } from '../status/status';
 
 type TBannerInfo = {
     id: string;
@@ -27,6 +27,7 @@ type TBannerInfo = {
         text?: string;
     };
     dismissible?: boolean;
+    type?: statusType;
 }
 
 type TLoadedProps = {
@@ -45,7 +46,9 @@ function Banner({ msgKey, banner, i18n, t }: TProps) {
     return null;
   }
   return banner && (
-    <Status dismissible={banner.dismissible ? `banner-${msgKey}-${banner.id}` : ''} type="warning">
+    <Status
+      dismissible={banner.dismissible ? `banner-${msgKey}-${banner.id}` : ''}
+      type={banner.type ? banner.type : 'warning'}>
       { banner.message[i18n.language] || banner.message[(i18n.options.fallbackLng as string[])[0]] }&nbsp;
       { banner.link && (
         <A href={banner.link.href}>

--- a/frontends/web/src/components/status/status.tsx
+++ b/frontends/web/src/components/status/status.tsx
@@ -20,9 +20,11 @@ import { getConfig, setConfig } from '../../utils/config';
 import { CloseXWhite } from '../icon';
 import style from './status.module.css';
 
+export type statusType = 'success' | 'warning' | 'info';
+
 type TPRops = {
     hidden?: boolean;
-    type?: 'success' | 'warning' | 'info';
+    type?: statusType;
     // used as keyName in the config if dismissing the status should be persisted, so it is not
     // shown again. Use an empty string if it should be dismissible without storing it in the
     // config, so the status will be shown again the next time.


### PR DESCRIPTION
Banner messages are available for bitbox01 trough a dedicated backend endpoint that allows to fetch a banner json exposed on a specific url.

This adds banner support also for bitbox02, which allows e.g. to advertise offers to the users or communicate important messages inside the app.