### PR TITLE
frontend: change conditions to show BuyReceiveCTA

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -193,7 +193,6 @@ export function Account({
     && transactions.success
     && transactions.list.length === 0;
 
-  const showBuyButton = exchangeBuySupported && isAccountEmpty;
 
   const actionButtonsProps = {
     code,
@@ -232,9 +231,10 @@ export function Account({
                 {!isAccountEmpty && <ActionButtons {...actionButtonsProps} />}
               </div>
             </div>
-            {showBuyButton && (
+            {isAccountEmpty && (
               <BuyReceiveCTA
                 code={code}
+                exchangeBuySupported={exchangeBuySupported}
                 unit={balance.available.unit}
                 balanceList={[[code, balance]]}
               />

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -13,22 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { route } from '../../../utils/route';
-import { CoinUnit, IBalance } from '../../../api/account';
+import { CoinUnit, IAccount, IBalance } from '../../../api/account';
 import { Button } from '../../../components/forms';
 import { Balances } from '../summary/accountssummary';
-import styles from './buyReceiveCTA.module.css';
 import { isBitcoinCoin } from '../utils';
+import { getExchangeSupportedAccounts } from '../../buy/utils';
+import styles from './buyReceiveCTA.module.css';
 
 type TBuyReceiveCTAProps = {
   balanceList?: [string, IBalance][];
   code?: string;
   unit?: string;
+  exchangeBuySupported?: boolean;
 };
 
-export const BuyReceiveCTA = ({ code, unit, balanceList }: TBuyReceiveCTAProps) => {
+type TAddBuyReceiveOnEmpyBalancesProps = {
+  balances?: Balances;
+  accounts: IAccount[];
+}
+
+export const BuyReceiveCTA = ({ code, unit, balanceList, exchangeBuySupported = true }: TBuyReceiveCTAProps) => {
   const formattedUnit = isBitcoinCoin(unit as CoinUnit) ? 'BTC' : unit;
   const { t } = useTranslation();
   const onBuyCTA = () => route(code ? `/buy/info/${code}` : '/buy/info');
@@ -48,14 +55,21 @@ export const BuyReceiveCTA = ({ code, unit, balanceList }: TBuyReceiveCTAProps) 
       <h3 className="subTitle">{t('accountInfo.buyCTA.information.start')}</h3>
       <div className={styles.container}>
         {balanceList && <Button primary onClick={onReceiveCTA}>{formattedUnit ? t('receive.title', { accountName: formattedUnit }) : t('receive.title', { accountName: t('buy.info.crypto') })}</Button>}
-        <Button primary onClick={onBuyCTA}>{formattedUnit ? t('accountInfo.buyCTA.buy', { unit: formattedUnit }) : t('accountInfo.buyCTA.buyCrypto')}</Button>
+        {exchangeBuySupported && <Button primary onClick={onBuyCTA}>{formattedUnit ? t('accountInfo.buyCTA.buy', { unit: formattedUnit }) : t('accountInfo.buyCTA.buyCrypto')}</Button>}
       </div>
     </div>);
 };
 
 
-export const AddBuyReceiveOnEmptyBalances = ({ balances }: {balances?: Balances}) => {
-  if (balances === undefined) {
+export const AddBuyReceiveOnEmptyBalances = ({ balances, accounts }: TAddBuyReceiveOnEmpyBalancesProps) => {
+
+  const [supportedAccounts, setSupportedAccounts] = useState<IAccount[]>();
+
+  useEffect(() => {
+    getExchangeSupportedAccounts(accounts).then(setSupportedAccounts);
+  }, [accounts]);
+
+  if (balances === undefined || supportedAccounts === undefined) {
     return null;
   }
   const balanceList = Object.entries(balances);
@@ -65,5 +79,5 @@ export const AddBuyReceiveOnEmptyBalances = ({ balances }: {balances?: Balances}
   if (balanceList.map(entry => entry[1].available.unit).every(isBitcoinCoin)) {
     return <BuyReceiveCTA code={balanceList[0][0]} unit={'BTC'} balanceList={balanceList} />;
   }
-  return <BuyReceiveCTA balanceList={balanceList} />;
+  return <BuyReceiveCTA exchangeBuySupported={supportedAccounts.length > 0} balanceList={balanceList} />;
 };

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -77,7 +77,9 @@ export const AddBuyReceiveOnEmptyBalances = ({ balances, accounts }: TAddBuyRece
     return null;
   }
   if (balanceList.map(entry => entry[1].available.unit).every(isBitcoinCoin)) {
-    return <BuyReceiveCTA code={balanceList[0][0]} unit={'BTC'} balanceList={balanceList} />;
+    const onlyHasOneAccount = balanceList.length === 1;
+    return <BuyReceiveCTA code={onlyHasOneAccount ? balanceList[0][0] : undefined} unit={'BTC'} balanceList={balanceList} />;
   }
+
   return <BuyReceiveCTA exchangeBuySupported={supportedAccounts.length > 0} balanceList={balanceList} />;
 };

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -154,7 +154,7 @@ export function AccountsSummary({
               data={summaryData}
               noDataPlaceholder={
                 (accounts.length === Object.keys(balances || {}).length) ? (
-                  <AddBuyReceiveOnEmptyBalances balances={balances} />
+                  <AddBuyReceiveOnEmptyBalances accounts={accounts} balances={balances} />
                 ) : undefined
               } />
             <SummaryBalance


### PR DESCRIPTION
We're now showing BuyReceiveCTA properly to avoid blank screen on account screen on testnet.

Now, BuyReceiveCTA on the account screen will always show when account is empty (instead of two conditions: empty account and supported buy).

Only when the exchange supports the buy of that certain coin, the BuyReceiveCTA will render the Buy button along with a Receive button. When it's not supported, only Receive button (and the default CTA message) will be rendered. 🙂 
 
Before (testnet, empty acc):
<img width="1490" alt="Screenshot 2023-07-03 at 20 50 51" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/c4b73ce5-0bb0-4337-9bf9-47276ed9b898">

After (testnet, empty acc):
<img width="1490" alt="Screenshot 2023-07-03 at 20 42 31" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/3883725e-b6d5-469d-953c-503ddd93f0b5">


On mainnet, there should be no difference. For reference:
After (mainnet, empty acc):
<img width="1490" alt="Screenshot 2023-07-03 at 20 44 06" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/b5ee51b4-6f88-40cd-9e1c-ce2ccfb0be46">