### PR TITLE
WIP draft show pending utxos

### DIFF
--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -145,14 +145,13 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (
 	if err != nil {
 		return nil, nil, err
 	}
+	utxo, err = account.transactions.SelectedOrSafeToSpendOutputs(args.SelectedUTXOs, utxo)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	wireUTXO := make(map[wire.OutPoint]maketx.UTXO, len(utxo))
 	for outPoint, txOut := range utxo {
-		// Apply coin control.
-		if len(args.SelectedUTXOs) != 0 {
-			if _, ok := args.SelectedUTXOs[outPoint]; !ok {
-				continue
-			}
-		}
 		wireUTXO[outPoint] = maketx.UTXO{
 			TxOut: txOut.TxOut,
 			Configuration: account.getAddress(

--- a/backend/coins/btc/transactions/transactions_test.go
+++ b/backend/coins/btc/transactions/transactions_test.go
@@ -178,6 +178,8 @@ func (s *transactionsSuite) TestUpdateAddressHistorySingleTxReceive() {
 	}
 	spendableOutputs, err := s.transactions.SpendableOutputs()
 	require.NoError(s.T(), err)
+	spendableOutputs, err = s.transactions.SelectedOrSafeToSpendOutputs(make(map[wire.OutPoint]struct{}), spendableOutputs)
+	require.NoError(s.T(), err)
 	require.Equal(s.T(),
 		map[wire.OutPoint]*transactions.SpendableOutput{
 			{Hash: tx1.TxHash(), Index: 0}: utxo,
@@ -195,6 +197,8 @@ func (s *transactionsSuite) TestUpdateAddressHistorySingleTxReceive() {
 func (s *transactionsSuite) TestSpendableOutputs() {
 	// Starts out empty.
 	spendableOutputs, err := s.transactions.SpendableOutputs()
+	require.NoError(s.T(), err)
+	spendableOutputs, err = s.transactions.SelectedOrSafeToSpendOutputs(make(map[wire.OutPoint]struct{}), spendableOutputs)
 	require.NoError(s.T(), err)
 	require.Empty(s.T(), spendableOutputs)
 	addresses, err := s.addressChain.EnsureAddresses()
@@ -222,6 +226,8 @@ func (s *transactionsSuite) TestSpendableOutputs() {
 
 	spendableOutputs, err = s.transactions.SpendableOutputs()
 	require.NoError(s.T(), err)
+	spendableOutputs, err = s.transactions.SelectedOrSafeToSpendOutputs(make(map[wire.OutPoint]struct{}), spendableOutputs)
+	require.NoError(s.T(), err)
 	// Two confirmed txs.
 	require.Len(s.T(), spendableOutputs, 2)
 	require.Contains(s.T(), spendableOutputs, wire.OutPoint{Hash: tx12.TxHash(), Index: 0})
@@ -237,6 +243,8 @@ func (s *transactionsSuite) TestSpendableOutputs() {
 	})
 	spendableOutputs, err = s.transactions.SpendableOutputs()
 	require.NoError(s.T(), err)
+	spendableOutputs, err = s.transactions.SelectedOrSafeToSpendOutputs(make(map[wire.OutPoint]struct{}), spendableOutputs)
+	require.NoError(s.T(), err)
 	require.Len(s.T(), spendableOutputs, 1)
 	require.NotContains(s.T(), spendableOutputs, wire.OutPoint{Hash: tx12.TxHash(), Index: 0})
 	require.Contains(s.T(), spendableOutputs, wire.OutPoint{Hash: tx22.TxHash(), Index: 0})
@@ -250,6 +258,8 @@ func (s *transactionsSuite) TestSpendableOutputs() {
 		{TXHash: blockchainpkg.TXHash(tx22Spend.TxHash()), Height: 0},
 	})
 	spendableOutputs, err = s.transactions.SpendableOutputs()
+	require.NoError(s.T(), err)
+	spendableOutputs, err = s.transactions.SelectedOrSafeToSpendOutputs(make(map[wire.OutPoint]struct{}), spendableOutputs)
 	require.NoError(s.T(), err)
 	require.Len(s.T(), spendableOutputs, 1)
 	// tx22 spent, not available anymore


### PR DESCRIPTION
I was thinking about implementing a feature to let users perform CPFP. As I learned this is more complex than making the outputs select-able and changing some fronted :) But this might be still a good change to set us up in the future for such changes.

My general idea is that `SpendableOutputs` _should_ return all outputs as it is our only api to those from the account. It should be the responsibility of functions calling it to filter the outputs appropriately, which is why I added the `SelectedOrSafeToSpendOutputs` method. I think that if there are selected outputs it should act like a `force select` ignoring the usual requirements.

Let me know what you think.

note: I think it would be worth to put more info (`confirmed bool`, `allInputOurs bool` right into the `SpendableOutput` struct so we do not have to hit the db again and return a potential error (see comment I left on the method)