### PR TITLE
frontend: fix route for `onReceiveCTA`

### DIFF
--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -45,7 +45,7 @@ export const BuyReceiveCTA = ({ code, unit, balanceList, exchangeBuySupported = 
         route('accounts/select-receive');
         return;
       }
-      route(`/account/${balanceList[0]}/receive`);
+      route(`/account/${code}/receive`);
     }
   };
 


### PR DESCRIPTION
fixing a small bug, regression happened here: https://github.com/digitalbitbox/bitbox-wallet-app/pull/2316/commits/3e2018d67774a83325c226ae6e3c7ba20b3d14bf

balanceList is of type `IBalance[]`, which is:

```js
IBalance {
    hasAvailable: boolean;
    available: IAmount;
    hasIncoming: boolean;
    incoming: IAmount;
}
```

thus `/account/balanceList[0]/receive` is an invalid route. 