### PR TITLE
frontend: using `word-break: break-word` for sidebarLabel

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.module.css
+++ b/frontends/web/src/components/sidebar/sidebar.module.css
@@ -172,9 +172,11 @@ a.sidebarActive .single img,
     line-height: 1;
     flex: 1;
     padding-top: 0;
+    padding-right: var(--space-default);
     font-size: var(--size-default);
     font-weight: 400;
     transition: all 0.2s ease;
+    word-break: break-word;
 }
 
 .activeGroup {


### PR DESCRIPTION
To break word (account name) appropriately, we need to use the `break-word` value for `word-break` css property for `.sidebarLabel`.

Previously, the sidebarLabel is able to break world "appropriately" when account name is either short or long **with** spaces. **Long names without spaces will cause the coin logo to shift to the left, which isn't ideal.**

Before:
![Screenshot 2023-08-08 at 12 48 12](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/17e0051f-c513-4fff-889f-0a6c1d9c9cd3)


After:
![Screenshot 2023-08-08 at 12 48 18](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/071eca6e-441a-4318-9267-5087e98ed7a7)
![Screenshot 2023-08-08 at 12 53 40](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/fd1578d4-e66b-41dd-96b6-e09395917aaa)
