### PR TITLE
frontend: adds loading state on dapp connect attempt using WC

### DIFF
--- a/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
@@ -27,6 +27,7 @@ import styles from './connect-form.module.css';
 
 type TWCConnectFormProps = {
     code: string;
+    connectLoading: boolean;
     uri: string;
     onInputChange: (value: SetStateAction<string>) => void;
     onSubmit: (uri: string) => void;
@@ -46,7 +47,13 @@ const MobileQRScanner = ({ onQRScanned }: TMobileQRScannerProps) => {
   );
 };
 
-export const WCConnectForm = ({ code, uri, onInputChange, onSubmit }: TWCConnectFormProps) => {
+export const WCConnectForm = ({
+  code,
+  uri,
+  onInputChange,
+  onSubmit,
+  connectLoading
+}: TWCConnectFormProps) => {
   const { t } = useTranslation();
   const isMobile = useMediaQuery('(max-width: 768px)');
   const hasCamera = useHasCamera();
@@ -76,8 +83,9 @@ export const WCConnectForm = ({ code, uri, onInputChange, onSubmit }: TWCConnect
           label={t('walletConnect.connect.dappLabel')}
           className={showQRButton ? styles.inputWithIcon : ''}
           value={uri}
+          readOnly={connectLoading}
           onInput={(e) => onInputChange(e.target.value)}>
-          {showQRButton && <ScanQRButton onClick={toggleScanQR} />}
+          {(showQRButton && !connectLoading) && <ScanQRButton onClick={toggleScanQR} />}
         </Input>
         <ScanQRDialog
           activeScanQR={activeScanQR && !isMobile}
@@ -87,11 +95,13 @@ export const WCConnectForm = ({ code, uri, onInputChange, onSubmit }: TWCConnect
         />
         <div className={styles.formButtonsContainer}>
           <Button
+            disabled={connectLoading}
             secondary
             onClick={() => route(`/account/${code}/wallet-connect/dashboard`)}>
             {t('dialog.cancel')}
           </Button>
           <Button
+            disabled={connectLoading}
             type="submit"
             primary
           >

--- a/frontends/web/src/routes/account/walletconnect/connect.tsx
+++ b/frontends/web/src/routes/account/walletconnect/connect.tsx
@@ -41,11 +41,14 @@ export const ConnectScreenWalletConnect = ({
 }: TProps) => {
   const [uri, setUri] = useState('');
   const [status, setStatus] = useState<TConnectStatus>('connect');
+  const [loading, setLoading] = useState(false);
   const { web3wallet, isWalletInitialized, pair } = useContext(WCWeb3WalletContext);
   const [currentProposal, setCurrentProposal] = useState<SignClientTypes.EventArguments['session_proposal']>();
   const receiveAddresses = useLoad(accountApi.getReceiveAddressList(code));
   const onSessionProposal = useCallback(
     (proposal: SignClientTypes.EventArguments['session_proposal']) => {
+      setUri('');
+      setLoading(false);
       setStatus('incoming_pairing');
       setCurrentProposal(proposal);
     },
@@ -77,12 +80,13 @@ export const ConnectScreenWalletConnect = ({
     if (!uri) {
       return;
     }
+    setLoading(true);
     try {
       await pair({ uri });
     } catch (err: any) {
       alertUser(err.message);
-    } finally {
       setUri('');
+      setLoading(false);
     }
   };
 
@@ -106,12 +110,15 @@ export const ConnectScreenWalletConnect = ({
               />
               <div className={styles.contentContainer}>
                 {status === 'connect' &&
-            <WCConnectForm
-              code={code}
-              uri={uri}
-              onInputChange={setUri}
-              onSubmit={handleConnect}
-            />}
+              <WCConnectForm
+                connectLoading={loading}
+                code={code}
+                uri={uri}
+                onInputChange={setUri}
+                onSubmit={async (uri) => {
+                  await handleConnect(uri);
+                }}
+              />}
                 {(status === 'incoming_pairing' && currentProposal) &&
               <WCIncomingPairing
                 currentProposal={currentProposal}

--- a/frontends/web/src/routes/account/walletconnect/dashboard.tsx
+++ b/frontends/web/src/routes/account/walletconnect/dashboard.tsx
@@ -85,7 +85,6 @@ export const DashboardWalletConnect = ({ code, accounts }: TProps) => {
       <GuidedContent>
         <Main>
           <Status
-            hidden={false}
             type="info"
             dismissible="walletConnectDisclaimerDismissed"
           >


### PR DESCRIPTION
uses loading state to disable buttons and text input when attempting to connect to a dapp using WC. Especially noticeable for slow connections


Previews below are created using a throttled network (which is very slow), available from chrome dev tools.

[Preview before, connect, cancel buttons, and textfield are interactable. Textfield also gets reset prematurely]:


https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/2ab4ad3f-010c-4822-bfdb-9df56f5a072b


[Preview after]:

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/2e81b6fe-0cd0-4c29-b721-de07d32c87a5



