### PR TITLE
ci: use latest nodejs 18.x lts version for macos

### DIFF
--- a/scripts/github-ci.sh
+++ b/scripts/github-ci.sh
@@ -35,7 +35,7 @@ if [ "$OS_NAME" == "osx" ]; then
     brew install qt@5
     brew install nvm
     source /usr/local/opt/nvm/nvm.sh
-    nvm install 18.17.1 # install this node version
+    nvm install 18 # install this node version
     export PATH="/usr/local/opt/qt@5/bin:$PATH"
     export LDFLAGS="-L/usr/local/opt/qt@5/lib"
     export CPPFLAGS="-I/usr/local/opt/qt@5/include"


### PR DESCRIPTION
This uses latest nodejs LTS 18.x version used in macOS GitHub ci.

Before that we set specifc node version but as soon as the version is not available anymore ci fails. Changed to just request major version.

Linux ci does not have specific nodejs version set but installs nodejs in scripts/docker_install.sh