### PR TITLE
frontend: add missing cz lang in settings

### DIFF
--- a/frontends/web/src/components/language/language.tsx
+++ b/frontends/web/src/components/language/language.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,35 +18,13 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dialog } from '../dialog/dialog';
-import { TActiveLanguageCodes, TLanguagesList } from './types';
+import { defaultLanguages, TActiveLanguageCodes, TLanguagesList } from './types';
 import style from './language.module.css';
 import { getSelectedIndex } from '../../utils/language';
 
 type TLanguageSwitchProps = {
     languages?: TLanguagesList;
 }
-
-const defaultLanguages = [
-  { code: 'ar', display: 'العربية' },
-  { code: 'bg', display: 'България' },
-  { code: 'cs', display: 'Čeština' },
-  { code: 'de', display: 'Deutsch' },
-  { code: 'en', display: 'English' },
-  { code: 'es', display: 'Español' },
-  { code: 'fa', display: 'فارسی' },
-  { code: 'fr', display: 'Français' },
-  { code: 'he', display: 'עברית' },
-  { code: 'hi', display: 'हिन्दी ' },
-  { code: 'it', display: 'Italiano' },
-  { code: 'ja', display: '日本語' },
-  { code: 'ms', display: 'Bahasa Melayu' },
-  { code: 'nl', display: 'Nederlands' },
-  { code: 'pt', display: 'Português' },
-  { code: 'ru', display: 'Русский' },
-  { code: 'sl', display: 'Slovenščina' },
-  { code: 'tr', display: 'Türkçe' },
-  { code: 'zh', display: '中文' },
-] as TLanguagesList;
 
 const LanguageSwitch = ({ languages }: TLanguageSwitchProps) => {
 

--- a/frontends/web/src/components/language/types.ts
+++ b/frontends/web/src/components/language/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,35 @@
  * limitations under the License.
  */
 
-export type TActiveLanguageCodes = 'bg' | 'de' | 'en' | 'es'
-    | 'fr' | 'hi' | 'it' | 'ja' | 'ms' | 'nl' | 'pt'
-    | 'ru' | 'sl' | 'tr' | 'zh' | 'fa' | 'he'| 'ar';
+export type TActiveLanguageCodes = 'ar' | 'bg' | 'cs' |'de'
+  | 'en' | 'es' | 'fa' | 'fr' | 'hi' | 'he' | 'it' | 'ja'
+  | 'ms' | 'nl' | 'pt' | 'ru' | 'sl' | 'tr' | 'zh';
 
 export type TLanguage = {
-    code: TActiveLanguageCodes;
-    display: string;
+  code: TActiveLanguageCodes;
+  display: string;
 };
 
 export type TLanguagesList = TLanguage[];
+
+export const defaultLanguages: TLanguagesList = [
+  { code: 'ar', display: 'العربية' },
+  { code: 'bg', display: 'България' },
+  { code: 'cs', display: 'Čeština' },
+  { code: 'de', display: 'Deutsch' },
+  { code: 'en', display: 'English' },
+  { code: 'es', display: 'Español' },
+  { code: 'fa', display: 'فارسی' },
+  { code: 'fr', display: 'Français' },
+  { code: 'he', display: 'עברית' },
+  { code: 'hi', display: 'हिन्दी ' },
+  { code: 'it', display: 'Italiano' },
+  { code: 'ja', display: '日本語' },
+  { code: 'ms', display: 'Bahasa Melayu' },
+  { code: 'nl', display: 'Nederlands' },
+  { code: 'pt', display: 'Português' },
+  { code: 'ru', display: 'Русский' },
+  { code: 'sl', display: 'Slovenščina' },
+  { code: 'tr', display: 'Türkçe' },
+  { code: 'zh', display: '中文' },
+];

--- a/frontends/web/src/routes/settings/components/appearance/languageDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/languageDropdownSetting.tsx
@@ -16,30 +16,9 @@
 
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { useTranslation } from 'react-i18next';
-import { TLanguagesList } from '../../../../components/language/types';
+import { defaultLanguages } from '../../../../components/language/types';
 import { getSelectedIndex } from '../../../../utils/language';
 import { SingleDropdown } from '../dropdowns/singledropdown';
-
-const defaultLanguages: TLanguagesList = [
-  { code: 'ar', display: 'العربية' },
-  { code: 'bg', display: 'България' },
-  { code: 'de', display: 'Deutsch' },
-  { code: 'en', display: 'English' },
-  { code: 'es', display: 'Español' },
-  { code: 'fa', display: 'فارسی' },
-  { code: 'fr', display: 'Français' },
-  { code: 'he', display: 'עברית' },
-  { code: 'hi', display: 'हिन्दी ' },
-  { code: 'it', display: 'Italiano' },
-  { code: 'ja', display: '日本語' },
-  { code: 'ms', display: 'Bahasa Melayu' },
-  { code: 'nl', display: 'Nederlands' },
-  { code: 'pt', display: 'Português' },
-  { code: 'ru', display: 'Русский' },
-  { code: 'sl', display: 'Slovenščina' },
-  { code: 'tr', display: 'Türkçe' },
-  { code: 'zh', display: '中文' },
-];
 
 export const LanguageDropdownSetting = () => {
   const { i18n, t } = useTranslation();


### PR DESCRIPTION
The new settings dropdown is missing Čeština (CZ lang), but it is shown in the language menu during setup or in the waiting view.

Changed so that both use the same list of languages and rearranged all languages types in alphabetical order.