### PR TITLE
ci: use macos 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           path: frontends/qt/build/linux/bitbox-*.rpm
           name: BitBoxApp-linux-${{github.sha}}.rpm
   macos:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Clone the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
CI currently always fails on macOS, seems due to homebrew not supporting macOS 11 anymore.