### PR TITLE
frontend: added missing withGuide prop in MobileHeader (manage acc)

### DIFF
--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -228,7 +228,7 @@ class ManageAccounts extends Component<Props, State> {
               title={
                 <>
                   <h2 className="hide-on-small">{t('settings.title')}</h2>
-                  <MobileHeader title={t('manageAccounts.title')} />
+                  <MobileHeader withGuide title={t('manageAccounts.title')} />
                 </>
               } />
             <View fullscreen={false}>


### PR DESCRIPTION
added missing `withGuide` prop in MobileHeader (manage accounts page).
without this prop, the positioning of the MobileHeader text won't be centred.

Before:
<img width="412" alt="Screenshot 2023-07-18 at 12 49 12" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/d1851c6d-819e-44fb-a79a-9c8079f07d10">

After:
<img width="407" alt="Screenshot 2023-07-18 at 12 49 32" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/f2c81028-a73d-45c7-9251-b865c5e0f2d0">
