### PR TITLE
frontend: fix margin issue for feetargets

### DIFF
--- a/frontends/web/src/routes/account/send/feetargets.module.css
+++ b/frontends/web/src/routes/account/send/feetargets.module.css
@@ -101,7 +101,7 @@ select.priority {
     margin-top: 0;
 }
 
-.feeDescription {
+.feeProposed {
     margin: 0;
 }
 


### PR DESCRIPTION
to fix the spacing between "Note" & Fee Target components on mobile.


Before fix:

![image (1)](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/c5db306a-520a-441a-b209-927b8d7dde4b)



After fix (various states):

<img width="306" alt="Screenshot 2023-07-18 at 13 16 47" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/0aead272-980b-4448-ba93-2840ee891e8d">
<img width="306" alt="Screenshot 2023-07-18 at 13 16 52" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/0d448d03-289a-49c1-b229-ce8252511412">
<img width="306" alt="Screenshot 2023-07-18 at 13 16 55" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/e4337d22-45dd-4b23-9418-c61b892f14d6">
<img width="306" alt="Screenshot 2023-07-18 at 13 17 02" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/3276082d-307e-42a0-b958-da7fb2c7f085">

After fix (various states, on desktop):
<img width="776" alt="Screenshot 2023-07-18 at 13 17 15" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/d520140b-a60e-4f8e-a0ef-71e6cf8220b5">
<img width="776" alt="Screenshot 2023-07-18 at 13 17 13" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/1667de86-d87b-45ec-b9de-6f18714a61c1">
<img width="776" alt="Screenshot 2023-07-18 at 13 17 08" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/3b2652f8-12a4-4e6a-920e-92a432ad0e34">

