### PR TITLE
frontend: block toggle account until coin is enabled

### DIFF
--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -61,7 +61,7 @@ class ManageAccounts extends Component<Props, State> {
   };
 
   private fetchAccounts = () => {
-    accountAPI.getAccounts().then(accounts => this.setState({ accounts }));
+    return accountAPI.getAccounts().then(accounts => this.setState({ accounts }));
   };
 
   public componentDidMount() {
@@ -94,7 +94,11 @@ class ManageAccounts extends Component<Props, State> {
           <Toggle
             checked={active}
             id={account.code}
-            onChange={() => this.toggleAccount(account.code, !active)} />
+            onChange={(event) => {
+              event.target.disabled = true;
+              this.toggleAccount(account.code, !active)
+                .then(() => event.target.disabled = false);
+            }} />
           {active && account.coinCode === 'eth' ? (
             <div className={style.tokenSection}>
               <div className={`${style.tokenContainer} ${tokensVisible ? style.tokenContainerOpen : ''}`}>
@@ -116,9 +120,9 @@ class ManageAccounts extends Component<Props, State> {
   };
 
   private toggleAccount = (accountCode: string, active: boolean) => {
-    backendAPI.setAccountActive(accountCode, active).then(({ success, errorMessage }) => {
+    return backendAPI.setAccountActive(accountCode, active).then(({ success, errorMessage }) => {
       if (success) {
-        this.fetchAccounts();
+        return this.fetchAccounts();
       } else if (errorMessage) {
         alertUser(errorMessage);
       }


### PR DESCRIPTION
With the 'encrypt seed in RAM' firmware it can now take slightly longer to enable an account. Clicking the toggle quickly can deactivate the account again.

https://github.com/digitalbitbox/bitbox02-firmware/pull/1056

This change sets the toggle to disabled until the enabling is complete. To keep it simple this doesn't keep the disabled state of each toggle, but just fire and forgets.

Setting the toggle to disabled quickly changes the color. In a future commit this could be changed a loading indicator  instead of chaning it to disabled color.