### PR TITLE
Frontend fix manage account

### DIFF
--- a/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/toggleshowfirmwarehash.tsx
@@ -48,8 +48,7 @@ export const ToggleShowFirmwareHash = ({ deviceID }: Props) => {
       <Toggle
         checked={enabledState}
         id="togggle-show-firmware-hash"
-        onChange={handleToggle}
-        className="text-medium" />
+        onChange={handleToggle} />
     </div>
   );
 };

--- a/frontends/web/src/components/toggle/toggle.tsx
+++ b/frontends/web/src/components/toggle/toggle.tsx
@@ -1,19 +1,15 @@
-import { ChangeEvent } from 'react';
 import style from './toggle.module.css';
 
-export type TToggleProps = {
-  checked: boolean;
-  className?: string;
-  disabled?: boolean;
-  id?: string;
-  name?: string;
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  value?: string;
-};
+export type TToggleProps = JSX.IntrinsicElements['input']
 
-export const Toggle = (props: TToggleProps) => {
+export const Toggle = (
+  {
+    className = '',
+    ...props
+  }: TToggleProps
+) => {
   return (
-    <label className={style.container}>
+    <label className={`${style.container} ${className}`}>
       <input
         type="checkbox"
         {...props} />

--- a/frontends/web/src/components/toggle/toggle.tsx
+++ b/frontends/web/src/components/toggle/toggle.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import style from './toggle.module.css';
 
 export type TToggleProps = JSX.IntrinsicElements['input']

--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -7,7 +7,7 @@
     align-items: center;
     display: flex;
     flex-direction: row;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     justify-content: flex-end;
     min-height: var(--item-height);
     padding: 10px var(--space-half);
@@ -21,16 +21,26 @@
 .acccountLink {
     align-items: center;
     display: flex;
-    flex-grow: 1;
+    flex-basis: calc(100% - 180px);
+    flex-grow: 0;
+    flex-shrink: 1;
 }
 
 .editBtn {
     background: transparent;
     border: none;
     color: var(--color-primary);
-    flex-shrink: 0;
+    flex-basis: content;
+    flex-grow: 1;
+    flex-shrink: 1;
     line-height: 2;
-    margin-right: var(--spacing-default);
+    text-align: right;
+}
+
+.toggle {
+    flex-basis: 60px;
+    flex-shrink: 0;
+    margin-left: var(--spacing-half);
 }
 
 .accountActive {

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -93,6 +93,7 @@ class ManageAccounts extends Component<Props, State> {
           </button>
           <Toggle
             checked={active}
+            className={style.toggle}
             id={account.code}
             onChange={(event) => {
               event.target.disabled = true;
@@ -173,6 +174,7 @@ class ManageAccounts extends Component<Props, State> {
           </div>
           <Toggle
             checked={active}
+            className={style.toggle}
             id={token.code}
             onChange={() => this.toggleToken(ethAccountCode, token.code, !active)} />
         </div>


### PR DESCRIPTION
Tokens did not break correctly to their own section.

Regression introduced in https://github.com/digitalbitbox/bitbox-wallet-app/commit/87b820d99dedf36050e89d7740987b03f405e2b7

This is only visible with make servewallet-mainnet as tokens are
only shown in mainnet.


also fixed className support on toggles see 2nd commit