### PR TITLE
frontend: bring back lost translation

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -467,6 +467,7 @@
   },
   "chart": {
     "dataMissing": "Gathering historical data... stay tuned.",
+    "dataOldTimestamp": "Historical exchange rates updating. The chart is not displaying data after {{time}}.",
     "dataUpdating": "updating data…",
     "filter": {
       "all": "All",


### PR DESCRIPTION
This commit added a message when chart data is missing: 2f8805c4764793648b53cc1f6b0547eda538afd7

The translation was lost in fe114752ccff387be72f65467ff42da3e34b5556

Added the translation again.