### PR TITLE
Keystore event fix

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -931,6 +931,7 @@ func (backend *Backend) uninitAccounts() {
 			backend.onAccountUninit(account)
 		}
 		account.Close()
+		backend.emitAccountsStatusChanged()
 	}
 	backend.accounts = []accounts.Interface{}
 }

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -474,7 +474,7 @@ func (backend *Backend) RenameAccount(accountCode accountsTypes.Code, name strin
 	if err != nil {
 		return err
 	}
-	backend.emitAccountsStatusChanged()
+	backend.emitAccountsListChanged()
 	return nil
 }
 
@@ -566,7 +566,7 @@ func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *
 	}
 }
 
-func (backend *Backend) emitAccountsStatusChanged() {
+func (backend *Backend) emitAccountsListChanged() {
 	backend.Notify(observable.Event{
 		Subject: "accounts",
 		Action:  action.Reload,
@@ -904,7 +904,7 @@ func (backend *Backend) initAccounts() {
 
 	backend.initPersistedAccounts()
 
-	backend.emitAccountsStatusChanged()
+	backend.emitAccountsListChanged()
 
 	// The updater fetches rates only for active accounts, so this seems the most
 	// appropriate place to update exchange rate configuration.
@@ -931,7 +931,7 @@ func (backend *Backend) uninitAccounts() {
 			backend.onAccountUninit(account)
 		}
 		account.Close()
-		backend.emitAccountsStatusChanged()
+		backend.emitAccountsListChanged()
 	}
 	backend.accounts = []accounts.Interface{}
 }
@@ -1058,7 +1058,7 @@ func (backend *Backend) maybeAddHiddenUnusedAccounts() {
 				continue
 			}
 			backend.createAndAddAccount(coin, accountConfig)
-			backend.emitAccountsStatusChanged()
+			backend.emitAccountsListChanged()
 		}
 	}
 }
@@ -1099,6 +1099,6 @@ func (backend *Backend) checkAccountUsed(account accounts.Interface) {
 		log.WithError(err).Error("checkAccountUsed")
 		return
 	}
-	backend.emitAccountsStatusChanged()
+	backend.emitAccountsListChanged()
 	backend.maybeAddHiddenUnusedAccounts()
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -476,7 +476,7 @@ func (backend *Backend) Start() <-chan interface{} {
 
 	defer backend.accountsAndKeystoreLock.Lock()()
 	backend.initPersistedAccounts()
-	backend.emitAccountsStatusChanged()
+	backend.emitAccountsListChanged()
 
 	backend.ratesUpdater.StartCurrentRates()
 	backend.configureHistoryExchangeRates()

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -558,7 +558,6 @@ func (backend *Backend) DeregisterKeystore() {
 	// TODO: classify accounts by keystore, remove only the ones belonging to the deregistered
 	// keystore. For now we just remove all, then re-add the rest.
 	backend.initPersistedAccounts()
-	backend.emitAccountsStatusChanged()
 }
 
 // Register registers the given device at this backend.


### PR DESCRIPTION
Fixes an event transmission lag that caused an unexpected error (discovered in #2307) and renames a misleading backend method. See commit messages for details.