### PR TITLE
frontend: remove sdcard warning in create mnemonic wallet

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/setup/name.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/name.tsx
@@ -22,24 +22,22 @@ import { Button, Input } from '../../../../components/forms';
 import style from './name.module.css';
 import { checkSDCard } from '../../../../api/bitbox02';
 
-type Props = {
-  deviceID: string;
+type TProps = {
   onDeviceName: (name: string) => void;
   onBack: () => void;
 }
 
+type TSetDeviceNameProps = TProps & {
+  missingSDCardWarning?: boolean;
+}
+
 export const SetDeviceName = ({
-  deviceID,
   onDeviceName,
   onBack,
-}: Props) => {
+  missingSDCardWarning,
+}: TSetDeviceNameProps) => {
   const { t } = useTranslation();
   const [deviceName, setDeviceName] = useState('');
-  const [hasSDCard, setSDCard] = useState<boolean>();
-
-  useEffect(() => {
-    checkSDCard(deviceID).then(setSDCard);
-  }, [deviceID]);
 
   const handleDeviceNameInput = (event: Event) => {
     const target = (event.target as HTMLInputElement);
@@ -61,7 +59,7 @@ export const SetDeviceName = ({
         width="600px">
         <ViewHeader title={t('bitbox02Wizard.stepCreate.title')}>
           <p>{t('bitbox02Wizard.stepCreate.description')}</p>
-          {hasSDCard === false && (
+          {missingSDCardWarning && (
             <Status className="m-bottom-half" type="warning">
               <span>{t('bitbox02Wizard.stepCreate.toastMicroSD')}</span>
             </Status>
@@ -94,5 +92,28 @@ export const SetDeviceName = ({
         </ViewButtons>
       </View>
     </form>
+  );
+};
+
+type TPropsWithSDCard = TProps & {
+  deviceID: string;
+}
+
+export const SetDeviceNameWithSDCard = ({
+  deviceID,
+  onDeviceName,
+  onBack,
+}: TPropsWithSDCard) => {
+  const [hasSDCard, setSDCard] = useState<boolean>();
+
+  useEffect(() => {
+    checkSDCard(deviceID).then(setSDCard);
+  }, [deviceID]);
+
+  return (
+    <SetDeviceName
+      onDeviceName={onDeviceName}
+      onBack={onBack}
+      missingSDCardWarning={hasSDCard === false} />
   );
 };

--- a/frontends/web/src/routes/device/bitbox02/setup/wallet-create.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/wallet-create.tsx
@@ -21,7 +21,7 @@ import { useMountedRef } from '../../../../hooks/mount';
 import { alertUser } from '../../../../components/alert/Alert';
 import { Wait } from './wait';
 import { ChecklistWalletCreate, ChecklistWalletCreateMnemonic } from './checklist';
-import { SetDeviceName } from './name';
+import { SetDeviceName, SetDeviceNameWithSDCard } from './name';
 import { SetPassword } from './password';
 import { WithSDCard } from './sdcard';
 
@@ -153,13 +153,24 @@ export const CreateWallet = ({
 
   switch (status) {
   case 'intro':
-    return (
-      <SetDeviceName
-        key="set-devicename"
-        deviceID={deviceID}
-        onDeviceName={setDeviceName}
-        onBack={onAbort} />
-    );
+    switch (backupType) {
+    case 'sdcard':
+      return (
+        <SetDeviceNameWithSDCard
+          key="set-devicename-sdcard"
+          deviceID={deviceID}
+          onDeviceName={setDeviceName}
+          onBack={onAbort} />
+      );
+    case 'mnemonic':
+      return (
+        <SetDeviceName
+          key="set-devicename-mnemonic"
+          onDeviceName={setDeviceName}
+          onBack={onAbort} />
+      );
+    }
+    break;
   case 'setName':
     return (
       <Wait title={t('bitbox02Interact.confirmName')} />


### PR DESCRIPTION
The please insert your microSD card warning should not show when the user setups with skip sdcard.