### PR TITLE
releases: bump version code, add 4.37.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Changed Litecoin block explorer to Blockchair
 - Show notes in coin control
 
+## 4.37.1
+- Fix BitBoxApp crash when processing BTC/LTC transactions containing too large witness items
+
 ## 4.37.0
 - Bundle BitBox02 firmware version v9.14.0
 - Enable auto HiDPI scaling to correctly manage scale factor on high density screens

--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -7,7 +7,7 @@ android {
         applicationId "ch.shiftcrypto.bitboxapp"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 43
+        versionCode 44
         versionName "android-4.38.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
v4.37.1 was a hotfix based on v4.37.0 with its own changelog entry and Android version code. For v4.38.0 we need to bump the version code to avoid a collision.