### PR TITLE
frontend: improve/add err handling for WC connect attempt & pairing approval

### DIFF
--- a/frontends/web/src/contexts/WCWeb3WalletProvider.tsx
+++ b/frontends/web/src/contexts/WCWeb3WalletProvider.tsx
@@ -15,6 +15,7 @@
  */
 
 import { ReactNode, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { WCWeb3WalletContext } from './WCWeb3WalletContext';
 import { IWeb3Wallet } from '@walletconnect/web3wallet';
 import { getTopicFromURI, pairingHasEverBeenRejected } from '../utils/walletconnect';
@@ -26,6 +27,7 @@ type TProps = {
   }
 
 export const WCWeb3WalletProvider = ({ children }: TProps) => {
+  const { t } = useTranslation();
   const [web3wallet, setWeb3wallet] = useState<IWeb3Wallet>();
   const [isWalletInitialized, setIsWalletInitialized] = useState(false);
   const config = useLoad(getConfig);
@@ -77,12 +79,17 @@ export const WCWeb3WalletProvider = ({ children }: TProps) => {
       const topic = getTopicFromURI(uri);
       const hasEverBeenRejected = pairingHasEverBeenRejected(topic, web3wallet);
       if (hasEverBeenRejected) {
-        throw new Error('Please use a new URI!');
+        throw new Error(t('walletConnect.useNewUri'));
       }
       await web3wallet?.core.pairing.pair({ uri });
       setConfig({ frontend: { hasUsedWalletConnect: true } });
     } catch (e: any) {
-      console.error(`Wallet connect pairing error ${e}`);
+      console.error(`Wallet connect attempt to pair error ${e}`);
+      if (e.message.includes('Pairing already exists')) {
+        throw new Error(t('walletConnect.useNewUri'));
+      }
+      //unexpected error, display native error message
+      throw new Error(e.message);
     }
   };
 

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1570,6 +1570,7 @@
       "successfullySigned": "Request succesfully signed",
       "walletConnectRequest": "WalletConnect request"
     },
+    "useNewUri": "This URI has already been used to attempt a connection. Please use a new URI.",
     "walletConnect": "WalletConnect"
   },
   "warning": {

--- a/frontends/web/src/routes/account/walletconnect/components/incoming-pairing/incoming-pairing.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/incoming-pairing/incoming-pairing.tsx
@@ -85,9 +85,20 @@ export const WCIncomingPairing = ({
       });
 
       onApprove();
-    } catch (e) {
-      alertUser(t('walletConnect.invalidPairingChain', { chains: '\n•Ethereum \n•Optimism \n•BSC \n•Polygon \n•Fantom \n•Arbitrum One' }));
+    } catch (e: any) {
+      console.error(`Wallet connect approve pairing error ${e}`);
+
       console.error(e);
+      if (e.message.includes('Non conforming namespaces')) {
+        alertUser(t('walletConnect.invalidPairingChain',
+          {
+            chains: '\n•Ethereum \n•Optimism \n•BSC \n•Polygon \n•Fantom \n•Arbitrum One'
+          }));
+      } else {
+        //unexpected error, display native error message
+        alertUser(e.messsage);
+      }
+      await handleRejectPairing();
     } finally {
       setPairingLoading(false);
     }


### PR DESCRIPTION
alerts user using localised error messages for common errors during
an attempt to connect to a dapp and when approving a pairing request.

Otherwise, alert them using the native/default error message
from WC library.

In both cases, errors get logged.