### PR TITLE
frontend: add success recommendation for created with mnemonic

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -262,6 +262,7 @@
     },
     "stepCreateSuccess": {
       "removeMicroSD": "Please remove the microSD card from your BitBox02 and store it in a secure location.",
+      "storeMnemonic": "Please store your recovery words in a secure location",
       "success": "You’ve successfully created your backup."
     },
     "stepInsertSD": {

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -222,7 +222,10 @@ class BitBox02 extends Component<Props, State> {
         )}
 
         { (appStatus === 'create-wallet' && status === 'initialized') && (
-          <CreateWalletSuccess key="success" onContinue={this.handleGetStarted} />
+          <CreateWalletSuccess
+            key="success"
+            backupType={(createOptions?.withMnemonic ? 'mnemonic' : 'sdcard')}
+            onContinue={this.handleGetStarted} />
         )}
         { (appStatus === 'restore-sdcard' && status === 'initialized') && (
           <RestoreFromSDCardSuccess key="backup-success" onContinue={this.handleGetStarted} />

--- a/frontends/web/src/routes/device/bitbox02/setup/success.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/success.tsx
@@ -18,11 +18,18 @@ import { useTranslation } from 'react-i18next';
 import { View, ViewButtons, ViewContent, ViewHeader } from '../../../../components/view/view';
 import { Button } from '../../../../components/forms';
 
-type Props = {
+type TProps = {
   onContinue: () => void;
+};
+
+type TCreateProps = TProps & {
+  backupType: 'sdcard' | 'mnemonic';
 }
 
-export const CreateWalletSuccess = ({ onContinue }: Props) => {
+export const CreateWalletSuccess = ({
+  backupType,
+  onContinue,
+}: TCreateProps) => {
   const { t } = useTranslation();
   return (
     <View
@@ -35,7 +42,11 @@ export const CreateWalletSuccess = ({ onContinue }: Props) => {
         <p>{t('bitbox02Wizard.stepCreateSuccess.success')}</p>
       </ViewHeader>
       <ViewContent withIcon="success">
-        <p>{t('bitbox02Wizard.stepCreateSuccess.removeMicroSD')}</p>
+        <p>
+          { backupType === 'sdcard'
+            ? t('bitbox02Wizard.stepCreateSuccess.removeMicroSD')
+            : t('bitbox02Wizard.stepCreateSuccess.storeMnemonic') }
+        </p>
       </ViewContent>
       <ViewButtons>
         <Button primary onClick={onContinue}>
@@ -46,7 +57,7 @@ export const CreateWalletSuccess = ({ onContinue }: Props) => {
   );
 };
 
-export const RestoreFromSDCardSuccess = ({ onContinue }: Props) => {
+export const RestoreFromSDCardSuccess = ({ onContinue }: TProps) => {
   const { t } = useTranslation();
   return (
     <View
@@ -80,7 +91,7 @@ export const RestoreFromSDCardSuccess = ({ onContinue }: Props) => {
   );
 };
 
-export const RestoreFromMnemonicSuccess = ({ onContinue }: Props) => {
+export const RestoreFromMnemonicSuccess = ({ onContinue }: TProps) => {
   const { t } = useTranslation();
   return (
     <View


### PR DESCRIPTION
The create wallet success step had a message specific to microSD card (remove the microSD card), added a message if wallet was created with mnemonic words instead.

![Screen Shot 2023-06-23 at 09 50 46](https://github.com/digitalbitbox/bitbox-wallet-app/assets/546900/e4d03c4c-cbdd-4afc-972d-864e640e73cf)
