### PR TITLE
ci: update nodejs to latest lts version 18.16.1

### DIFF
--- a/scripts/github-ci.sh
+++ b/scripts/github-ci.sh
@@ -35,7 +35,7 @@ if [ "$OS_NAME" == "osx" ]; then
     brew install qt@5
     brew install nvm
     source /usr/local/opt/nvm/nvm.sh
-    nvm install 18.16.0 # install this node version
+    nvm install 18.16.1 # install this node version
     export PATH="/usr/local/opt/qt@5/bin:$PATH"
     export LDFLAGS="-L/usr/local/opt/qt@5/lib"
     export CPPFLAGS="-I/usr/local/opt/qt@5/include"


### PR DESCRIPTION
This should fix macos ci '404 Not Found'
/Users/runner/.nvm/.cache/bin/node-v18.16.0-darwin-x64/node-v18.16.0-darwin-x64.tar.xz

Changelog:
- https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.16.1