### PR TITLE
frontend: fix breaking word in tabs navigation

### DIFF
--- a/frontends/web/src/routes/settings/components/tabs.module.css
+++ b/frontends/web/src/routes/settings/components/tabs.module.css
@@ -1,6 +1,7 @@
 .container {
     display: flex;
     margin-bottom: var(--space-default);
+    word-break: keep-all;
 }
 
 .container a {


### PR DESCRIPTION
There is a global style to break text in long words, this is a precausion to always show long addresses and break the address in the worst case.

But this rule breaks the tab text of the new settings view on some breakpoints (medium-ish screeen size).