### PR TITLE
frontend: refactor firmware-upgrade-required to functional component

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -21,11 +21,9 @@ import { attestationCheckDone, statusChanged } from '../../../api/devicessync';
 import { UnsubscribeList, unsubscribe } from '../../../utils/subscriptions';
 import { route } from '../../../utils/route';
 import { AppUpgradeRequired } from '../../../components/appupgraderequired';
-import { CenteredContent } from '../../../components/centeredcontent/centeredcontent';
+import { FirmwareUpgradeRequired } from '../upgrade-firmware-required';
 import { Main } from '../../../components/layout';
-import { translate, TranslateProps } from '../../../decorators/translate';
 import { BB02Settings } from '../../settings/bb02-settings';
-import { FirmwareSetting } from '../../settings/components/device-settings/firmware-setting';
 import { Unlock } from './unlock';
 import { Pairing } from './setup/pairing';
 import { Wait } from './setup/wait';
@@ -34,15 +32,13 @@ import { CreateWallet } from './setup/wallet-create';
 import { RestoreFromSDCard, RestoreFromMnemonic } from './setup/wallet-restore';
 import { CreateWalletSuccess, RestoreFromMnemonicSuccess, RestoreFromSDCardSuccess } from './setup/success';
 
-interface BitBox02Props {
+type Props = {
   deviceID: string;
   deviceIDs: string[];
   hasAccounts: boolean;
 }
 
-type Props = BitBox02Props & TranslateProps;
-
-interface State {
+type State = {
     versionInfo?: VersionInfo;
     attestation: boolean | null;
     status: '' | TStatus;
@@ -57,7 +53,7 @@ interface State {
     };
 }
 
-class BitBox02 extends Component<Props, State> {
+export class BitBox02 extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -124,7 +120,7 @@ class BitBox02 extends Component<Props, State> {
   }
 
   public render() {
-    const { t, deviceID, hasAccounts, deviceIDs } = this.props;
+    const { deviceID, hasAccounts, deviceIDs } = this.props;
     const {
       attestation,
       createOptions,
@@ -144,16 +140,9 @@ class BitBox02 extends Component<Props, State> {
     }
     if (status === 'require_firmware_upgrade') {
       return (
-        <CenteredContent>
-          <div className="box large">
-            <p>{t('upgradeFirmware.label')}</p>
-            <FirmwareSetting
-              asButton
-              deviceID={deviceID}
-              versionInfo={versionInfo}
-            />
-          </div>
-        </CenteredContent>
+        <FirmwareUpgradeRequired
+          deviceID={deviceID}
+          versionInfo={versionInfo} />
       );
     }
     if (status === 'require_app_upgrade') {
@@ -237,6 +226,3 @@ class BitBox02 extends Component<Props, State> {
     );
   }
 }
-
-const HOC = translate()(BitBox02);
-export { HOC as BitBox02 };

--- a/frontends/web/src/routes/device/upgrade-firmware-required.tsx
+++ b/frontends/web/src/routes/device/upgrade-firmware-required.tsx
@@ -36,14 +36,17 @@ export const FirmwareUpgradeRequired = ({
       <View
         fullscreen
         verticallyCentered
+        textCenter
         width="840px"
         withBottomBar>
         <ViewHeader title={t('upgradeFirmware.label')} />
         <ViewButtons>
-          <FirmwareSetting
-            asButton
-            deviceID={deviceID}
-            versionInfo={versionInfo} />
+          <div>
+            <FirmwareSetting
+              asButton
+              deviceID={deviceID}
+              versionInfo={versionInfo} />
+          </div>
         </ViewButtons>
       </View>
     </Main>

--- a/frontends/web/src/routes/device/upgrade-firmware-required.tsx
+++ b/frontends/web/src/routes/device/upgrade-firmware-required.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { VersionInfo } from '../../api/bitbox02';
+import { View, ViewButtons, ViewHeader } from '../../components/view/view';
+import { Header, Main } from '../../components/layout';
+import { FirmwareSetting } from '../settings/components/device-settings/firmware-setting';
+
+type TProps = {
+  deviceID: string;
+  versionInfo: VersionInfo;
+}
+
+export const FirmwareUpgradeRequired = ({
+  deviceID,
+  versionInfo,
+}: TProps) => {
+  const { t } = useTranslation();
+  return (
+    <Main>
+      <Header />
+      <View
+        fullscreen
+        verticallyCentered
+        width="840px"
+        withBottomBar>
+        <ViewHeader title={t('upgradeFirmware.label')} />
+        <ViewButtons>
+          <FirmwareSetting
+            asButton
+            deviceID={deviceID}
+            versionInfo={versionInfo} />
+        </ViewButtons>
+      </View>
+    </Main>
+  );
+};

--- a/frontends/web/src/routes/settings/components/device-settings/firmware-setting.module.css
+++ b/frontends/web/src/routes/settings/components/device-settings/firmware-setting.module.css
@@ -1,7 +1,0 @@
-.asButton {
-    background-color: var(--background-blue);
-}
-
-.asButton p {
-    color: var(--color-white);
-}

--- a/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
@@ -21,7 +21,6 @@ import { Dialog, DialogButtons } from '../../../../components/dialog/dialog';
 import { Button } from '../../../../components/forms';
 import { Checked, RedDot } from '../../../../components/icon';
 import { SettingsItem } from '../settingsItem/settingsItem';
-import styles from './firmware-setting.module.css';
 
 export type TProps = {
     deviceID: string;
@@ -45,6 +44,7 @@ const FirmwareSetting = ({ deviceID, versionInfo, asButton = false }: TProps) =>
   const secondaryText = canUpgrade ? t('deviceSettings.firmware.upgradeAvailable') : t('deviceSettings.firmware.upToDate');
   const extraComponent = canUpgrade ? <RedDot width={8} height={8}/> : <Checked />;
 
+  const handleOpenDialog = canUpgrade ? () => setDialogOpen(true) : undefined;
 
   const handleUpgradeFirmware = async () => {
     setConfirming(true);
@@ -55,14 +55,21 @@ const FirmwareSetting = ({ deviceID, versionInfo, asButton = false }: TProps) =>
 
   return (
     <>
-      <SettingsItem
-        className={`${asButton ? styles.asButton : ''}`}
-        settingName={t('deviceSettings.firmware.title')}
-        secondaryText={secondaryText}
-        onClick={canUpgrade ? () => setDialogOpen(true) : undefined}
-        displayedValue={versionInfo.currentVersion}
-        extraComponent={extraComponent}
-      />
+      { asButton ? (
+        <Button
+          onClick={handleOpenDialog}
+          primary>
+          {t('button.upgrade')}
+        </Button>
+      ) : (
+        <SettingsItem
+          settingName={t('deviceSettings.firmware.title')}
+          secondaryText={secondaryText}
+          onClick={handleOpenDialog}
+          displayedValue={versionInfo.currentVersion}
+          extraComponent={extraComponent}
+        />
+      )}
       <UpgradeDialog
         open={dialogOpen && canUpgrade}
         versionInfo={versionInfo}


### PR DESCRIPTION
Changed FirmwareUpgradeRequired to use View component, also with this BitBox02.tsx does not need to use translation decorator anymore and types can be simplified.

Test by increasing lowestSupportedFirmwareVersion in:
- bitbox02-api-go/api/firmware/device.go