### PR TITLE
Show recovery words warning

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -137,7 +137,8 @@
     },
     "showMnemonic": {
       "description": "You will be presented with your recovery words, which form a backup of your wallet. Write them down on paper.\n\n<strong>Do not store them digitally or take pictures of it.</strong>\n\n<strong>Do not say the words out loud.</strong>\n\n<strong>This backup is not password-protected.</strong>\n\nAfterwards, you will be asked to confirm each word.",
-      "title": "Show recovery words"
+      "title": "Show recovery words",
+      "warning": "<strong>Never share your recovery words with anyone.</strong> Your recovery words give full access to your wallet. If someone is asking you for your recovery words, it's a scammer, do not share them!"
     },
     "title": "Manage backups"
   },

--- a/frontends/web/src/routes/settings/components/device-settings/show-recovery-words-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/show-recovery-words-setting.tsx
@@ -19,9 +19,11 @@ import { useTranslation } from 'react-i18next';
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { ChevronRightDark } from '../../../../components/icon';
 import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
-import { MultilineMarkup } from '../../../../utils/markup';
+import { MultilineMarkup, SimpleMarkup } from '../../../../utils/markup';
 import { showMnemonic } from '../../../../api/bitbox02';
-import { confirmation } from '../../../../components/confirm/Confirm';
+import { Message } from '../../../../components/message/message';
+import { Dialog, DialogButtons } from '../../../../components/dialog/dialog';
+import { Button } from '../../../../components/forms';
 
 type TProps = {
   deviceID: string;
@@ -34,15 +36,14 @@ type TDialog = {
 const ShowRecoveryWordsSetting = ({ deviceID }: TProps) => {
   const { t } = useTranslation();
   const [inProgress, setInProgress] = useState(false);
+  const [showDialog, setShowDialog] = useState(false);
 
-  const handleShowMnemonic = () => {
-    confirmation(t('backup.showMnemonic.description'), async result => {
-      if (result) {
-        setInProgress(true);
-        await showMnemonic(deviceID);
-        setInProgress(false);
-      }
-    });
+  const confirmShowWords = async () => {
+    setShowDialog(false);
+    setInProgress(true);
+    await showMnemonic(deviceID);
+    setInProgress(false);
+
   };
   return (
     <>
@@ -50,9 +51,25 @@ const ShowRecoveryWordsSetting = ({ deviceID }: TProps) => {
         settingName={t('backup.showMnemonic.title')}
         secondaryText={t('deviceSettings.backups.showRecoveryWords.description')}
         extraComponent={<ChevronRightDark />}
-        onClick={handleShowMnemonic}
+        onClick={() => setShowDialog(true)}
       />
       <ShowMnemonicWaitDialog inProgress={inProgress} />
+
+      <Dialog title={t('backup.showMnemonic.title')} open={showDialog} onClose={() => setShowDialog(false)}>
+        <Message type="warning">
+          <SimpleMarkup tagName="span" markup={t('backup.showMnemonic.warning')}/>
+        </Message>
+        <p>
+          <MultilineMarkup
+            markup={t('backup.showMnemonic.description')}
+            tagName="span"
+            withBreaks />
+        </p>
+        <DialogButtons>
+          <Button primary onClick={confirmShowWords}>{t('dialog.confirm')}</Button>
+          <Button secondary onClick={() => setShowDialog(false)}>{t('dialog.cancel')}</Button>
+        </DialogButtons>
+      </Dialog>
     </>
   );
 };
@@ -66,6 +83,9 @@ const ShowMnemonicWaitDialog = ({ inProgress }: TDialog) => {
 
   return (
     <WaitDialog title={t('backup.showMnemonic.title')}>
+      <Message type="warning">
+        <SimpleMarkup tagName="span" markup={t('backup.showMnemonic.warning')}/>
+      </Message>
       <p>
         <MultilineMarkup
           markup={t('backup.showMnemonic.description')}


### PR DESCRIPTION
Show a warning in the app before showing the recovery words (mnemonic) on the device:
_Never share your recovery words with anyone. Your recovery words give full access to your wallet. If someone is asking you for your recovery words, it's a scammer, do not share them!_

~~Requires: #2262 to be merged-~~

~~Please point me in the right direction on how to style this, if I understood correctly it should not be part of the `description` in the `app.json` but another key (`warning`) this means it could also use a strong tag anywhere but we would need to use `SimpleMarkup` instead of `Message`.~~

~~note: **don't look at the 'files changed' diff as it contains commits from the confrim dialog refactor, select the last commit to see the relevant changes**~~