### PR TITLE
frontend: fix layout of manage accounts with long account names

### DIFF
--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -7,7 +7,7 @@
     align-items: center;
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: flex-end;
     min-height: var(--item-height);
     padding: 10px var(--space-half);
@@ -28,6 +28,7 @@
     background: transparent;
     border: none;
     color: var(--color-primary);
+    flex-shrink: 0;
     line-height: 2;
     margin-right: var(--spacing-default);
 }


### PR DESCRIPTION
On small screen long accountnames/edit/toggle break in various different ways.

Fixed by letting the name break, so that edit and toggle are always on the same line.