### PR TITLE
cleanup bitsurance widget and redirect to dashboard after contract confirmation

### DIFF
--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -29,6 +29,7 @@ import { alertUser } from '../../components/alert/Alert';
 import { BitsuranceGuide } from './guide';
 import style from './widget.module.css';
 import { getBitsuranceURL } from '../../api/bitsurance';
+import { route } from '../../utils/route';
 
 type TProps = {
     code: string;
@@ -148,7 +149,13 @@ export const BitsuranceWidget = ({ code }: TProps) => {
 
     // handle requests from Bitsurance iframe
     try {
-      const message = parseMessage(m.data);
+      let message = JSON.parse(m.data);
+      if (message?.type === 'showInsuranceDashboard') {
+        route('bitsurance/dashboard');
+        return;
+      }
+
+      message = parseMessage(m.data);
       switch (message.type) {
       case V0MessageType.RequestAddress:
         // we ignore further signing requests

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -18,10 +18,8 @@ import { useTranslation } from 'react-i18next';
 import { useState, useEffect, createRef } from 'react';
 import { RequestAddressV0Message, MessageVersion, parseMessage, serializeMessage, V0MessageType } from 'request-address';
 import { getConfig } from '../../utils/config';
-import { getTransactionList, ScriptType } from '../../api/account';
-import { Dialog } from '../../components/dialog/dialog';
-import { confirmation } from '../../components/confirm/Confirm';
-import { verifyAddress, signAddress } from '../../api/exchanges';
+import { ScriptType } from '../../api/account';
+import { signAddress } from '../../api/exchanges';
 import { getInfo } from '../../api/account';
 import { Header } from '../../components/layout';
 import { Spinner } from '../../components/spinner/Spinner';
@@ -42,7 +40,6 @@ export const BitsuranceWidget = ({ code }: TProps) => {
   const [height, setHeight] = useState(0);
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const [agreedTerms, setAgreedTerms] = useState(false);
-  const [verifying, setVerifying] = useState(false);
 
   const iframeURL = useLoad(getBitsuranceURL);
   const config = useLoad(getConfig);
@@ -109,7 +106,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
 
   const handleRequestAddress = (message: RequestAddressV0Message) => {
     signing = true;
-    const addressType = message.withScriptType ? String(message.withScriptType) : '';
+    const addressType = message.withScriptType ? String(message.withScriptType) : 'p2wpkh';
     const withMessageSignature = message.withMessageSignature ? message.withMessageSignature : '';
     const withExtendedPublicKey = !!message.withExtendedPublicKey;
     signAddress(
@@ -120,7 +117,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
         signing = false;
         if (response.success) {
           if (withExtendedPublicKey) {
-            const xpub = getXPub('p2wpkh');
+            const xpub = getXPub(addressType as ScriptType);
             if (xpub) {
               sendAddressWithXPub(response.address, response.signature, xpub);
             } else {
@@ -137,61 +134,6 @@ export const BitsuranceWidget = ({ code }: TProps) => {
         }
       });
 
-  };
-
-  const handleVerifyAddress = (address: string) => {
-    setVerifying(true);
-    verifyAddress(address, code)
-      .then(response => {
-        setVerifying(false);
-        if (!response.success) {
-          if (response.errorCode === 'addressNotFound') {
-            // This should not happen, unless the user receives a tx on the same address between the message signing
-            // and the address verification.
-            alertUser(t('buy.pocket.usedAddress', { address:  address })); //FIXME label
-          } else {
-            alertUser(t('unknownError', { errorMessage: response.errorMessage }));
-            console.log('error: ' + response.errorMessage);
-          }
-        }
-      });
-  };
-
-  const sendXpub = () => {
-    if (accountInfo) {
-      const bitcoinSimple = accountInfo.signingConfigurations[0].bitcoinSimple;
-      if (bitcoinSimple) {
-        const xpub = bitcoinSimple.keyInfo.xpub;
-        const { current } = iframeRef;
-        if (!current) {
-          return;
-        }
-        const message = serializeMessage({
-          version: MessageVersion.V0,
-          type: V0MessageType.ExtendedPublicKey,
-          extendedPublicKey: xpub,
-        });
-        current.contentWindow?.postMessage(message, '*');
-      }
-    }
-  };
-
-  const handleRequestXpub = () => {
-    getTransactionList(code).then(txs => {
-      if (!txs.success) {
-        alertUser(t('transactions.errorLoadTransactions'));
-        return;
-      }
-      if (txs.list.length > 0) {
-        confirmation(t('buy.pocket.previousTransactions'), result => { //FIXME label
-          if (result) {
-            sendXpub();
-          }
-        });
-      } else {
-        sendXpub();
-      }
-    });
   };
 
   const onMessage = (m: MessageEvent) => {
@@ -215,13 +157,6 @@ export const BitsuranceWidget = ({ code }: TProps) => {
           handleRequestAddress(message);
         }
         break;
-      case V0MessageType.VerifyAddress:
-        if (!verifying) {
-          handleVerifyAddress(message.bitcoinAddress);
-        }
-        break;
-      case V0MessageType.RequestExtendedPublicKey:
-        handleRequestXpub();
       }
     } catch (e) {
       console.log(e);
@@ -259,13 +194,6 @@ export const BitsuranceWidget = ({ code }: TProps) => {
               </iframe>
             </div>
           )}
-          <Dialog
-            open={verifying}
-            title={t('receive.verifyBitBox02')} //FIXME label
-            disableEscape={true}
-            medium centered>
-            <div className="text-center">{t('buy.pocket.verifyBitBox02')}</div> //FIXME label
-          </Dialog>
         </div>
       </div>
       <BitsuranceGuide/>


### PR DESCRIPTION
The widget integration and the dashboard redirect at the end of the workflow can be tested by adding a `mockup=1` param at the widget URL: https://github.com/Beerosagos/bitbox-wallet-app/blob/bitsurance-widget-route/backend/bitsurance/bitsurance.go#L35

`widgetTestURL = "https://test.bitsurance.eu/?wallet=bitbox&version=" + widgetVersion + "&mockup=1&lang="`

Notes: 
- Bitsurance is not available on testnet, please use `make servewallet-mainnet`
- This branch doesn't include the dashboard page yet (PR in review #2334), so the redirect will bring to an empty page, this is ok.