### PR TITLE
frontend: increase displayedValue setting item left padding

### DIFF
--- a/frontends/web/src/routes/settings/components/settingsItem/settingsItem.module.css
+++ b/frontends/web/src/routes/settings/components/settingsItem/settingsItem.module.css
@@ -39,6 +39,7 @@
     color: var(--color-secondary);
     font-size: 14px;
     margin: 0;
+    padding-left: var(--space-half);
     overflow: hidden;
     text-overflow: ellipsis;
 }


### PR DESCRIPTION
to prevent displayedValue text and the setting description text collapsing with one another, we adjusted the left padding of displayedValue text.

Before:
![Screenshot 2023-08-23 at 13 53 34](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/e23b550e-23fb-48ae-b8c0-ca10225601b6)

After:
![Screenshot 2023-08-23 at 13 53 45](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/4f77ba21-4c9b-4f11-990e-98c119be2359)

