### PR TITLE
Specify 'platform' parameter to run docker build on Apple Silicon

### DIFF
--- a/scripts/dockerdev.sh
+++ b/scripts/dockerdev.sh
@@ -50,6 +50,7 @@ dockerdev () {
     local repo_path="$DIR/.."
     $RUNTIME run \
            --detach \
+           --platform "linux/amd64" \
            --privileged -v /dev/bus/usb:/dev/bus/usb \
            --interactive --tty \
            --name=$container_name -p 8080:8080 -p 8082:8082 \


### PR DESCRIPTION
With the current `dockerdev.sh` I was not able to get the `amd64` docker image started on my M2 arm based Mac. By adding the `--platform "linux/amd64"` parameter I was able to enforce virtualization with docker and get it running. So I recommed to add it for future developers using a Mac arm based laptop.

On other machines this additional parameter should not change anything - but I was not able to test it.