### PR TITLE
Watchonly: prompt user to connect device/keystore when needed 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,14 @@ environment:
   nodejs_version: "18"
   matrix:
     - QT: C:\Qt\5.15.2\msvc2019_64
-      GOROOT: C:\go119
+      GOROOT: C:\go120
       GOPATH: C:\gopath\
       PLATFORM: amd64
       COMPILER: msvc
 
 # https://www.appveyor.com/docs/windows-images-software/#golang
 # If you change this, also change the GOROOT variable above to point to the right installation folder.
-stack: go 1.19 # should be 1.20, but that is not available yet, see https://www.appveyor.com/docs/windows-images-software/#golang
+stack: go 1.20
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -45,7 +45,7 @@ type AccountConfig struct {
 	DBFolder string
 	// NotesFolder is the folder where the transaction notes are stored. Full path.
 	NotesFolder     string
-	Keystore        keystore.Keystore
+	ConnectKeystore func() (keystore.Keystore, error)
 	OnEvent         func(types.Event)
 	RateUpdater     *rates.RateUpdater
 	GetNotifier     func(signing.Configurations) Notifier

--- a/backend/accounts/baseaccount_test.go
+++ b/backend/accounts/baseaccount_test.go
@@ -65,7 +65,6 @@ func TestBaseAccount(t *testing.T) {
 		},
 		DBFolder:        test.TstTempDir("baseaccount_test_dbfolder"),
 		NotesFolder:     test.TstTempDir("baseaccount_test_notesfolder"),
-		Keystore:        nil,
 		OnEvent:         func(event types.Event) { events <- event },
 		RateUpdater:     nil,
 		GetNotifier:     nil,

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -164,7 +164,10 @@ type Backend struct {
 	accounts                accountsList
 	// keystore is nil if no keystore is connected.
 	keystore keystore.Keystore
-	aopp     AOPP
+
+	connectKeystore connectKeystore
+
+	aopp AOPP
 
 	// makeBtcAccount creates a BTC account. In production this is `btc.NewAccount`, but can be
 	// overridden in unit tests for mocking.
@@ -505,7 +508,11 @@ func (backend *Backend) Keystore() keystore.Keystore {
 func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 	defer backend.accountsAndKeystoreLock.Lock()()
 	// Only for logging, if there is an error we continue anyway.
-	fingerprint, _ := keystore.RootFingerprint()
+	fingerprint, err := keystore.RootFingerprint()
+	if err != nil {
+		backend.log.WithError(err).Error("could not retrieve keystore fingerprint")
+		return
+	}
 	log := backend.log.WithField("rootFingerprint", fingerprint)
 	log.Info("registering keystore")
 	backend.keystore = keystore
@@ -515,19 +522,10 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 	})
 
 	belongsToKeystore := func(account *config.Account) bool {
-		fingerprint, err := keystore.RootFingerprint()
-		if err != nil {
-			log.WithError(err).Error("Could not retrieve root fingerprint")
-			return false
-		}
 		return account.SigningConfigurations.ContainsRootFingerprint(fingerprint)
 	}
 
 	persistKeystore := func(accountsConfig *config.AccountsConfig) error {
-		fingerprint, err := keystore.RootFingerprint()
-		if err != nil {
-			return errp.WithMessage(err, "could not retrieve root fingerprint")
-		}
 		keystoreName, err := keystore.Name()
 		if err != nil {
 			return errp.WithMessage(err, "could not retrieve keystore name")
@@ -538,7 +536,7 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 		return nil
 	}
 
-	err := backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
+	err = backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
 		// Persist keystore with its name in the config.
 		if err := persistKeystore(accountsConfig); err != nil {
 			log.WithError(err).Error("Could not persist keystore")
@@ -559,6 +557,8 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 	backend.initAccounts(false)
 
 	backend.aoppKeystoreRegistered()
+
+	backend.connectKeystore.onConnect(backend.keystore)
 }
 
 // DeregisterKeystore removes the registered keystore.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -784,3 +784,8 @@ func (backend *Backend) GetAccountFromCode(code string) (accounts.Interface, err
 
 	return acct, nil
 }
+
+// CancelConnectKeystore cancels a pending keystore connection request if one exists.
+func (backend *Backend) CancelConnectKeystore() {
+	backend.connectKeystore.cancel(errUserAbort)
+}

--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -73,7 +73,6 @@ func TestAccount(t *testing.T) {
 				SigningConfigurations: signingConfigurations,
 			},
 			DBFolder:        dbFolder,
-			Keystore:        nil,
 			OnEvent:         func(accountsTypes.Event) {},
 			RateUpdater:     nil,
 			GetNotifier:     func(signing.Configurations) accounts.Notifier { return nil },

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -16,6 +16,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -542,6 +543,10 @@ func (handlers *Handlers) postVerifyExtendedPublicKey(r *http.Request) (interfac
 		}, nil
 	}
 	canVerify, err := btcAccount.VerifyExtendedPublicKey(input.SigningConfigIndex)
+	// User canceled keystore connect prompt - no special action or message needed in the frontend.
+	if errp.Cause(err) == context.Canceled {
+		return result{Success: true}, nil
+	}
 	if err != nil {
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -69,6 +69,7 @@ func NewHandlers(
 	handleFunc("/has-secure-output", handlers.ensureAccountInitialized(handlers.getHasSecureOutput)).Methods("GET")
 	handleFunc("/propose-tx-note", handlers.ensureAccountInitialized(handlers.postProposeTxNote)).Methods("POST")
 	handleFunc("/notes/tx", handlers.ensureAccountInitialized(handlers.postSetTxNote)).Methods("POST")
+	handleFunc("/connect-keystore", handlers.ensureAccountInitialized(handlers.postConnectKeystore)).Methods("POST")
 	return handlers
 }
 
@@ -583,4 +584,13 @@ func (handlers *Handlers) postSetTxNote(r *http.Request) (interface{}, error) {
 	}
 
 	return nil, handlers.account.SetTxNote(args.InternalTxID, args.Note)
+}
+
+func (handlers *Handlers) postConnectKeystore(r *http.Request) (interface{}, error) {
+	type response struct {
+		Success bool `json:"success"`
+	}
+
+	_, err := handlers.account.Config().ConnectKeystore()
+	return response{Success: err == nil}, nil
 }

--- a/backend/coins/btc/sign.go
+++ b/backend/coins/btc/sign.go
@@ -63,7 +63,11 @@ func (account *Account) signTransaction(
 		FormatUnit:                   account.coin.formatUnit,
 	}
 
-	if err := account.Config().Keystore.SignTransaction(proposedTransaction); err != nil {
+	keystore, err := account.Config().ConnectKeystore()
+	if err != nil {
+		return err
+	}
+	if err := keystore.SignTransaction(proposedTransaction); err != nil {
 		return err
 	}
 

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -88,7 +88,6 @@ func newAccount(t *testing.T) *Account {
 				SigningConfigurations: signingConfigurations,
 			},
 			DBFolder:        dbFolder,
-			Keystore:        nil,
 			OnEvent:         func(accountsTypes.Event) {},
 			RateUpdater:     nil,
 			GetNotifier:     func(signing.Configurations) accounts.Notifier { return nil },

--- a/backend/connectkeystore.go
+++ b/backend/connectkeystore.go
@@ -1,0 +1,133 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"time"
+
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
+)
+
+var errWrongKeystore = errors.New("Wrong device/keystore connected.")
+var errUserAbort = errors.New("aborted by user")
+var errReplaced = errors.New("replaced by new prompt")
+
+// connectKeystore is a helper struct to enable connecting to a keystore with a specific root
+// fingerprint.
+type connectKeystore struct {
+	locker.Locker
+	// connectKeystoreCallback, if not nil, is called when a keystore is registered.
+	connectKeystoreCallback func(keystore.Keystore)
+	cancelFunc              context.CancelCauseFunc
+}
+
+func compareRootFingerprint(ks keystore.Keystore, rootFingerprint []byte) error {
+	keystoreRootFingerprint, err := ks.RootFingerprint()
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(rootFingerprint, keystoreRootFingerprint) {
+		return errWrongKeystore
+	}
+	return nil
+}
+
+// connect blocks until the keystore with the given rootFingerprint is connected and then returns
+// that keystore. If it is already connected, the it is returned immediately. If the next keystore
+// being connected is not the right fingerprint, `errWrongKeystore` is returned.
+//
+// Only one such call is supported at once. If another call is aleady ongoing, `errReplaced` is returned.
+// If `c.cancel(err)` is called, this function returns `err`.
+// If the keystore is not connected within the specified time, `context.DeadlineExceeded` is returned.
+func (c *connectKeystore) connect(
+	currentKeystore keystore.Keystore,
+	rootFingerprint []byte,
+	timeout time.Duration,
+) (keystore.Keystore, error) {
+	type result struct {
+		ks  keystore.Keystore
+		err error
+	}
+
+	resultCh := make(chan result)
+	alreadyRunning := func() bool {
+		defer c.RLock()()
+		return c.connectKeystoreCallback != nil
+	}()
+	if alreadyRunning {
+		// Cancel previous prompt - new prompt takes precedence.
+		c.cancel(errReplaced)
+	}
+
+	if currentKeystore != nil {
+		if err := compareRootFingerprint(currentKeystore, rootFingerprint); err != nil {
+			return nil, err
+		}
+		return currentKeystore, nil
+	}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	// clean up the cancel resource in case we resolve the context by timeout.
+	defer cancel(nil)
+	ctx, cancelTimeout := context.WithTimeout(ctx, timeout)
+	// clean up the timeout resource in case we resolve the context by manual cancellation.
+	// this is technically not needed as the parent context cancel above also cleans up the derived
+	// context, but `go vet` complains about it as it is best practice to be explicit.
+	defer cancelTimeout()
+
+	go func() {
+		defer c.Lock()()
+		c.cancelFunc = cancel
+		c.connectKeystoreCallback = func(ks keystore.Keystore) {
+			if err := compareRootFingerprint(ks, rootFingerprint); err != nil {
+				resultCh <- result{nil, err}
+				return
+			}
+			resultCh <- result{ks, nil}
+		}
+	}()
+
+	select {
+	case r := <-resultCh:
+		return r.ks, r.err
+	case <-ctx.Done():
+		return nil, context.Cause(ctx)
+	}
+}
+
+// onConnect should be called when a keystore is registered. It will resolve a pending call to
+// `connect()`.
+func (c *connectKeystore) onConnect(keystore keystore.Keystore) {
+	defer c.Lock()()
+	if c.connectKeystoreCallback != nil {
+		c.connectKeystoreCallback(keystore)
+		c.connectKeystoreCallback = nil
+		c.cancelFunc = nil
+	}
+}
+
+// cancel fails a pending call to `connect()`, making it return `cause` as the error.
+func (c *connectKeystore) cancel(cause error) {
+	defer c.Lock()()
+	if c.cancelFunc != nil {
+		c.cancelFunc(cause)
+		c.cancelFunc = nil
+		c.connectKeystoreCallback = nil
+	}
+}

--- a/backend/connectkeystore_test.go
+++ b/backend/connectkeystore_test.go
@@ -1,0 +1,111 @@
+// Copyright 2023 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	keystoremock "github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/mocks"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectKeystore(t *testing.T) {
+	ck := connectKeystore{}
+	fingerprint := []byte{1, 2, 3, 4}
+	fingerprint2 := []byte{5, 6, 7, 8}
+
+	expectedKeystore := &keystoremock.KeystoreMock{
+		RootFingerprintFunc: func() ([]byte, error) {
+			return fingerprint, nil
+		},
+	}
+
+	t.Run("timeout", func(t *testing.T) {
+		_, err := ck.connect(nil, fingerprint, time.Millisecond)
+		require.Equal(t, context.DeadlineExceeded, err)
+	})
+
+	t.Run("already connected", func(t *testing.T) {
+		ks, err := ck.connect(expectedKeystore, fingerprint, time.Millisecond)
+		require.NoError(t, err)
+		require.Equal(t, expectedKeystore, ks)
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(50 * time.Millisecond)
+			ck.cancel(errUserAbort)
+		}()
+		_, err := ck.connect(nil, fingerprint, time.Second)
+		require.Equal(t, errUserAbort, err)
+		wg.Wait()
+	})
+
+	t.Run("success", func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(50 * time.Millisecond)
+			ck.onConnect(expectedKeystore)
+		}()
+		ks, err := ck.connect(nil, fingerprint, time.Second)
+		require.NoError(t, err)
+		require.Equal(t, expectedKeystore, ks)
+		wg.Wait()
+	})
+
+	t.Run("already connecting", func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(50 * time.Millisecond)
+			ck.onConnect(expectedKeystore)
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Previous prompt is canceled by new prompt.
+			_, err := ck.connect(nil, fingerprint2, time.Minute)
+			require.Equal(t, errReplaced, err)
+		}()
+
+		time.Sleep(25 * time.Millisecond)
+		_, err := ck.connect(nil, fingerprint, time.Second)
+		require.NoError(t, err)
+		wg.Wait()
+	})
+
+	t.Run("wrong keystore", func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(50 * time.Millisecond)
+			ck.onConnect(expectedKeystore)
+		}()
+		_, err := ck.connect(nil, fingerprint2, time.Second)
+		require.Equal(t, errWrongKeystore, err)
+		wg.Wait()
+	})
+}

--- a/backend/exchanges/pocket.go
+++ b/backend/exchanges/pocket.go
@@ -132,7 +132,12 @@ func PocketWidgetSignAddress(account accounts.Interface, message string, format 
 		return "", "", errp.Newf("Coin not supported %s", account.Coin().Code())
 	}
 
-	canSign := account.Config().Keystore.CanSignMessage(account.Coin().Code())
+	keystore, err := account.Config().ConnectKeystore()
+	if err != nil {
+		return "", "", err
+	}
+
+	canSign := keystore.CanSignMessage(account.Coin().Code())
 	if !canSign {
 		return "", "", errp.Newf("The connected device or keystore cannot sign messages for %s",
 			account.Coin().Code())
@@ -155,7 +160,7 @@ func PocketWidgetSignAddress(account accounts.Interface, message string, format 
 	}
 	addr := unused[signingConfigIdx].Addresses[0]
 
-	sig, err := account.Config().Keystore.SignBTCMessage(
+	sig, err := keystore.SignBTCMessage(
 		[]byte(message),
 		addr.AbsoluteKeypath(),
 		account.Config().Config.SigningConfigurations[signingConfigIdx].ScriptType(),

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -103,6 +103,7 @@ type Backend interface {
 	AOPPChooseAccount(code accountsTypes.Code)
 	GetAccountFromCode(code string) (accounts.Interface, error)
 	HTTPClient() *http.Client
+	CancelConnectKeystore()
 }
 
 // Handlers provides a web api to the backend.
@@ -232,6 +233,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/aopp/cancel", handlers.postAOPPCancelHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/aopp/approve", handlers.postAOPPApproveHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/aopp/choose-account", handlers.postAOPPChooseAccountHandler).Methods("POST")
+	getAPIRouter(apiRouter)("/cancel-connect-keystore", handlers.postCancelConnectKeystoreHandler).Methods("POST")
 
 	devicesRouter := getAPIRouterNoError(apiRouter.PathPrefix("/devices").Subrouter())
 	devicesRouter("/registered", handlers.getDevicesRegisteredHandler).Methods("GET")
@@ -1275,4 +1277,9 @@ func (handlers *Handlers) postAOPPCancelHandler(r *http.Request) interface{} {
 func (handlers *Handlers) postAOPPApproveHandler(r *http.Request) interface{} {
 	handlers.backend.AOPPApprove()
 	return nil
+}
+
+func (handlers *Handlers) postCancelConnectKeystoreHandler(r *http.Request) (interface{}, error) {
+	handlers.backend.CancelConnectKeystore()
+	return nil, nil
 }

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -325,3 +325,7 @@ export const addAccount = (coinCode: string, name: string): Promise<TAddAccount>
 export const testRegister = (pin: string): Promise<null> => {
   return apiPost('test/register', { pin });
 };
+
+export const connectKeystore = (code: AccountCode): Promise<{ success: boolean; }> => {
+  return apiPost(`account/${code}/connect-keystore`);
+};

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -17,6 +17,7 @@
 import { AccountCode, CoinCode } from './account';
 import { apiGet, apiPost } from '../utils/request';
 import { FailResponse, SuccessResponse } from './response';
+import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
 
 export interface ICoin {
     coinCode: CoinCode;
@@ -73,4 +74,33 @@ export const getDefaultConfig = (): Promise<any> => {
 
 export const socksProxyCheck = (proxyAddress: string): Promise<ISuccess> => {
   return apiPost('socksproxy/check', proxyAddress);
+};
+
+export type TSyncConnectKeystore = null | {
+  typ: 'connect';
+  keystoreName: string;
+} | {
+  typ: 'error';
+  errorCode: 'wrongKeystore';
+  errorMessage: '';
+};
+
+/**
+ * Returns a function that subscribes a callback on a "connect-keystore".
+ * Meant to be used with `useSubscribe`.
+ */
+export const syncConnectKeystore = () => {
+  return (
+    cb: TSubscriptionCallback<TSyncConnectKeystore>
+  ) => {
+    return subscribeEndpoint('connect-keystore', (
+      obj: TSyncConnectKeystore,
+    ) => {
+      cb(obj);
+    });
+  };
+};
+
+export const cancelConnectKeystore = (): Promise<void> => {
+  return apiPost('cancel-connect-keystore');
 };

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -30,6 +30,7 @@ import { Alert } from './components/alert/Alert';
 import { Aopp } from './components/aopp/aopp';
 import { Banner } from './components/banner/banner';
 import { Confirm } from './components/confirm/Confirm';
+import { KeystoreConnectPrompt } from './components/keystoreconnectprompt';
 import { panelStore } from './components/sidebar/sidebar';
 import { MobileDataWarning } from './components/mobiledatawarning';
 import { Sidebar, toggleSidebar } from './components/sidebar/sidebar';
@@ -193,6 +194,7 @@ class App extends Component<Props, State> {
                 <Banner msgKey="bitbox02" />
                 <MobileDataWarning />
                 <Aopp />
+                <KeystoreConnectPrompt />
                 {
                   Object.entries(devices).map(([deviceID, productName]) => {
                     if (productName === 'bitbox02') {

--- a/frontends/web/src/components/accountselector/accountselector.tsx
+++ b/frontends/web/src/components/accountselector/accountselector.tsx
@@ -32,11 +32,12 @@ export type TOption = {
 }
 
 type TAccountSelector = {
-    title: string;
-    options: TOption[];
-    selected?: string;
-    onChange: (value: string) => void;
-    onProceed: () => void;
+  title: string;
+  disabled?: boolean;
+  options: TOption[];
+  selected?: string;
+  onChange: (value: string) => void;
+  onProceed: () => void;
 }
 
 const SelectSingleValue: FunctionComponent<SingleValueProps<TOption>> = (props) => {
@@ -80,7 +81,7 @@ const DropdownIndicator: FunctionComponent<DropdownIndicatorProps<TOption>> = (p
 
 
 
-export const AccountSelector = ({ title, options, selected, onChange, onProceed }: TAccountSelector) => {
+export const AccountSelector = ({ title, disabled, options, selected, onChange, onProceed }: TAccountSelector) => {
   const { t } = useTranslation();
   const [selectedAccount, setSelectedAccount] = useState<TOption>();
 
@@ -118,7 +119,7 @@ export const AccountSelector = ({ title, options, selected, onChange, onProceed 
         <Button
           primary
           onClick={onProceed}
-          disabled={!selected}>
+          disabled={!selected || disabled}>
           {t('buy.info.next')}
         </Button>
       </div>

--- a/frontends/web/src/components/keystoreconnectprompt.tsx
+++ b/frontends/web/src/components/keystoreconnectprompt.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Button } from './forms';
+import { cancelConnectKeystore, syncConnectKeystore } from '../api/backend';
+import { useSubscribeReset } from '../hooks/api';
+import { SkipForTesting } from '../routes/device/components/skipfortesting';
+
+export function KeystoreConnectPrompt() {
+  const { t } = useTranslation();
+
+  const [data, reset] = useSubscribeReset(syncConnectKeystore());
+  if (!data) {
+    return null;
+  }
+  switch (data.typ) {
+  case 'connect':
+    // TODO: make this look nice.
+    return (
+      <>
+        { data.keystoreName === '' ?
+          t('connectKeystore.promptNoName') :
+          t('connectKeystore.promptWithName', { name: data.keystoreName })
+        }
+        {/* Software keystore is unlocked from the app, so we add the button here.
+            The BitBox02 unlock is triggered by inserting it using the globally mounted BitBox02Wizard.
+            Te BitBox01 is ignored - BitBox01 users will simply need to unlock before being prompted.
+          */}
+        <SkipForTesting />
+        <Button primary onClick={() => cancelConnectKeystore()}>{t('dialog.cancel')}</Button>
+      </>
+    );
+  case 'error':
+    return (
+      <>
+        { data.errorCode === 'wrongKeystore' ? t('error.wrongKeystore') : data.errorMessage }
+        <Button primary onClick={() => reset()}>{t('button.dismiss')}</Button>
+      </>
+    );
+  default:
+    return null;
+  }
+}

--- a/frontends/web/src/hooks/api.ts
+++ b/frontends/web/src/hooks/api.ts
@@ -19,13 +19,15 @@ import { TSubscriptionCallback, TUnsubscribe } from '../api/subscribe';
 import { useMountedRef } from './mount';
 
 /**
- * useSubscribe is a hook to subscribe to a subscription function.
+ * useSubscribeReset is a hook to subscribe to a subscription function.
  * starts on first render, and returns undefined while there is no first response.
  * re-renders on every update.
+ * An array is returned: `[value, reset]`, where value is the subscribed value and `reset()` resets
+ * the value to `undefined`.
  */
-export const useSubscribe = <T>(
+export const useSubscribeReset = <T>(
   subscription: ((callback: TSubscriptionCallback<T>) => TUnsubscribe),
-): (T | undefined) => {
+): [T | undefined, () => void] => {
   const [response, setResponse] = useState<T>();
   const mounted = useMountedRef();
   const subscribe = () => {
@@ -40,6 +42,18 @@ export const useSubscribe = <T>(
     // empty dependencies because it's only subscribed once
     [] // eslint-disable-line react-hooks/exhaustive-deps
   );
+  return [response, () => setResponse(undefined)];
+};
+
+/**
+ * useSubscribe is a hook to subscribe to a subscription function.
+ * starts on first render, and returns undefined while there is no first response.
+ * re-renders on every update.
+ */
+export const useSubscribe = <T>(
+  subscription: ((callback: TSubscriptionCallback<T>) => TUnsubscribe),
+): (T | undefined) => {
+  const [response] = useSubscribeReset(subscription);
   return response;
 };
 

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -487,6 +487,10 @@
     "infoWhenPaired": "First on the paired mobile and then your BitBox"
   },
   "confirmOnDevice": "Please confirm on your device.",
+  "connectKeystore": {
+    "promptNoName": "Please connect your BitBox02",
+    "promptWithName": "Please connect your BitBox02 named \"{{name}}\""
+  },
   "darkmode": {
     "toggle": "Dark mode"
   },
@@ -606,7 +610,8 @@
     "aoppUnsupportedAsset": "The asset is not supported.",
     "aoppUnsupportedFormat": "There are no available accounts that support the requested address format.",
     "aoppUnsupportedKeystore": "The connected device cannot sign messages for this asset.",
-    "aoppVersion": "Unknown version."
+    "aoppVersion": "Unknown version.",
+    "wrongKeystore": "Wrong wallet connected - please make sure to insert the correct device matching this account. If you use the optional passphrase, make sure to use the passphrase matching this account."
   },
   "fiat": {
     "default": "default",

--- a/frontends/web/src/routes/account/receive/index.tsx
+++ b/frontends/web/src/routes/account/receive/index.tsx
@@ -44,7 +44,6 @@ export const Receive = (props: TProps) => {
   default: // software keystore
     return (
       <ReceiveBB02
-        deviceID={deviceID}
         {...props} />
     );
   }

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -109,14 +109,20 @@ export const Receive = ({
     }
   };
 
-  const verifyAddress = (addressesIndex: number) => {
+  const verifyAddress = async (addressesIndex: number) => {
     if (receiveAddresses) {
       if (code === undefined) {
         return;
       }
+
+      const connectResult = await accountApi.connectKeystore(code);
+      if (!connectResult.success) {
+        return;
+      }
+
       setVerifying(true);
-      accountApi.verifyAddress(code, receiveAddresses[addressesIndex].addresses[activeIndex].addressID)
-        .then(() => setVerifying(false));
+      await accountApi.verifyAddress(code, receiveAddresses[addressesIndex].addresses[activeIndex].addressID);
+      setVerifying(false);
     }
   };
 
@@ -134,7 +140,8 @@ export const Receive = ({
     }
   };
 
-  const hasDevice = deviceID !== undefined;
+  // TODO change label on verify button, make it work w/ software keystore
+  const hasDevice = true || deviceID !== undefined;
   const enableCopy = hasDevice ? false : true;
 
   let uriPrefix = '';

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -35,7 +35,6 @@ import style from './receive.module.css';
 type TProps = {
   accounts: accountApi.IAccount[];
   code: string;
-  deviceID?: string;
 };
 
 type AddressDialog = { addressType: number } | undefined;
@@ -58,10 +57,9 @@ const getIndexOfMatchingScriptType = (
 export const Receive = ({
   accounts,
   code,
-  deviceID,
 }: TProps) => {
   const { t } = useTranslation();
-  const [verifying, setVerifying] = useState<boolean>(false);
+  const [verifying, setVerifying] = useState<false | 'secure' | 'insecure'>(false);
   const [activeIndex, setActiveIndex] = useState<number>(0);
   // index into `availableScriptTypes`, or 0 if none are available.
   const [addressType, setAddressType] = useState<number>(0);
@@ -110,18 +108,26 @@ export const Receive = ({
   };
 
   const verifyAddress = async (addressesIndex: number) => {
-    if (receiveAddresses) {
-      if (code === undefined) {
-        return;
-      }
+    if (!receiveAddresses || code === undefined) {
+      return;
+    }
+    const connectResult = await accountApi.connectKeystore(code);
+    if (!connectResult.success) {
+      return;
+    }
 
-      const connectResult = await accountApi.connectKeystore(code);
-      if (!connectResult.success) {
-        return;
-      }
+    const hasSecureOutput = await accountApi.hasSecureOutput(code)();
+    if (!hasSecureOutput.hasSecureOutput) {
+      setVerifying('insecure');
+      // For the software keystore, the dialog is dismissed manually.
+      return;
+    }
 
-      setVerifying(true);
+    // For devices with a display, the dialog is dismissed by tapping the device.
+    setVerifying('secure');
+    try {
       await accountApi.verifyAddress(code, receiveAddresses[addressesIndex].addresses[activeIndex].addressID);
+    } finally {
       setVerifying(false);
     }
   };
@@ -140,10 +146,6 @@ export const Receive = ({
     }
   };
 
-  // TODO change label on verify button, make it work w/ software keystore
-  const hasDevice = true || deviceID !== undefined;
-  const enableCopy = hasDevice ? false : true;
-
   let uriPrefix = '';
   if (account) {
     if (account.coinCode === 'btc' || account.coinCode === 'tbtc') {
@@ -156,7 +158,7 @@ export const Receive = ({
   let address = '';
   if (currentAddresses) {
     address = currentAddresses[activeIndex].address;
-    if (hasDevice && !verifying) {
+    if (!verifying) {
       address = address.substring(0, 8) + '...';
     }
   }
@@ -171,7 +173,7 @@ export const Receive = ({
               { currentAddresses && (
                 <div style={{ position: 'relative' }}>
                   <div className={style.qrCodeContainer}>
-                    <QRCode data={enableCopy ? uriPrefix + address : undefined} />
+                    <QRCode data={undefined} />
                   </div>
                   <div className={style.labels}>
                     { currentAddresses.length > 1 && (
@@ -200,7 +202,7 @@ export const Receive = ({
                       </button>
                     )}
                   </div>
-                  <CopyableInput disabled={!enableCopy} value={address} flexibleHeight />
+                  <CopyableInput disabled={true} value={address} flexibleHeight />
                   { hasManyScriptTypes && (
                     <button
                       className={style.changeType}
@@ -239,8 +241,7 @@ export const Receive = ({
                   </form>
                   <div className="buttons">
                     <Button
-                      disabled={verifying}
-                      hidden={!hasDevice}
+                      disabled={verifying !== false}
                       onClick={() => verifyAddress(currentAddressIndex)}
                       primary>
                       {t('receive.verifyBitBox02')}
@@ -257,7 +258,14 @@ export const Receive = ({
                   <Dialog
                     open={!!(account && verifying)}
                     title={t('receive.verifyBitBox02')}
-                    disableEscape={true}
+                    // disable escape for secure outputs like the BitBox02, where the dialog is
+                    // dimissed by tapping the device
+                    disableEscape={verifying === 'secure'}
+                    onClose={() => {
+                      if (verifying === 'insecure') {
+                        setVerifying(false);
+                      }
+                    }}
                     medium centered>
                     {account && <>
                       <div className="text-center">

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -17,7 +17,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { route } from '../../utils/route';
-import { IAccount } from '../../api/account';
+import * as accountApi from '../../api/account';
 import { getExchangeSupportedAccounts } from './utils';
 import { getBalance } from '../../api/account';
 import Guide from './guide';
@@ -29,13 +29,14 @@ import { View, ViewContent } from '../../components/view/view';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
 
 type TProps = {
-    accounts: IAccount[];
+    accounts: accountApi.IAccount[];
     code: string;
 }
 
 export const BuyInfo = ({ code, accounts }: TProps) => {
   const [selected, setSelected] = useState<string>(code);
   const [options, setOptions] = useState<TOption[]>();
+  const [disabled, setDisabled] = useState<boolean>(false);
 
   const { t } = useTranslation();
 
@@ -52,9 +53,14 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
 
   }, [accounts]);
 
-  const maybeProceed = useCallback(() => {
+  const maybeProceed = useCallback(async () => {
     if (options !== undefined && options.length === 1) {
-      route(`/buy/exchange/${options[0].value}`);
+      const accountCode = options[0].value;
+      const connectResult = await accountApi.connectKeystore(accountCode);
+      if (!connectResult.success) {
+        return;
+      }
+      route(`/buy/exchange/${accountCode}`);
     }
   }, [options]);
 
@@ -81,7 +87,17 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
     });
   };
 
-  const handleProceed = () => {
+  const handleProceed = async () => {
+    setDisabled(true);
+    try {
+      const connectResult = await accountApi.connectKeystore(selected);
+      if (!connectResult.success) {
+        return;
+      }
+    } finally {
+      setDisabled(false);
+    }
+
     route(`/buy/exchange/${selected}`);
   };
   if (options === undefined) {
@@ -105,6 +121,7 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
               ) : (
                 <AccountSelector
                   title={t('buy.title', { name })}
+                  disabled={disabled}
                   options={options}
                   selected={selected}
                   onChange={handleChangeAccount}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalbitbox/bitbox-wallet-app
 
-go 1.19
+go 1.20
 
 require (
 	github.com/btcsuite/btcd v0.23.4


### PR DESCRIPTION
Whenever the keystore is needed to perform an action on an account (verify address, send tx, ...), the user is prompted to connect the device/keystore. 

- If it is already connected, it proceeds automatically.
- If the user cancels, whatever action the user is doing aborts
- If the user connects the wrong device (or right device but wrong passphrase), the action aborts with a relevant error message

This is invoked automatically in the backend whenever the keystore is needed. In addition, an API call `connectKeystore()` is added that manually invokes this prompt. This is useful to prompt the user to connect before upfront, e.g. in the first step of the "Buy crypto" workflow instead of in the middle of it.


