### PR TITLE
Frontend button and toggle styling

### DIFF
--- a/frontends/web/src/components/forms/button.module.css
+++ b/frontends/web/src/components/forms/button.module.css
@@ -1,27 +1,25 @@
 .button {
     align-items: center;
-    border-width: 1px;
-    border-style: solid;
+    appearance: none;
     border-color: transparent;
     border-radius: 2px;
+    border-style: solid;
+    border-width: 1px;
     cursor: default;
     /* Otter doesn't like display: inline-flex; */
     display: inline-flex;
     flex-direction: row;
-    justify-content: center;
-    align-items: center;
     font-family: var(--font-family);
     font-size: var(--size-default);
     font-weight: 400;
     justify-content: center;
     min-width: 100px !important;
     height: 50px;
+    outline: none;
     padding: 0 var(--space-default);
     position: relative;
-    outline: none;
     text-align: center;
     text-decoration: none;
-    -webkit-appearance: none;
     transition: background-color .2s ease-out, color .2s ease-out;
     will-change: background-color, color;
 }
@@ -50,13 +48,13 @@
 
 .secondary:not([disabled]):focus,
 .secondary:not([disabled]):hover {
-    color: var(--color-blue);
     border-color: var(--color-blue);
+    color: var(--color-blue);
 }
 
 .secondary[disabled] {
-    color: var(--color-tertiary);
     border-color: var(--background-quaternary);
+    color: var(--color-tertiary);
 }
 
 .danger {
@@ -79,14 +77,14 @@
 .transparent {
     composes: button;
     background-color: transparent;
-    color: var(--color-blue);
     border-color: var(--color-blue);
+    color: var(--color-blue);
 }
 
 .transparent:not([disabled]):focus,
 .transparent:not([disabled]):hover {
-    color: var(--color-lightblue);
     border-color: var(--color-lightblue);
+    color: var(--color-lightblue);
 }
 
 .primary[disabled],

--- a/frontends/web/src/components/forms/button.test.tsx
+++ b/frontends/web/src/components/forms/button.test.tsx
@@ -5,7 +5,7 @@ import { ButtonLink, Button } from './button';
 describe('components/forms/button', () => {
   describe('ButtonLink', () => {
     it('renders as button when disabled with disabled attribute', () => {
-      render(<ButtonLink to="/settings" disabled>A ButtonLink</ButtonLink>);
+      render(<ButtonLink primary to="/settings" disabled>A ButtonLink</ButtonLink>);
       expect(screen.getByRole('button', { name: /A ButtonLink/i })).toHaveAttribute('disabled');
     });
 

--- a/frontends/web/src/components/forms/button.tsx
+++ b/frontends/web/src/components/forms/button.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,25 +19,34 @@ import { ComponentPropsWithoutRef, ReactNode } from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 import style from './button.module.css';
 
-type TProps = {
-    danger?: boolean;
-    disabled?: boolean;
-    primary?: boolean;
-    secondary?: boolean;
-    transparent?: boolean;
-    children: ReactNode;
+type TButtonStyleProp =
+  ({ danger: true } & Omit<TButtonStyleBase, 'danger'>)
+  | ({ primary: true } & Omit<TButtonStyleBase, 'primary'>)
+  | ({ secondary: true } & Omit<TButtonStyleBase, 'secondary'>)
+  | ({ transparent: true } & Omit<TButtonStyleBase, 'transparent'>)
+
+type TButtonStyleBase = {
+  danger?: false;
+  primary?: false;
+  secondary?: false;
+  transparent?: false;
+}
+
+type TProps = TButtonStyleProp & {
+  disabled?: boolean;
+  children: ReactNode;
 }
 
 export const ButtonLink = ({
-  primary = false,
-  secondary = false,
-  transparent = false,
-  danger = false,
+  primary,
+  secondary,
+  transparent,
+  danger,
   className = '',
   children,
   disabled,
   ...props
-}: TProps & LinkProps) => {
+}: LinkProps & TProps) => {
   const classNames = [
     style[
       (primary && 'primary')
@@ -68,10 +77,10 @@ export const ButtonLink = ({
 
 export const Button = ({
   type = 'button',
-  primary = false,
-  secondary = false,
-  transparent = false,
-  danger = false,
+  primary,
+  secondary,
+  transparent,
+  danger,
   className = '',
   children,
   ...props

--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -128,8 +128,7 @@ class Restore extends Component<Props, State> {
     return (
       <span>
         <Button
-          danger={requireConfirmation}
-          primary={!requireConfirmation}
+          {...(requireConfirmation ? { danger: true } : { primary: true })}
           disabled={!selectedBackup}
           onClick={() => this.setState({ activeDialog: true })}>
           {t('button.restore')}
@@ -157,8 +156,7 @@ class Restore extends Component<Props, State> {
                 <DialogButtons>
                   <Button
                     type="submit"
-                    danger={requireConfirmation}
-                    primary={!requireConfirmation}
+                    {...(requireConfirmation ? { danger: true } : { primary: true })}
                     disabled={!understand || !this.validate() || isConfirming}>
                     {t('button.restore')}
                   </Button>

--- a/frontends/web/src/style/variables.css
+++ b/frontends/web/src/style/variables.css
@@ -144,7 +144,7 @@
         --background-secondary: var(--color-softblack);
         --background-dark: var(--color-softblack);
         --background-focus: var(--color-softblack);
-        --background-tertiary: var(--color-dark);
+        --background-tertiary: var(--color-gray);
         --background-quaternary: var(--color-dark);
         --background-custom-select-hover: var(--color-dark);
         --background-custom-select-selected: var(--color-dark);
@@ -170,7 +170,7 @@
         --background-secondary: var(--color-softblack);
         --background-dark: var(--color-softblack);
         --background-focus: var(--color-softblack);
-        --background-tertiary: var(--color-dark);
+        --background-tertiary: var(--color-gray);
         --background-quaternary: var(--color-dark);
         --background-custom-select-hover: var(--color-dark);
         --background-custom-select-selected: var(--color-dark);


### PR DESCRIPTION
The background color of unchecked toggles were hard to see in dark
mode, background tertiary is also used for secondary buttons.

Changed background tertiary in darkmode to fix the toggle color,
this also changes button secondary color.

Another issue is that button secondary and button transparent are
visually very similar, but the transparent style is not a text only
transparent button as the name implies. This can be improved in a
subsequent change.

Also added stricter types for button and a cleanup commit that removes
duplicate CSS properties.