### PR TITLE
frontend: fix css regression toggle tokens in manage accounts

### DIFF
--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -126,6 +126,7 @@
     background-position: 100% center;
     background-repeat: no-repeat;
     height: 40px;
+    padding: 0 var(--space-default);
 }
 
 .expandBtnOpen {


### PR DESCRIPTION
The expand icon was not aligned properly with the toggle button text, this probably is a regression from recent button refactor.

![Screen Shot 2023-10-11 at 11 04 05](https://github.com/digitalbitbox/bitbox-wallet-app/assets/546900/a58ab169-b2e3-41b0-9916-13df370014e7)

or expanded:

![Screen Shot 2023-10-11 at 11 04 15](https://github.com/digitalbitbox/bitbox-wallet-app/assets/546900/e0c080e8-211e-4078-90ae-7f41d30d67f1)
