### PR TITLE
backend/banner: deactivate banner when device is removed

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -610,7 +610,7 @@ func (backend *Backend) Register(theDevice device.Interface) error {
 
 // Deregister deregisters the device with the given ID from this backend.
 func (backend *Backend) Deregister(deviceID string) {
-	if _, ok := backend.devices[deviceID]; ok {
+	if device, ok := backend.devices[deviceID]; ok {
 		backend.onDeviceUninit(deviceID)
 		delete(backend.devices, deviceID)
 		backend.DeregisterKeystore()
@@ -622,6 +622,13 @@ func (backend *Backend) Deregister(deviceID string) {
 			Subject: "devices/registered",
 			Action:  action.Reload,
 		})
+		switch device.ProductName() {
+		case bitbox.ProductName:
+			backend.banners.Deactivate(banners.KeyBitBox01)
+		case bitbox02.ProductName:
+			backend.banners.Deactivate(banners.KeyBitBox02)
+		}
+
 	}
 }
 

--- a/backend/banners/banners.go
+++ b/backend/banners/banners.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/logging"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/observable/action"
@@ -71,7 +72,8 @@ type Banners struct {
 		BitBox02 *Message `json:"bitbox02"`
 	}
 
-	active map[MessageKey]struct{}
+	active     map[MessageKey]struct{}
+	activeLock locker.Locker
 
 	log *logrus.Entry
 }
@@ -111,7 +113,23 @@ func (banners *Banners) Init(httpClient *http.Client) {
 
 // Activate invokes showing the message for the given key.
 func (banners *Banners) Activate(key MessageKey) {
+	defer banners.activeLock.Lock()()
 	banners.active[key] = struct{}{}
+	banners.Notify(observable.Event{
+		Subject: "banners/" + string(key),
+		Action:  action.Reload,
+	})
+}
+
+// Deactivate removes the message key from the active map and makes the frontend reload the banner.
+func (banners *Banners) Deactivate(key MessageKey) {
+	defer banners.activeLock.Lock()()
+	_, keyExists := banners.active[key]
+	if !keyExists {
+		banners.log.Errorf("Trying to deactivate unactivated key: %s", key)
+		return
+	}
+	delete(banners.active, key)
 	banners.Notify(observable.Event{
 		Subject: "banners/" + string(key),
 		Action:  action.Reload,
@@ -120,6 +138,7 @@ func (banners *Banners) Activate(key MessageKey) {
 
 // GetMessage gets a message for a key if it was activated. nil otherwise, or if no msg exists.
 func (banners *Banners) GetMessage(key MessageKey) *Message {
+	defer banners.activeLock.RLock()()
 	_, active := banners.active[key]
 	if !active {
 		return nil


### PR DESCRIPTION
This avoids showing a device related banner (e.g. warning about bb01 being at end of life) also after the device has been removed.