### PR TITLE
frontend: collapse/wrap header when there is not enough space 

### DIFF
--- a/frontends/web/src/components/hideamountsbutton/hideamountsbutton.module.css
+++ b/frontends/web/src/components/hideamountsbutton/hideamountsbutton.module.css
@@ -1,5 +1,7 @@
 .button {
+    border-width: 0;
     display: flex;
+    padding: 0;
 }
 
 .button img {

--- a/frontends/web/src/components/layout/header.module.css
+++ b/frontends/web/src/components/layout/header.module.css
@@ -1,32 +1,9 @@
-.container {
-    width: 100%;
-}
-
-.container.fixed {
-    position: fixed;
-    left: var(--sidebar-width);
-    height: var(--header-height);
-    width: calc(100% - var(--sidebar-width));
-    z-index: 1001;
-}
-
-.header {
-    padding: 0 var(--space-default);
-    max-width: var(--content-width);
-    height: var(--header-height);
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    flex: none;
-    margin: 0 auto;
-}
-
 .children {
     display: flex;
+    gap: var(--space-half);
     flex-direction: row;
     align-items: center;
+    margin-bottom: var(--space-quarter);
 }
 
 .children > a {
@@ -43,50 +20,24 @@
     stroke-width: 2;
 }
 
-.header.narrow > *:nth-child(2) {
-    text-align: center;
-}
-
-.header.narrow > *:nth-child(2) > * {
-    max-width: 600px;
+.container {
     width: 100%;
 }
 
-.title {
-    white-space: nowrap;
-    flex: 1;
+.container.fixed {
+    position: fixed;
+    left: var(--sidebar-width);
+    height: var(--header-height);
+    width: calc(100% - var(--sidebar-width));
+    z-index: 1001;
 }
 
-.title > * {
-    margin: 0;
-    font-size: var(--header-default-font-size);
-    font-weight: 400;
-    line-height: 1;
-    display: inline-flex;
-    align-items: center;
-    user-select: none;
-}
-
-.sidebarToggler {
-    width: 32px;
-    height: 32px;
-    margin-right: var(--spacing-default);
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-}
-
-.sidebarToggler img {
-    width: 20px;
+.disabled {
+    opacity: 0.4;    
 }
 
 .forceHidden .sidebarToggler {
     display: none !important;
-}
-
-.guideIconContainer {
-    margin-left: var(--space-half);
-    height: 18px;
 }
 
 .guideIcon {
@@ -104,32 +55,79 @@
     margin-right: calc(var(--space-quarter) / 2);
 }
 
-.disabled {
-    opacity: 0.4;    
+.guideIconContainer {
+    height: 18px;
 }
 
-@media (min-width: 1200px) {
-    .sidebarToggler {
-        display: none;
-    }
+.header {
+    padding: 0 var(--space-default);
+    max-width: var(--content-width);
+    min-height: var(--header-height);
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    flex: none;
+    margin: 0 auto;
+    flex-wrap: wrap;
+}
+
+.header.narrow > *:nth-child(2) {
+    text-align: center;
+}
+
+.header.narrow > *:nth-child(2) > * {
+    max-width: 600px;
+    width: 100%;
+}
+
+.sidebarToggler {
+    width: 32px;
+    height: 32px;
+    margin-bottom: var(--space-quarter);
+    margin-right: var(--spacing-default);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.sidebarToggler img {
+    width: 20px;
+}
+
+.title {
+    white-space: nowrap;
+    flex-grow: 1;
+    margin-bottom: var(--space-quarter);
+    padding-right: var(--space-half);
+}
+
+.title > * {
+    margin: 0;
+    font-size: var(--header-default-font-size);
+    font-weight: 400;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    user-select: none;
 }
 
 @media (max-width: 768px) {
-
+    .header {
+        padding: var(--space-half);
+    }
     .sidebarToggler.hideSidebarToggler {
         display: none;
-    }
-
-    .container .header {
-        padding: 0 var(--space-half);
     }
 
     .container .sidebarToggler {
         margin-right: 0;
     }
+}
 
-    .children > a,
-    .guideIcon {
-        font-size: var(--size-small);
+@media (min-width: 1200px) {
+    .sidebarToggler {
+        display: none;
     }
 }


### PR DESCRIPTION
To improve the UI, especially on mobile,  we'd like to be able to collapse / wrap the icons on the header into the 2nd row.


Before:
<img width="375" alt="xx" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/606289e0-ff96-4a77-b595-b57e8fb3ddcb">


After:

(mobile)
<img width="372" alt="Screenshot 2023-11-07 at 11 19 53" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/916cb579-c909-4529-a88d-0d8024dc0034">

(mobile, with headerssync)
<img width="401" alt="gg" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/8b17164e-f4f2-4a23-96ac-7df1f7b70820">

(tablet, with headerssync)
<img width="736" alt="cc" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/00bfec8c-abe5-4c74-aa18-31ac2d480f6d">

(desktop, with headerssync)
<img width="1092" alt="pp" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/a7c90595-0bfb-4c4e-9c37-d0e837f62fa0">
