### PR TITLE
frontend: created Dashboard screen for wallet connect

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -16,6 +16,7 @@
 
 import { apiGet, apiPost } from '../utils/request';
 import { ChartData } from '../routes/account/summary/chart';
+import { SuccessResponse } from './response';
 
 export type CoinCode = 'btc' | 'tbtc' | 'ltc' | 'tltc' | 'eth' | 'goeth';
 
@@ -63,6 +64,15 @@ export interface ITotalBalance {
 
 export const getAccountsTotalBalance = (): Promise<ITotalBalance> => {
   return apiGet('accounts/total-balance');
+};
+
+type TETHAddressByAccountCode = SuccessResponse & {
+  code: AccountCode;
+  name: string;
+}
+
+export const getETHAddressByAccountCode = (address: string): Promise<TETHAddressByAccountCode> => {
+  return apiPost('accounts/eth-account-code', { address });
 };
 
 export interface IStatus {
@@ -349,3 +359,4 @@ export const ethSignTypedMessage = (code: AccountCode, chainId: number, data: an
 export const ethSignWalletConnectTx = (code: AccountCode, send: boolean, chainId: number, tx: any): Promise<TSignWalletConnectTx> => {
   return apiPost(`account/${code}/eth-sign-wallet-connect-tx`, { send, chainId, tx });
 };
+

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1537,13 +1537,19 @@
       "button": "Connect",
       "dappLabel": "Enter URI address of DApp"
     },
+    "dashboard": {
+      "allSessions": "All sessions",
+      "newConnection": "New connection",
+      "noConnectedSessions": "No accounts are currently connected to any DApps."
+    },
     "invalidPairingChain": "Error in approving pairing. Please make sure to use one of the supported chains: {{chains}}",
     "pairingRequest": {
       "approve": "Approve Connection",
       "reject": "Reject",
       "title": "New connection request from"
     },
-    "pairingSuccess": "Dapp successfully connected. You can continue on the Dapp website."
+    "pairingSuccess": "Dapp successfully connected. You can continue on the Dapp website.",
+    "walletConnect": "WalletConnect"
   },
   "warning": {
     "receivePairing": "Please pair the BitBox to enable secure address verification. Go to 'Manage device' in the sidebar.",

--- a/frontends/web/src/routes/account/actionButtons.tsx
+++ b/frontends/web/src/routes/account/actionButtons.tsx
@@ -52,7 +52,7 @@ export const ActionButtons = ({ canSend, code, exchangeBuySupported, account }: 
           <span>{t('button.buy')}</span>
         </Link>
       )}
-      {walletConnectEnabled && <Link key="wallet-connect" to={`/account/${code}/wallet-connect/connect`} className={style.walletConnect}>
+      {walletConnectEnabled && <Link key="wallet-connect" to={`/account/${code}/wallet-connect/dashboard`} className={style.walletConnect}>
         <WalletConnectLight width={18} /> {!isLargeTablet && <span>Wallet Connect</span>}
       </Link>}
     </div>

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -44,7 +44,7 @@ export const BuyReceiveCTA = ({ code, unit, balanceList, exchangeBuySupported = 
   const isMobile = useMediaQuery('(max-width: 768px)');
 
   const onBuyCTA = () => route(code ? `/buy/info/${code}` : '/buy/info');
-  const onWalletConnect = () => route(`/account/${code}/wallet-connect/connect`);
+  const onWalletConnect = () => route(`/account/${code}/wallet-connect/dashboard`);
   const onReceiveCTA = () => {
     if (balanceList) {
       if (balanceList.length > 1) {

--- a/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
@@ -45,7 +45,7 @@ export const WCConnectForm = ({ code, uri, onInputChange, onSubmit }: TWCConnect
         <div className={styles.formButtonsContainer}>
           <Button
             secondary
-            onClick={() => route(`/account/${code}`)}>
+            onClick={() => route(`/account/${code}/wallet-connect/dashboard`)}>
             {t('dialog.cancel')}
           </Button>
           <Button

--- a/frontends/web/src/routes/account/walletconnect/components/header/header.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/header/header.tsx
@@ -16,6 +16,7 @@
  */
 
 import { WalletConnectDefaultLogo } from '../../../../../components/icon';
+import { truncateAddress } from '../../utils';
 import styles from './header.module.css';
 
 type TWalletConnectProps = {
@@ -24,7 +25,7 @@ type TWalletConnectProps = {
 }
 
 export const WCHeader = ({ receiveAddress, accountName }: TWalletConnectProps) => {
-  const displayedReceiveAddress = `${receiveAddress.substring(0, 6)}...${receiveAddress.substring(receiveAddress.length - 6)}`;
+  const displayedReceiveAddress = truncateAddress(receiveAddress);
   return (
     <div className={styles.headerContainer}>
       <WalletConnectDefaultLogo />

--- a/frontends/web/src/routes/account/walletconnect/components/incoming-pairing/incoming-pairing.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/incoming-pairing/incoming-pairing.tsx
@@ -21,6 +21,7 @@ import { Button } from '../../../../../components/forms';
 import { alertUser } from '../../../../../components/alert/Alert';
 import { SUPPORTED_CHAINS, web3wallet } from '../../utils';
 import styles from './incoming-pairing.module.css';
+import { useState } from 'react';
 
 type TIncomingPairingProps = {
     currentProposal: SignClientTypes.EventArguments['session_proposal'];
@@ -52,8 +53,10 @@ export const WCIncomingPairing = ({
   onReject,
   onApprove
 }: TIncomingPairingProps) => {
+  const [pairingLoading, setPairingLoading] = useState(false);
   const { t } = useTranslation();
   const handleApprovePairing = async () => {
+    setPairingLoading(true);
     try {
       const { id, params } = currentProposal;
       const { requiredNamespaces } = params;
@@ -83,15 +86,19 @@ export const WCIncomingPairing = ({
     } catch (e) {
       alertUser(t('walletConnect.invalidPairingChain', { chains: '\n•Ethereum \n•Optimism \n•BSC \n•Polygon \n•Fantom \n•Arbitrum One' }));
       console.error(e);
+    } finally {
+      setPairingLoading(false);
     }
   };
 
   const handleRejectPairing = async () => {
+    setPairingLoading(true);
     await web3wallet.rejectSession({
       id: currentProposal.id,
       reason: getSdkError('USER_REJECTED_METHODS')
     });
     onReject();
+    setPairingLoading(false);
   };
 
   return (
@@ -100,8 +107,8 @@ export const WCIncomingPairing = ({
       <PairingContainer pairingMetadata={pairingMetadata} />
       <p className={styles.receiveAddress}>{t('accountInfo.address')}: {receiveAddress}</p>
       <div className={styles.buttonsContainer}>
-        <Button secondary onClick={handleRejectPairing}>{t('walletConnect.pairingRequest.reject')}</Button>
-        <Button primary onClick={handleApprovePairing}>{t('walletConnect.pairingRequest.approve')}</Button>
+        <Button disabled={pairingLoading} secondary onClick={handleRejectPairing}>{t('walletConnect.pairingRequest.reject')}</Button>
+        <Button disabled={pairingLoading} primary onClick={handleApprovePairing}>{t('walletConnect.pairingRequest.approve')}</Button>
       </div>
     </div>
   );

--- a/frontends/web/src/routes/account/walletconnect/components/session-card/session-card.module.css
+++ b/frontends/web/src/routes/account/walletconnect/components/session-card/session-card.module.css
@@ -1,0 +1,100 @@
+.container {
+    background-color: var(--background-session-card);
+    display: flex;
+    width: 100%;
+    padding: calc(var(--space-half) + var(--space-quarter));
+}
+
+.container p {
+    color: var(--color-default);
+    font-size: 16px;
+    line-height: 1.9;
+    margin: 0;
+}
+
+.textDataContainer {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--space-quarter) + var(--space-half));
+}
+
+.receiveAddress {
+    color: var(--color-secondary);
+}
+
+.accountName {
+    font-weight: bold;
+    width: 240px;
+    padding-right: 16px;
+}
+
+.dAppMetadataAndIconContainer {
+    align-items: center;
+    display: flex;
+}
+
+.dAppMetadataAndIconContainer img {
+    width: var(--item-height);
+    height: var(--item-height);
+    margin-left: calc(var(--space-quarter) + var(--space-half));
+}
+
+.dAppNameAndUrlContainer {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--space-eight) * 2);
+    width: 240px;
+}
+
+.accountNameAndWalletContainer {
+    display: flex;
+}
+
+.buttonAndIconContainer {
+    align-items: flex-end;
+    display: flex;
+    margin-left: auto;
+}
+
+.buttonDisconnect {
+    height: unset;
+    padding: calc(var(--space-eight) + var(--space-quarter)) calc(var(--space-default) + var(--space-default));
+}
+
+@media (max-width: 768px) { 
+    .container {
+        padding: calc(var(--space-quarter) * 2);
+    }
+
+    .container p { 
+        font-size: var(--size-default);
+    }
+
+    .textDataContainer {
+        gap: var(--space-quarter);
+        width: 50%;
+    }
+
+    .dAppNameAndUrlContainer,
+    .accountName {
+        width: 100%;
+    }
+
+    .buttonAndIconContainer {
+        flex-direction: column;
+        justify-content: flex-end;
+    }
+
+    .buttonDisconnect {
+        font-size: var(--size-default);
+        height: var(--item-height-small);
+        padding: var(--space-eight) calc(var(--space-quarter) + var(--space-half));
+    }
+
+    .buttonAndIconContainer img {
+        height: var(--item-height-small);
+        width: var(--item-height-small);
+        margin-top: var(--space-default);
+        margin-bottom: var(--space-default);
+    }
+}

--- a/frontends/web/src/routes/account/walletconnect/components/session-card/session-card.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/session-card/session-card.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CoreTypes } from '@walletconnect/types';
+import { Button } from '../../../../../components/forms';
+import { useTranslation } from 'react-i18next';
+import { useLoad } from '../../../../../hooks/api';
+import { getETHAddressByAccountCode } from '../../../../../api/account';
+import { truncateAddress } from '../../utils';
+import styles from './session-card.module.css';
+
+type TTextDataProps = {
+    accountName: string;
+    receiveAddress: string;
+    dAppName: string;
+    dAppUrl: string;
+    iconUrl?: string;
+}
+
+type TWCSessionCardProps = {
+  metadata: CoreTypes.Metadata;
+  onDisconnect: () => void;
+  receiveAddress: string;
+}
+
+const TextData = ({ accountName, receiveAddress, dAppName, dAppUrl, iconUrl }: TTextDataProps) => {
+  return <div className={styles.textDataContainer}>
+
+    <div className={styles.accountNameAndWalletContainer}>
+      <p className={styles.accountName}>{accountName}</p>
+      <p className={`${styles.receiveAddress} hide-on-small`}>{receiveAddress}</p>
+    </div>
+
+    <p className={`${styles.receiveAddress} show-on-small`}>{receiveAddress}</p>
+
+    <div className={styles.dAppMetadataAndIconContainer}>
+      <div className={styles.dAppNameAndUrlContainer}>
+        <p>{dAppName}</p>
+        <p className={styles.dappUrl}>{dAppUrl}</p>
+      </div>
+      {iconUrl && <img className="hide-on-small" src={iconUrl} alt="dApp icon" />}
+    </div>
+
+  </div>;
+};
+
+
+export const WCSessionCard = ({ metadata, receiveAddress, onDisconnect }: TWCSessionCardProps) => {
+  const { t } = useTranslation();
+  const { name, url, icons } = metadata;
+  const accountDetail = useLoad(() => getETHAddressByAccountCode(receiveAddress), []);
+  const truncatedAddress = truncateAddress(receiveAddress);
+  const accountName = accountDetail && accountDetail.success ? accountDetail.name : '';
+
+  return (
+    <div className={styles.container}>
+      <TextData
+        accountName={accountName}
+        receiveAddress={truncatedAddress}
+        dAppName={name}
+        dAppUrl={url}
+        iconUrl={icons[0]}
+      />
+      <div className={styles.buttonAndIconContainer}>
+        <img className="show-on-small" src={icons[0]} alt="logo" />
+        <Button className={styles.buttonDisconnect} onClick={onDisconnect} danger>{t('settings.electrum.remove-server')}</Button>
+      </div>
+    </div>
+  );
+};

--- a/frontends/web/src/routes/account/walletconnect/components/success-pairing/success-pairing.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/success-pairing/success-pairing.tsx
@@ -31,7 +31,7 @@ export const WCSuccessPairing = ({ accountCode }: TProps) => {
     <div className={styles.container}>
       <AnimatedChecked className={styles.successIcon} />
       <p className={styles.successText}>{t('walletConnect.pairingSuccess')}</p>
-      <Button primary onClick={() => route(`/account/${accountCode}`)}>{t('button.done')}</Button>
+      <Button primary onClick={() => route(`/account/${accountCode}/wallet-connect/dashboard`)}>{t('button.done')}</Button>
     </div>
   );
 };

--- a/frontends/web/src/routes/account/walletconnect/dashboard.module.css
+++ b/frontends/web/src/routes/account/walletconnect/dashboard.module.css
@@ -1,0 +1,75 @@
+.buttonNewConnection {
+    height: calc(var(--space-default) + var(--space-quarter));
+}
+
+.headerContainer {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: calc(var(--space-half) + var(--space-quarter));
+}
+
+.headerContainer p {
+    margin: 0;
+}
+
+.headerContainer p.receiveAddress { 
+    color: var(--color-secondary);
+    margin-top: var(--space-quarter);
+    font-size: 16px;
+}
+
+.noConnectedSessions {
+    color: var(--color-secondary);
+    font-size: 16px;
+    margin: 0;
+    margin-top: var(--space-large);
+    text-align: center;
+}
+
+.separator {
+    background: var(--color-disabled);
+    border: none;
+    height: 2px;
+    margin: 0;
+}
+
+.sessionCardsContainer {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--space-quarter) + var(--space-half));
+}
+
+.allSessionsHeading {
+    color: var(--color-secondary);
+    font-size: 16px;
+    margin: 0;
+    margin-top: var(--space-half);
+}
+
+
+@media (max-width: 768px) {
+    .buttonNewConnection {
+        height: var(--space-default);
+        padding: 0 16px;
+    }
+
+    .headerContainer p {
+        font-size: 16px;
+    }
+    
+    .headerContainer p.receiveAddress,
+    .noConnectedSessions,
+    .allSessionsHeading
+    { 
+        font-size: var(--size-default);
+    }
+
+    .sessionCardsContainer {
+        gap: var(--space-half);
+    }
+
+    .allSessionsHeading {
+        margin-top: var(--space-quarter);
+    }
+}

--- a/frontends/web/src/routes/account/walletconnect/dashboard.tsx
+++ b/frontends/web/src/routes/account/walletconnect/dashboard.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLoad } from '../../../hooks/api';
+import { SessionTypes } from '@walletconnect/types';
+import { getSdkError } from '@walletconnect/utils';
+import { route } from '../../../utils/route';
+import useInitialization, { getAddressFromEIPString, truncateAddress, web3wallet, } from './utils';
+import { IAccount, getReceiveAddressList } from '../../../api/account';
+import { Header, Main } from '../../../components/layout';
+import { View, ViewContent } from '../../../components/view/view';
+import { WCSessionCard } from './components/session-card/session-card';
+import { Button } from '../../../components/forms';
+import styles from './dashboard.module.css';
+
+type TProps = {
+  accounts: IAccount[];
+  code: string;
+}
+
+export const DashboardWalletConnect = ({ code, accounts }: TProps) => {
+  const isInitialized = useInitialization();
+  const { t } = useTranslation();
+  const [sessions, setSessions] = useState<SessionTypes.Struct[]>();
+  const receiveAddresses = useLoad(getReceiveAddressList(code));
+
+  const updateSessions = () => {
+    setSessions(Object.values(web3wallet?.getActiveSessions()));
+  };
+
+  useEffect(() => {
+    if (isInitialized) {
+      updateSessions();
+    }
+  }, [isInitialized]);
+
+  useEffect(() => {
+    if (isInitialized) {
+      web3wallet?.on('session_delete', updateSessions);
+      return () => {
+        web3wallet?.off('session_delete', updateSessions);
+      };
+    }
+  }, [isInitialized]);
+
+  const handleDisconnectSession = async (topic: string) => {
+    await web3wallet.disconnectSession({
+      topic,
+      reason: getSdkError('USER_DISCONNECTED'),
+    });
+    updateSessions();
+  };
+
+  if (!receiveAddresses || !isInitialized) {
+    return null;
+  }
+
+  const receiveAddress = truncateAddress(receiveAddresses[0].addresses[0].address);
+  const accountName = (accounts && accounts.find(acct => acct.code === code))?.name || '';
+  const hasSession = sessions && sessions.length > 0;
+
+  return (
+    <Main>
+      <Header
+        title={<h2>{t('walletConnect.walletConnect')}</h2>}
+      />
+      <View>
+        <ViewContent>
+          <div className={styles.headerContainer}>
+            <div>
+              <p>{accountName}</p>
+              <p className={styles.receiveAddress}>{receiveAddress}</p>
+            </div>
+            <Button className={styles.buttonNewConnection} onClick={() => route(`/account/${code}/wallet-connect/connect`)} primary>{t('walletConnect.dashboard.newConnection')}</Button>
+          </div>
+          <hr className={styles.separator} />
+          {hasSession &&
+            <div className={styles.sessionCardsContainer}>
+              <p className={styles.allSessionsHeading}>{t('walletConnect.dashboard.allSessions')}</p>
+              {sessions.map(session =>
+                <WCSessionCard
+                  key={session.topic}
+                  receiveAddress={getAddressFromEIPString(session.namespaces['eip155'].accounts[0])}
+                  metadata={session.peer.metadata}
+                  onDisconnect={() => handleDisconnectSession(session.topic)}
+                />
+              )}
+            </div>
+          }
+          {!hasSession &&
+            <p className={styles.noConnectedSessions}>{t('walletConnect.dashboard.noConnectedSessions')}</p>
+          }
+        </ViewContent>
+      </View>
+    </Main>
+  );
+};
+

--- a/frontends/web/src/routes/account/walletconnect/utils.ts
+++ b/frontends/web/src/routes/account/walletconnect/utils.ts
@@ -119,3 +119,15 @@ export async function pair(params: { uri: string }) {
   }
   await web3wallet?.core.pairing.pair({ uri });
 }
+
+export const getAddressFromEIPString = (address: string) => {
+  const parts = address.split(':');
+  return parts.length > 2 ? parts[2] : '';
+};
+
+export const truncateAddress = (address: string) => {
+  if (!address) {
+    return '';
+  }
+  return `${address.substring(0, 6)}...${address.substring(address.length - 6)}`;
+};

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -24,6 +24,7 @@ import { About } from './settings/about';
 import { AdvancedSettings } from './settings/advanced-settings';
 import { WalletConnect } from './account/walletconnect';
 import { ConnectScreenWalletConnect } from './account/walletconnect/connect';
+import { DashboardWalletConnect } from './account/walletconnect/dashboard';
 
 type TAppRouterProps = {
     devices: TDevices;
@@ -98,6 +99,13 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
   const AccWalletConnect = <InjectParams>
     <WalletConnect
       code={'' /* dummy to satisfy TS */}
+    />
+  </InjectParams>;
+
+  const AccDashboardWC = <InjectParams>
+    <DashboardWalletConnect
+      accounts={activeAccounts}
+      code={''}
     />
   </InjectParams>;
 
@@ -179,6 +187,7 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
         <Route path="info" element={AccInfo} />
         <Route path="wallet-connect" element={AccWalletConnect} />
         <Route path="wallet-connect/connect" element={AccConnectScreenWC} />
+        <Route path="wallet-connect/dashboard" element={AccDashboardWC} />
       </Route>
       <Route path="add-account" element={<AddAccount />} />
       <Route path="account-summary" element={AccountsSummaryEl} />

--- a/frontends/web/src/style/variables.css
+++ b/frontends/web/src/style/variables.css
@@ -122,6 +122,7 @@
     --background-quaternary: var(--color-mediumgray);
     --background-custom-select-hover: var(--color-powder-blue);
     --background-custom-select-selected: var(--color-pale-ice-blue);
+    --background-session-card: var(--color-white);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -148,6 +149,7 @@
         --background-quaternary: var(--color-dark);
         --background-custom-select-hover: var(--color-dark);
         --background-custom-select-selected: var(--color-dark);
+        --background-session-card: var(--color-softblack);
     }
 }
 @media (prefers-color-scheme: light) {
@@ -174,6 +176,7 @@
         --background-quaternary: var(--color-dark);
         --background-custom-select-hover: var(--color-dark);
         --background-custom-select-selected: var(--color-dark);
+        --background-session-card: var(--color-softblack);
     }
 }
 


### PR DESCRIPTION
The dashboard screen contains all connected WC sessions of all accounts in the bitbox (to dApps), as well as a button to go to the connect screen.

It also contains some general information of the currently opened account such as the account name and its receive/wallet address.

Preview:
<img width="420" alt="Screenshot 2023-09-02 at 12 58 05" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/a92aec97-0a0b-4ef0-a6cc-abe37a0ad48b">
<img width="1488" alt="Screenshot 2023-09-02 at 12 58 10" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/1fbbbbef-2182-4604-b40d-cc8d5fbbf7cd">
