### PR TITLE
Bitsurance Widget: Adding `sendAddressWithXPub`

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -317,10 +317,10 @@
     "title": "Insurance"
   },
   "bitsuranceAccount": {
+    "errorNoXpub": "Error: Was not able to get xpub from account.",
     "noAccount": "There are no accounts that can be insured.",
     "select": "Select account",
-    "title": "Insurance",
-    "errorNoXpub": "Error: Was not able to get xpub from account."
+    "title": "Insurance"
   },
   "blink": {
     "button": "Blink"

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -319,7 +319,8 @@
   "bitsuranceAccount": {
     "noAccount": "There are no accounts that can be insured.",
     "select": "Select account",
-    "title": "Insurance"
+    "title": "Insurance",
+    "errorNoXpub": "Error: Was not able to get xpub from account."
   },
   "blink": {
     "button": "Blink"

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { useState, useEffect, createRef } from 'react';
 import { RequestAddressV0Message, MessageVersion, parseMessage, serializeMessage, V0MessageType } from 'request-address';
 import { getConfig } from '../../utils/config';
-import { getTransactionList } from '../../api/account';
+import { getTransactionList, ScriptType } from '../../api/account';
 import { Dialog } from '../../components/dialog/dialog';
 import { confirmation } from '../../components/confirm/Confirm';
 import { verifyAddress, signAddress } from '../../api/exchanges';
@@ -100,9 +100,9 @@ export const BitsuranceWidget = ({ code }: TProps) => {
     current.contentWindow?.postMessage(message, '*');
   };
 
-  const getWPKHxPub = () => {
+  const getXPub = (wantedScriptType: ScriptType) => {
     let wpkhConfig = accountInfo?.signingConfigurations.find(config =>
-      config.bitcoinSimple?.scriptType === 'p2wpkh'
+      config.bitcoinSimple?.scriptType === wantedScriptType
     );
     return wpkhConfig?.bitcoinSimple?.keyInfo.xpub;
   };
@@ -120,7 +120,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
         signing = false;
         if (response.success) {
           if (withExtendedPublicKey) {
-            const xpub = getWPKHxPub();
+            const xpub = getXPub('p2wpkh');
             if (xpub) {
               sendAddressWithXPub(response.address, response.signature, xpub);
             } else {

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -101,10 +101,10 @@ export const BitsuranceWidget = ({ code }: TProps) => {
   };
 
   const getXPub = (wantedScriptType: ScriptType) => {
-    let wpkhConfig = accountInfo?.signingConfigurations.find(config =>
+    let xpubConfig = accountInfo?.signingConfigurations.find(config =>
       config.bitcoinSimple?.scriptType === wantedScriptType
     );
-    return wpkhConfig?.bitcoinSimple?.keyInfo.xpub;
+    return xpubConfig?.bitcoinSimple?.keyInfo.xpub;
   };
 
   const handleRequestAddress = (message: RequestAddressV0Message) => {

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -82,23 +82,6 @@ export const BitsuranceWidget = ({ code }: TProps) => {
     }, 200);
   };
 
-  const sendAddress = (address: string, sig: string) => {
-    const { current } = iframeRef;
-
-    if (!current) {
-      return;
-    }
-
-    const message = serializeMessage({
-      version: MessageVersion.V0,
-      type: V0MessageType.Address,
-      bitcoinAddress: address,
-      signature: sig,
-    });
-
-    current.contentWindow?.postMessage(message, '*');
-  };
-
   const sendAddressWithXPub = (address: string, sig: string, xpub: string) => {
     const { current } = iframeRef;
 
@@ -121,7 +104,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
     signing = true;
     const addressType = message.withScriptType ? String(message.withScriptType) : '';
     const withMessageSignature = message.withMessageSignature ? message.withMessageSignature : '';
-    const withExtendedPublicKey: boolean = message.withExtendedPublicKey ? message.withExtendedPublicKey : false;
+    const withExtendedPublicKey = !!message.withExtendedPublicKey;
     signAddress(
       addressType,
       withMessageSignature,
@@ -141,7 +124,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
 
           } else {
             // sending without xpub
-            sendAddress(response.address, response.signature);
+            sendAddressWithXPub(response.address, response.signature, "");
           }
         } else {
           if (response.errorCode !== 'userAbort') {

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -100,6 +100,13 @@ export const BitsuranceWidget = ({ code }: TProps) => {
     current.contentWindow?.postMessage(message, '*');
   };
 
+  const getWPKHxPub = () => {
+    let wpkhConfig = accountInfo?.signingConfigurations.find(config => 
+      config.bitcoinSimple?.scriptType === 'p2wpkh'
+    );
+    return wpkhConfig?.bitcoinSimple?.keyInfo.xpub;
+  };
+
   const handleRequestAddress = (message: RequestAddressV0Message) => {
     signing = true;
     const addressType = message.withScriptType ? String(message.withScriptType) : '';
@@ -113,17 +120,13 @@ export const BitsuranceWidget = ({ code }: TProps) => {
         signing = false;
         if (response.success) {
           if (withExtendedPublicKey) {
-            const bitcoinSimple = accountInfo?.signingConfigurations[0].bitcoinSimple;
-            if (bitcoinSimple) {
-              // sending with xpub
-              const xpub = bitcoinSimple.keyInfo.xpub;
+            const xpub = getWPKHxPub();
+            if (xpub) {
               sendAddressWithXPub(response.address, response.signature, xpub);
             } else {
               alertUser(t('bitsuranceAccount.errorNoXpub'));
             }
-
           } else {
-            // sending without xpub
             sendAddressWithXPub(response.address, response.signature, "");
           }
         } else {

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -101,7 +101,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
   };
 
   const getWPKHxPub = () => {
-    let wpkhConfig = accountInfo?.signingConfigurations.find(config => 
+    let wpkhConfig = accountInfo?.signingConfigurations.find(config =>
       config.bitcoinSimple?.scriptType === 'p2wpkh'
     );
     return wpkhConfig?.bitcoinSimple?.keyInfo.xpub;
@@ -127,7 +127,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
               alertUser(t('bitsuranceAccount.errorNoXpub'));
             }
           } else {
-            sendAddressWithXPub(response.address, response.signature, "");
+            sendAddressWithXPub(response.address, response.signature, '');
           }
         } else {
           if (response.errorCode !== 'userAbort') {


### PR DESCRIPTION
On the `requestAddress` message that is send from the Bitsurance-iFrame-App to the BitBoxApp was already the `withExtendedPublicKey` parameter available, but it was not implemented yet on the Bitsurance Widget page of the BitBox App that processes that message.

This PR adds checking this parameter and sends the xpub of the previous selected account as part of the answere with the `sendAddressWithXPub`.