### PR TITLE
Frontend button secondary

### DIFF
--- a/frontends/web/src/components/confirm/Confirm.tsx
+++ b/frontends/web/src/components/confirm/Confirm.tsx
@@ -81,7 +81,7 @@ export const Confirm = () => {
     </div>
     <DialogButtons>
       <Button primary onClick={() => respond(true)}>{customButtonText ? customButtonText : t('dialog.confirm')}</Button>
-      <Button transparent onClick={() => respond(false)}>{t('dialog.cancel')}</Button>
+      <Button secondary onClick={() => respond(false)}>{t('dialog.cancel')}</Button>
     </DialogButtons>
   </DialogLegacy>;
 };

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -148,7 +148,7 @@ class BitBox02Bootloader extends Component<Props, State> {
             ) : null }
             { !versionInfo.erased && (
               <Button
-                transparent
+                secondary
                 onClick={this.reboot}>
                 {t('bb02Bootloader.abort', { context: !versionInfo.canUpgrade ? 'noUpgrade' : '' })}
               </Button>

--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -233,13 +233,13 @@ export const AddAccount = () => {
                 <Button
                   onClick={back}
                   hidden={step === 'success'}
-                  transparent>
+                  secondary>
                   {t('button.back')}
                 </Button>
                 <Button
                   onClick={handleAddAnotherAccount}
                   hidden={step !== 'success'}
-                  transparent>
+                  secondary>
                   {t('addAccount.success.addAnotherAccount')}
                 </Button>
               </div>

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -91,7 +91,7 @@ export const Info = ({
                 info={config}
                 signingConfigIndex={viewXPub}>
                 <ButtonLink
-                  transparent
+                  secondary
                   to={`/account/${code}`}>
                   {t('button.back')}
                 </ButtonLink>

--- a/frontends/web/src/routes/account/receive/receive-bb01.tsx
+++ b/frontends/web/src/routes/account/receive/receive-bb01.tsx
@@ -241,7 +241,7 @@ export const Receive = ({
                       forceVerification={forceVerification}
                       onClick={() => verifyAddress(currentAddressIndex)}/>
                     <ButtonLink
-                      transparent
+                      secondary
                       to={`/account/${code}`}>
                       {t('button.back')}
                     </ButtonLink>

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -239,7 +239,7 @@ export const Receive = ({
                       {t('receive.verifyBitBox02')}
                     </Button>
                     <ButtonLink
-                      transparent
+                      secondary
                       to={`/account/${code}`}>
                       {t('button.back')}
                     </ButtonLink>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -754,7 +754,7 @@ class Send extends Component<Props, State> {
                         {t('send.button')}
                       </Button>
                       <ButtonLink
-                        transparent
+                        secondary
                         to={`/account/${code}`}>
                         {t('button.back')}
                       </ButtonLink>

--- a/frontends/web/src/routes/device/bitbox01/check.jsx
+++ b/frontends/web/src/routes/device/bitbox01/check.jsx
@@ -101,7 +101,7 @@ class Check extends Component {
                 <div>
                   <p style={{ minHeight: '3rem' }}>{message}</p>
                   <div className={style.actions}>
-                    <Button transparent onClick={this.abort}>
+                    <Button secondary onClick={this.abort}>
                       {t('button.back')}
                     </Button>
                   </div>
@@ -117,7 +117,7 @@ class Check extends Component {
                     <Button type="submit" primary disabled={!this.validate()}>
                       {t('button.check')}
                     </Button>
-                    <Button transparent onClick={this.abort}>
+                    <Button secondary onClick={this.abort}>
                       {t('button.back')}
                     </Button>
                   </div>

--- a/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
+++ b/frontends/web/src/routes/device/bitbox01/components/upgradefirmware.jsx
@@ -99,7 +99,7 @@ class UpgradeFirmware extends Component {
                 <Button primary onClick={this.upgradeFirmware}>
                   {t('button.upgrade')}
                 </Button>
-                <Button transparent onClick={this.abort}>
+                <Button secondary onClick={this.abort}>
                   {t('button.back')}
                 </Button>
               </DialogButtons>

--- a/frontends/web/src/routes/device/bitbox01/create.jsx
+++ b/frontends/web/src/routes/device/bitbox01/create.jsx
@@ -110,7 +110,7 @@ class Create extends Component {
                   <Button type="submit" primary disabled={waiting || !this.validate()}>
                     {t('button.create')}
                   </Button>
-                  <Button transparent onClick={this.abort}>
+                  <Button secondary onClick={this.abort}>
                     {t('button.abort')}
                   </Button>
                 </div>

--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -161,7 +161,7 @@ class Restore extends Component<Props, State> {
                     {t('button.restore')}
                   </Button>
                   <Button
-                    transparent
+                    secondary
                     onClick={this.abort}
                     disabled={isConfirming}>
                     {t('button.back')}

--- a/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/changepin.jsx
@@ -117,7 +117,7 @@ class ChangePIN extends Component {
                   <Button type="submit" danger disabled={!this.validate() || isConfirming}>
                     {t('button.changepin')}
                   </Button>
-                  <Button transparent onClick={this.abort} disabled={isConfirming}>
+                  <Button secondary onClick={this.abort} disabled={isConfirming}>
                     {t('button.back')}
                   </Button>
                 </DialogButtons>

--- a/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/device-lock.jsx
@@ -81,7 +81,7 @@ class DeviceLock extends Component {
                 <Button danger onClick={this.resetDevice}>
                   {t('deviceLock.confirm')}
                 </Button>
-                <Button transparent onClick={this.abort}>
+                <Button secondary onClick={this.abort}>
                   {t('button.back')}
                 </Button>
               </div>

--- a/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/hiddenwallet.jsx
@@ -124,7 +124,7 @@ class HiddenWallet extends Component {
                   <Button type="submit" danger disabled={!this.validate() || isConfirming}>
                     {t('button.hiddenwallet')}
                   </Button>
-                  <Button transparent onClick={this.abort} disabled={isConfirming}>
+                  <Button secondary onClick={this.abort} disabled={isConfirming}>
                     {t('button.abort')}
                   </Button>
                 </DialogButtons>

--- a/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
@@ -231,7 +231,7 @@ class MobilePairing extends Component<Props, State> {
                 }
               </div>
               <DialogButtons>
-                <Button transparent onClick={this.abort}>
+                <Button secondary onClick={this.abort}>
                   {t('button.back')}
                 </Button>
               </DialogButtons>

--- a/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/reset.jsx
@@ -108,7 +108,7 @@ class Reset extends Component {
                 <Button danger disabled={!pin || !understand} onClick={this.resetDevice}>
                   {t('reset.title')}
                 </Button>
-                <Button transparent onClick={this.abort} disabled={isConfirming}>
+                <Button secondary onClick={this.abort} disabled={isConfirming}>
                   {t('button.back')}
                 </Button>
               </DialogButtons>

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -127,7 +127,7 @@ class Initialize extends Component<Props, State> {
             {t('button.continue')}
           </Button>
           <Button
-            transparent
+            secondary
             onClick={goBack}>
             {t('button.abort')}
           </Button>
@@ -150,7 +150,7 @@ class Initialize extends Component<Props, State> {
             {t('initialize.create')}
           </Button>
           <Button
-            transparent
+            secondary
             onClick={goBack}>
             {t('button.abort')}
           </Button>

--- a/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
@@ -78,7 +78,7 @@ class SecurityInformation extends Component<Props, State> {
                         {t('button.continue')}
                       </Button>
                       <Button
-                        transparent
+                        secondary
                         onClick={goBack}>
                         {t('button.abort')}
                       </Button>
@@ -100,7 +100,7 @@ class SecurityInformation extends Component<Props, State> {
                         {t('button.continue')}
                       </Button>
                       <Button
-                        transparent
+                        secondary
                         onClick={goBack}>
                         {t('button.abort')}
                       </Button>

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-create-new.jsx
@@ -166,7 +166,7 @@ class SeedCreateNew extends Component {
             {t('seed.info.button')}
           </Button>
           <Button
-            transparent
+            secondary
             onClick={goBack}>
             {t('button.abort')}
           </Button>
@@ -219,7 +219,7 @@ class SeedCreateNew extends Component {
             {t('seed.create')}
           </Button>
           <Button
-            transparent
+            secondary
             onClick={goBack}>
             {t('button.abort')}
           </Button>

--- a/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/seed-restore.jsx
@@ -122,7 +122,7 @@ class SeedRestore extends Component {
                         {t('button.continue')}
                       </Button>
                       <Button
-                        transparent
+                        secondary
                         onClick={goBack}>
                         {t('button.abort')}
                       </Button>
@@ -135,7 +135,7 @@ class SeedRestore extends Component {
                     requireConfirmation={false}
                     onRestore={onSuccess}>
                     <Button
-                      transparent
+                      secondary
                       onClick={goBack}>
                       {t('button.abort')}
                     </Button>

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -147,7 +147,7 @@ class Passphrase extends Component<Props, State> {
             <Button primary onClick={this.continueInfo}>
               {t('passphrase.what.button')}
             </Button>
-            <Button transparent onClick={this.backInfo}>
+            <Button secondary onClick={this.backInfo}>
               {t('button.back')}
             </Button>
           </ViewButtons>
@@ -169,7 +169,7 @@ class Passphrase extends Component<Props, State> {
             <Button primary onClick={this.continueInfo}>
               {t('passphrase.why.button')}
             </Button>
-            <Button transparent onClick={this.backInfo}>
+            <Button secondary onClick={this.backInfo}>
               {t('button.back')}
             </Button>
           </ViewButtons>
@@ -191,7 +191,7 @@ class Passphrase extends Component<Props, State> {
             <Button primary onClick={this.continueInfo}>
               {t('passphrase.considerations.button')}
             </Button>
-            <Button transparent onClick={this.backInfo}>
+            <Button secondary onClick={this.backInfo}>
               {t('button.back')}
             </Button>
           </ViewButtons>
@@ -213,7 +213,7 @@ class Passphrase extends Component<Props, State> {
             <Button primary onClick={this.continueInfo}>
               {t('passphrase.how.button')}
             </Button>
-            <Button transparent onClick={this.backInfo}>
+            <Button secondary onClick={this.backInfo}>
               {t('button.back')}
             </Button>
           </ViewButtons>
@@ -235,7 +235,7 @@ class Passphrase extends Component<Props, State> {
             <Button primary onClick={this.continueInfo}>
               {t('passphrase.summary.button')}
             </Button>
-            <Button transparent onClick={this.backInfo}>
+            <Button secondary onClick={this.backInfo}>
               {t('button.back')}
             </Button>
           </ViewButtons>
@@ -270,7 +270,7 @@ class Passphrase extends Component<Props, State> {
             <Button primary onClick={this.continueInfo} disabled={!understood}>
               {t('passphrase.enable')}
             </Button>
-            <Button transparent onClick={this.backInfo}>
+            <Button secondary onClick={this.backInfo}>
               {t('button.back')}
             </Button>
           </ViewButtons>
@@ -299,7 +299,7 @@ class Passphrase extends Component<Props, State> {
           <Button primary onClick={this.continueInfo}>
             {t('passphrase.disableInfo.button')}
           </Button>
-          <Button transparent onClick={this.backInfo}>
+          <Button secondary onClick={this.backInfo}>
             {t('button.back')}
           </Button>
         </ViewButtons>

--- a/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
+++ b/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
@@ -61,7 +61,7 @@ const SDCardCheck = ({ deviceID, children }: TProps) => {
               {t('button.ok')}
             </Button>
             <ButtonLink
-              transparent
+              secondary
               to={`/settings/device-settings/${deviceID}`}>
               {t('button.back')}
             </ButtonLink>

--- a/frontends/web/src/routes/device/bitbox02/setup/choose.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/choose.tsx
@@ -151,7 +151,7 @@ export const SetupOptions = ({
                     setWith12Words(false);
                     setAdvanced(false);
                   }}
-                  transparent>
+                  secondary>
                   {t('button.back')}
                 </Button>
               </ColumnButtons>
@@ -213,13 +213,13 @@ export const SetupOptions = ({
             <ColumnButtons>
               <Button
                 onClick={() => onSelectSetup('restore-sdcard')}
-                transparent>
+                secondary>
                 {t('bitbox02Wizard.stepUninitialized.restoreMicroSD')}
               </Button>
               <Button
                 onClick={() => onSelectSetup('restore-mnemonic')}
                 style={{ marginBottom: '40px' }}
-                transparent>
+                secondary>
                 {t('bitbox02Wizard.stepUninitialized.restoreMnemonic')}
               </Button>
             </ColumnButtons>

--- a/frontends/web/src/routes/device/bitbox02/setup/name.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/name.tsx
@@ -85,7 +85,7 @@ export const SetDeviceName = ({
           </Button>
           <Button
             onClick={onBack}
-            transparent
+            secondary
             type="button">
             {t('button.back')}
           </Button>

--- a/frontends/web/src/routes/device/bitbox02/setup/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/restore.tsx
@@ -50,7 +50,7 @@ export const RestoreFromSDCardBackup = ({
           onSelectBackup={onSelectBackup}
           onRestoreBackup={onRestoreBackup}>
           <Button
-            transparent
+            secondary
             onClick={onBack}>
             {t('button.back')}
           </Button>

--- a/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
+++ b/frontends/web/src/routes/device/manage-backups/manage-backups.jsx
@@ -39,7 +39,7 @@ class ManageBackups extends Component {
   backButton = () => {
     return (
       <ButtonLink
-        transparent
+        secondary
         to={`/settings/device-settings/${this.props.deviceID}`}>
         {this.props.t('button.back')}
       </ButtonLink>

--- a/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
@@ -97,7 +97,7 @@ const UpgradeDialog = ({
             onClick={onUpgradeFirmware}>
             {t('button.upgrade')}
           </Button>
-          <Button transparent onClick={onClose}>
+          <Button secondary onClick={onClose}>
             {t('button.back')}
           </Button>
         </DialogButtons>


### PR DESCRIPTION
Our transparent buttons are not transparent and look similar to
the secondary button.

Changed most transparent buttons to secondary so they are more
consistent and we can use real transparent buttons in the future.

The only 2 buttons that remain using transparent and should be
visually transparent (no button styling) are in choose component
the advanced setup options and on manage accounts toggle tokens
(only visible in mainnet).

After this commit is merged, button transparent style can be
updated (remove button border) and used everywhere were we should
use button component without border.
