### PR TITLE
frontend: refactor anchor component

### DIFF
--- a/frontends/web/src/components/anchor/anchor.module.css
+++ b/frontends/web/src/components/anchor/anchor.module.css
@@ -1,4 +1,10 @@
 .link {
-    text-decoration: underline;
+    color: var(--color-blue);
     cursor: pointer;
+    text-decoration: underline;
+}
+
+.link:focus {
+    outline: 1px solid var(--color-blue);
+    text-decoration: none;
 }

--- a/frontends/web/src/components/anchor/anchor.tsx
+++ b/frontends/web/src/components/anchor/anchor.tsx
@@ -20,9 +20,11 @@ import { apiPost } from '../../utils/request';
 import style from './anchor.module.css';
 
 type TProps = {
-    href: string;
-    children: ReactNode;
-    [property: string]: any;
+  children: ReactNode;
+  className?: string;
+  href: string;
+  icon?: ReactNode;
+  title?: string;
 }
 
 export const A = ({

--- a/frontends/web/src/components/anchor/anchor.tsx
+++ b/frontends/web/src/components/anchor/anchor.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +15,8 @@
  * limitations under the License.
  */
 
-import { ReactNode, SyntheticEvent, useContext } from 'react';
-import { route } from '../../utils/route';
-import { debug } from '../../utils/env';
+import { ReactNode, SyntheticEvent } from 'react';
 import { apiPost } from '../../utils/request';
-import AppContext from '../../contexts/AppContext';
 import style from './anchor.module.css';
 
 type TProps = {
@@ -27,18 +25,16 @@ type TProps = {
     [property: string]: any;
 }
 
-const A = ({ href, icon, children, ...props }: TProps) => {
-  const { setGuideShown } = useContext(AppContext);
+const A = ({
+  href,
+  icon,
+  children,
+  ...props
+}: TProps) => {
   return (
     <span className={style.link} onClick={(e: SyntheticEvent) => {
       e.preventDefault();
-      const { hostname, origin } = new URL(href, window.location.href);
-      if (origin === 'qrc:' || (debug && hostname === window.location.hostname)) {
-        setGuideShown(false);
-        route(href);
-      } else {
-        apiPost('open', href).catch(console.error);
-      }
+      apiPost('open', href).catch(console.error);
     }} title={props.title || href} {...props}>
       {icon ? icon : null}
       {children}

--- a/frontends/web/src/components/anchor/anchor.tsx
+++ b/frontends/web/src/components/anchor/anchor.tsx
@@ -25,7 +25,7 @@ type TProps = {
     [property: string]: any;
 }
 
-const A = ({
+export const A = ({
   href,
   icon,
   children,
@@ -41,5 +41,3 @@ const A = ({
     </span>
   );
 };
-
-export default A;

--- a/frontends/web/src/components/anchor/anchor.tsx
+++ b/frontends/web/src/components/anchor/anchor.tsx
@@ -27,17 +27,35 @@ type TProps = {
   title?: string;
 }
 
+/**
+ * Renders a link to an external URL or file, which will open in the native browser or application.
+ * Use Link or ButtonLink component for internal links.
+ *
+ * @typedef {Object} LinkProps
+ * @property {string} href - The link to the external URL or file path on the local file system.
+ * @property {string} [icon] - (Optional) An icon associated with the link.
+ * @property {string} [className] - (Optional) Additional CSS class names for styling the link.
+ * @property {string} [title] - (Optional) A title used as tooltip for the link.
+ *
+ * @param {LinkProps} props - The props object containing properties for the Link component.
+ */
 export const A = ({
   href,
   icon,
+  className,
   children,
   ...props
 }: TProps) => {
   return (
-    <span className={style.link} onClick={(e: SyntheticEvent) => {
-      e.preventDefault();
-      apiPost('open', href).catch(console.error);
-    }} title={props.title || href} {...props}>
+    <span
+      className={`${style.link} ${className || ''}`}
+      title={props.title || href}
+      onClick={(e: SyntheticEvent) => {
+        e.preventDefault();
+        apiPost('open', href).catch(console.error);
+      }}
+      tabIndex={0}
+      {...props}>
       {icon ? icon : null}
       {children}
     </span>

--- a/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
+++ b/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
@@ -17,8 +17,8 @@
 import { useTranslation } from 'react-i18next';
 import { i18n } from '../../i18n/i18n';
 import { URL_CONSTANTS } from '../../utils/url_constants';
-import A from '../anchor/anchor';
 import { Button } from '../forms';
+import { A } from '../anchor/anchor';
 
 export const downloadLinkByLanguage = () => {
   const language = i18n.language;

--- a/frontends/web/src/components/banner/banner.module.css
+++ b/frontends/web/src/components/banner/banner.module.css
@@ -1,0 +1,7 @@
+.link {
+  color: var(--color-alt);
+}
+
+.link:focus {
+  outline-color: inherit;
+}

--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -19,7 +19,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getBanner, syncBanner, TBannerInfo } from '../../api/banners';
 import { Status } from '../status/status';
-import A from '../anchor/anchor';
+import { A } from '../anchor/anchor';
 
 type TBannerProps = {
   msgKey: 'bitbox01' | 'bitbox02';

--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { getBanner, syncBanner, TBannerInfo } from '../../api/banners';
 import { Status } from '../status/status';
 import { A } from '../anchor/anchor';
+import style from './banner.module.css';
 
 type TBannerProps = {
   msgKey: 'bitbox01' | 'bitbox02';
@@ -46,7 +47,7 @@ export const Banner = ({ msgKey }: TBannerProps) => {
       { message[i18n.language] || message[(i18n.options.fallbackLng as string[])[0]] }
       &nbsp;
       { link && (
-        <A href={link.href}>
+        <A href={link.href} className={style.link}>
           { link.text || t('clickHere') }
         </A>
       )}

--- a/frontends/web/src/components/forms/button.module.css
+++ b/frontends/web/src/components/forms/button.module.css
@@ -6,14 +6,13 @@
     border-style: solid;
     border-width: 1px;
     cursor: default;
-    /* Otter doesn't like display: inline-flex; */
     display: inline-flex;
     flex-direction: row;
     font-family: var(--font-family);
     font-size: var(--size-default);
     font-weight: 400;
     justify-content: center;
-    min-width: 100px !important;
+    min-width: 100px;
     height: 50px;
     outline: none;
     padding: 0 var(--space-default);
@@ -77,13 +76,16 @@
 .transparent {
     composes: button;
     background-color: transparent;
-    border-color: var(--color-blue);
+    border-color: transparent;
     color: var(--color-blue);
+    display: inline-block;
+    height: auto;
+    min-width: 0;
+    padding: var(--space-half);
 }
 
 .transparent:not([disabled]):focus,
 .transparent:not([disabled]):hover {
-    border-color: var(--color-lightblue);
     color: var(--color-lightblue);
 }
 

--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -15,7 +15,7 @@
  */
 
 import { FunctionComponent, useState } from 'react';
-import A from '../anchor/anchor';
+import { A } from '../anchor/anchor';
 import style from './guide.module.css';
 
 export type TEntryProp = {

--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
+ * Copyright 2023 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +56,14 @@ export const Entry: FunctionComponent<TProps> = props => {
           <div className="flex-1">
             {entry.text.trim().split('\n').map(p => <p key={p}>{p}</p>)}
             {entry.link && (
-              <p><A data-testid="link" href={entry.link.url}>{entry.link.text}</A></p>
+              <p>
+                <A
+                  className={style.link}
+                  data-testid="link"
+                  href={entry.link.url}>
+                  {entry.link.text}
+                </A>
+              </p>
             )}
             {props.children}
           </div>

--- a/frontends/web/src/components/guide/guide.module.css
+++ b/frontends/web/src/components/guide/guide.module.css
@@ -122,6 +122,15 @@
     flex-basis: 0;
 }
 
+.link {
+    color: inherit;
+    text-decoration: underline;
+}
+
+.link:focus {
+    outline-color: inherit;
+}
+
 @media (max-width: 1348px) {
     .guideWrapper {
         width: calc( (((100% - var(--sidebar-width-large)) - var(--content-width)) / 2) + 18px + var(--space-default) );

--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -16,7 +16,7 @@
 
 import { ReactNode, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import A from '../anchor/anchor';
+import { A } from '../anchor/anchor';
 import { CloseXWhite } from '../icon';
 import AppContext from '../../contexts/AppContext';
 import style from './guide.module.css';

--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -52,7 +52,9 @@ const Guide = ({ children }: TProps) => {
           <div className={style.entry}>
             {t('guide.appendix.text')}
             {' '}
-            <A href="https://bitbox.swiss/support/">{t('guide.appendix.link')}</A>
+            <A className={style.link} href="https://bitbox.swiss/support/">
+              {t('guide.appendix.link')}
+            </A>
             <br />
             <br />
           </div>

--- a/frontends/web/src/components/transactions/transaction.module.css
+++ b/frontends/web/src/components/transactions/transaction.module.css
@@ -138,11 +138,6 @@
     text-overflow: ellipsis;
 }
 
-.externalLink {
-    color: var(--color-blue);
-    cursor: pointer;
-}
-
 .detail,
 .detailInput {
     display: flex;

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -19,7 +19,7 @@ import React, { Component, createRef } from 'react';
 import * as accountApi from '../../api/account';
 import { Input } from '../../components/forms';
 import { translate, TranslateProps } from '../../decorators/translate';
-import A from '../anchor/anchor';
+import { A } from '../anchor/anchor';
 import { Dialog } from '../dialog/dialog';
 import { CopyableInput } from '../copy/Copy';
 import { Edit, EditLight, ExpandIcon, Save, SaveLight } from '../icon/icon';

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -416,9 +416,8 @@ class Transaction extends Component<Props, State> {
             <div className={[style.detail, 'flex-center'].join(' ')}>
               <p>
                 <A
-                  className={style.externalLink}
                   href={explorerURL + transactionInfo.txID}
-                  title={t('transaction.explorerTitle') + '\n' + explorerURL + transactionInfo.txID}>
+                  title={`${t('transaction.explorerTitle')}\n${explorerURL}${transactionInfo.txID}`}>
                   {t('transaction.explorerTitle')}
                 </A>
               </p>

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -27,9 +27,9 @@ import { ProgressRing } from '../progressRing/progressRing';
 import { FiatConversion } from '../rates/rates';
 import { Amount } from '../../components/amount/amount';
 import { ArrowIn, ArrowOut, ArrowSelf } from './components/icons';
-import style from './transaction.module.css';
-import parentStyle from './transactions.module.css';
 import { getDarkmode } from '../darkmode/darkmode';
+import parentStyle from './transactions.module.css';
+import style from './transaction.module.css';
 
 interface State {
     transactionDialog: boolean;
@@ -414,13 +414,11 @@ class Transaction extends Component<Props, State> {
               </div>
             </div>
             <div className={[style.detail, 'flex-center'].join(' ')}>
-              <p>
-                <A
-                  href={explorerURL + transactionInfo.txID}
-                  title={`${t('transaction.explorerTitle')}\n${explorerURL}${transactionInfo.txID}`}>
-                  {t('transaction.explorerTitle')}
-                </A>
-              </p>
+              <A
+                href={explorerURL + transactionInfo.txID}
+                title={`${t('transaction.explorerTitle')}\n${explorerURL}${transactionInfo.txID}`}>
+                {t('transaction.explorerTitle')}
+              </A>
             </div>
           </> }
         </Dialog>

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -17,9 +17,9 @@
 
 import { useTranslation } from 'react-i18next';
 import { TTransactions } from '../../api/account';
-import { A } from '../../components/anchor/anchor';
 import { runningInAndroid } from '../../utils/env';
 import { Transaction } from './transaction';
+import { Button } from '../forms';
 import style from './transactions.module.css';
 
 type TProps = {
@@ -48,9 +48,12 @@ export const Transactions = ({
           {t('accountSummary.transactionHistory')}
         </label>
         { !csvExportDisabled && (
-          <A key="export" href="#" onClick={handleExport} className="labelXLarge labelLink" title={t('account.exportTransactions')}>
+          <Button
+            transparent
+            onClick={handleExport}
+            title={t('account.exportTransactions')}>
             {t('account.export')}
-          </A>
+          </Button>
         ) }
       </div>
       <div className={[style.columns, style.headers, style.showOnMedium].join(' ')}>

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -17,7 +17,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { TTransactions } from '../../api/account';
-import A from '../../components/anchor/anchor';
+import { A } from '../../components/anchor/anchor';
 import { runningInAndroid } from '../../utils/env';
 import { Transaction } from './transaction';
 import style from './transactions.module.css';

--- a/frontends/web/src/components/update/update.module.css
+++ b/frontends/web/src/components/update/update.module.css
@@ -1,0 +1,3 @@
+.link {
+  color: inherit;
+}

--- a/frontends/web/src/components/update/update.tsx
+++ b/frontends/web/src/components/update/update.tsx
@@ -21,6 +21,7 @@ import { getUpdate } from '../../api/version';
 import { Status } from '../status/status';
 import { AppDownloadLink } from '../appdownloadlink/appdownloadlink';
 import { useLoad } from '../../hooks/api';
+import style from './update.module.css';
 
 export const Update = () => {
   const { t } = useTranslation();
@@ -37,7 +38,7 @@ export const Update = () => {
       {file.description}
       {' '}
       {/* Don't show download link on Android because they should update from stores */}
-      {!runningInAndroid() && <AppDownloadLink />}
+      {!runningInAndroid() && <AppDownloadLink className={style.link} />}
     </Status>
   );
 };

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -590,7 +590,7 @@ class Send extends Component<Props, State> {
                   <label className="labelXLarge">{t('send.transactionDetails')}</label>
                   { coinControl && (
                     <Button
-                      className="m-bottom-default"
+                      className="m-bottom-quarter p-right-none"
                       transparent
                       onClick={this.toggleCoinControl}>
                       {t('send.toggleCoinControl')}

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -23,7 +23,6 @@ import { View, ViewContent } from '../../../components/view/view';
 import { TDevices } from '../../../api/devices';
 import { getDeviceInfo } from '../../../api/bitbox01';
 import { alertUser } from '../../../components/alert/Alert';
-import { A } from '../../../components/anchor/anchor';
 import { Balance } from '../../../components/balance/balance';
 import { Button, ButtonLink, Checkbox, Input } from '../../../components/forms';
 import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
@@ -590,7 +589,12 @@ class Send extends Component<Props, State> {
                 <div className={`flex flex-row flex-between ${style.container}`}>
                   <label className="labelXLarge">{t('send.transactionDetails')}</label>
                   { coinControl && (
-                    <A href="#" onClick={this.toggleCoinControl} className="labelLarge labelLink">{t('send.toggleCoinControl')}</A>
+                    <Button
+                      className="m-bottom-default"
+                      transparent
+                      onClick={this.toggleCoinControl}>
+                      {t('send.toggleCoinControl')}
+                    </Button>
                   )}
                 </div>
                 <Grid col="1">

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -23,7 +23,7 @@ import { View, ViewContent } from '../../../components/view/view';
 import { TDevices } from '../../../api/devices';
 import { getDeviceInfo } from '../../../api/bitbox01';
 import { alertUser } from '../../../components/alert/Alert';
-import A from '../../../components/anchor/anchor';
+import { A } from '../../../components/anchor/anchor';
 import { Balance } from '../../../components/balance/balance';
 import { Button, ButtonLink, Checkbox, Input } from '../../../components/forms';
 import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';

--- a/frontends/web/src/routes/account/send/utxos.module.css
+++ b/frontends/web/src/routes/account/send/utxos.module.css
@@ -15,6 +15,7 @@
 }
 
 .utxoContent {
+    align-items: flex-start;
     color: var(--color-default);
     display: flex;
     flex-wrap: nowrap;
@@ -38,9 +39,6 @@
 }
 
 .utxoExplorer {
-    background: none;
-    border: none;
-    cursor: pointer;
     margin-top: calc(var(--space-quarter) * -1);
     padding: var(--space-quarter);
 }

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -24,7 +24,7 @@ import {
   TUTXO,
 } from '../../../api/account';
 import { syncdone } from '../../../api/accountsync';
-import A from '../../../components/anchor/anchor';
+import { A } from '../../../components/anchor/anchor';
 import { Dialog } from '../../../components/dialog/dialog';
 import { Button, Checkbox } from '../../../components/forms';
 import { ExternalLink } from '../../../components/icon';

--- a/frontends/web/src/routes/buy/components/infocontent.tsx
+++ b/frontends/web/src/routes/buy/components/infocontent.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import A from '../../../components/anchor/anchor';
+import { A } from '../../../components/anchor/anchor';
 import { Info } from '../types';
 import style from './infocontent.module.css';
 

--- a/frontends/web/src/routes/buy/moonpay-terms.tsx
+++ b/frontends/web/src/routes/buy/moonpay-terms.tsx
@@ -21,7 +21,7 @@ import { ChangeEvent } from 'react';
 import { Button, Checkbox } from '../../components/forms';
 import { setConfig } from '../../utils/config';
 import { IAccount } from '../../api/account';
-import A from '../../components/anchor/anchor';
+import { A } from '../../components/anchor/anchor';
 import style from './terms.module.css';
 
 type TProps = {

--- a/frontends/web/src/routes/buy/moonpay-terms.tsx
+++ b/frontends/web/src/routes/buy/moonpay-terms.tsx
@@ -84,7 +84,7 @@ export const MoonpayTerms = ({ account, onAgreedTerms }: TProps) => {
         </h2>
         <p>{t('buy.info.disclaimer.security.description', { name })}</p>
         <p>
-          <A className={style.link} href="https://bitbox.swiss/bitbox02/threat-model/">
+          <A href="https://bitbox.swiss/bitbox02/threat-model/">
             {t('buy.info.disclaimer.security.link')}
           </A>
         </p>
@@ -93,7 +93,7 @@ export const MoonpayTerms = ({ account, onAgreedTerms }: TProps) => {
         </h2>
         <p>{t('buy.info.disclaimer.protection.description', { name })}</p>
         <p>
-          <A className={style.link} href="https://www.moonpay.com/privacy_policy">
+          <A href="https://www.moonpay.com/privacy_policy">
             {t('buy.info.disclaimer.privacyPolicy')}
           </A>
         </p>

--- a/frontends/web/src/routes/buy/pocket-terms.tsx
+++ b/frontends/web/src/routes/buy/pocket-terms.tsx
@@ -46,14 +46,14 @@ export const PocketTerms = ({ onAgreedTerms }: TProps) => {
         <h2 className={style.title}>{t('buy.pocket.security.title')}</h2>
         <p>{t('buy.pocket.security.p1')}</p>
         <p>
-          <A className={style.link} href="https://bitbox.swiss/bitbox02/threat-model/">
+          <A href="https://bitbox.swiss/bitbox02/threat-model/">
             {t('buy.pocket.security.link')}
           </A>
         </p>
         <h2 className={style.title}>{t('buy.pocket.kyc.title')}</h2>
         <p>{t('buy.pocket.kyc.p1')}</p>
         <p>
-          <A className={style.link} href="https://pocketbitcoin.com/faq">
+          <A href="https://pocketbitcoin.com/faq">
             {t('buy.pocket.kyc.link')}
           </A>
         </p>
@@ -61,7 +61,7 @@ export const PocketTerms = ({ onAgreedTerms }: TProps) => {
         <h2 className={style.title}>{t('buy.pocket.data.title')}</h2>
         <p>{t('buy.pocket.data.p1')}</p>
         <p>
-          <A className={style.link} href="https://pocketbitcoin.com/policy/privacy">
+          <A href="https://pocketbitcoin.com/policy/privacy">
             {t('buy.pocket.data.link')}
           </A>
         </p>

--- a/frontends/web/src/routes/buy/pocket-terms.tsx
+++ b/frontends/web/src/routes/buy/pocket-terms.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { ChangeEvent } from 'react';
 import { Button, Checkbox } from '../../components/forms';
 import { setConfig } from '../../utils/config';
-import A from '../../components/anchor/anchor';
+import { A } from '../../components/anchor/anchor';
 import style from './terms.module.css';
 
 type TProps = {

--- a/frontends/web/src/routes/buy/terms.module.css
+++ b/frontends/web/src/routes/buy/terms.module.css
@@ -49,12 +49,6 @@
   margin: 2.5rem 0 0 0;
 }
 
-.link {
-  color: var(--color-blue);
-  cursor: pointer;
-  text-decoration: underline;
-}
-
 .table {
   overflow: auto;
 }

--- a/frontends/web/src/routes/settings/electrum-servers.tsx
+++ b/frontends/web/src/routes/settings/electrum-servers.tsx
@@ -22,7 +22,7 @@ import { TElectrumServer } from './types';
 import { getDefaultConfig } from '../../api/backend';
 import { getConfig, setConfig } from '../../utils/config';
 import { confirmation } from '../../components/confirm/Confirm';
-import { A } from '../../components/anchor/anchor';
+import { Button } from '../../components/forms';
 import style from './electrum.module.css';
 
 type Props = {
@@ -82,9 +82,14 @@ export const ElectrumServers = ({
   return (
     <div className={style.serversContainer}>
       <div className="row">
-        <div className={['flex flex-row flex-between flex-items-center', style.titleContainer].join(' ')}>
-          <h4 className="subTitle m-none">{t('settings.electrum.servers')}</h4>
-          <A href="#" className={['labelLarge labelLink', style.resetLink].join(' ')} onClick={resetToDefault}>{t('settings.electrum.reset')}</A>
+        <div className="flex flex-row flex-between flex-items-center">
+          <h4 className="subTitle">{t('settings.electrum.servers')}</h4>
+          <Button
+            transparent
+            className={style.resetLink}
+            onClick={resetToDefault}>
+            {t('settings.electrum.reset')}
+          </Button>
         </div>
         <ul className={style.servers}>
           {

--- a/frontends/web/src/routes/settings/electrum-servers.tsx
+++ b/frontends/web/src/routes/settings/electrum-servers.tsx
@@ -22,8 +22,8 @@ import { TElectrumServer } from './types';
 import { getDefaultConfig } from '../../api/backend';
 import { getConfig, setConfig } from '../../utils/config';
 import { confirmation } from '../../components/confirm/Confirm';
+import { A } from '../../components/anchor/anchor';
 import style from './electrum.module.css';
-import A from '../../components/anchor/anchor';
 
 type Props = {
   coin: 'btc' | 'tbtc' | 'ltc' | 'tltc';

--- a/frontends/web/src/routes/settings/electrum.module.css
+++ b/frontends/web/src/routes/settings/electrum.module.css
@@ -1,11 +1,3 @@
-.titleContainer {
-    margin-bottom: var(--space-half);
-}
-
-.titleContainer > span {
-    margin-bottom: 0 !important;
-}
-
 .title {
     margin: 0;
     font-size: var(--size-subheader);

--- a/frontends/web/src/style/layout.css
+++ b/frontends/web/src/style/layout.css
@@ -311,6 +311,7 @@
 .p-top-default { padding-top: var(--space-default) !important; }
 .p-top-default-extra { padding-top: calc(var(--space-default) * 1.5) !important; }
 .p-top-large { padding-top: var(--space-large) !important; }
+.p-right-none { padding-right: 0 !important; }
 .p-right-quarter { padding-right: var(--space-quarter) !important; }
 .p-right-half { padding-right: var(--space-half) !important; }
 .p-right-default { padding-right: var(--space-default) !important; }
@@ -319,6 +320,7 @@
 .p-bottom-half { padding-bottom: var(--space-half) !important; }
 .p-bottom-default { padding-bottom: var(--space-default) !important; }
 .p-bottom-large { padding-bottom: calc(var(--space-half) * 1.5) !important; }
+.p-left-none { padding-left: 0 !important; }
 .p-left-quarter { padding-left: var(--space-quarter) !important; }
 .p-left-half { padding-left: var(--space-half) !important; }
 .p-left-default { padding-left: var(--space-default) !important; }


### PR DESCRIPTION
The anchor component initially only supported links to external urls which opened in the native browser.

With exchange recommendations linking to internal routes got added in c595e1d8a741bb75af190e54d0ae692854c91fe2

This was linked from the guide, so there is some logic to close the guide after clicking an internal link. Since we removed exchanges recommendation support for internal urls is not needed and could probably be removed completely.

### Type:

Anchor component should be used for outgoing links, but was also used as buttons.

Changed anchors that used onClick to Button component.

### Styling:

Most anchors should look like a link (blue + underlines), changed
default styling of A component.

Other changes are:
- className should be added together with internal anchor className
- added tabindex so anchors can be focused with keyboard navigation

Used in:
- Tansaction details
- UTXO selection (coincontrol)
- AppDownloadLink
- Banner
- Guide/Entry
- Exchanges terms