### PR TITLE
docs/BUILD: bump min. required version for Debian and Fedora

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -3,9 +3,9 @@ systems may be possible but it is explicitly unsupported. The following
 platforms should be viable for development, building, and use of the BitBox
 Wallet application.
 
-* Debian GNU/Linux: Stretch and Buster or newer
+* Debian: 11 bullseye or newer
 * Ubuntu: 20.04+
-* Fedora: 26+
+* Fedora: 36+
 * MacOS: 10.13+
 * Windows: Windows 7+
 


### PR DESCRIPTION
Since 732c0ef3d815f7673ba7b7c824e54fb76fa5d06a we build on Ubuntu 20.0. Ubuntu 20 comes with glibc 2.31. Debian 9 (Stretch) and 10 (Buster) have glibc's older than that. Debian 11 (bullseye) is also at 2.31. Fedora 37 is at
2.36 (https://packages.fedoraproject.org/pkgs/glibc/glibc/). Fedora 36 has been EOL since 2023‑05‑16.