### PR TITLE
frontend: full screen qr-video for mobile

### DIFF
--- a/frontends/web/src/components/dialog/dialog.module.css
+++ b/frontends/web/src/components/dialog/dialog.module.css
@@ -248,6 +248,26 @@
 
 @media (max-width: 768px) {
 
+    .header.fullscreenOnMobile {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 1;
+        border-bottom: none;
+    }
+
+    .fullscreenOnMobile .dialogButtons {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+    }
+
+    .contentContainer.fullscreenOnMobile {
+        padding: 0;
+    }
+
     .header .title{
         font-size: var(--header-default-font-size);
     }
@@ -263,6 +283,11 @@
         transition: transform 300ms;
         border-top-right-radius: var(--space-half);
         border-top-left-radius: var(--space-half);
+    }
+
+    .modal.fullscreenOnMobile {
+        border-top-right-radius: 0;
+        border-top-left-radius: 0;
     }
 
     .modal.open {

--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -30,6 +30,7 @@ interface Props {
     disabledClose?: boolean;
     children: React.ReactNode;
     open: boolean;
+    fullscreenOnMobile?: boolean;
 }
 
 interface State {
@@ -198,6 +199,7 @@ class Dialog extends Component<Props, State> {
       onClose,
       disabledClose,
       children,
+      fullscreenOnMobile,
     } = this.props;
     const { renderDialog } = this.state;
     const isSmall = small ? style.small : '';
@@ -205,6 +207,7 @@ class Dialog extends Component<Props, State> {
     const isLarge = large ? style.large : '';
     const isSlim = slim ? style.slim : '';
     const isCentered = centered && !onClose ? style.centered : '';
+    const isFullscreen = fullscreenOnMobile ? style.fullscreenOnMobile : '';
 
     if (!renderDialog) {
       return null;
@@ -213,11 +216,11 @@ class Dialog extends Component<Props, State> {
     return (
       <div className={style.overlay} ref={this.overlay}>
         <div
-          className={[style.modal, isSmall, isMedium, isLarge].join(' ')}
+          className={[style.modal, isSmall, isMedium, isLarge, isFullscreen].join(' ')}
           ref={this.modal}>
           {
             title && (
-              <div className={[style.header, isCentered].join(' ')}>
+              <div className={[style.header, isCentered, isFullscreen].join(' ')}>
                 <h3 className={style.title}>{title}</h3>
                 { onClose ? (
                   <button className={style.closeButton} onClick={() => {
@@ -231,7 +234,7 @@ class Dialog extends Component<Props, State> {
             )
           }
           <div
-            className={[style.contentContainer, isSlim].join(' ')}
+            className={[style.contentContainer, isSlim, isFullscreen].join(' ')}
             ref={this.modalContent}>
             <div className={style.content}>
               {children}

--- a/frontends/web/src/routes/account/send/components/dialogs/scan-qr-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/scan-qr-dialog.tsx
@@ -32,6 +32,7 @@ export const ScanQRDialog = ({ parseQRResult, activeScanQR, toggleScanQR, onChan
   return (
     <Dialog
       large
+      fullscreenOnMobile
       open={activeScanQR}
       title={t('send.scanQR')}
       onClose={toggleScanQR}>

--- a/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.module.css
+++ b/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.module.css
@@ -9,9 +9,18 @@
 
 .qrVideo {
   width: 100%;
+  object-fit: cover;
   margin-bottom: var(--spacing-default);
 }
 .qrVideo + :global(.scan-region-highlight) svg {
   stroke: var(--color-darkyellow) !important;
   stroke-width: 3 !important;
+}
+
+@media (max-width: 768px) {
+  .qrVideo {
+    height: 100vh;
+    object-fit: cover;
+    margin-bottom: 0;
+  }
 }

--- a/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
@@ -44,7 +44,7 @@ export const ScanQRVideo = ({
       <video
         className={style.qrVideo}
         ref={videoRef}
-        poster="%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%2264%22%20height=%2248%22%3E%3C/svg%3E"
+        poster="data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%3E%20width=%2264%22%20height=%2248%22%3C/svg%3E"
       />
     </>
   );


### PR DESCRIPTION
The video element in te ScanQRVideo component did not have a mimetype in the uri of the poster attribute which caused Qt to display a warning. Using `data:image/svg+xml` fixes this. However this makes the video fit into the size of the placeholder svg.

TODO: 
- [ ] either scale the svg placeholders size, or change the qr videos content box if possible
- [ ] there might be a vertical/horizontal scroll on mobile

~~Using the mimetype `image/svg+xml` caused the camera view to be distorted/sqished. Using `image` has the desired effect.
Also added `utf8` to be more explicit, and removed unnecessary encoding (`%22`, `%20`)~~