### PR TITLE
frontend/hooks: fix permissions hook android bug

### DIFF
--- a/frontends/web/src/hooks/permissions.ts
+++ b/frontends/web/src/hooks/permissions.ts
@@ -35,7 +35,8 @@ export const useDevicePermission = (deviceName: TExperimentalDeviceName) => {
       // TypeScript broke this somehow in 4.4.2
       // https://github.com/microsoft/TypeScript/issues/33923
       // Type '"camera"' is not assignable to type 'PermissionName'.ts(2322)
-      .query({ name: deviceName } as unknown as PermissionDescriptor)
+      // `navigator.permissions` can be undefined on Android
+      ?.query({ name: deviceName } as unknown as PermissionDescriptor)
       .then((permissionStatus) => {
         permissionObject.current = permissionStatus;
         handlePermissionChange();


### PR DESCRIPTION
Recent commit 48eebe9 introduced a new hook to check for camera permissions and inform the user about that, that was causing a frontend exception on Android. This fixes the bug.