### PR TITLE
frontend: added guides on /dashboard and /connect WC pages

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -986,6 +986,20 @@
         "text": "Thanks for using this app built by Shift Crypto in Switzerland. We appreciate any input you have to share. Please give feedback using the link at the bottom.",
         "title": "Welcome to the BitBoxApp!"
       }
+    },
+    "walletConnect": {
+      "noPreviousConnections": {
+        "text": "If you are using a new phone/computer with the BitBoxApp, then you will need to connect to the dapps again. You will then see your coins on the dapp again like usual.",
+        "title": "I don't see my previous connections."
+      },
+      "supportedNetworks": {
+        "text": "Currently, only Ethereum mainnet is supported using WalletConnect in the BitBoxApp. To use other EVM compatible chains please use the Rabby browser extension wallet.",
+        "title": "What networks are supported?"
+      },
+      "whatIsWalletConnect": {
+        "text": "WalletConnect is a communication protocol for web3 applications. It allows you to conveniently connect to Ethereum based DApps and web wallets without using a third party app, which is particularly useful for Android users of the BitBoxApp.",
+        "title": "What is WalletConnect?"
+      }
     }
   },
   "headerssync": {

--- a/frontends/web/src/routes/account/walletconnect/connect.tsx
+++ b/frontends/web/src/routes/account/walletconnect/connect.tsx
@@ -15,16 +15,17 @@
  */
 
 import { useCallback, useContext, useEffect, useState } from 'react';
+import { SignClientTypes } from '@walletconnect/types';
 import { useLoad } from '../../../hooks/api';
 import * as accountApi from '../../../api/account';
-import { SignClientTypes } from '@walletconnect/types';
 import { WCWeb3WalletContext } from '../../../contexts/WCWeb3WalletContext';
-import { Header, Main } from '../../../components/layout';
+import { WCGuide } from './guide';
+import { TConnectStatus } from './types';
+import { GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
 import { alertUser } from '../../../components/alert/Alert';
 import { View, ViewContent } from '../../../components/view/view';
 import { WCHeader } from './components/header/header';
 import { WCConnectForm } from './components/connect-form/connect-form';
-import { TConnectStatus } from './types';
 import { WCIncomingPairing } from './components/incoming-pairing/incoming-pairing';
 import { WCSuccessPairing } from './components/success-pairing/success-pairing';
 import styles from './connect.module.css';
@@ -93,23 +94,25 @@ export const ConnectScreenWalletConnect = ({
   const receiveAddress = receiveAddresses[0].addresses[0].address;
 
   return (
-    <Main>
-      <Header />
-      <View verticallyCentered fullscreen={false}>
-        <ViewContent>
-          <WCHeader
-            accountName={accountName}
-            receiveAddress={receiveAddress}
-          />
-          <div className={styles.contentContainer}>
-            {status === 'connect' &&
+    <GuideWrapper>
+      <GuidedContent>
+        <Main>
+          <Header />
+          <View verticallyCentered fullscreen={false}>
+            <ViewContent>
+              <WCHeader
+                accountName={accountName}
+                receiveAddress={receiveAddress}
+              />
+              <div className={styles.contentContainer}>
+                {status === 'connect' &&
             <WCConnectForm
               code={code}
               uri={uri}
               onInputChange={setUri}
               onSubmit={handleConnect}
             />}
-            {(status === 'incoming_pairing' && currentProposal) &&
+                {(status === 'incoming_pairing' && currentProposal) &&
               <WCIncomingPairing
                 currentProposal={currentProposal}
                 pairingMetadata={currentProposal.params.proposer.metadata}
@@ -117,11 +120,14 @@ export const ConnectScreenWalletConnect = ({
                 onApprove={handleApprovePairingStates}
                 onReject={handleRejectPairingStates}
               />
-            }
-            {status === 'success' && <WCSuccessPairing accountCode={code} />}
-          </div>
-        </ViewContent>
-      </View>
-    </Main>
+                }
+                {status === 'success' && <WCSuccessPairing accountCode={code} />}
+              </div>
+            </ViewContent>
+          </View>
+        </Main>
+      </GuidedContent>
+      <WCGuide />
+    </GuideWrapper>
   );
 };

--- a/frontends/web/src/routes/account/walletconnect/dashboard.tsx
+++ b/frontends/web/src/routes/account/walletconnect/dashboard.tsx
@@ -23,11 +23,12 @@ import { WCWeb3WalletContext } from '../../../contexts/WCWeb3WalletContext';
 import { route } from '../../../utils/route';
 import { getAddressFromEIPString, truncateAddress } from '../../../utils/walletconnect';
 import { IAccount, getReceiveAddressList } from '../../../api/account';
-import { Header, Main } from '../../../components/layout';
+import { GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
 import { View, ViewContent } from '../../../components/view/view';
 import { WCSessionCard } from './components/session-card/session-card';
 import { Button } from '../../../components/forms';
 import { Status } from '../../../components/status/status';
+import { WCGuide } from './guide';
 import styles from './dashboard.module.css';
 
 type TProps = {
@@ -80,28 +81,30 @@ export const DashboardWalletConnect = ({ code, accounts }: TProps) => {
   const hasSession = sessions && sessions.length > 0;
 
   return (
-    <Main>
-      <Status
-        hidden={false}
-        type="info"
-        dismissible="walletConnectDisclaimerDismissed"
-      >
-        {t('walletConnect.dashboard.disclaimer')}
-      </Status>
-      <Header
-        title={<h2>{t('walletConnect.walletConnect')}</h2>}
-      />
-      <View>
-        <ViewContent>
-          <div className={styles.headerContainer}>
-            <div>
-              <p>{accountName}</p>
-              <p className={styles.receiveAddress}>{receiveAddress}</p>
-            </div>
-            <Button className={styles.buttonNewConnection} onClick={() => route(`/account/${code}/wallet-connect/connect`)} primary>{t('walletConnect.dashboard.newConnection')}</Button>
-          </div>
-          <hr className={styles.separator} />
-          {hasSession &&
+    <GuideWrapper>
+      <GuidedContent>
+        <Main>
+          <Status
+            hidden={false}
+            type="info"
+            dismissible="walletConnectDisclaimerDismissed"
+          >
+            {t('walletConnect.dashboard.disclaimer')}
+          </Status>
+          <Header
+            title={<h2>{t('walletConnect.walletConnect')}</h2>}
+          />
+          <View>
+            <ViewContent>
+              <div className={styles.headerContainer}>
+                <div>
+                  <p>{accountName}</p>
+                  <p className={styles.receiveAddress}>{receiveAddress}</p>
+                </div>
+                <Button className={styles.buttonNewConnection} onClick={() => route(`/account/${code}/wallet-connect/connect`)} primary>{t('walletConnect.dashboard.newConnection')}</Button>
+              </div>
+              <hr className={styles.separator} />
+              {hasSession &&
             <div className={styles.sessionCardsContainer}>
               <p className={styles.allSessionsHeading}>{t('walletConnect.dashboard.allSessions')}</p>
               {sessions.map(session =>
@@ -113,13 +116,15 @@ export const DashboardWalletConnect = ({ code, accounts }: TProps) => {
                 />
               )}
             </div>
-          }
-          {!hasSession &&
+              }
+              {!hasSession &&
             <p className={styles.noConnectedSessions}>{t('walletConnect.dashboard.noConnectedSessions')}</p>
-          }
-        </ViewContent>
-      </View>
-    </Main>
+              }
+            </ViewContent>
+          </View>
+        </Main>
+      </GuidedContent>
+      <WCGuide />
+    </GuideWrapper>
   );
 };
-

--- a/frontends/web/src/routes/account/walletconnect/guide.tsx
+++ b/frontends/web/src/routes/account/walletconnect/guide.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from 'react-i18next';
+import { Guide } from '../../../components/guide/guide';
+import { Entry } from '../../../components/guide/entry';
+
+export const WCGuide = () => {
+  const { t } = useTranslation();
+  return (
+    <Guide>
+      <Entry
+        key="guide.walletConnect.whatIsWalletConnect"
+        entry={t('guide.walletConnect.whatIsWalletConnect')}
+      />
+      <Entry
+        key="guide.walletConnect.supportedNetworks"
+        entry={t('guide.walletConnect.supportedNetworks')}
+      />
+      <Entry
+        key="guide.walletConnect.noPreviousConnections"
+        entry={t('guide.walletConnect.noPreviousConnections')}
+      />
+    </Guide>
+  );
+};


### PR DESCRIPTION
Guides for wallet connect-related pages (/dashboard and /connect).

Preview:

<img width="1483" alt="xd" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/d9428f07-ebd3-4756-bd48-a983ae0ee75e">

<img width="1483" alt="ddxcx" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/445e129b-617e-4fb7-a0fd-7035c17290f0">
