### PR TITLE
frontend: improve bitsurance page CSS

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -297,22 +297,23 @@
       "button": "Detect insured account",
       "insured": "Insured account detected:",
       "notInsured": "No insured accounts detected. If you are sure you have an insured account, please make sure you have the correct wallet connected.",
-      "text": "If you already have an insured account, please click the button below so the BitBoxApp can detect your insured accounts.",
+      "text": "If you already signed up with Bitsurance, the BitBoxApp can automatically synchronize your existing insurance coverage.",
       "title": "Already have an insured account?"
     },
     "insure": {
       "button": "Check availability and pricing",
       "faq": "Read more on Bitsurance FAQs",
-      "listItem1": "Loss through Fire/Water/Storm",
-      "listItem2": "Extortion ($5 wrench attack)",
+      "listItem1": "Robbery, burglary or vandalism",
+      "listItem2": "Extortion (e.g., $5 wrench attack)",
+      "listItem3": "Destruction due to fire, water or natural disasters",
       "month": "month",
-      "text": "Insure Bitcoin on this hardware wallet against:",
+      "text": "Insure your BitBox02 and up to €100,000 worth of bitcoin against",
+      "text2": "Insurance plans start at €2.50/month (€30/year). You can learn more about Bitsurance and their exact insurance offerings on the",
       "title": "Get started"
     },
     "intro": {
       "link": "Bitsurance website",
-      "text1": "BitBox has partened with Bitsurance to offer {{- amount}} worth of Bitcoin insurance.",
-      "text2": "Read more about the insurance offering on the"
+      "text1": "BitBox partners with Bitsurance to add an additional layer of protection for your bitcoin. While the BitBox02 keeps your funds secure, Bitsurance covers threats that can’t be mitigated with technology alone, like physical theft, extortion, or destruction of the wallet itself."
     },
     "title": "Insurance"
   },

--- a/frontends/web/src/routes/bitsurance/bitsurance.module.css
+++ b/frontends/web/src/routes/bitsurance/bitsurance.module.css
@@ -1,20 +1,89 @@
-.title {
-  font-size: 2rem;
-  font-weight: 400;
-  text-align: center;
+.cardBody {
+  font-size: 16px;
+  margin-bottom: calc(var(--space-half) + var(--space-quarter));
 }
 
-.clean {
-    padding-left: 0px !important;
-    list-style-type: none;
-    margin-top: 0px;
+.cardBody2 {
+  font-size: 14px;
+  margin-bottom: var(--space-default);
+}
+
+.clean li {
+  align-items: center;
+  display: flex;
+  margin-bottom: var(--space-half);
 }
 
 .clean span {
   margin-left: 10px;
 }
 
+.ctaButton button{
+  max-width: 240px;
+  padding: 0;
+}
+
+.ctaButton img {
+  margin-right: var(--space-quarter);
+}
+
+.ctaButton:focus img,
+.ctaButton:hover img {
+  /* Applying "primary" (blue) color to the originally dark img SVG when button is hovered */
+  filter: invert(53%) sepia(20%) saturate(1200%) hue-rotate(180deg) brightness(95%) contrast(90%); 
+}
+
+.errorMessage {
+  color: var(--color-danger);
+}
+
+.gridContainer {
+  margin-top: calc(var(--space-default) + var(--space-half));
+}
+
 .noVspace {
-    margin-bottom: 0px;
-    margin-top: 0px;
+  line-height: 1.4;
+  margin-bottom: 0px;
+  margin-top: 0px;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 400;
+  margin: 0;
+  margin-bottom: var(--space-half);
+}
+
+ul.clean {
+  list-style-type: none;
+  margin: 0;
+  padding-left: 0px;
+}
+
+@media (max-width: 768px) {
+  .cardBody {
+    font-size: var(--size-default);
+  }
+
+  .cardBody2 {
+    font-size: var(--size-small);
+  }
+
+  .clean li {
+    align-items: start;
+    margin-bottom: var(--space-quarter);
+  }
+
+  .ctaButton {
+    height: 40px;
+    max-width: unset;
+  }
+
+  .gridContainer {
+    margin-top: var(--space-half);
+  }
+
+  .title {
+    font-size: 16px;
+  }
 }

--- a/frontends/web/src/routes/bitsurance/bitsurance.tsx
+++ b/frontends/web/src/routes/bitsurance/bitsurance.tsx
@@ -23,7 +23,7 @@ import { A } from '../../components/anchor/anchor';
 import { Button } from '../../components/forms';
 import { Checked, Sync, SyncLight } from '../../components/icon';
 import Logo from '../../components/icon/logo';
-import { Column, Grid, GuidedContent, GuideWrapper, Header, Main } from '../../components/layout';
+import { Column, ColumnButtons, Grid, GuidedContent, GuideWrapper, Header, Main } from '../../components/layout';
 import { View, ViewContent } from '../../components/view/view';
 import { useDarkmode } from '../../hooks/darkmode';
 import { route } from '../../utils/route';
@@ -39,6 +39,7 @@ export const Bitsurance = ({ accounts }: TProps) => {
   const { isDarkMode } = useDarkmode();
   const [insuredAccounts, setInsuredAccounts] = useState<IAccount[]>([]);
   const [scanDone, setScanDone] = useState(false);
+  const [scanLoading, setScanLoading] = useState(false);
 
   const amount = '100.000€';
 
@@ -48,6 +49,7 @@ export const Bitsurance = ({ accounts }: TProps) => {
   }, [accounts]);
 
   const detect = async () => {
+    setScanLoading(true);
     setScanDone(false);
     setInsuredAccounts([]);
     const response = await bitsuranceLookup();
@@ -57,6 +59,7 @@ export const Bitsurance = ({ accounts }: TProps) => {
     }
     setInsuredAccounts(accounts.filter(({ code }) => response.accountCodes.includes(code)));
     setScanDone(true);
+    setScanLoading(false);
   };
 
   const maybeProceed = async () => {
@@ -71,51 +74,63 @@ export const Bitsurance = ({ accounts }: TProps) => {
         <GuidedContent>
           <Header title={<h2>{t('sidebar.insurance')}</h2>} />
           <View fullscreen={false}>
-            <ViewContent fullWidth>
+            <ViewContent>
               <p className={style.noVspace}>{t('bitsurance.intro.text1', { amount })}</p>
-              <p className={style.noVspace}>{t('bitsurance.intro.text2')} <A href="https://www.bitsurance.eu/">{t('bitsurance.intro.link')}</A>.</p>
-              <Grid col="2" textAlign="left">
-                <Column asCard>
-                  <h3 className="title">
-                    {t('bitsurance.insure.title')}
-                  </h3>
-                  <p>{t('bitsurance.insure.text')}</p>
-                  <ul className={style.clean}>
-                    <li><Checked/><span>{t('bitsurance.insure.listItem1')}</span></li>
-                    <li><Checked/><span>{t('bitsurance.insure.listItem2')}</span></li>
-                  </ul>
-                  <Button onClick={ maybeProceed } primary>
-                    {t('bitsurance.insure.button')}
-                  </Button>
-                  <A href="https://www.bitsurance.eu/faq/">{t('bitsurance.insure.faq')}</A>
-                </Column>
-                <Column asCard>
-                  <h3 className="title">
-                    {t('bitsurance.detect.title')}
-                  </h3>
-                  <p>{t('bitsurance.detect.text')}</p>
-                  {insuredAccounts.length > 0 ? (
+              <div className={style.gridContainer}>
+                <Grid col="2" textAlign="left">
+                  <Column asCard>
+                    <h3 className={style.title}>
+                      {t('bitsurance.insure.title')}
+                    </h3>
+                    <p className={style.cardBody}>{t('bitsurance.insure.text')}</p>
+                    <ul className={style.clean}>
+                      <li><Checked/><span>{t('bitsurance.insure.listItem1')}</span></li>
+                      <li><Checked/><span>{t('bitsurance.insure.listItem2')}</span></li>
+                      <li><Checked/><span>{t('bitsurance.insure.listItem3')}</span></li>
+                    </ul>
+                    <p className={style.cardBody2}>
+                      {t('bitsurance.insure.text2')} {' '}
+                      <A href="https://www.bitsurance.eu/">{t('bitsurance.intro.link')}</A>.
+                    </p>
+                    <ColumnButtons className={style.ctaButton}>
+                      <Button onClick={maybeProceed} primary>
+                        {t('bitsurance.insure.button')}
+                      </Button>
+                    </ColumnButtons>
+                  </Column>
+                  <Column asCard>
+                    <h3 className={style.title}>
+                      {t('bitsurance.detect.title')}
+                    </h3>
+                    <p className={style.cardBody}>{t('bitsurance.detect.text')}</p>
+                    {insuredAccounts.length > 0 ? (
                     //FIXME this will be removed and a new page listing the dashboard of the
                     // insured accounts will be introduced in a next commit.
-                    <div>
-                      <p>{t('bitsurance.detect.insured')}</p>
-                      <ul className={style.clean}>
-                        {insuredAccounts.map(account => <li key={account.code}>
-                          <Logo coinCode="btc" active={true} alt="btc" />
-                          {account.name}</li>)}
-                      </ul>
-                    </div>
-                  ) : scanDone && (
-                    <p>{t('bitsurance.detect.notInsured')}</p>
-                  )}
-                  <Button
-                    onClick={detect }
-                    primary>
-                    {isDarkMode ? <SyncLight/> : <Sync/>}
-                    {t('bitsurance.detect.button')}
-                  </Button>
-                </Column>
-              </Grid>
+                      <div>
+                        <p>{t('bitsurance.detect.insured')}</p>
+                        <ul className={style.clean}>
+                          {insuredAccounts.map(account => <li key={account.code}>
+                            <Logo coinCode="btc" active={true} alt="btc" />
+                            {account.name}</li>)}
+                        </ul>
+                      </div>
+                    ) : scanDone && (
+                      <p className={`${style.cardBody2} ${style.errorMessage}`}>{t('bitsurance.detect.notInsured')}</p>
+                    )}
+                    <ColumnButtons className={style.ctaButton}>
+                      <Button
+                        onClick={detect}
+                        disabled={scanLoading}
+                        secondary
+                      >
+                        {isDarkMode ? <SyncLight/> : <Sync/>}
+                        {t('bitsurance.detect.button')}
+                      </Button>
+                    </ColumnButtons>
+
+                  </Column>
+                </Grid>
+              </div>
             </ViewContent>
           </View>
         </GuidedContent>


### PR DESCRIPTION
To improve the application's UI according to its Mockups.

Preview:

<img width="1483" alt="aa" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/91442769-946b-4d29-8edb-94eef72f5473">
<img width="1483" alt="b" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/0e152f7f-dc03-4f19-b12a-5ac7d3482744">
<img width="339" alt="92o" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/fc9c860d-1158-4992-a1c3-4f72af832430">


