### PR TITLE
frontend: show current firmware version

### DIFF
--- a/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
@@ -44,7 +44,6 @@ const FirmwareSetting = ({ deviceID, versionInfo, asButton = false }: TProps) =>
   const canUpgrade = versionInfo.canUpgrade;
   const secondaryText = canUpgrade ? t('deviceSettings.firmware.upgradeAvailable') : t('deviceSettings.firmware.upToDate');
   const extraComponent = canUpgrade ? <RedDot width={8} height={8}/> : <Checked />;
-  const displayedValue = canUpgrade ? versionInfo.newVersion : versionInfo.currentVersion;
 
 
   const handleUpgradeFirmware = async () => {
@@ -61,7 +60,7 @@ const FirmwareSetting = ({ deviceID, versionInfo, asButton = false }: TProps) =>
         settingName={t('deviceSettings.firmware.title')}
         secondaryText={secondaryText}
         onClick={canUpgrade ? () => setDialogOpen(true) : undefined}
-        displayedValue={displayedValue}
+        displayedValue={versionInfo.currentVersion}
         extraComponent={extraComponent}
       />
       <UpgradeDialog


### PR DESCRIPTION
Previously, we show the most up-to-date firmware version when there's a firmware update available on the settings.
This is unclear, and now we want to always show the currently installed version instead.

