### PR TITLE
frontend: fix restore from mnemonic success message

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/setup/success.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/success.tsx
@@ -96,9 +96,10 @@ export const RestoreFromMnemonicSuccess = ({ onContinue }: Props) => {
         </p>
         <ul>
           <li>{t('bitbox02Wizard.backup.userConfirmation1')}</li>
+          <li>{t('bitbox02Wizard.backup.userConfirmation2')}</li>
           <li>{t('bitbox02Wizard.backup.userConfirmation3')}</li>
           <li>{t('bitbox02Wizard.backup.userConfirmation4')}</li>
-          <li>{t('bitbox02Wizard.backup.userConfirmation5')}</li>
+          <li>{t('bitbox02Wizard.backup.userConfirmation5mnemonic')}</li>
         </ul>
       </ViewContent>
       <ViewButtons>


### PR DESCRIPTION
The restore from mnemonic success view the last point mentioned sdcard changed to security notice about recovery words.