### PR TITLE
frontend: make clean work cross platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ servewallet-mainnet-prodservers:
 buildweb:
 	node --version
 	npm --version
-	rm -rf ${WEBROOT}/build
+	cd ${WEBROOT} && ${MAKE} clean
 	cd ${WEBROOT} && npm ci --ignore-scripts
 	cd ${WEBROOT} && npm run build
 webdev:
@@ -84,7 +84,7 @@ osx-sec-check:
 ci:
 	./scripts/ci.sh
 clean:
-	rm -rf ${WEBROOT}/build
+	cd ${WEBROOT} && ${MAKE} clean
 	cd frontends/qt && $(MAKE) clean
 	cd frontends/android && $(MAKE) clean
 dockerinit:

--- a/frontends/web/Makefile
+++ b/frontends/web/Makefile
@@ -28,3 +28,5 @@ jstest-cover:
 listdeps:
 	@echo "Listing JavaScript production dependencies. Be careful to not pull in many deps accidentally."
 	npm list -prod -long
+clean:
+	npm run clean

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -47,6 +47,7 @@
     "start": "PORT=8080 react-scripts start",
     "startwindows": "set PORT=8080 && react-scripts start",
     "build": "react-scripts build",
+    "clean": "node -e \"fs.rmSync('./build', { recursive: true, force: true })\"",
     "lint": "eslint --ext .jsx,.js,.ts,.tsx ./src",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
make buildweb is required to install all frontend dependencies, and get started with using make webdev. Unfortunatelly it fails on windows as Powershell errors with

    process_begin: CreateProcess(NULL, rm -rf frontends/web/build, ...) failed.
    make (e=2): The system cannot find the file specified.
    make: *** [Makefile:55: buildweb] Error 2

This adds a propoer clean task to the frontend directory, without using rimraf or other dependency, just calling node directly.