### PR TITLE
frontend: convert guide and sidebar into functional components

### DIFF
--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Shift Devices AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Component } from 'react';
+import { ReactNode, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { share } from '../../decorators/share';
 import { Store } from '../../decorators/store';
 import { translate, TranslateProps } from '../../decorators/translate';
@@ -24,7 +25,7 @@ import A from '../anchor/anchor';
 import { CloseXWhite } from '../icon';
 import style from './guide.module.css';
 
-export interface SharedProps {
+export type TSharedProps = {
     shown: boolean;
     // eslint-disable-next-line react/no-unused-prop-types
     activeSidebar: boolean;
@@ -34,7 +35,11 @@ export interface SharedProps {
     guideExists: boolean;
 }
 
-export const store = new Store<SharedProps>({
+export type TProps = TSharedProps & {
+    children?: ReactNode;
+}
+
+export const store = new Store<TSharedProps>({
   shown: false,
   activeSidebar: false,
   sidebarStatus: '',
@@ -72,45 +77,41 @@ export function hide() {
   setGuideShown(false);
 }
 
-type Props = SharedProps & TranslateProps;
+const Guide = ({ shown, children }: TProps) => {
 
-class Guide extends Component<Props> {
-  public componentDidMount() {
+  useEffect(() => {
     store.setState({ guideExists: true });
-  }
+    return () => {
+      store.setState({ guideExists: false });
+    };
+  }, []);
 
-  public componentWillUnmount() {
-    store.setState({ guideExists: false });
-  }
-
-  public render() {
-    const { shown, t, children } = this.props;
-    return (
-      <div className={style.wrapper}>
-        <div className={[style.overlay, shown && style.show].join(' ')} onClick={toggle}></div>
-        <div className={[style.guide, shown && style.show].join(' ')}>
-          <div className={[style.header, 'flex flex-row flex-between flex-items-center'].join(' ')}>
-            <h2>{t('guide.title')}</h2>
-            <a href="#" className={style.close} onClick={toggle}>
-              {t('guide.toggle.close')}
-              <CloseXWhite />
-            </a>
-          </div>
-          <div className={style.content}>
-            {children}
-            <div className={style.entry}>
-              {t('guide.appendix.text')}
-              {' '}
-              <A href="https://bitbox.swiss/support/">{t('guide.appendix.link')}</A>
-              <br />
-              <br />
-            </div>
+  const { t } = useTranslation();
+  return (
+    <div className={style.wrapper}>
+      <div className={[style.overlay, shown && style.show].join(' ')} onClick={toggle}></div>
+      <div className={[style.guide, shown && style.show].join(' ')}>
+        <div className={[style.header, 'flex flex-row flex-between flex-items-center'].join(' ')}>
+          <h2>{t('guide.title')}</h2>
+          <a href="#" className={style.close} onClick={toggle}>
+            {t('guide.toggle.close')}
+            <CloseXWhite />
+          </a>
+        </div>
+        <div className={style.content}>
+          {children}
+          <div className={style.entry}>
+            {t('guide.appendix.text')}
+            {' '}
+            <A href="https://bitbox.swiss/support/">{t('guide.appendix.link')}</A>
+            <br />
+            <br />
           </div>
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
-const HOC = translate()(share<SharedProps, TranslateProps>(store)(Guide));
+const HOC = translate()(share<TSharedProps, TranslateProps>(store)(Guide));
 export { HOC as Guide };

--- a/frontends/web/src/components/layout/header.tsx
+++ b/frontends/web/src/components/layout/header.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2022 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +15,11 @@
  * limitations under the License.
  */
 
-import React, { Component } from 'react';
+import React, { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { share } from '../../decorators/share';
 import { translate, TranslateProps } from '../../decorators/translate';
-import { SharedProps as SharedPanelProps, store as panelStore, toggle as toggleGuide } from '../guide/guide';
+import { TSharedProps as SharedPanelProps, store as panelStore, toggle as toggleGuide } from '../guide/guide';
 import { GuideActive, MenuLight, MenuDark } from '../icon';
 import { toggleSidebar } from '../sidebar/sidebar';
 import style from './header.module.css';
@@ -26,46 +28,54 @@ interface HeaderProps {
     title?: string | JSX.Element | JSX.Element[];
     narrow?: boolean;
     hideSidebarToggler?: boolean;
+    children?: ReactNode;
 }
 type Props = HeaderProps & SharedPanelProps & TranslateProps;
 
-class Header extends Component<Props> {
-  private toggle = (e: React.SyntheticEvent) => {
+const Header = ({
+  sidebarStatus,
+  narrow,
+  title,
+  hideSidebarToggler,
+  shown,
+  guideExists,
+  children
+}: Props) => {
+  const { t } = useTranslation();
+
+  const toggle = (e: React.SyntheticEvent) => {
     e.preventDefault();
-    if (!this.props.shown) {
+    if (!shown) {
       toggleGuide();
     }
     return false;
   };
 
-  public render() {
-    const { t, title, narrow, children, guideExists, shown, sidebarStatus, hideSidebarToggler } = this.props;
-    return (
-      <div className={[style.container, sidebarStatus ? style[sidebarStatus] : ''].join(' ')}>
-        <div className={[style.header, narrow ? style.narrow : ''].join(' ')}>
-          <div className={`${style.sidebarToggler} ${hideSidebarToggler ? style.hideSidebarToggler : ''}`} onClick={toggleSidebar}>
-            <MenuDark className="show-in-lightmode" />
-            <MenuLight className="show-in-darkmode" />
-          </div>
-          <div className={style.title}>{title}</div>
-          <div className={style.children}>
-            {children}
-            {
-              guideExists && (
-                <span className={style.guideIconContainer}>
-                  <a href="#" onClick={this.toggle} className={[style.guideIcon, shown ? style.disabled : ''].join(' ')}>
-                    <GuideActive />
-                    {t('guide.toggle.open')}
-                  </a>
-                </span>
-              )
-            }
-          </div>
+  return (
+    <div className={[style.container, sidebarStatus ? style[sidebarStatus] : ''].join(' ')}>
+      <div className={[style.header, narrow ? style.narrow : ''].join(' ')}>
+        <div className={`${style.sidebarToggler} ${hideSidebarToggler ? style.hideSidebarToggler : ''}`} onClick={toggleSidebar}>
+          <MenuDark className="show-in-lightmode" />
+          <MenuLight className="show-in-darkmode" />
+        </div>
+        <div className={style.title}>{title}</div>
+        <div className={style.children}>
+          {children}
+          {
+            guideExists && (
+              <span className={style.guideIconContainer}>
+                <a href="#" onClick={toggle} className={[style.guideIcon, shown ? style.disabled : ''].join(' ')}>
+                  <GuideActive />
+                  {t('guide.toggle.open')}
+                </a>
+              </span>
+            )
+          }
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 const SharedHeader = share<SharedPanelProps, HeaderProps & TranslateProps>(panelStore)(Header);
 const TranslatedHeader = translate()(SharedHeader);

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -23,7 +23,7 @@ import ejectIcon from '../../assets/icons/eject.svg';
 import info from '../../assets/icons/info.svg';
 import settings from '../../assets/icons/settings-alt.svg';
 import settingsGrey from '../../assets/icons/settings-alt_disabled.svg';
-import { SharedProps as SharedPanelProps, store as panelStore } from '../../components/guide/guide';
+import { TSharedProps as SharedPanelProps, store as panelStore } from '../../components/guide/guide';
 import { share } from '../../decorators/share';
 import { subscribe } from '../../decorators/subscribe';
 import { translate, TranslateProps } from '../../decorators/translate';

--- a/frontends/web/src/routes/account/guide.tsx
+++ b/frontends/web/src/routes/account/guide.tsx
@@ -1,4 +1,5 @@
 /**
+ * Copyright 2018 Shift Devices AG
  * Copyright 2022 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
As we're looking into migrating our class-based HoC pattern store into React's Context API, we'd first need the components that use these store directly to be converted into functional components.