### PR TITLE
backend: don't log account name upon creation

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -614,7 +614,7 @@ func (backend *Backend) persistBTCAccountConfig(
 	configs []scriptTypeWithKeypath,
 	accountsConfig *config.AccountsConfig,
 ) error {
-	log := backend.log.WithField("code", code).WithField("name", name)
+	log := backend.log.WithField("code", code)
 	var supportedConfigs []scriptTypeWithKeypath
 	for _, cfg := range configs {
 		if keystore.SupportsAccount(coin, cfg.scriptType) {


### PR DESCRIPTION
Serves little purpose and can harm privacy.