### PR TITLE
Add watchonly setting to accounts & handle watchonly account loading/unloading

### DIFF
--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -561,6 +561,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "btc",
 				Name:     "bitcoin 2",
 				Code:     "v0-55555555-btc-1",
@@ -583,6 +584,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		require.Equal(t, "v0-55555555-ltc-1", string(acctCode))
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "ltc",
 				Name:     "litecoin 2",
 				Code:     "v0-55555555-ltc-1",
@@ -604,6 +606,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		require.Equal(t, "v0-55555555-eth-1", string(acctCode))
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "eth",
 				Name:     "ethereum 2",
 				Code:     "v0-55555555-eth-1",
@@ -624,6 +627,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		require.Equal(t, "v0-55555555-btc-2", string(acctCode))
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "btc",
 				Name:     "bitcoin 3",
 				Code:     "v0-55555555-btc-2",
@@ -646,6 +650,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		require.Equal(t, "v0-55555555-ltc-2", string(acctCode))
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "ltc",
 				Name:     "litecoin 2",
 				Code:     "v0-55555555-ltc-2",
@@ -667,6 +672,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		require.Equal(t, "v0-55555555-eth-2", string(acctCode))
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "eth",
 				Name:     "ethereum 2",
 				Code:     "v0-55555555-eth-2",
@@ -682,6 +688,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		require.Equal(t,
 			&config.Account{
 				HiddenBecauseUnused: true,
+				Watch:               nil,
 				CoinCode:            "btc",
 				Name:                "Bitcoin 4",
 				Code:                "v0-55555555-btc-3",
@@ -704,6 +711,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		require.Equal(t, "v0-55555555-btc-3", string(acctCode))
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "btc",
 				Name:     "bitcoin 4 new name",
 				Code:     "v0-55555555-btc-3",
@@ -734,6 +742,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		require.Equal(t, "v0-55555555-btc-0", string(acctCode))
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "btc",
 				Name:     "bitcoin 1: bech32",
 				Code:     "v0-55555555-btc-0-p2wpkh",
@@ -745,6 +754,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		)
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "btc",
 				Name:     "bitcoin 1",
 				Code:     "v0-55555555-btc-0-p2wpkh-p2sh",
@@ -756,6 +766,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		)
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "btc",
 				Name:     "bitcoin 1: legacy",
 				Code:     "v0-55555555-btc-0-p2pkh",
@@ -777,6 +788,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		require.Equal(t, "v0-55555555-ltc-0", string(acctCode))
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "ltc",
 				Name:     "litecoin 1: bech32",
 				Code:     "v0-55555555-ltc-0-p2wpkh",
@@ -788,6 +800,7 @@ func TestCreateAndPersistAccountConfig(t *testing.T) {
 		)
 		require.Equal(t,
 			&config.Account{
+				Watch:    nil,
 				CoinCode: "ltc",
 				Name:     "litecoin 1",
 				Code:     "v0-55555555-ltc-0-p2wpkh-p2sh",

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -556,7 +556,7 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 		log.WithError(err).Error("Could not persist default accounts")
 	}
 
-	backend.initAccounts()
+	backend.initAccounts(false)
 
 	backend.aoppKeystoreRegistered()
 }
@@ -578,7 +578,7 @@ func (backend *Backend) DeregisterKeystore() {
 		Action:  action.Reload,
 	})
 
-	backend.uninitAccounts()
+	backend.uninitAccounts(false)
 	// TODO: classify accounts by keystore, remove only the ones belonging to the deregistered
 	// keystore. For now we just remove all, then re-add the rest.
 	backend.initPersistedAccounts()
@@ -721,7 +721,7 @@ func (backend *Backend) Close() error {
 
 	backend.ratesUpdater.Stop()
 
-	backend.uninitAccounts()
+	backend.uninitAccounts(true)
 
 	for _, coin := range backend.coins {
 		if err := coin.Close(); err != nil {

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -101,6 +101,11 @@ func TestRegisterKeystore(t *testing.T) {
 	require.Equal(t, "Bitcoin", b.Config().AccountsConfig().Accounts[0].Name)
 	require.Equal(t, "Litecoin", b.Config().AccountsConfig().Accounts[1].Name)
 	require.Equal(t, "Ethereum", b.Config().AccountsConfig().Accounts[2].Name)
+	// All accounts default to not being watch-only.
+	for _, acct := range b.Accounts() {
+		require.Nil(t, acct.Config().Config.Watch)
+	}
+
 	require.Len(t, b.Config().AccountsConfig().Keystores, 1)
 	require.Equal(t, "Mock keystore 1", b.Config().AccountsConfig().Keystores[0].Name)
 	require.Equal(t, rootFingerprint1, []byte(b.Config().AccountsConfig().Keystores[0].RootFingerprint))

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -22,6 +22,7 @@ import (
 	accountsTypes "github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
 	keystoremock "github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/mocks"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/software"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/signing"
@@ -98,6 +99,9 @@ func TestRegisterKeystore(t *testing.T) {
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-55555555-btc-0"))
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-55555555-ltc-0"))
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-55555555-eth-0"))
+	require.NotNil(t, b.accounts.lookup("v0-55555555-btc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-55555555-ltc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-55555555-eth-0"))
 	require.Equal(t, "Bitcoin", b.Config().AccountsConfig().Accounts[0].Name)
 	require.Equal(t, "Litecoin", b.Config().AccountsConfig().Accounts[1].Name)
 	require.Equal(t, "Ethereum", b.Config().AccountsConfig().Accounts[2].Name)
@@ -113,32 +117,79 @@ func TestRegisterKeystore(t *testing.T) {
 	// tests, but we check that it was set and recent.
 	require.True(t, time.Since(b.Config().AccountsConfig().Keystores[0].LastConnected) < 10*time.Second)
 
-	// Deregistering the keystore removes the loaded accounts, but not the persisted accounts and
-	// keystores.
+	// Deregistering the keystore leaves the loaded accounts (watchonly), and leaves the persisted
+	// accounts and keystores.
+	// Mark accounts as watch-only.
+	require.NoError(t, b.config.ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
+		for _, acct := range cfg.Accounts {
+			f := true
+			acct.Watch = &f
+		}
+		return nil
+	}))
 	b.DeregisterKeystore()
-	require.Len(t, b.Accounts(), 0)
+	require.Len(t, b.Accounts(), 3)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
 	require.Len(t, b.Config().AccountsConfig().Keystores, 1)
 
 	// Registering the same keystore again loads the previously persisted accounts and does not
 	// automatically persist more accounts.
-	b.DeregisterKeystore()
 	b.registerKeystore(ks1)
 	require.Len(t, b.Accounts(), 3)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
 	require.Len(t, b.Config().AccountsConfig().Keystores, 1)
 
 	// Registering another keystore persists a set of initial default accounts and loads them.
+	// They are added to the previous set of watchonly accounts
 	b.DeregisterKeystore()
 	b.registerKeystore(ks2)
-	require.Len(t, b.Accounts(), 3)
+	require.Len(t, b.Accounts(), 6)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 6)
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-66666666-btc-0"))
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-66666666-ltc-0"))
 	require.NotNil(t, b.Config().AccountsConfig().Lookup("v0-66666666-eth-0"))
+	require.NotNil(t, b.accounts.lookup("v0-66666666-btc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-66666666-ltc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-66666666-eth-0"))
 	require.Len(t, b.Config().AccountsConfig().Keystores, 2)
 	require.Equal(t, "Mock keystore 2", b.Config().AccountsConfig().Keystores[1].Name)
 	require.Equal(t, rootFingerprint2, []byte(b.Config().AccountsConfig().Keystores[1].RootFingerprint))
+
+	b.DeregisterKeystore()
+	// Enable watch-only for all but two accounts, one of each keystore. Now, all watch-only
+	// accounts plus the non-watch only accounts of the connected keystore will be loaded.
+	require.NoError(t, b.config.ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
+		for _, acct := range cfg.Accounts {
+			t := true
+			acct.Watch = &t
+		}
+
+		f := false
+		cfg.Lookup("v0-55555555-btc-0").Watch = &f
+		cfg.Lookup("v0-66666666-ltc-0").Watch = &f
+		return nil
+	}))
+	b.registerKeystore(ks1)
+	require.Len(t, b.Accounts(), 5)
+	// v0-55555555-btc-0 loaded even though watch=false, as the keystore is connected.
+	require.NotNil(t, b.accounts.lookup("v0-55555555-btc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-55555555-ltc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-55555555-eth-0"))
+	require.NotNil(t, b.accounts.lookup("v0-66666666-btc-0"))
+	// v0-66666666-ltc-0 not loaded (watch=false).
+	require.Nil(t, b.accounts.lookup("v0-66666666-ltc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-66666666-eth-0"))
+
+	b.DeregisterKeystore()
+	require.Len(t, b.Accounts(), 4)
+	// v0-55555555-btc-0 not loaded (watch = false)
+	require.Nil(t, b.accounts.lookup("v0-55555555-btc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-55555555-ltc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-55555555-eth-0"))
+	require.NotNil(t, b.accounts.lookup("v0-66666666-btc-0"))
+	// v0-66666666-ltc-0 not loaded (watch=false).
+	require.Nil(t, b.accounts.lookup("v0-66666666-ltc-0"))
+	require.NotNil(t, b.accounts.lookup("v0-66666666-eth-0"))
 }
 
 func lookup(accts []accounts.Interface, code accountsTypes.Code) accounts.Interface {

--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -73,6 +73,11 @@ func (acct *Account) SetTokenActive(tokenCode string, active bool) error {
 	return nil
 }
 
+// IsWatchOnly returns true if the `Watch` setting is set to true.
+func (acct *Account) IsWatch() bool {
+	return acct.Watch != nil && *acct.Watch
+}
+
 // Keystore holds information related to keystores such as the BitBox02.
 type Keystore struct {
 	// The root fingerprint is the first 32 bits of the hash160 of the pubkey at the keypath m/.

--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -36,7 +36,14 @@ type Account struct {
 	// HiddenBecauseUnused is true if the account should not loaded in the sidebar and portfolio,
 	// and not be shown in 'Manage accounts', because the account is unused (has no transaction
 	// history). This is used to facilitate automatic discovery of used accounts.
-	HiddenBecauseUnused   bool                   `json:"hiddenBecauseUnused"`
+	HiddenBecauseUnused bool `json:"hiddenBecauseUnused"`
+	// Watch indicates if the account should be loaded even if its keystore is not connected.
+	//
+	// If false, the account is only displayed if the keystore is connected. If true, it is loaded
+	// and displayed when the app launches.
+	//
+	// If nil, it is considered false.
+	Watch                 *bool                  `json:"watch"`
 	CoinCode              coin.Code              `json:"coinCode"`
 	Name                  string                 `json:"name"`
 	Code                  accountsTypes.Code     `json:"code"`

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -529,12 +529,7 @@ func (handlers *Handlers) getAccountsHandler(_ *http.Request) interface{} {
 		}
 		var activeTokens []activeToken
 
-		persistedAccount := persistedAccounts.Lookup(account.Config().Config.Code)
-		if persistedAccount == nil {
-			handlers.log.WithField("code", account.Config().Config.Code).Error("account not found in accounts database")
-			continue
-		}
-
+		persistedAccount := account.Config().Config
 		if account.Coin().Code() == coinpkg.CodeETH {
 			for _, tokenCode := range persistedAccount.ActiveTokens {
 				activeTokens = append(activeTokens, activeToken{

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -48,6 +48,7 @@ export type TKeystore = {
 export interface IAccount {
   keystore: TKeystore;
   active: boolean;
+  watch: boolean;
   coinCode: CoinCode;
   coinUnit: string;
   coinName: string;

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -47,6 +47,10 @@ export const renameAccount = (accountCode: AccountCode, name: string): Promise<I
   return apiPost('rename-account', { accountCode, name });
 };
 
+export const accountSetWatch = (accountCode: AccountCode, watch: boolean): Promise<ISuccess> => {
+  return apiPost('account-set-watch', { accountCode, watch });
+};
+
 export const reinitializeAccounts = (): Promise<null> => {
   return apiPost('accounts/reinitialize');
 };

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -203,7 +203,7 @@ class Sidebar extends Component<Props> {
           {
             accountsByKeystore.map(keystore => (<React.Fragment key={keystore.keystore.rootFingerprint}>
               <div className={style.sidebarHeaderContainer}>
-                <span className={style.sidebarHeader} hidden={!keystores?.length}>
+                <span className={style.sidebarHeader} hidden={!keystore.accounts.length}>
                   {t('sidebar.accounts')} - {keystore.keystore.name}
                 </span>
               </div>

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -101,6 +101,16 @@ class ManageAccounts extends Component<Props, State> {
               this.toggleAccount(account.code, !active)
                 .then(() => event.target.disabled = false);
             }} />
+          Watchonly:
+          <Toggle
+            checked={account.watch}
+            className={style.toggle}
+            id={account.code}
+            onChange={async (event) => {
+              event.target.disabled = true;
+              await this.setWatch(account.code, !account.watch);
+              event.target.disabled = false;
+            }} />
           {active && account.coinCode === 'eth' ? (
             <div className={style.tokenSection}>
               <div className={`${style.tokenContainer} ${tokensVisible ? style.tokenContainerOpen : ''}`}>
@@ -129,6 +139,19 @@ class ManageAccounts extends Component<Props, State> {
         alertUser(errorMessage);
       }
     });
+  };
+
+  private setWatch = async (accountCode: string, watch: boolean) => {
+    // TODO: ask user if they really want to proceed if they disable watch-only, if its keystore is
+    // not currently loaded. Disabling watch-only in this case immediately removes the account from
+    // the sidebar and manage accounts and cannot be brought back without connecting the keystore.
+
+    const result = await backendAPI.accountSetWatch(accountCode, watch);
+    if (result.success) {
+      await this.fetchAccounts();
+    } else if (result.errorMessage) {
+      alertUser(result.errorMessage);
+    }
   };
 
   private toggleShowTokens = (accountCode: string) => {


### PR DESCRIPTION
Enabling the watchonly setting on an account leaves the account loaded when the keystore is removed, and the account is loaded at app launch too.

Watch-only is opt-in per account for now - in the future we might switch to enabling watch-only by default.

**Not done in this PR:** handling the case when the user performs an action on a watchonly account that requires the keystore, like verifying an address or transaction. This will follow in another PR. 