### PR TITLE
frontend: refactored appupgraderequired view

### DIFF
--- a/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
+++ b/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { i18n } from '../../i18n/i18n';
 import { URL_CONSTANTS } from '../../utils/url_constants';
 import A from '../anchor/anchor';
+import { Button } from '../forms';
 
 export const downloadLinkByLanguage = () => {
   const language = i18n.language;
@@ -29,10 +30,24 @@ export const downloadLinkByLanguage = () => {
   }
 };
 
-const AppDownloadLink = ({ ...props }) => {
+export const AppDownloadLink = ({ ...props }) => {
   const { t } = useTranslation();
-
-  return <A href={downloadLinkByLanguage()} {...props}>{t('button.download')}</A>;
+  return (
+    <A href={downloadLinkByLanguage()} {...props}>
+      {t('button.download')}
+    </A>
+  );
 };
 
-export { AppDownloadLink };
+export const AppDownloadButton = ({ ...props }) => {
+  const { t } = useTranslation();
+
+  // button as child of an anchor element would be invalid HTML, but our A component does not use <a> element. However Button should probably accept href directly so that <A> isn't needed.
+  return (
+    <A href={downloadLinkByLanguage()} {...props}>
+      <Button primary>
+        {t('button.download')}
+      </Button>
+    </A>
+  );
+};

--- a/frontends/web/src/components/appupgraderequired.tsx
+++ b/frontends/web/src/components/appupgraderequired.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,27 +15,26 @@
  * limitations under the License.
  */
 
-import { translate, TranslateProps } from '../decorators/translate';
-import { AppDownloadLink } from './appdownloadlink/appdownloadlink';
+import { useTranslation } from 'react-i18next';
+import { View, ViewButtons, ViewHeader } from './view/view';
+import { AppDownloadButton } from './appdownloadlink/appdownloadlink';
+import { Header, Main } from './layout';
 
-function AppUpgradeRequired({ t }: TranslateProps) {
+export const AppUpgradeRequired = () => {
+  const { t } = useTranslation();
   return (
-    <div className="contentWithGuide">
-      <div className="container">
-        <div className="innerContainer">
-          <div className="content narrow isVerticallyCentered">
-            <div className="box large">
-              <p className="m-top-none">{t('device.appUpradeRequired')}</p>
-              <div className="buttons m-top-half">
-                <AppDownloadLink className="text-medium text-blue" />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <Main>
+      <Header />
+      <View
+        fullscreen
+        verticallyCentered
+        width="840px"
+        withBottomBar>
+        <ViewHeader title={t('device.appUpradeRequired')} />
+        <ViewButtons>
+          <AppDownloadButton />
+        </ViewButtons>
+      </View>
+    </Main>
   );
-}
-
-const HOC = translate()(AppUpgradeRequired);
-export { HOC as AppUpgradeRequired };
+};


### PR DESCRIPTION
Changed AppUpgradeRequired component to use View component, also changed download link to use Button and added ViewFooter to display language menu.

Another noticeable change is that the view is now fullscreen without
showing the sidebar that contains settings.

Test by lowering semver number for lowestSupportedFirmwareVersion and lowestNonSupportedFirmwareVersion in:
- bitbox02-api-go/api/firmware/device.go