### PR TITLE
frontend: display root fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Display the wallet root fingerprint in the account info and device settings
+
 ## 4.38.0
 - Bundle BitBox02 firmware version v9.14.1
 - Automatically discover used Bitcoin and Litecoin accounts

--- a/backend/devices/bitbox02/handlers/handlers.go
+++ b/backend/devices/bitbox02/handlers/handlers.go
@@ -15,6 +15,7 @@
 package handlers
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -53,6 +54,7 @@ type BitBox02 interface {
 	RestoreFromMnemonic() error
 	Product() bitbox02common.Product
 	GotoStartupSettings() error
+	RootFingerprint() ([]byte, error)
 }
 
 // Handlers provides a web API to the Bitbox.
@@ -89,6 +91,7 @@ func NewHandlers(
 	handleFunc("/show-mnemonic", handlers.postShowMnemonicHandler).Methods("POST")
 	handleFunc("/restore-from-mnemonic", handlers.postRestoreFromMnemonicHandler).Methods("POST")
 	handleFunc("/goto-startup-settings", handlers.postGotoStartupSettings).Methods("POST")
+	handleFunc("/root-fingerprint", handlers.getRootFingerprint).Methods("GET")
 	return handlers
 }
 
@@ -360,4 +363,15 @@ func (handlers *Handlers) postGotoStartupSettings(_ *http.Request) interface{} {
 		return maybeBB02Err(err, handlers.log)
 	}
 	return map[string]interface{}{"success": true}
+}
+
+func (handlers *Handlers) getRootFingerprint(_ *http.Request) interface{} {
+	fingerprint, err := handlers.device.RootFingerprint()
+	if err != nil {
+		return maybeBB02Err(err, handlers.log)
+	}
+	return map[string]interface{}{
+		"success":         true,
+		"rootFingerprint": hex.EncodeToString(fingerprint),
+	}
 }

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -186,3 +186,9 @@ export const setShowFirmwareHash = (
     enabled,
   );
 };
+
+export const getRootFingerprint = (
+  deviceID: string
+): Promise<(SuccessResponse & { rootFingerprint: string }) | FailResponse> => {
+  return apiGet(`devices/bitbox02/${deviceID}/root-fingerprint`);
+};

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -516,6 +516,9 @@
       "deviceName": {
         "description": "Change the name of your device."
       },
+      "rootFingerprint": {
+        "description": "The root fingerprint is a unique identifier for the wallet currently in use. It can help you distinguish between different wallets if you use passphrases."
+      },
       "securechip": {
         "description": "The model of the secure chip."
       },

--- a/frontends/web/src/routes/account/info/signingconfiguration.tsx
+++ b/frontends/web/src/routes/account/info/signingconfiguration.tsx
@@ -47,7 +47,6 @@ export const SigningConfiguration = ({ account, info, code, signingConfigIndex, 
 
   const config = getSimpleInfo();
   const bitcoinBased = isBitcoinBased(account.coinCode);
-
   return (
     <div className={style.address}>
       <div className={style.qrCode}>
@@ -75,6 +74,10 @@ export const SigningConfiguration = ({ account, info, code, signingConfigIndex, 
               <span>{getScriptName(config.scriptType)}</span>
             </p>
           ) : null}
+          <p key="rootFingerprint" className={style.entry}>
+            <strong>Root fingerprint:</strong>
+            <code>{config.keyInfo.rootFingerprint}</code>
+          </p>
           <p key="coinName" className={style.entry}>
             <strong>{account.isToken ? 'Token' : 'Coin'}:</strong>
             <span>{account.coinName} ({account.coinUnit})</span>

--- a/frontends/web/src/routes/settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/settings/bb02-settings.tsx
@@ -25,7 +25,7 @@ import { ManageBackupSetting } from './components/device-settings/manage-backup-
 import { ShowRecoveryWordsSetting } from './components/device-settings/show-recovery-words-setting';
 import { GoToStartupSettings } from './components/device-settings/go-to-startup-settings';
 import { PassphraseSetting } from './components/device-settings/passphrase-setting';
-import { DeviceInfo, getDeviceInfo, getVersion } from '../../api/bitbox02';
+import { DeviceInfo, getDeviceInfo, getVersion, getRootFingerprint } from '../../api/bitbox02';
 import { alertUser } from '../../components/alert/Alert';
 import { Skeleton } from '../../components/skeleton/skeleton';
 import { AttestationCheckSetting } from './components/device-settings/attestation-check-setting';
@@ -33,6 +33,7 @@ import { FirmwareSetting } from './components/device-settings/firmware-setting';
 import { SecureChipSetting } from './components/device-settings/secure-chip-setting';
 import { DeviceNameSetting } from './components/device-settings/device-name-setting';
 import { FactoryResetSetting } from './components/device-settings/factory-reset-setting';
+import { RootFingerprintSetting } from './components/device-settings/root-fingerprint-setting';
 import styles from './bb02-settings.module.css';
 import { ManageDeviceGuide } from '../device/bitbox02/settings-guide';
 import { MobileHeader } from './components/mobile-header';
@@ -89,6 +90,7 @@ const Content = ({ deviceID }: TProps) => {
 
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo>();
   const versionInfo = useLoad(() => getVersion(deviceID), [deviceID]);
+  const rootFingerprintResult = useLoad(() => getRootFingerprint(deviceID), [deviceID]);
 
   useEffect(() => {
     getDeviceInfo(deviceID)
@@ -133,6 +135,12 @@ const Content = ({ deviceID }: TProps) => {
         {
           deviceInfo && deviceInfo.securechipModel !== '' ?
             <SecureChipSetting secureChipModel={deviceInfo.securechipModel} />
+            :
+            <StyledSkeleton />
+        }
+        {
+          rootFingerprintResult && rootFingerprintResult.success ?
+            <RootFingerprintSetting rootFingerprint={rootFingerprintResult.rootFingerprint} />
             :
             <StyledSkeleton />
         }

--- a/frontends/web/src/routes/settings/components/device-settings/root-fingerprint-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/root-fingerprint-setting.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { SettingsItem } from '../settingsItem/settingsItem';
+
+type TProps = {
+    rootFingerprint: string;
+}
+
+const RootFingerprintSetting = ({ rootFingerprint }: TProps) => {
+  const { t } = useTranslation();
+  return (
+    <SettingsItem
+      settingName={'Root fingerprint'}
+      secondaryText={t('deviceSettings.deviceInformation.rootFingerprint.description')}
+      displayedValue={rootFingerprint}
+    />
+  );
+};
+
+export { RootFingerprintSetting };

--- a/frontends/web/src/routes/settings/components/settingsItem/settingsItem.module.css
+++ b/frontends/web/src/routes/settings/components/settingsItem/settingsItem.module.css
@@ -21,7 +21,7 @@
 .primaryText {
     color: var(--color-default);
     font-size: 16px;
-    margin: 0;    
+    margin: 0;
 }
 
 .isButton:hover {
@@ -32,6 +32,7 @@
 .rightContentContainer {
     display: flex;
     align-items: center;
+    flex-shrink: 0;
 }
 
 .displayedValue {
@@ -55,7 +56,7 @@
     text-overflow: ellipsis;
 }
 
-@media (max-width: 768px) { 
+@media (max-width: 768px) {
     .container {
          height: auto;
          margin-bottom: 5px;
@@ -68,7 +69,7 @@
 }
 
 @media (max-width: 560px) {
-    
+
     .container.collapse {
         align-items: start;
         flex-direction: column;
@@ -85,5 +86,5 @@
     .hideDisplayedValueOnSmall {
         display: none;
     }
-    
+
 }


### PR DESCRIPTION
Display the root fingerprint in the account info and in the Manage Device section. This helps identify the current wallet for passphrase users, and could be helpful for multisig/descriptor users where the root fingerprint is often used.

The fingerprint shown in both places because:

- useful in the device settings to quickly check the wallet ID after unlock
- useful in the account info for watch-only accounts in the future