### PR TITLE
Custom block explorer

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -377,13 +377,15 @@ func (backend *Backend) Coin(code coinpkg.Code) (coinpkg.Coin, error) {
 		servers := backend.defaultElectrumXServers(code)
 		coin = btc.NewCoin(coinpkg.CodeRBTC, "Bitcoin Regtest", "RBTC", coinpkg.BtcUnitDefault, &chaincfg.RegressionNetParams, dbFolder, servers, "", backend.socksProxy)
 	case code == coinpkg.CodeTBTC:
+		blockExplorerPrefix := backend.config.AppConfig().Backend.TBTC.ExplorerURL()
 		servers := backend.defaultElectrumXServers(code)
 		coin = btc.NewCoin(coinpkg.CodeTBTC, "Bitcoin Testnet", "TBTC", btcFormatUnit, &chaincfg.TestNet3Params, dbFolder, servers,
-			"https://blockstream.info/testnet/tx/", backend.socksProxy)
+			blockExplorerPrefix, backend.socksProxy)
 	case code == coinpkg.CodeBTC:
+		blockExplorerPrefix := backend.config.AppConfig().Backend.BTC.ExplorerURL()
 		servers := backend.defaultElectrumXServers(code)
 		coin = btc.NewCoin(coinpkg.CodeBTC, "Bitcoin", "BTC", btcFormatUnit, &chaincfg.MainNetParams, dbFolder, servers,
-			"https://blockstream.info/tx/", backend.socksProxy)
+			blockExplorerPrefix, backend.socksProxy)
 	case code == coinpkg.CodeTLTC:
 		servers := backend.defaultElectrumXServers(code)
 		coin = btc.NewCoin(coinpkg.CodeTLTC, "Litecoin Testnet", "TLTC", coinpkg.BtcUnitDefault, &ltc.TestNet4Params, dbFolder, servers,

--- a/backend/config/blockexplorer.go
+++ b/backend/config/blockexplorer.go
@@ -1,0 +1,44 @@
+package config
+
+import "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
+
+// BlockExplorer interface that different coin configurations can implement.
+// It defines the Enabled() method which returns true if the user enabled the
+// option to use a custom blockexplorer in the settings. The ExplorerURL() method
+// returns the configured URL or a defined default as a string.
+type BlockExplorer interface {
+	Enabled()
+	ExplorerURL()
+}
+
+// The BlockExplorerConfig struct is used by the Backend configuration.
+type BlockExplorerConfig struct {
+	UseExplorer bool `json:"useCustomBlockExplorer"`
+	// Thies field is filled with a default when the config is created
+	// the default needs to be the placeholder value specified in the frontend.
+	ExplorerURL string `json:"explorerURL"`
+}
+
+// Implement custom blockexplorer for Bitcoin
+
+const defaultTestnet = "https://blockstream.info/testnet/tx/"
+const defaultBitcoin = "https://blockstream.info/tx/"
+
+func (btcCfg btcCoinConfig) Enabled() bool {
+	return btcCfg.BlockExplorer.UseExplorer
+}
+
+func (btcCfg btcCoinConfig) ExplorerURL() string {
+	if btcCfg.Enabled() {
+		return btcCfg.BlockExplorer.ExplorerURL
+	}
+	url := ""
+	switch btcCfg.Code {
+	case coin.CodeBTC:
+		url = defaultBitcoin
+	case coin.CodeTBTC:
+		url = defaultTestnet
+
+	}
+	return url
+}

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -41,7 +41,9 @@ func (s *ServerInfo) String() string {
 
 // btcCoinConfig holds configurations specific to a btc-based coin.
 type btcCoinConfig struct {
-	ElectrumServers []*ServerInfo `json:"electrumServers"`
+	Code            coin.Code
+	ElectrumServers []*ServerInfo       `json:"electrumServers"`
+	BlockExplorer   BlockExplorerConfig `json:"explorer"`
 }
 
 // ETHTransactionsSource  where to get Ethereum transactions from. See the list of consts
@@ -153,6 +155,7 @@ func NewDefaultAppConfig() AppConfig {
 			DeprecatedEthereumActive: true,
 
 			BTC: btcCoinConfig{
+				Code: coin.CodeBTC,
 				ElectrumServers: []*ServerInfo{
 					{
 						Server:  "btc1.shiftcrypto.io:443",
@@ -165,8 +168,13 @@ func NewDefaultAppConfig() AppConfig {
 						PEMCert: shiftRootCA,
 					},
 				},
+				BlockExplorer: BlockExplorerConfig{
+					UseExplorer: false,
+					ExplorerURL: "https://blockstream.info/tx/",
+				},
 			},
 			TBTC: btcCoinConfig{
+				Code: coin.CodeTBTC,
 				ElectrumServers: []*ServerInfo{
 					{
 						Server:  "tbtc1.shiftcrypto.io:443",
@@ -179,8 +187,13 @@ func NewDefaultAppConfig() AppConfig {
 						PEMCert: shiftRootCA,
 					},
 				},
+				BlockExplorer: BlockExplorerConfig{
+					UseExplorer: false,
+					ExplorerURL: "https://blockstream.info/testnet/tx/",
+				},
 			},
 			RBTC: btcCoinConfig{
+				Code: coin.CodeRBTC,
 				ElectrumServers: []*ServerInfo{
 					{
 						Server:  "127.0.0.1:52001",

--- a/frontends/web/src/components/confirm/Confirmation.tsx
+++ b/frontends/web/src/components/confirm/Confirmation.tsx
@@ -1,0 +1,26 @@
+import { Dialog, DialogButtons } from '../dialog/dialog';
+import { Message } from '../message/message';
+import { Button } from '../forms';
+import { useTranslation } from 'react-i18next';
+
+type TConfirmProps = {
+    title: string,
+    message: string,
+    open: boolean,
+    onClick: (status: boolean) => void,
+}
+
+export const Confirmation = ({ title, message, open, onClick }: TConfirmProps) => {
+  const { t } = useTranslation();
+
+  return (<Dialog title={title} open={open}>
+    <Message type="warning">
+      {message}
+    </Message>
+    <DialogButtons>
+      <Button primary onClick={() => onClick(true)}>{t('dialog.confirm')}</Button>
+      <Button secondary onClick={() => onClick(false)}>{t('dialog.cancel')}</Button>
+    </DialogButtons>
+  </Dialog>
+  );
+};

--- a/frontends/web/src/hooks/confirm.tsx
+++ b/frontends/web/src/hooks/confirm.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { Dialog, DialogButtons } from '../components/dialog/dialog';
+import { Message } from '../components/message/message';
+import { Button } from '../components/forms';
+import { useTranslation } from 'react-i18next';
+
+type TUseConfirm = [
+  (title: string, message: string) => Promise<boolean>,
+  React.FunctionComponent
+];
+
+type TProps = {
+    title: string
+    message: string
+}
+
+type TResolve = (value: boolean | PromiseLike<boolean>) => void;
+
+type TResolver = {
+    resolve: TResolve;
+};
+
+const createPromise = (): [Promise<boolean>, TResolve ] => {
+  let resolver: TResolve | null = null;
+  const promise = new Promise<boolean>((resolve, _reject) => {
+    resolver = resolve;
+  });
+
+  if (resolver === null) {
+    throw new Error('Failed to create promise');
+  }
+  return [promise, resolver];
+};
+
+const useConfirm = (): TUseConfirm => {
+  const { t } = useTranslation();
+  const [ open, setOpen ] = useState(false);
+  const [ resolver, setResolver ] = useState<TResolver>();
+  const [ confirmationProps, setConfirmationProps ] = useState<TProps>({ title: '', message: '' });
+
+  const getConfirmation = async (title: string, message: string) => {
+    setConfirmationProps({ title: title, message: message });
+    setOpen(true);
+    const [ promise, resolve ] = createPromise();
+    setResolver({ resolve });
+    return promise;
+  };
+
+  const onClick = async(status: boolean) => {
+    setOpen(false);
+    resolver?.resolve(status);
+  };
+
+  const Confirmation: React.FunctionComponent = () => (
+    <Dialog title={confirmationProps.title} open={open}>
+      <Message type="warning">
+        {confirmationProps.message}
+      </Message>
+      <DialogButtons>
+        <Button primary onClick={() => onClick(true)}>{t('dialog.confirm')}</Button>
+        <Button secondary onClick={() => onClick(false)}>{t('dialog.cancel')}</Button>
+      </DialogButtons>
+    </Dialog>
+  );
+
+  return [ getConfirmation, Confirmation ];
+
+};
+
+export default useConfirm;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1075,6 +1075,9 @@
       },
       "torProxy": {
         "description": "Connect over Tor for better privacy."
+      },
+      "explorer": {
+        "description": "Use your preferred blockexplorer"
       }
     },
     "appearance": {
@@ -1448,7 +1451,9 @@
       "setProxyAddress": "Set proxy address",
       "title": "Expert settings",
       "useProxy": "Enable tor proxy",
-      "useSats": "Display BTC values in Satoshis"
+      "useSats": "Display BTC values in Satoshis",
+      "useCustomBlockExplorer": "Custom Bitcoin block explorer",
+      "setBlockExplorerURL": "Set Bitcoin block explorer URL"
     },
     "header": {
       "home": "Home"

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -290,6 +290,10 @@
   "blink": {
     "button": "Blink"
   },
+  "blockedOpen": {
+    "message": "Are you sure you want to open this link ?",
+    "title": "This link is not on our whitelist"
+  },
   "bootloader": {
     "button": "Upgrade firmware now",
     "button_install": "Install firmware now",
@@ -1073,11 +1077,11 @@
       "customFees": {
         "description": "Lets you enter your own fee when sending."
       },
-      "torProxy": {
-        "description": "Connect over Tor for better privacy."
-      },
       "explorer": {
         "description": "Use your preferred blockexplorer"
+      },
+      "torProxy": {
+        "description": "Connect over Tor for better privacy."
       }
     },
     "appearance": {
@@ -1448,12 +1452,12 @@
         "title": "Connect your own full node"
       },
       "fee": "Enable custom fees",
+      "setBlockExplorerURL": "Set Bitcoin block explorer URL",
       "setProxyAddress": "Set proxy address",
       "title": "Expert settings",
-      "useProxy": "Enable tor proxy",
-      "useSats": "Display BTC values in Satoshis",
       "useCustomBlockExplorer": "Custom Bitcoin block explorer",
-      "setBlockExplorerURL": "Set Bitcoin block explorer URL"
+      "useProxy": "Enable tor proxy",
+      "useSats": "Display BTC values in Satoshis"
     },
     "header": {
       "home": "Home"

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -29,10 +29,22 @@ import { getConfig } from '../../utils/config';
 import { MobileHeader } from './components/mobile-header';
 import { Guide } from '../../components/guide/guide';
 import { Entry } from '../../components/guide/entry';
+import { EnableExplorerSetting } from './components/advanced-settings/enable-explorer-setting';
+import { debug } from '../../utils/env';
+import { getTesting } from '../../api/backend';
 
 export type TProxyConfig = {
   proxyAddress: string;
   useProxy: boolean;
+}
+
+export type TBitcoinExplorerConfig = {
+  explorerURL: string;
+  useCustomBlockExplorer: boolean;
+}
+
+export type TBitcoinConfig = {
+  explorer: TBitcoinExplorerConfig;
 }
 
 export type TFrontendConfig = {
@@ -42,6 +54,8 @@ export type TFrontendConfig = {
 
 type TBackendConfig = {
   proxy?: TProxyConfig
+  btc?: TBitcoinConfig
+  tbtc?: TBitcoinConfig
 }
 
 export type TConfig = {
@@ -50,12 +64,14 @@ export type TConfig = {
 }
 
 export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
+  const testing = useLoad(debug ? getTesting : () => Promise.resolve(false));
   const { t } = useTranslation();
   const fetchedConfig = useLoad(getConfig) as TConfig;
   const [config, setConfig] = useState<TConfig>();
 
   const frontendConfig = config?.frontend;
   const proxyConfig = config?.backend?.proxy;
+  const bitcoinConfig = testing ? config?.backend?.tbtc : config?.backend?.btc;
 
   useEffect(() => {
     setConfig(fetchedConfig);
@@ -83,6 +99,7 @@ export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetti
                 <EnableCustomFeesToggleSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
                 <EnableCoinControlSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
                 <EnableTorProxySetting proxyConfig={proxyConfig} onChangeConfig={setConfig} />
+                <EnableExplorerSetting bitcoinConfig={bitcoinConfig} onChangeConfig={setConfig} />
                 <ConnectFullNodeSetting />
               </WithSettingsTabs>
             </ViewContent>

--- a/frontends/web/src/routes/settings/components/advanced-settings/enable-explorer-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/enable-explorer-setting.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dispatch, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SettingsItem } from '../settingsItem/settingsItem';
+import { ChevronRightDark } from '../../../../components/icon';
+import { TBitcoinConfig } from '../../advanced-settings';
+import styles from './enable-tor-proxy-setting.module.css';
+import { ExplorerDialog } from './explorer-dialog';
+import InlineMessage from '../../../../components/inlineMessage/InlineMessage';
+
+type TProps = {
+    bitcoinConfig?: TBitcoinConfig;
+    onChangeConfig: Dispatch<any>;
+}
+
+export const EnableExplorerSetting = ({ bitcoinConfig, onChangeConfig }: TProps) => {
+  const { t } = useTranslation();
+  const [showExplorerDialog, setShowExplorerDialog] = useState(false);
+  const [showRestartMessage, setShowRestartMessage] = useState(false);
+
+  const explorerEnabled = bitcoinConfig?.explorer ? bitcoinConfig.explorer.useCustomBlockExplorer : false;
+
+  return (
+    <>
+      {
+        showRestartMessage ?
+          <InlineMessage
+            type="success"
+            align="left"
+            message={t('settings.restart')}
+            onEnd={() => setShowRestartMessage(false)}
+          /> : null
+      }
+      <SettingsItem
+        className={styles.settingItem}
+        settingName={t('settings.expert.useCustomBlockExplorer')}
+        onClick={() => setShowExplorerDialog(true)}
+        secondaryText={t('newSettings.advancedSettings.explorer.description')}
+        displayedValue={explorerEnabled ? t('generic.enabled_true') : t('generic.enabled_false')}
+        extraComponent={<ChevronRightDark width={24} height={24} />}
+      />
+      <ExplorerDialog
+        open={showExplorerDialog}
+        bitcoinConfig={bitcoinConfig}
+        onCloseDialog={() => setShowExplorerDialog(false)}
+        onChangeConfig={onChangeConfig}
+        handleShowRestartMessage={setShowRestartMessage}
+      />
+    </>
+  );
+};

--- a/frontends/web/src/routes/settings/components/advanced-settings/explorer-dialog.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/explorer-dialog.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Dispatch, useEffect, useState } from 'react';
+import { Dialog, DialogButtons } from '../../../../components/dialog/dialog';
+import { Toggle } from '../../../../components/toggle/toggle';
+import { Button, Input } from '../../../../components/forms';
+import { setConfig } from '../../../../utils/config';
+import { TConfig, TBitcoinExplorerConfig, TBitcoinConfig } from '../../advanced-settings';
+import { debug } from '../../../../utils/env';
+import { useLoad } from '../../../../hooks/api';
+import { getTesting } from '../../../../api/backend';
+
+type TProps = {
+    open: boolean;
+    bitcoinConfig?: TBitcoinConfig;
+    onCloseDialog: () => void;
+    onChangeConfig: (config: any) => void;
+    handleShowRestartMessage: Dispatch<boolean>;
+}
+
+export const ExplorerDialog = ({ open, bitcoinConfig, onCloseDialog, onChangeConfig, handleShowRestartMessage }: TProps) => {
+  const testing = useLoad(debug ? getTesting : () => Promise.resolve(false));
+  const [explorerURL, setExplorerURL] = useState<string>();
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (bitcoinConfig?.explorer) {
+      setExplorerURL(bitcoinConfig.explorer.explorerURL);
+    }
+  }, [bitcoinConfig]);
+
+
+  const handleSetExplorerButton = async () => {
+    if (!bitcoinConfig?.explorer || explorerURL === undefined) {
+      return;
+    }
+    const explorer = bitcoinConfig.explorer;
+    explorer.explorerURL = explorerURL.trim();
+
+    // TODO: Validate that the URL can be reached. Because of CORS we would need to make a request to the backen.
+    // this is not super important as the user gets the same feedback when the link can't be opened later.
+    await setExplorerConfig(explorer);
+  };
+
+  const setExplorerConfig = async (explorerConfig: TBitcoinExplorerConfig) => {
+    const config = await setConfig({
+      backend: { ...(testing ? { tbtc: { ...bitcoinConfig, explorer: explorerConfig } } : { btc: { ...bitcoinConfig, explorer: explorerConfig } }) },
+    }) as TConfig;
+
+    setExplorerURL(explorerConfig.explorerURL);
+    onChangeConfig(config);
+    handleShowRestartMessage(true);
+  };
+
+  const handleToggleExplorer = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!bitcoinConfig) {
+      return;
+    }
+    const explorer = { ...bitcoinConfig.explorer, useCustomBlockExplorer: e.target.checked };
+    await setExplorerConfig(explorer);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setExplorerURL(e.target.value);
+    handleShowRestartMessage(false);
+  };
+
+  // if no config nor explorerURL
+  if (!bitcoinConfig?.explorer || explorerURL === undefined) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onClose={onCloseDialog} title={t('settings.expert.setBlockExplorerURL')} small>
+      <div className="flex flex-row flex-between flex-items-center">
+        <p className="m-none">{t('settings.expert.useCustomBlockExplorer')}</p>
+        <Toggle
+          id="useCustomBlockExplorer"
+          checked={bitcoinConfig.explorer.useCustomBlockExplorer}
+          onChange={handleToggleExplorer} />
+      </div>
+      <div className="m-top-half">
+        <Input
+          name="explorerURL"
+          onInput={handleInputChange}
+          value={explorerURL}
+          placeholder={testing ? 'https://blockstream.info/testnet/tx/' : 'https://blockstream.info/tx/'}
+          disabled={!bitcoinConfig.explorer.useCustomBlockExplorer}
+        />
+        <DialogButtons>
+          <Button primary
+            onClick={handleSetExplorerButton}
+            disabled={!bitcoinConfig.explorer.useCustomBlockExplorer || explorerURL === bitcoinConfig.explorer.explorerURL}>
+            {t('settings.expert.setBlockExplorerURL')}
+          </Button>
+        </DialogButtons>
+      </div>
+    </Dialog>
+  );
+};

--- a/frontends/web/src/utils/request.ts
+++ b/frontends/web/src/utils/request.ts
@@ -54,6 +54,12 @@ function handleError(endpoint: string) {
           // which case the result does not matter.
           return;
         }
+        if (json.error.indexOf('Blocked') !== -1) {
+          // Skip alertUser() because we ask for confirmation
+          // to open links that are blocked.
+          reject(json.error);
+          return;
+        }
         console.error('error from endpoint', endpoint, json);
         // TODO: remove i18n.t dependency because if cyclic i18n<->request dependency
         // TODO: deprecate alertUser


### PR DESCRIPTION
This PR implements enabling a custom block explorer for the bitcoin config, since it is implemented as an interface it will be easy to use it for other coin configs too.

**Non-Whitelisted URLs**
I decided to approach this problem by implementing a confirmation dialog (thanks to [this](https://daveteu.medium.com/react-custom-confirmation-box-458cceba3f7b) ) we might want to use this approach instead of the deprecated `alertUser` and `confirmation` but this should be done in another PR.

Let me know if you think there is a better approach (e.g selecting from a predefined whitelisted list, or handling the warning differently)

Should I add a commit that adds popular bitcoin blockexplorers like mempool.space, and others ? This would give the user still complete freedom to choose but users that stick with common explorers don't see the warning.

**Restart the app**
I wasted a lot of time on trying to understand how to get the frontend to reload the `account` by calling the `/accounts` endpoint again..I could not figure it out so I added the _restart the app_ message to the setting that. We should think about making it easy for the settings to trigger config/account refreshing but this can also be another PR.

**using bitcoinConfig instead of explorerConfig**
I noticed that I need to [spread out](https://github.com/digitalbitbox/bitbox-wallet-app/compare/master...NicolaLS:bitbox-wallet-app:custom-block-explorer?expand=1#diff-7a4636f83354958dfaf38414670500261eaa14fdad5b3499925067c7cc0e67a8R59) the bitcionConfig because the `setConfig()` function does not _merge/update_ the config but overwrites it for nested config as is the case in `backend.btc.XX` `backend.tbtc.XXX` maybe we should refactor this function so we can be less verbose elsewhere.