### PR TITLE
backend/accounts: fix scanning of first 5 accounts

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1061,6 +1061,11 @@ func (backend *Backend) maybeAddHiddenUnusedAccounts() {
 }
 
 func (backend *Backend) checkAccountUsed(account accounts.Interface) {
+	if backend.tstCheckAccountUsed != nil {
+		if !backend.tstCheckAccountUsed(account) {
+			return
+		}
+	}
 	log := backend.log.WithField("accountCode", account.Config().Config.Code)
 	if err := account.Initialize(); err != nil {
 		log.WithError(err).Error("error initializing account")
@@ -1071,7 +1076,10 @@ func (backend *Backend) checkAccountUsed(account accounts.Interface) {
 		log.WithError(err).Error("discoverAccount")
 		return
 	}
+
 	if len(txs) == 0 {
+		// Invoke this here too because even if an account is unused, we scan up to 5 accounts.
+		backend.maybeAddHiddenUnusedAccounts()
 		return
 	}
 	log.Info("marking account as used")

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -315,6 +315,9 @@ func newBackend(t *testing.T, testing, regtest bool) *Backend {
 			&types.GapLimits{Receive: 20, Change: 6}),
 		environment{},
 	)
+	b.tstCheckAccountUsed = func(accounts.Interface) bool {
+		return false
+	}
 	b.ratesUpdater.SetCoingeckoURL("unused") // avoid hitting real API
 
 	b.makeBtcAccount = func(config *accounts.AccountConfig, coin *btc.Coin, gapLimits *types.GapLimits, log *logrus.Entry) accounts.Interface {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -188,6 +188,9 @@ type Backend struct {
 	etherScanHTTPClient *http.Client
 	ratesUpdater        *rates.RateUpdater
 	banners             *banners.Banners
+
+	// For unit tests, called when `backend.checkAccountUsed()` is called.
+	tstCheckAccountUsed func(accounts.Interface) bool
 }
 
 // NewBackend creates a new backend with the given arguments.


### PR DESCRIPTION
The step to look for more accounts was only invoked when the previous account was used. If one had e.g. account 4 unused, but account 5 used, this could prevent discovery of account 5.

It worked anyway in some cases due to a race condition, as maybeAddHiddenUnusedAccounts could be invoked after account 4 was scanned (e.g. a different coin's account being added after acount 4 was scanned).