### PR TITLE
frontend: fix usemounted hook in react 18 mode

### DIFF
--- a/frontends/web/src/hooks/mount.ts
+++ b/frontends/web/src/hooks/mount.ts
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-import { useRef, useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 /**
- * useMountedRef returns a `react.Ref` with `ref.current` boolean defining if
- * the component is actually mounted.
+ * useMounted returns a boolean which is true if the component is actually mounted.
  */
-
 export const useMountedRef = () => {
-  const mounted = useRef(true);
-  useEffect(() => (
-    () => {
-      mounted.current = false;
-    }
-  ), []);
-  return mounted;
+  const isMountedRef = useRef(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  return isMountedRef;
 };


### PR DESCRIPTION
Regression introduced in https://github.com/thisconnect/bitbox-wallet-app/commit/d120245f2346ead89c37b4c51147f0cfb74d9979

In webdev, this caused useLoad hook to always return undefined
which broke various components.

Issues appeared with syncheaders on account summary (never ended),
some settings did not load (that depend on useLoad) or the skip for
testing was missing on the waiting view.

> React 18 introduces a new development-only check to Strict Mode.
> This new check will automatically unmount and remount every
> component, whenever a component mounts for the first time,
> restoring the previous state on the second mount.

https://react.dev/blog/2022/03/29/react-v18#new-strict-mode-behaviors

This explains why useLoad broke, as it cleaned up after first
unmount and after that the mounted ref was undefined.