### PR TITLE
frontend: fix overflowing WC CTA text when balance is very long

### DIFF
--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -22,6 +22,7 @@
 
 .actionsContainer {
     display: flex;
+    gap: var(--space-quarter);
     transform: translateY(-36%);
     margin-top: var(--space-quarter);
 }
@@ -46,15 +47,14 @@
     will-change: background-color;
 }
 
-.withWalletConnect .walletConnect { 
-    display: flex;
-    gap: var(--space-eight);
+.withWalletConnect.actionsContainer {
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
-.buy,
-.receive,
-.send {
-    margin-right: var(--space-quarter);
+
+.withWalletConnect .walletConnect { 
+    display: flex;
 }
 
 .buy:hover,


### PR DESCRIPTION
improving the account page UI by collapsing the buttons when there's not enough space.

This is probably quite an edge case, and the changes in this PR shouldn't affect anything else except for: **the account page that's compatible with WC on desktop.**

Before:
![99gnmm](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/922d6bb8-a00c-4f22-9b7c-3fbb386f909e)


After:
![xx9927](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/5e61f641-e028-48c2-b89c-a81721cd946f)

Mobile (no difference):

![x92](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/8eae42a0-839b-44a2-babd-7cd6dc09274c)
