### PR TITLE
frontend: fix react 18 render warning

### DIFF
--- a/frontends/web/src/index.tsx
+++ b/frontends/web/src/index.tsx
@@ -16,15 +16,17 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { I18nextProvider } from 'react-i18next';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './app';
 import { i18n } from './i18n/i18n';
 import './style/index.css';
 
+const rootEl = document.getElementById('root') as HTMLDivElement;
+const root = createRoot(rootEl);
 
-ReactDOM.render(
+root.render(
   <React.StrictMode>
     <I18nextProvider i18n={i18n}>
       <React.Suspense fallback={null}>
@@ -33,6 +35,5 @@ ReactDOM.render(
         </BrowserRouter>
       </React.Suspense>
     </I18nextProvider>
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );


### PR DESCRIPTION
ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it’s running React 17.

https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis