### PR TITLE
frontend: better error message for invalid pairing uri WC

### DIFF
--- a/frontends/web/src/components/forms/button.module.css
+++ b/frontends/web/src/components/forms/button.module.css
@@ -27,6 +27,10 @@
     cursor: pointer;
 }
 
+.button:disabled {
+    cursor: not-allowed;
+}
+
 .button:focus {
     outline: none;
 }

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1557,7 +1557,8 @@
   "walletConnect": {
     "connect": {
       "button": "Connect",
-      "dappLabel": "Enter URI address of dapp"
+      "dappLabel": "Enter URI address of dapp",
+      "invalidPairingUri": "Invalid pairing uri"
     },
     "dashboard": {
       "allSessions": "All sessions",

--- a/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
@@ -82,7 +82,7 @@ export const WCConnectForm = ({
           className={showQRButton ? styles.inputWithIcon : ''}
           value={uri}
           readOnly={connectLoading}
-          onInput={(e) => onInputChange(e.target.value)}>
+          onInput={(e) => onInputChange(e.target.value.replaceAll(' ', ''))}>
           {(showQRButton && !connectLoading) && <ScanQRButton onClick={toggleScanQR} />}
         </Input>
         <ScanQRDialog
@@ -99,7 +99,7 @@ export const WCConnectForm = ({
             {t('dialog.cancel')}
           </Button>
           <Button
-            disabled={connectLoading}
+            disabled={connectLoading || !uri}
             type="submit"
             primary
           >

--- a/frontends/web/src/routes/account/walletconnect/connect.tsx
+++ b/frontends/web/src/routes/account/walletconnect/connect.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useCallback, useContext, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { SignClientTypes } from '@walletconnect/types';
 import { useLoad } from '../../../hooks/api';
 import * as accountApi from '../../../api/account';
@@ -44,6 +45,7 @@ export const ConnectScreenWalletConnect = ({
   const [loading, setLoading] = useState(false);
   const { web3wallet, isWalletInitialized, pair } = useContext(WCWeb3WalletContext);
   const [currentProposal, setCurrentProposal] = useState<SignClientTypes.EventArguments['session_proposal']>();
+  const { t } = useTranslation();
   const receiveAddresses = useLoad(accountApi.getReceiveAddressList(code));
   const onSessionProposal = useCallback(
     (proposal: SignClientTypes.EventArguments['session_proposal']) => {
@@ -84,7 +86,11 @@ export const ConnectScreenWalletConnect = ({
     try {
       await pair({ uri });
     } catch (err: any) {
-      alertUser(err.message);
+      if (err.message.includes('Missing or invalid. pair()')) {
+        alertUser(`${t('walletConnect.connect.invalidPairingUri')}: ${uri}`);
+      } else {
+        alertUser(err.message);
+      }
       setUri('');
       setLoading(false);
     }


### PR DESCRIPTION
To improve UX, we'd like to make the error message clearer when user is pairing dapp via WC using invalid URI.

[Preview before]: 

![xxx](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/2d5a0190-f289-455a-8b04-da8eeefd691f)


[Preview after]:

<img width="1483" alt="qwedas" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/71f9f62b-f85a-4fb6-ac38-a001ba75df04">
