### PR TITLE
frontend/guide/entry: fix repeated key=''

### DIFF
--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -54,7 +54,7 @@ export const Entry: FunctionComponent<TProps> = props => {
       <div className={[style.entryContent, shown ? style.expanded : ''].join(' ')}>
         {shown ? (
           <div className="flex-1">
-            {entry.text.trim().split('\n').map(p => <p key={p}>{p}</p>)}
+            {entry.text.trim().split('\n').map((p, idx) => <p key={idx}>{p}</p>)}
             {entry.link && (
               <p>
                 <A


### PR DESCRIPTION
Multiple empty lines in an entry result in a duplicate key. We use the index instead. This is not a problem as the order of the lines in the entry never change.