### PR TITLE
frontend: move SkipForTesting to sidebar

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -32,6 +32,7 @@ import Logo, { AppLogoInverted } from '../icon/logo';
 import { useLocation } from 'react-router';
 import { CloseXWhite } from '../icon';
 import { isBitcoinOnly } from '../../routes/account/utils';
+import { SkipForTesting } from '../../routes/device/components/skipfortesting';
 import { Store } from '../../decorators/store';
 import style from './sidebar.module.css';
 
@@ -232,6 +233,7 @@ class Sidebar extends Component<Props> {
               <span className={style.sidebarLabel}>{t('sidebar.settings')}</span>
             </NavLink>
           </div>
+          { !keystores || keystores.length === 0 ? <SkipForTesting /> : null }
           {(debug && keystores?.some(({ type }) => type === 'software') && deviceIDs.length === 0) && (
             <div key="eject" className={style.sidebarItem}>
               <a href="#" onClick={eject}>

--- a/frontends/web/src/routes/device/bitbox01/bitbox01.module.css
+++ b/frontends/web/src/routes/device/bitbox01/bitbox01.module.css
@@ -136,14 +136,6 @@
     margin-bottom: 0;
 }
 
-.testingContainer {
-    margin-top: var(--space-default);
-}
-
-.testingContainer > * {
-    margin: 0 auto;
-}
-
 @media screen and (max-width: 640px) {
     .qrcodeContainer {
         width: 50%;

--- a/frontends/web/src/routes/device/components/skipfortesting.tsx
+++ b/frontends/web/src/routes/device/components/skipfortesting.tsx
@@ -16,32 +16,45 @@
 
 import React, { useState } from 'react';
 import { testRegister } from '../../../api/account';
+import { getTesting } from '../../../api/backend';
 import { Button } from '../../../components/forms';
 import { PasswordSingleInput } from '../../../components/password';
+import { Dialog, DialogButtons } from '../../../components/dialog/dialog';
+import { useLoad } from '../../../hooks/api';
+import { debug } from '../../../utils/env';
 
 export const SkipForTesting = () => {
+  const [dialog, setDialog] = useState(false);
+  const show = useLoad(debug ? getTesting : () => Promise.resolve(false));
   const [testPIN, setTestPIN] = useState('');
   const registerTestingDevice = async (e: React.SyntheticEvent) => {
     e.preventDefault();
     await testRegister(testPIN);
-  };
-  const handleFormChange = (value: string) => {
-    setTestPIN(value);
+    setDialog(false);
   };
 
-
+  if (!show) {
+    return null;
+  }
+  const title = 'Unlock software kestore';
   return (
-    <form onSubmit={registerTestingDevice} style={{ flexGrow: 0, maxWidth: 400, width: '100%', alignSelf: 'center' }}>
-      <PasswordSingleInput
-        type="password"
-        autoFocus
-        label="Test Password"
-        onValidPassword={handleFormChange}
-        value={testPIN} />
-      <Button type="submit" secondary>
-        Skip for Testing
-      </Button>
-    </form>
+    <>
+      <button onClick={() => setDialog(true)}>{title}</button>
+      <Dialog open={dialog} title={title} onClose={() => setDialog(false)}>
+        <form onSubmit={registerTestingDevice}>
+          <PasswordSingleInput
+            type="password"
+            autoFocus
+            label="Test Password"
+            onValidPassword={setTestPIN}
+            value={testPIN} />
+          <DialogButtons>
+            <Button primary type="submit">
+              Unlock
+            </Button>
+          </DialogButtons>
+        </form>
+      </Dialog>
+    </>
   );
-
 };

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -16,20 +16,15 @@
 
 import { useTranslation } from 'react-i18next';
 import { i18n } from '../../i18n/i18n';
-import { useLoad } from '../../hooks/api';
 import { useDarkmode } from '../../hooks/darkmode';
-import { getTesting } from '../../api/backend';
 import { Entry } from '../../components/guide/entry';
 import { Guide } from '../../components/guide/guide';
 import { AppLogo, AppLogoInverted, SwissMadeOpenSource, SwissMadeOpenSourceDark } from '../../components/icon/logo';
 import { Footer, Header } from '../../components/layout';
-import { debug } from '../../utils/env';
-import { SkipForTesting } from './components/skipfortesting';
 import style from './bitbox01/bitbox01.module.css';
 
 export const Waiting = () => {
   const { t } = useTranslation();
-  const testing = useLoad(debug ? getTesting : () => Promise.resolve(false));
   const { isDarkMode } = useDarkmode();
 
   return (
@@ -43,13 +38,6 @@ export const Waiting = () => {
               <h3 className={style.waitingText}>{t('welcome.insertDevice')}</h3>
               <p className={style.waitingDescription}>{t('welcome.insertBitBox02')}</p>
             </div>
-            {
-              testing && (
-                <div className={style.testingContainer}>
-                  <SkipForTesting />
-                </div>
-              )
-            }
           </div>
         </div>
         <Footer>


### PR DESCRIPTION
In watch-only, accounts can be loaded even if no keystore is connected. The debug "skip for testing" software keystore unlock would not be shown, as the app would always route to the portfolio.

We simply move it to the sidebar where it is always accessible.