### PR TITLE
frontend: fix empty accounts message

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -231,7 +231,7 @@ export function Account({
                 code={code}
                 exchangeBuySupported={exchangeBuySupported}
                 unit={balance.available.unit}
-                balanceList={[[code, balance]]}
+                balanceList={[balance]}
               />
             )}
             { !status.synced || offlineErrorTextLines.length || !hasDataLoaded || status.fatalError ? (

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -24,7 +24,7 @@ import { getExchangeSupportedAccounts } from '../../buy/utils';
 import styles from './buyReceiveCTA.module.css';
 
 type TBuyReceiveCTAProps = {
-  balanceList?: [string, IBalance][];
+  balanceList?: IBalance[];
   code?: string;
   unit?: string;
   exchangeBuySupported?: boolean;
@@ -45,7 +45,7 @@ export const BuyReceiveCTA = ({ code, unit, balanceList, exchangeBuySupported = 
         route('accounts/select-receive');
         return;
       }
-      route(`/account/${balanceList[0][0]}/receive`);
+      route(`/account/${balanceList[0]}/receive`);
     }
   };
 
@@ -72,13 +72,15 @@ export const AddBuyReceiveOnEmptyBalances = ({ balances, accounts }: TAddBuyRece
   if (balances === undefined || supportedAccounts === undefined) {
     return null;
   }
-  const balanceList = Object.entries(balances);
-  if (balanceList.some(entry => entry[1].hasAvailable)) {
+  const balanceList = accounts
+    .map(account => balances[account.code])
+    .filter(balance => !!balance);
+
+  if (balanceList.some(entry => entry.hasAvailable)) {
     return null;
   }
-  if (balanceList.map(entry => entry[1].available.unit).every(isBitcoinCoin)) {
-    const onlyHasOneAccount = balanceList.length === 1;
-    return <BuyReceiveCTA code={onlyHasOneAccount ? balanceList[0][0] : undefined} unit={'BTC'} balanceList={balanceList} />;
+  if (balanceList.map(entry => entry.available.unit).every(isBitcoinCoin)) {
+    return <BuyReceiveCTA code={accounts.length === 1 ? accounts[0].code : undefined} unit={'BTC'} balanceList={balanceList} />;
   }
 
   return <BuyReceiveCTA exchangeBuySupported={supportedAccounts.length > 0} balanceList={balanceList} />;

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -161,7 +161,7 @@ export function AccountsSummary({
               hideAmounts={hideAmounts}
               data={summaryData}
               noDataPlaceholder={
-                (accounts.length === Object.keys(balances || {}).length) ? (
+                (accounts.length && accounts.length <= Object.keys(balances || {}).length) ? (
                   <AddBuyReceiveOnEmptyBalances accounts={accounts} balances={balances} />
                 ) : undefined
               } />


### PR DESCRIPTION
After chaning account settings and navigating back to account summary, sometimes no chart and no empty-wallet message show.

Reason seems to be that in this moment the frontend has all balances and wrong condition on when to render the message.

Changed and simplified the logic a bit. It should now show the message unless there is either a balance or one of the accounts once had coins.