### PR TITLE
backend/config: persist keystore with keystore name

### DIFF
--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -78,6 +78,9 @@ func makeBitbox02LikeKeystore() *keystoremock.KeystoreMock {
 	keystoreHelper := software.NewKeystore(rootKey)
 
 	return &keystoremock.KeystoreMock{
+		NameFunc: func() (string, error) {
+			return "Mock name", nil
+		},
 		RootFingerprintFunc: func() ([]byte, error) {
 			return fingerprint, nil
 		},
@@ -979,6 +982,9 @@ func TestAccountSupported(t *testing.T) {
 
 	fingerprint := []byte{0x55, 0x055, 0x55, 0x55}
 	bb02Multi := &keystoremock.KeystoreMock{
+		NameFunc: func() (string, error) {
+			return "Mock multi", nil
+		},
 		RootFingerprintFunc: func() ([]byte, error) {
 			return fingerprint, nil
 		},
@@ -1000,6 +1006,9 @@ func TestAccountSupported(t *testing.T) {
 		ExtendedPublicKeyFunc: keystoreHelper.ExtendedPublicKey,
 	}
 	bb02BtcOnly := &keystoremock.KeystoreMock{
+		NameFunc: func() (string, error) {
+			return "Mock btconly", nil
+		},
 		RootFingerprintFunc: func() ([]byte, error) {
 			return fingerprint, nil
 		},
@@ -1113,6 +1122,9 @@ func TestTaprootUpgrade(t *testing.T) {
 	fingerprint := []byte{0x55, 0x055, 0x55, 0x55}
 
 	bitbox02NoTaproot := &keystoremock.KeystoreMock{
+		NameFunc: func() (string, error) {
+			return "Mock no taproot", nil
+		},
 		RootFingerprintFunc: func() ([]byte, error) {
 			return fingerprint, nil
 		},
@@ -1135,6 +1147,9 @@ func TestTaprootUpgrade(t *testing.T) {
 		ExtendedPublicKeyFunc: keystoreHelper.ExtendedPublicKey,
 	}
 	bitbox02Taproot := &keystoremock.KeystoreMock{
+		NameFunc: func() (string, error) {
+			return "Mock taproot", nil
+		},
 		RootFingerprintFunc: func() ([]byte, error) {
 			return fingerprint, nil
 		},

--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -56,6 +56,9 @@ func makeKeystore(
 	t.Helper()
 
 	return &keystoremock.KeystoreMock{
+		NameFunc: func() (string, error) {
+			return "Mock keystore", nil
+		},
 		RootFingerprintFunc: func() ([]byte, error) {
 			return rootFingerprint, nil
 		},

--- a/backend/config/accounts_test.go
+++ b/backend/config/accounts_test.go
@@ -60,6 +60,32 @@ func TestSetTokenActive(t *testing.T) {
 	require.Equal(t, []string{"TOKEN-2"}, acct.ActiveTokens)
 }
 
+func TestGetOrAddKeystore(t *testing.T) {
+	cfg := &AccountsConfig{}
+	fp1 := []byte("aaaa")
+	fp2 := []byte("bbbb")
+
+	ks := cfg.GetOrAddKeystore(fp1)
+	ks.Name = "ks1"
+
+	require.Len(t, cfg.Keystores, 1)
+	require.Equal(t, ks, cfg.Keystores[0])
+	require.Equal(t, fp1, []byte(cfg.Keystores[0].RootFingerprint))
+	require.Equal(t, "ks1", cfg.Keystores[0].Name)
+
+	ks = cfg.GetOrAddKeystore(fp1)
+	require.Len(t, cfg.Keystores, 1)
+	require.Equal(t, "ks1", ks.Name)
+
+	ks = cfg.GetOrAddKeystore(fp2)
+	ks.Name = "ks2"
+
+	require.Len(t, cfg.Keystores, 2)
+	require.Equal(t, ks, cfg.Keystores[1])
+	require.Equal(t, fp2, []byte(cfg.Keystores[1].RootFingerprint))
+	require.Equal(t, "ks2", cfg.Keystores[1].Name)
+}
+
 func TestMigrateActiveToken(t *testing.T) {
 	config := &Config{
 		appConfigFilename: "appConfigFilename",

--- a/backend/devices/bitbox/keystore.go
+++ b/backend/devices/bitbox/keystore.go
@@ -45,6 +45,12 @@ func (keystore *keystore) Type() keystorePkg.Type {
 	return keystorePkg.TypeHardware
 }
 
+// Name implements keystore.Keystore.
+func (keystore *keystore) Name() (string, error) {
+	// Won't bother getting the actual name here.
+	return "BitBox01", nil
+}
+
 // RootFingerprint implements keystore.Keystore.
 func (keystore *keystore) RootFingerprint() ([]byte, error) {
 	keystore.rootFingerMu.Lock()

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -52,6 +52,15 @@ func (keystore *keystore) Type() keystorePkg.Type {
 	return keystorePkg.TypeHardware
 }
 
+// Name implements keystore.Keystore.
+func (keystore *keystore) Name() (string, error) {
+	info, err := keystore.device.DeviceInfo()
+	if err != nil {
+		return "", errp.WithStack(err)
+	}
+	return info.Name, nil
+}
+
 // RootFingerprint implements keystore.Keystore.
 func (keystore *keystore) RootFingerprint() ([]byte, error) {
 	keystore.rootFingerMu.Lock()

--- a/backend/keystore/keystore.go
+++ b/backend/keystore/keystore.go
@@ -44,6 +44,9 @@ type Keystore interface {
 	// Type denotes the type of the keystore.
 	Type() Type
 
+	// Returns the name of the keystore, e.g. the BitBox02 device name.
+	Name() (string, error)
+
 	// RootFingerprint returns the keystore's root fingerprint, which is the first 32 bits of the
 	// hash160 of the pubkey at the keypath m/.
 	//

--- a/backend/keystore/mocks/keystore.go
+++ b/backend/keystore/mocks/keystore.go
@@ -33,6 +33,9 @@ var _ keystore.Keystore = &KeystoreMock{}
 //			ExtendedPublicKeyFunc: func(coinMoqParam coin.Coin, absoluteKeypath signing.AbsoluteKeypath) (*hdkeychain.ExtendedKey, error) {
 //				panic("mock out the ExtendedPublicKey method")
 //			},
+//			NameFunc: func() (string, error) {
+//				panic("mock out the Name method")
+//			},
 //			RootFingerprintFunc: func() ([]byte, error) {
 //				panic("mock out the RootFingerprint method")
 //			},
@@ -84,6 +87,9 @@ type KeystoreMock struct {
 
 	// ExtendedPublicKeyFunc mocks the ExtendedPublicKey method.
 	ExtendedPublicKeyFunc func(coinMoqParam coin.Coin, absoluteKeypath signing.AbsoluteKeypath) (*hdkeychain.ExtendedKey, error)
+
+	// NameFunc mocks the Name method.
+	NameFunc func() (string, error)
 
 	// RootFingerprintFunc mocks the RootFingerprint method.
 	RootFingerprintFunc func() ([]byte, error)
@@ -139,6 +145,9 @@ type KeystoreMock struct {
 			CoinMoqParam coin.Coin
 			// AbsoluteKeypath is the absoluteKeypath argument value.
 			AbsoluteKeypath signing.AbsoluteKeypath
+		}
+		// Name holds details about calls to the Name method.
+		Name []struct {
 		}
 		// RootFingerprint holds details about calls to the RootFingerprint method.
 		RootFingerprint []struct {
@@ -204,6 +213,7 @@ type KeystoreMock struct {
 	lockCanVerifyAddress           sync.RWMutex
 	lockCanVerifyExtendedPublicKey sync.RWMutex
 	lockExtendedPublicKey          sync.RWMutex
+	lockName                       sync.RWMutex
 	lockRootFingerprint            sync.RWMutex
 	lockSignBTCMessage             sync.RWMutex
 	lockSignETHMessage             sync.RWMutex
@@ -341,6 +351,33 @@ func (mock *KeystoreMock) ExtendedPublicKeyCalls() []struct {
 	mock.lockExtendedPublicKey.RLock()
 	calls = mock.calls.ExtendedPublicKey
 	mock.lockExtendedPublicKey.RUnlock()
+	return calls
+}
+
+// Name calls NameFunc.
+func (mock *KeystoreMock) Name() (string, error) {
+	if mock.NameFunc == nil {
+		panic("KeystoreMock.NameFunc: method is nil but Keystore.Name was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockName.Lock()
+	mock.calls.Name = append(mock.calls.Name, callInfo)
+	mock.lockName.Unlock()
+	return mock.NameFunc()
+}
+
+// NameCalls gets all the calls that were made to Name.
+// Check the length with:
+//
+//	len(mockedKeystore.NameCalls())
+func (mock *KeystoreMock) NameCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockName.RLock()
+	calls = mock.calls.Name
+	mock.lockName.RUnlock()
 	return calls
 }
 

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
@@ -71,6 +72,15 @@ func NewKeystoreFromPIN(pin string) *Keystore {
 // Type implements keystore.Keystore.
 func (keystore *Keystore) Type() keystorePkg.Type {
 	return keystorePkg.TypeSoftware
+}
+
+// Name implements keystore.Keystore.
+func (keystore *Keystore) Name() (string, error) {
+	fingerprint, err := keystore.RootFingerprint()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Software keystore %x", fingerprint), nil
 }
 
 // RootFingerprint implements keystore.Keystore.

--- a/util/jsonp/jsonp.go
+++ b/util/jsonp/jsonp.go
@@ -14,7 +14,10 @@
 
 package jsonp
 
-import "encoding/json"
+import (
+	"encoding/hex"
+	"encoding/json"
+)
 
 // MustMarshal encodes a value that cannot fail. Panics on an encoding error.
 func MustMarshal(value interface{}) []byte {
@@ -30,4 +33,26 @@ func MustUnmarshal(jsonBytes []byte, value interface{}) {
 	if err := json.Unmarshal(jsonBytes, value); err != nil {
 		panic(err)
 	}
+}
+
+// HexBytes is a helper type to serialize/deserialize bytes as hex in JSON.
+type HexBytes []byte
+
+// MarshalJSON implements json.Marshaler.
+func (h HexBytes) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hex.EncodeToString(h))
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (h *HexBytes) UnmarshalJSON(data []byte) error {
+	var hexStr string
+	if err := json.Unmarshal(data, &hexStr); err != nil {
+		return err
+	}
+	bytes, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return err
+	}
+	*h = bytes
+	return nil
 }

--- a/util/jsonp/jsonp_test.go
+++ b/util/jsonp/jsonp_test.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHexBytesMarshalUnmarshal(t *testing.T) {
+	original := HexBytes{0x1, 0x2, 0x3, 0x4}
+	expectedJSON := "\"01020304\""
+
+	// Test MarshalJSON
+	marshaled, err := json.Marshal(original)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedJSON, string(marshaled))
+
+	// Test UnmarshalJSON
+	var unmarshaled HexBytes
+	err = json.Unmarshal([]byte(expectedJSON), &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, original, unmarshaled)
+}


### PR DESCRIPTION
We want to display the name of the keystore (e.g. BitBox02 device name) in the sidebar above the accounts derived from that keystore. This is useful for watch-only mode when someone uses multiple keystores.

The BitBox02 keystore name for now is simply the device name. For passphrase users that means that multiple keystores will have the same name. We will not give this any special consideration for now. The user can label the individual accounts, which is enough to disambiguate.