### PR TITLE
frontend: decrease sats separator spacing

### DIFF
--- a/frontends/web/src/components/amount/amount.module.css
+++ b/frontends/web/src/components/amount/amount.module.css
@@ -1,3 +1,3 @@
 .space {
-    margin-left: 0.5ch;
+    margin-left: 0.33ch;
 }


### PR DESCRIPTION
The sats separator should improve reading Bitcoin sats values, but the space is unnecessary big and almost hard to read.

Reduced sats separator spacing so the number looks more natural.