### PR TITLE
frontend/receive: limit receiving to p2wpkh for insured accounts

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1222,6 +1222,7 @@
     "description": "Your BitBox generated the following {{bits}}-bit random number:"
   },
   "receive": {
+    "bitsuranceWarning": "This is an insured account, meaning it can only receive to Native Segwit. This is so you don't accidently receive to Wrapped Segwit or Taproot, which are not insured.",
     "changeScriptType": "Change address type",
     "label": "Your address",
     "onlyThisCoin": {

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -205,24 +205,30 @@ export const Receive = ({
                     <Dialog open={scriptTypeDialogOpened} onClose={() => setAddressDialog(undefined)} medium title={t('receive.changeScriptType')} >
                       {availableScriptTypes.current && availableScriptTypes.current.map((scriptType, i) => (
                         <div key={scriptType}>
-                          {addressDialog && <>
-                            <Radio
-                              checked={addressDialog.addressType === i}
-                              id={scriptType}
-                              name="scriptType"
-                              onChange={() => setAddressDialog({ addressType: i })}
-                              title={getScriptName(scriptType)}>
-                              {t(`receive.scriptType.${scriptType}`)}
-                            </Radio>
-                            {scriptType === 'p2tr' && addressDialog.addressType === i && (
-                              <Message type="warning">
-                                {t('receive.taprootWarning')}
-                              </Message>
-                            )}
-                          </>
-                          }
+                          {addressDialog && (!account?.bitsuranceId || scriptType === 'p2wpkh') && (
+                            <>
+                              <Radio
+                                checked={addressDialog.addressType === i}
+                                id={scriptType}
+                                name="scriptType"
+                                onChange={() => setAddressDialog({ addressType: i })}
+                                title={getScriptName(scriptType)}>
+                                {t(`receive.scriptType.${scriptType}`)}
+                              </Radio>
+                              {scriptType === 'p2tr' && addressDialog.addressType === i && (
+                                <Message type="warning">
+                                  {t('receive.taprootWarning')}
+                                </Message>
+                              )}
+                            </>
+                          )}
                         </div>
                       ))}
+                      {account?.bitsuranceId && (
+                        <Message type="warning">
+                          {t('receive.bitsuranceWarning')}
+                        </Message>
+                      )}
                       <DialogButtons>
                         <Button primary type="submit">
                           {t('button.done')}


### PR DESCRIPTION
Bitsurance service only covers funds received on native segwit addresses. This limits the receiving options dialog to this script type for insured accounts, in order to avoid users to accidently receiving on uncovered addresses.