### PR TITLE
frontend: optimise wc loading and web3wallet initialisation

### DIFF
--- a/frontends/web/src/contexts/WCWeb3WalletContext.tsx
+++ b/frontends/web/src/contexts/WCWeb3WalletContext.tsx
@@ -23,6 +23,7 @@ type Props = {
     pair: (params: {
         uri: string;
     }) => Promise<void>;
+    initializeWeb3Wallet: () => void;
 }
 
 export const WCWeb3WalletContext = createContext<Props>({} as Props);

--- a/frontends/web/src/routes/account/walletconnect/dashboard.tsx
+++ b/frontends/web/src/routes/account/walletconnect/dashboard.tsx
@@ -36,7 +36,7 @@ type TProps = {
 
 export const DashboardWalletConnect = ({ code, accounts }: TProps) => {
   const { t } = useTranslation();
-  const { web3wallet, isWalletInitialized } = useContext(WCWeb3WalletContext);
+  const { web3wallet, isWalletInitialized, initializeWeb3Wallet } = useContext(WCWeb3WalletContext);
   const [sessions, setSessions] = useState<SessionTypes.Struct[]>();
   const receiveAddresses = useLoad(getReceiveAddressList(code));
 
@@ -46,10 +46,12 @@ export const DashboardWalletConnect = ({ code, accounts }: TProps) => {
   }, [web3wallet]);
 
   useEffect(() => {
-    if (isWalletInitialized) {
-      updateSessions();
+    if (!web3wallet) {
+      initializeWeb3Wallet();
+      return;
     }
-  }, [isWalletInitialized, updateSessions]);
+    updateSessions();
+  }, [initializeWeb3Wallet, updateSessions, web3wallet]);
 
   useEffect(() => {
     if (isWalletInitialized) {


### PR DESCRIPTION
Every time a user visits `/wallet-connect/dashboard`, the app initialises the `web3wallet` object, achieved through the use of `Core` and `Web3Wallet`, which are lazy-loaded. The function is called `initializeWeb3Wallet`

Only on a successful dapp via WC connection, `hasUsedWalletConnect` is set to config. This condition essentially used to check if we should call `initializeWeb3Wallet` on app start (via provider), or on dashboard first visit.