### PR TITLE
frontend: using context to replace guide store

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -27,7 +27,7 @@ import { Alert } from './components/alert/Alert';
 import { Aopp } from './components/aopp/aopp';
 import { Banner } from './components/banner/banner';
 import { Confirm } from './components/confirm/Confirm';
-import { store as panelStore } from './components/guide/guide';
+import { panelStore } from './components/sidebar/sidebar';
 import { MobileDataWarning } from './components/mobiledatawarning';
 import { Sidebar, toggleSidebar } from './components/sidebar/sidebar';
 import { Update } from './components/update/update';
@@ -37,6 +37,7 @@ import { apiWebsocket } from './utils/websocket';
 import { route, RouterWatcher } from './utils/route';
 import { Darkmode } from './components/darkmode/darkmode';
 import { DarkModeProvider } from './contexts/DarkmodeProvider';
+import { AppProvider } from './contexts/AppProvider';
 
  interface State {
      accounts: IAccount[];
@@ -184,31 +185,34 @@ class App extends Component<Props, State> {
     const activeAccounts = this.activeAccounts();
     return (
       <ConnectedApp>
-        <DarkModeProvider>
-          <Darkmode />
-          <div className="app">
-            <Sidebar
-              accounts={activeAccounts}
-              deviceIDs={deviceIDs} />
-            <div className="appContent flex flex-column flex-1" style={{ minWidth: 0 }}>
-              <Update />
-              <Banner msgKey="bitbox01" />
-              <Banner msgKey="bitbox02" />
-              <MobileDataWarning />
-              <Aopp />
-              <AppRouter
-                accounts={accounts}
-                activeAccounts={activeAccounts}
+        <AppProvider>
+          <DarkModeProvider>
+            <Darkmode />
+            <div className="app">
+              <Sidebar
+                accounts={activeAccounts}
                 deviceIDs={deviceIDs}
-                devices={devices}
-                devicesKey={this.devicesKey}
               />
-              <RouterWatcher onChange={this.handleRoute} />
+              <div className="appContent flex flex-column flex-1" style={{ minWidth: 0 }}>
+                <Update />
+                <Banner msgKey="bitbox01" />
+                <Banner msgKey="bitbox02" />
+                <MobileDataWarning />
+                <Aopp />
+                <AppRouter
+                  accounts={accounts}
+                  activeAccounts={activeAccounts}
+                  deviceIDs={deviceIDs}
+                  devices={devices}
+                  devicesKey={this.devicesKey}
+                />
+                <RouterWatcher onChange={this.handleRoute} />
+              </div>
+              <Alert />
+              <Confirm />
             </div>
-            <Alert />
-            <Confirm />
-          </div>
-        </DarkModeProvider>
+          </DarkModeProvider>
+        </AppProvider>
       </ConnectedApp>
     );
   }

--- a/frontends/web/src/components/anchor/anchor.tsx
+++ b/frontends/web/src/components/anchor/anchor.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { ReactNode, SyntheticEvent } from 'react';
+import { ReactNode, SyntheticEvent, useContext } from 'react';
 import { route } from '../../utils/route';
-import { hide } from '../guide/guide';
 import { debug } from '../../utils/env';
 import { apiPost } from '../../utils/request';
+import AppContext from '../../contexts/AppContext';
 import style from './anchor.module.css';
 
 type TProps = {
@@ -28,12 +28,13 @@ type TProps = {
 }
 
 const A = ({ href, icon, children, ...props }: TProps) => {
+  const { setGuideShown } = useContext(AppContext);
   return (
     <span className={style.link} onClick={(e: SyntheticEvent) => {
       e.preventDefault();
       const { hostname, origin } = new URL(href, window.location.href);
       if (origin === 'qrc:' || (debug && hostname === window.location.hostname)) {
-        hide();
+        setGuideShown(false);
         route(href);
       } else {
         apiPost('open', href).catch(console.error);

--- a/frontends/web/src/components/layout/header.tsx
+++ b/frontends/web/src/components/layout/header.tsx
@@ -15,37 +15,36 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { share } from '../../decorators/share';
-import { translate, TranslateProps } from '../../decorators/translate';
-import { TSharedProps as SharedPanelProps, store as panelStore, toggle as toggleGuide } from '../guide/guide';
+import { SharedPanelProps, panelStore } from '../sidebar/sidebar';
 import { GuideActive, MenuLight, MenuDark } from '../icon';
 import { toggleSidebar } from '../sidebar/sidebar';
+import AppContext from '../../contexts/AppContext';
 import style from './header.module.css';
-
 interface HeaderProps {
     title?: string | JSX.Element | JSX.Element[];
     narrow?: boolean;
     hideSidebarToggler?: boolean;
     children?: ReactNode;
 }
-type Props = HeaderProps & SharedPanelProps & TranslateProps;
+type Props = HeaderProps & SharedPanelProps;
 
 const Header = ({
   sidebarStatus,
   narrow,
   title,
   hideSidebarToggler,
-  shown,
-  guideExists,
   children
 }: Props) => {
   const { t } = useTranslation();
 
+  const { guideShown, guideExists, toggleGuide } = useContext(AppContext);
+
   const toggle = (e: React.SyntheticEvent) => {
     e.preventDefault();
-    if (!shown) {
+    if (!guideShown) {
       toggleGuide();
     }
     return false;
@@ -64,7 +63,7 @@ const Header = ({
           {
             guideExists && (
               <span className={style.guideIconContainer}>
-                <a href="#" onClick={toggle} className={[style.guideIcon, shown ? style.disabled : ''].join(' ')}>
+                <a href="#" onClick={toggle} className={[style.guideIcon, guideShown ? style.disabled : ''].join(' ')}>
                   <GuideActive />
                   {t('guide.toggle.open')}
                 </a>
@@ -77,6 +76,5 @@ const Header = ({
   );
 };
 
-const SharedHeader = share<SharedPanelProps, HeaderProps & TranslateProps>(panelStore)(Header);
-const TranslatedHeader = translate()(SharedHeader);
-export { TranslatedHeader as Header };
+const SharedHeader = share<SharedPanelProps, HeaderProps>(panelStore)(Header);
+export { SharedHeader as Header };

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -23,7 +23,6 @@ import ejectIcon from '../../assets/icons/eject.svg';
 import info from '../../assets/icons/info.svg';
 import settings from '../../assets/icons/settings-alt.svg';
 import settingsGrey from '../../assets/icons/settings-alt_disabled.svg';
-import { TSharedProps as SharedPanelProps, store as panelStore } from '../../components/guide/guide';
 import { share } from '../../decorators/share';
 import { subscribe } from '../../decorators/subscribe';
 import { translate, TranslateProps } from '../../decorators/translate';
@@ -33,6 +32,7 @@ import Logo, { AppLogoInverted } from '../icon/logo';
 import { useLocation } from 'react-router';
 import { CloseXWhite } from '../icon';
 import { isBitcoinOnly } from '../../routes/account/utils';
+import { Store } from '../../decorators/store';
 import style from './sidebar.module.css';
 
 interface SidebarProps {
@@ -44,6 +44,13 @@ interface SubscribedProps {
     keystores?: Array<{ type: 'hardware' | 'software' }>;
 }
 
+export type SharedPanelProps = {
+  // eslint-disable-next-line react/no-unused-prop-types
+  activeSidebar: boolean;
+  // eslint-disable-next-line react/no-unused-prop-types
+  sidebarStatus: string;
+}
+
 type Props = SubscribedProps & SharedPanelProps & SidebarProps & TranslateProps;
 
 type TGetAccountLinkProps = IAccount & { handleSidebarItemClick: ((e: React.SyntheticEvent) => void) };
@@ -53,6 +60,11 @@ interface SwipeAttributes {
     y: number;
     active?: boolean;
 }
+
+export const panelStore = new Store<SharedPanelProps>({
+  activeSidebar: false,
+  sidebarStatus: '',
+});
 
 export function toggleSidebar() {
   const toggled = !panelStore.state.activeSidebar;
@@ -151,7 +163,6 @@ class Sidebar extends Component<Props> {
       deviceIDs,
       accounts,
       keystores,
-      shown,
       activeSidebar,
       sidebarStatus,
     } = this.props;
@@ -160,7 +171,7 @@ class Sidebar extends Component<Props> {
     return (
       <div className={[style.sidebarContainer, hidden ? style.forceHide : ''].join(' ')}>
         <div className={[style.sidebarOverlay, activeSidebar ? style.active : ''].join(' ')} onClick={toggleSidebar}></div>
-        <nav className={[style.sidebar, activeSidebar ? style.forceShow : '', shown ? style.withGuide : ''].join(' ')}>
+        <nav className={[style.sidebar, activeSidebar ? style.forceShow : ''].join(' ')}>
           <div className={style.sidebarLogoContainer}>
             <Link
               to={accounts.length ? '/account-summary' : '/'}

--- a/frontends/web/src/components/spinner/Spinner.tsx
+++ b/frontends/web/src/components/spinner/Spinner.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { toggle as toggleGuide } from '../guide/guide';
 import { toggleSidebar } from '../sidebar/sidebar';
 import { MenuDark } from '../icon';
+import AppContext from '../../contexts/AppContext';
 import style from './Spinner.module.css';
 
 type TProps = {
@@ -29,6 +29,8 @@ type TProps = {
 
 const Spinner = ({ text, guideExists }: TProps) => {
   const { t } = useTranslation();
+
+  const { toggleGuide } = useContext(AppContext);
 
   const handleKeyDown = (e: KeyboardEvent) => {
     e.preventDefault();

--- a/frontends/web/src/contexts/AppContext.tsx
+++ b/frontends/web/src/contexts/AppContext.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+*
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dispatch, SetStateAction, createContext } from 'react';
+
+type AppContextProps = {
+    guideShown: boolean;
+    guideExists: boolean;
+    setGuideExists: Dispatch<SetStateAction<boolean>>;
+    setGuideShown: Dispatch<SetStateAction<boolean>>;
+    toggleGuide: () => void;
+}
+
+const AppContext = createContext<AppContextProps>({} as AppContextProps);
+
+export default AppContext;

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode, useEffect, useState } from 'react';
+import { getConfig, setConfig } from '../utils/config';
+import AppContext from './AppContext';
+
+type TProps = {
+    children: ReactNode;
+  }
+
+export const AppProvider = ({ children }: TProps) => {
+  const [guideShown, setGuideShown] = useState(false);
+  const [guideExists, setGuideExists] = useState(false);
+
+  const toggleGuide = () => {
+    setConfig({ frontend: { guideShown: !guideShown } });
+    setGuideShown(prev => !prev);
+  };
+
+  useEffect(() => {
+    getConfig().then(({ frontend }) => {
+      if (frontend && frontend.guideShown !== undefined) {
+        setGuideShown(frontend.guideShown);
+      } else {
+        setGuideShown(true);
+      }
+    });
+  }, []);
+
+  return (
+    <AppContext.Provider
+      value={{
+        toggleGuide,
+        guideShown,
+        guideExists,
+        setGuideShown,
+        setGuideExists,
+      }}>
+      {children}
+    </AppContext.Provider>
+  );
+};
+

--- a/frontends/web/src/routes/settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/settings/mobile-settings.tsx
@@ -41,7 +41,7 @@ export const MobileSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetting
   }, [isMobile]);
   return (
     <Main>
-      <Header guideExists={false} title={<h2>{t('settings.title')}</h2>} />
+      <Header title={<h2>{t('settings.title')}</h2>} />
       <View fullscreen={false}>
         <ViewContent>
           <Tabs deviceIDs={deviceIDs} hasAccounts={hasAccounts} />


### PR DESCRIPTION
As a part of the refactoring effort, we want to move away from class based components and HoC. In this PR, we're removing the guide store (and the HoC related to it). We're using context API to fulfil the same goal.