### PR TITLE
frontend: fix slow camera detection

### DIFF
--- a/frontends/web/src/hooks/qrcodescanner.ts
+++ b/frontends/web/src/hooks/qrcodescanner.ts
@@ -18,12 +18,20 @@ import { RefObject, useEffect, useState } from 'react';
 import QrScanner from 'qr-scanner';
 import { useMountedRef } from './mount';
 
+const hasSomeCamera = async (): Promise<boolean> => {
+  if (!navigator.mediaDevices) {
+    return false;
+  }
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  return devices.some((device) => device.kind === 'videoinput');
+};
+
 export const useHasCamera = () => {
   const [hasCamera, setHasCamera] = useState(false);
   const mounted = useMountedRef();
 
   useEffect(() => {
-    QrScanner.hasCamera()
+    hasSomeCamera()
       .then(result => {
         if (mounted.current) {
           setHasCamera(result);


### PR DESCRIPTION
On macOS M1/M2 the whole send screen takes a long time to load and QrScanner icon is even slower. This is an indication that qr-scanner hasCamera takes very long to test if there are any available cameras.

https://github.com/nimiq/qr-scanner/blob/abcfe1bce2703721408d8ce7ebde94a359998506/src/qr-scanner.ts#L13-L54