### PR TITLE
frontend/account: add alert if insured account has uncovered utxos

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -10,7 +10,10 @@
     "insured": "Insured account",
     "maybeProxyError": "Tor proxy enabled. Ensure that your Tor proxy is running properly, or disable the proxy setting.",
     "reconnecting": "Lost connection, trying to reconnect…",
-    "syncedAddressesCount": "Scanned {{count}} addresses"
+    "syncedAddressesCount": "Scanned {{count}} addresses",
+    "uncoveredFunds": "You have coins on the following uncovered address types of your <strong>{{name}}</strong> account: {{uncovered}}.\nSince the account is insured, only coins received via the <strong>Native Segwit</strong> address type are covered. Coins on different address types, even if they are on the same account, are not insured.\nPlease move all your coins from the unsupported address types to the <strong>Native Segwit</strong> address type, so all your coins on this account are insured.",
+    "uncoveredFundsLink": "Follow this guide on how to move your coins.",
+    "warning": "Warning!\n"
   },
   "accountInfo": {
     "address": "Address",


### PR DESCRIPTION
Bitsurance service only covers p2wpkh utxos. This adds a check in the account page that warns the user in case the account is insured but there are uncovered utxos that need to be moved.