### PR TITLE
testing: run tests with -race flag

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -89,6 +89,8 @@ type Account struct {
 	// if not nil, SendTx() will sign and send this transaction. Set by TxProposal().
 	activeTxProposal *TxProposal
 
+	// quitChan is used to send a quit signal to the accounts long running routines that
+	// should listen to it.
 	quitChan chan struct{}
 
 	log *logrus.Entry

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -17,9 +17,12 @@
 set -e
 set -x
 
+# Set go-langs data race detector options
+export GORACE="halt_on_error=1"
+
 # This script has to be called from the project root directory.
 go build -mod=vendor ./...
-go test -mod=vendor ./... -count=1 -v
+go test -race -mod=vendor ./... -count=1 -v
 golangci-lint run
 
 npm --prefix=frontends/web install # needed to install dev dependencies.


### PR DESCRIPTION
Add the -race flag for go test in the ci.sh script to detect race conditions.

Fix failing test by closing the channel and document the `quitChan` in the `Account` struct.


**note for reviewers:**

In case there are tests that we know have races but it does not matter or it's intentional we can use the [build tag](https://pkg.go.dev/go/build#hdr-Build_Constraints) `!race` to exclude that test. In this case we would need to add a script to build/run these tests without the `-race` flag.

I can drop the documentation commit if you want as it's a bit unnecessary.

Feel free to close this if you think adding this will be to annoying/slowing dev. down.