### PR TITLE
golangci-lint: enable check that exported items have comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,6 +80,10 @@ linters-settings:
     line-length: 120
     # allow long comments.
     exclude: '//'
+  revive:
+    rules:
+      - name: exported
+        disabled: false
 
 linters:
   enable-all: true
@@ -133,7 +137,6 @@ linters:
     - gocyclo
     - nosnakecase
     - interfacebloat
-    - revive
     - musttag
     - structcheck
     - deadcode

--- a/backend/banners/banners.go
+++ b/backend/banners/banners.go
@@ -31,17 +31,22 @@ const bannersURL = "https://bitbox.swiss/updates/banners.json"
 // MessageKey enumerates the possible keys in the banners json.
 type MessageKey string
 
+// TypeCode determines the type of banner.
 type TypeCode string
 
 const (
+	// TypeWarning means the banner will be shown and styled as a warning.
 	TypeWarning TypeCode = "warning"
+	// TypeSuccess means the banner will be shown and styled as a success message.
 	TypeSuccess TypeCode = "success"
-	TypeInfo    TypeCode = "info"
+	// TypeInfo means the banner will be shown and styled as an info.
+	TypeInfo TypeCode = "info"
 )
 
 const (
 	// KeyBitBox01 is the message key for the event when a BitBox01 gets connected.
 	KeyBitBox01 MessageKey = "bitbox01"
+	// KeyBitBox02 is the message key for the event when a BitBox02 gets connected.
 	KeyBitBox02 MessageKey = "bitbox02"
 )
 

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -196,12 +196,14 @@ func (env *BackendEnvironment) GetSaveFilename(suggestedFilename string) string 
 	return ""
 }
 
+// SetDarkTheme implements backend.Environment.
 func (env *BackendEnvironment) SetDarkTheme(isDark bool) {
 	if env.SetDarkThemeFunc != nil {
 		env.SetDarkThemeFunc(isDark)
 	}
 }
 
+// DetectDarkTheme implements backend.Environment.
 func (env *BackendEnvironment) DetectDarkTheme() bool {
 	if env.DetectDarkThemeFunc != nil {
 		return env.DetectDarkThemeFunc()

--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -843,7 +843,8 @@ func (account *Account) SignTypedMsg(
 	return "0x" + hex.EncodeToString(signedMessage), nil
 }
 
-// TX proposal arguments received from Wallet Connect with Gas, GasPrice, Value and Nonce being optional.
+// WalletConnectArgs are the tx proposal arguments received from Wallet Connect with Gas, GasPrice,
+// Value and Nonce being optional.
 type WalletConnectArgs struct {
 	From     string `json:"from"`
 	To       string `json:"to"`
@@ -854,7 +855,7 @@ type WalletConnectArgs struct {
 	Nonce    string `json:"nonce,omitempty"`
 }
 
-// EthSignTypedMsg signs an Ethereum Tx received from WalletConnect.
+// EthSignWalletConnectTx signs an Ethereum Tx received from WalletConnect.
 func (account *Account) EthSignWalletConnectTx(
 	// send: whether transaction should be broadcast after signing
 	send bool,

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -266,7 +266,7 @@ func (keystore *Keystore) SignETHMessage(message []byte, keypath signing.Absolut
 	return nil, errp.New("unsupported")
 }
 
-// SignETHMessage implements keystore.Keystore.
+// SignETHTypedMessage implements keystore.Keystore.
 func (keystore *Keystore) SignETHTypedMessage(chainId uint64, data []byte, keypath signing.AbsoluteKeypath) ([]byte, error) {
 	return nil, errp.New("unsupported")
 }


### PR DESCRIPTION
This used to be included in golint or go vet, but was moved to the `revive` linter.

https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported

It is good practice to document all exported items.