### PR TITLE
frontend: fix camera on linux

### DIFF
--- a/frontends/web/src/hooks/permissions.ts
+++ b/frontends/web/src/hooks/permissions.ts
@@ -41,7 +41,7 @@ export const useDevicePermission = (deviceName: TExperimentalDeviceName) => {
         permissionObject.current = permissionStatus;
         handlePermissionChange();
       });
-  });
+  }, [handlePermissionChange, deviceName]);
 
   useEffect(() => {
     if (permissionObject.current) {

--- a/frontends/web/src/routes/account/send/components/dialogs/scan-qr-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/scan-qr-dialog.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { useTranslation } from 'react-i18next';
+import { useDevicePermission } from '../../../../../hooks/permissions';
 import { Dialog, DialogButtons } from '../../../../../components/dialog/dialog';
 import { ScanQRVideo } from '../inputs/scan-qr-video';
-import { useTranslation } from 'react-i18next';
 import { Button } from '../../../../../components/forms';
 
 type TProps = {
@@ -25,6 +26,19 @@ type TProps = {
     onChangeActiveScanQR: (active: boolean) => void;
     parseQRResult: (result: string) => void;
 }
+
+const PermissionWarning = () => {
+  const { t } = useTranslation();
+  const permission = useDevicePermission('camera');
+
+  const permissionWarning = permission !== 'granted'
+    ? t('permission.camera')
+    : null;
+
+  return (
+    <div>{permissionWarning}</div>
+  );
+};
 
 export const ScanQRDialog = ({ parseQRResult, activeScanQR, toggleScanQR, onChangeActiveScanQR }: TProps) => {
   const { t } = useTranslation();
@@ -36,6 +50,7 @@ export const ScanQRDialog = ({ parseQRResult, activeScanQR, toggleScanQR, onChan
       open={activeScanQR}
       title={t('send.scanQR')}>
       <div style={{ minHeight: '300px' }}>
+        <PermissionWarning />
         <ScanQRVideo
           onResult={result => {
             parseQRResult(result);

--- a/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
@@ -15,9 +15,7 @@
  */
 
 import { useRef } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useQRScanner } from '../../../../../hooks/qrcodescanner';
-import { useDevicePermission } from '../../../../../hooks/permissions';
 import { SpinnerAnimation } from '../../../../../components/spinner/SpinnerAnimation';
 import style from '../../send.module.css';
 
@@ -28,18 +26,12 @@ type TProps = {
 export const ScanQRVideo = ({
   onResult,
 }: TProps) => {
-  const { t } = useTranslation();
   const videoRef = useRef<HTMLVideoElement>(null);
-  const permission = useDevicePermission('camera');
 
   useQRScanner(videoRef, {
     onResult: result => onResult(result.data),
     onError: console.error
   });
-
-  const permissionWarning = permission !== 'granted'
-    ? <div>{t('permission.camera')}</div>
-    : null;
 
   return (
     <>
@@ -48,7 +40,6 @@ export const ScanQRVideo = ({
        gets loaded.*/}
       <div className={style.spinnerAnimationContainer}>
         <SpinnerAnimation />
-        {permissionWarning}
       </div>
       <video
         className={style.qrVideo}


### PR DESCRIPTION
Regression introduced in 48eebe98e81fa1c026c45e3b9ed1b1f602aae435

That commit added a please-grant-camera-permission warning, in the same component that contains the video element. It uses a new hook to check for camera devices and conditionally renders the warning.

Conditionally showing the warning based on the hook re-renders the component and seems to be the cause for the video to error with:

    DOMException: The play() request was interrupted by a new load request.

This commit is an approach to lift the warning up to the parent component. It seems to work on macOS, but the warning does not go away.
Could be that the event listener on permissionstate object is not working.