### PR TITLE
backend: add PreviousOutputs to TxProposal

### DIFF
--- a/backend/coins/btc/maketx/maketx.go
+++ b/backend/coins/btc/maketx/maketx.go
@@ -23,11 +23,20 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/errors"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/addresses"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/transactions"
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/sirupsen/logrus"
 )
+
+// PreviousOutputs represents a UTXO set. It also implements `txscript.PrevOutputFetcher`.
+type PreviousOutputs map[wire.OutPoint]*transactions.SpendableOutput
+
+// FetchPrevOutput implements `txscript.PrevOutputFetcher`.
+func (p PreviousOutputs) FetchPrevOutput(op wire.OutPoint) *wire.TxOut {
+	return p[op].TxOut
+}
 
 // TxProposal is the data needed for a new transaction to be able to display it and sign it.
 type TxProposal struct {
@@ -39,7 +48,8 @@ type TxProposal struct {
 	Fee         btcutil.Amount
 	Transaction *wire.MsgTx
 	// ChangeAddress is the address of the wallet to which the change of the transaction is sent.
-	ChangeAddress *addresses.AccountAddress
+	ChangeAddress   *addresses.AccountAddress
+	PreviousOutputs PreviousOutputs
 }
 
 // Total is amount+fee.
@@ -206,9 +216,13 @@ func NewTx(
 		}
 
 		inputs := make([]*wire.TxIn, len(selectedOutPoints))
+		previousOutputs := make(PreviousOutputs, len(selectedOutPoints))
 		for i, outPoint := range selectedOutPoints {
 			outPoint := outPoint // avoids referencing the same variable across loop iterations
 			inputs[i] = wire.NewTxIn(&outPoint, nil, nil)
+			previousOutputs[outPoint] = &transactions.SpendableOutput{
+				TxOut: spendableOutputs[outPoint].TxOut,
+			}
 		}
 		unsignedTransaction := &wire.MsgTx{
 			Version:  wire.TxVersion,
@@ -235,11 +249,12 @@ func NewTx(
 
 		setRBF(coin, unsignedTransaction)
 		return &TxProposal{
-			Coin:          coin,
-			Amount:        targetAmount,
-			Fee:           finalFee,
-			Transaction:   unsignedTransaction,
-			ChangeAddress: changeAddress,
+			Coin:            coin,
+			Amount:          targetAmount,
+			Fee:             finalFee,
+			Transaction:     unsignedTransaction,
+			ChangeAddress:   changeAddress,
+			PreviousOutputs: previousOutputs,
 		}, nil
 	}
 }

--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -237,11 +237,7 @@ func (account *Account) SendTx() error {
 	}
 
 	account.log.Info("Signing and sending transaction")
-	utxos, err := account.transactions.SpendableOutputs()
-	if err != nil {
-		return err
-	}
-	if err := account.signTransaction(txProposal, utxos, account.coin.Blockchain().TransactionGet); err != nil {
+	if err := account.signTransaction(txProposal, account.coin.Blockchain().TransactionGet); err != nil {
 		return errp.WithMessage(err, "Failed to sign transaction")
 	}
 

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -148,7 +148,7 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 	keyPaths := []string{}
 	transaction := btcProposedTx.TXProposal.Transaction
 	for index, txIn := range transaction.TxIn {
-		spentOutput, ok := btcProposedTx.PreviousOutputs[txIn.PreviousOutPoint]
+		spentOutput, ok := btcProposedTx.TXProposal.PreviousOutputs[txIn.PreviousOutPoint]
 		if !ok {
 			keystore.log.Error("There needs to be exactly one output being spent per input.")
 			return errp.New("There needs to be exactly one output being spent per input.")

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -303,7 +303,7 @@ func (keystore *keystore) signBTCTransaction(btcProposedTx *btc.ProposedTransact
 
 	inputs := make([]*firmware.BTCTxInput, len(tx.TxIn))
 	for inputIndex, txIn := range tx.TxIn {
-		prevOut, ok := btcProposedTx.PreviousOutputs[txIn.PreviousOutPoint]
+		prevOut, ok := btcProposedTx.TXProposal.PreviousOutputs[txIn.PreviousOutPoint]
 		if !ok {
 			keystore.log.Error("There needs to be exactly one output being spent per input.")
 			return errp.New("There needs to be exactly one output being spent per input.")

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -181,7 +181,7 @@ func (keystore *Keystore) SignTransaction(
 	transaction := btcProposedTx.TXProposal.Transaction
 	signatures := make([]*types.Signature, len(transaction.TxIn))
 	for index, txIn := range transaction.TxIn {
-		spentOutput, ok := btcProposedTx.PreviousOutputs[txIn.PreviousOutPoint]
+		spentOutput, ok := btcProposedTx.TXProposal.PreviousOutputs[txIn.PreviousOutPoint]
 		if !ok {
 			keystore.log.Error("There needs to be exactly one output being spent per input.")
 			return errp.New("There needs to be exactly one output being spent per input.")
@@ -201,7 +201,7 @@ func (keystore *Keystore) SignTransaction(
 			prv = txscript.TweakTaprootPrivKey(*prv, nil)
 			signatureHash, err := txscript.CalcTaprootSignatureHash(
 				btcProposedTx.SigHashes, txscript.SigHashDefault, transaction,
-				index, btcProposedTx.PreviousOutputs)
+				index, btcProposedTx.TXProposal.PreviousOutputs)
 			if err != nil {
 				return errp.Wrap(err, "Failed to calculate Taproot signature hash")
 			}


### PR DESCRIPTION
Refactor the TxProposal to contain PreviousOutputs which are all Outputs selected in coin selection as Inputs for the transaction.

I noticed we pass all spendable outputs as `previousOutputs` [here](https://github.com/digitalbitbox/bitbox-wallet-app/blob/master/backend/coins/btc/transaction.go#L240-L244) this is not a performance problem since it is a map but I felt like it would make more sense that it is available in the TxProposal since it knows which Outputs it used for its Transaction Inputs.

**motivation**: drafting CPFP I refactored the `SpendableOutputs` to also return unconfirmed outputs and it made me wonder if it is correct to pass all outputs to the `signTransaction` function.

**note**: maybe its not good that `maketx` depends on `transactions` now..but we need the methods defined on `SpendableOutput`. An alternative would be to just duplicate the SpendableOutput in maketx. 

This might be kind of a unnecessary refactor, I'm just trying to do something with the codebase, so feel free to close.