### PR TITLE
frontend: created WC QR code reading functionality

### DIFF
--- a/frontends/web/src/components/scanqrdialog/scan-qr-dialog.module.css
+++ b/frontends/web/src/components/scanqrdialog/scan-qr-dialog.module.css
@@ -1,0 +1,13 @@
+.qrVideo {
+    width: 100%;
+    margin-bottom: var(--spacing-default);
+}
+
+.spinnerAnimationContainer {
+    align-items: center;
+    display: flex;
+    height: 0;
+    justify-content: center;
+    position: relative;
+    top: calc(300px / 2) /*300px is the height of video element in ScanQRDialog*/
+}

--- a/frontends/web/src/components/scanqrdialog/scan-qr-dialog.tsx
+++ b/frontends/web/src/components/scanqrdialog/scan-qr-dialog.tsx
@@ -15,21 +15,36 @@
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Dialog, DialogButtons } from '../../../../../components/dialog/dialog';
-import { Button } from '../../../../../components/forms';
-import { SpinnerAnimation } from '../../../../../components/spinner/SpinnerAnimation';
-import style from '../../send.module.css';
+import { Dialog, DialogButtons } from '../dialog/dialog';
+import { Button } from '../forms';
+import { SpinnerAnimation } from '../spinner/SpinnerAnimation';
+import style from './scan-qr-dialog.module.css';
 
 type TProps = {
   activeScanQR: boolean;
   onToggleScanQR: () => void;
 }
 
+export const QRVideo = () => {
+  const [videoLoading, setVideoLoading] = useState(true);
+  return (<>
+    {videoLoading &&
+        <div className={style.spinnerAnimationContainer}>
+          <SpinnerAnimation />
+        </div>
+    }
+    <video
+      id="video"
+      height={300 /* fix height to avoid ugly resize effect after open */}
+      className={style.qrVideo}
+      onLoadedData={() => setVideoLoading(false)}
+    />
+  </>);
+};
+
 export const ScanQRDialog = ({ activeScanQR, onToggleScanQR }: TProps) => {
   const { t } = useTranslation();
-  const [videoLoading, setVideoLoading] = useState(true);
   const toggleScanQR = () => {
-    setVideoLoading(true);
     onToggleScanQR();
   };
   return (
@@ -37,19 +52,8 @@ export const ScanQRDialog = ({ activeScanQR, onToggleScanQR }: TProps) => {
       open={activeScanQR}
       title={t('send.scanQR')}
       onClose={toggleScanQR}>
-      {videoLoading &&
-        <div className={style.spinnerAnimationContainer}>
-          <SpinnerAnimation />
-        </div>
-      }
-      <video
-        id="video"
-        width={400}
-        height={300 /* fix height to avoid ugly resize effect after open */}
-        className={style.qrVideo}
-        onLoadedData={() => setVideoLoading(false)}
-      />
 
+      <QRVideo />
       <DialogButtons>
         <Button
           secondary

--- a/frontends/web/src/hooks/qrcodescanner.test.ts
+++ b/frontends/web/src/hooks/qrcodescanner.test.ts
@@ -36,6 +36,7 @@ describe('useQRCodeScanner', () => {
   it('should determine if a camera is available', async () => {
     const qrCodeReaderRef = { current: mockedQRCodeReaderInstance() } as unknown as MutableRefObject<BrowserQRCodeReader | undefined>;
     const props = {
+      onError: () => {},
       qrCodeReaderRef,
       activeScanQR: false,
       onChangeActiveScanQR: jest.fn(),
@@ -58,6 +59,7 @@ describe('useQRCodeScanner', () => {
     const parseQRResult = jest.fn();
 
     const props = {
+      onError: () => {},
       qrCodeReaderRef,
       activeScanQR: true,
       onChangeActiveScanQR,

--- a/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.tsx
@@ -21,9 +21,10 @@ import { getReceiveAddressList } from '../../../../../api/account';
 import DarkModeContext from '../../../../../contexts/DarkmodeContext';
 import { Input } from '../../../../../components/forms';
 import { QRCodeLight, QRCodeDark } from '../../../../../components/icon';
-import { ScanQRDialog } from '../dialogs/scan-qr-dialog';
+import { ScanQRDialog } from '../../../../../components/scanqrdialog/scan-qr-dialog';
 import { BrowserQRCodeReader } from '@zxing/library';
 import { useQRCodeScanner } from '../../../../../hooks/qrcodescanner';
+import { alertUser } from '../../../../../components/alert/Alert';
 import style from '../../send.module.css';
 
 type TToggleScanQRButtonProps = {
@@ -41,10 +42,13 @@ type TReceiverAddressInputProps = {
     onChangeActiveScanQR: (activeScanQR: boolean) => void
 }
 
-const ScanQRButton = ({ onClick }: TToggleScanQRButtonProps) => {
+export const ScanQRButton = ({ onClick }: TToggleScanQRButtonProps) => {
   const { isDarkMode } = useContext(DarkModeContext);
   return (
-    <button onClick={onClick} className={style.qrButton}>
+    <button onClick={(e) => {
+      e.preventDefault();
+      onClick();
+    }} className={style.qrButton}>
       {isDarkMode ? <QRCodeLight /> : <QRCodeDark />}
     </button>);
 };
@@ -62,6 +66,7 @@ export const ReceiverAddressInput = ({
   const { t } = useTranslation();
   const qrCodeReader = useRef<BrowserQRCodeReader>();
   const hasCamera = useQRCodeScanner({
+    onError: (error) => alertUser(error.message || error),
     qrCodeReaderRef: qrCodeReader,
     activeScanQR,
     onChangeActiveScanQR,
@@ -82,7 +87,6 @@ export const ReceiverAddressInput = ({
     }
   };
 
-
   const toggleScanQR = () => {
     if (activeScanQR) {
       if (qrCodeReader.current) {
@@ -92,9 +96,7 @@ export const ReceiverAddressInput = ({
       onChangeActiveScanQR(false);
       return;
     }
-
     onChangeActiveScanQR(true);
-
   };
 
   return (

--- a/frontends/web/src/routes/account/send/send.module.css
+++ b/frontends/web/src/routes/account/send/send.module.css
@@ -92,11 +92,6 @@
     height: 18px;
 }
 
-.qrVideo {
-    width: 100%;
-    margin-bottom: var(--spacing-default);
-}
-
 .confirmItem p {
     margin-top: var(--space-quarter);
     word-break: break-all;
@@ -112,13 +107,4 @@
     font-size: var(--size-small);
     font-weight: 400;
     margin-top: 0;
-}
-
-.spinnerAnimationContainer {
-    align-items: center;
-    display: flex;
-    height: 0;
-    justify-content: center;
-    position: relative;
-    top: calc(300px / 2) /*300px is the height of video element in ScanQRDialog*/
 }

--- a/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.module.css
+++ b/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.module.css
@@ -3,11 +3,42 @@
     flex-direction: column;
 }
 
-.formContainer p.label {
-    margin-bottom: var(--space-half);
-}
-
 .formButtonsContainer {
     display: flex;
     justify-content: space-between;
+}
+
+.inputWithIcon {
+    position: relative;
+}
+
+.inputWithIcon input {
+    padding-right: calc(var(--spacing-default) * 2 + 18px);
+}
+
+@media (max-width: 768px) {
+    .formButtonsContainer {
+        flex-direction: column-reverse;
+        gap: var(--space-half);
+        margin-top: calc(var(--space-half) + var(--space-quarter));
+    }
+
+    .mobileQRScanner {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: var(--space-half);
+    }
+
+    .mobileQRScanner video {
+        margin: 0 auto;
+        max-width: 300px;
+        object-fit: cover;
+    }
+
+    .mobileQRScanner .scanQRLabel {
+        margin-bottom: var(--space-quarter);
+        margin-left: auto;
+        margin-right: auto;
+        text-align: center;
+    }
 }

--- a/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
@@ -15,10 +15,16 @@
  * limitations under the License.
  */
 
-import { SetStateAction } from 'react';
+import { SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Input } from '../../../../../components/forms';
 import { route } from '../../../../../utils/route';
+import { useQRCodeScanner } from '../../../../../hooks/qrcodescanner';
+import { useMediaQuery } from '../../../../../hooks/mediaquery';
+import { BrowserQRCodeReader } from '@zxing/library';
+import { QRVideo, ScanQRDialog } from '../../../../../components/scanqrdialog/scan-qr-dialog';
+import { ScanQRButton } from '../../../send/components/inputs/receiver-address-input';
+import { alertUser } from '../../../../../components/alert/Alert';
 import styles from './connect-form.module.css';
 
 type TWCConnectFormProps = {
@@ -28,20 +34,95 @@ type TWCConnectFormProps = {
     onSubmit: (uri: string) => void;
 }
 
-export const WCConnectForm = ({ code, uri, onInputChange, onSubmit }: TWCConnectFormProps) => {
+const MobileQRScanner = () => {
   const { t } = useTranslation();
   return (
+    <div className={styles.mobileQRScanner}>
+      <p className={styles.scanQRLabel}>{t('send.scanQR')}</p>
+      <QRVideo />
+    </div>
+  );
+};
+
+export const WCConnectForm = ({ code, uri, onInputChange, onSubmit }: TWCConnectFormProps) => {
+  const { t } = useTranslation();
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const qrCodeReaderRef = useRef<BrowserQRCodeReader>();
+  const [activeScanQR, setActiveScanQR] = useState(isMobile ? true : false); // default to true on mobile
+  const handleQRScanError = (error: any) => {
+    // Preventing error alerting when user on mobile
+    // navigates from WC connect screen to another page
+    // (this error is 'classified' as NotFoundException).
+    if (error.toString().includes('NotFoundException') && isMobile) {
+      return;
+    }
+    // Otherwise, alert as normal.
+    alertUser(error.message || error);
+  };
+
+  const hasCamera = useQRCodeScanner({
+    onError: handleQRScanError,
+    qrCodeReaderRef,
+    activeScanQR,
+    onChangeActiveScanQR: () => setActiveScanQR(false),
+    parseQRResult: (uri: string) => onSubmit(uri)
+  });
+
+
+  const showMobileQRReader = isMobile && hasCamera;
+  const showQRButton = !isMobile && hasCamera;
+
+  const deactivateQRScanner = () => {
+    if (qrCodeReaderRef.current) {
+      // release camera;
+      qrCodeReaderRef.current.reset();
+    }
+    setActiveScanQR(false);
+    return;
+  };
+
+  const toggleScanQR = useCallback(() => {
+    if (activeScanQR) {
+      deactivateQRScanner();
+    }
+
+    // if, for some reason, mobile has no camera
+    if (isMobile && !hasCamera) {
+      setActiveScanQR(false);
+      return;
+    }
+
+    setActiveScanQR(true);
+  }, [activeScanQR, hasCamera, isMobile]);
+
+  useEffect(() => {
+    // tries to automatically activate QR reader functionality
+    // on mobile during page load.
+    if (isMobile) {
+      toggleScanQR();
+      return;
+    }
+
+  }, [activeScanQR, isMobile, toggleScanQR]);
+
+
+  return (
     <div className={styles.formContainer}>
-      <form onSubmit={(e) => {
-        e.preventDefault();
-        onSubmit(uri);
-      }}>
-        <p className={styles.label}>{t('walletConnect.connect.dappLabel')}</p>
+      {showMobileQRReader && <MobileQRScanner />}
+      <form
+        className={showMobileQRReader ? styles.showMobileQRReader : ''}
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSubmit(uri);
+        }}>
         <Input
+          label={t('walletConnect.connect.dappLabel')}
+          className={showQRButton ? styles.inputWithIcon : ''}
           value={uri}
           onInput={(e) => onInputChange(e.target.value)}>
+          {showQRButton && <ScanQRButton onClick={toggleScanQR} />}
         </Input>
-
+        <ScanQRDialog activeScanQR={activeScanQR && !isMobile} onToggleScanQR={toggleScanQR} />
         <div className={styles.formButtonsContainer}>
           <Button
             secondary


### PR DESCRIPTION
To improve WC user experience especially on mobile, we allow users to connect to dApps using  QR code provided by WC.

We use our existing qr code reader hook to read the QR codes.

Also fixed / adjusted some CSS, as well as moved `scan-qr-dialog` component from `send` to `components` directory as it's now technically a shared component (it's used here in WC qr code scanning desktop view, and still used in the send screen).

Previews: 

<img width="1488" alt="Screenshot 2023-09-04 at 12 52 53" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/106708d1-b42c-4a9c-804f-7796bef766e8">


<img width="415" alt="Screenshot 2023-09-04 at 17 17 22" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/5edf1baf-9bc3-4fd1-a335-9f3b1f57b561">

