### PR TITLE
frontend: add poster attribute video tag

### DIFF
--- a/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
@@ -44,6 +44,7 @@ export const ScanQRVideo = ({
       <video
         className={style.qrVideo}
         ref={videoRef}
+        poster="%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%2264%22%20height=%2248%22%3E%3C/svg%3E"
       />
     </>
   );


### PR DESCRIPTION
In the scan-qr-video component, we use a html video tag which has an unappealing placeholder image. Adding a poster attribute changes that placeholder image, we use an empty svg in this case.