### PR TITLE
frontend/send: fix bug in send form

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -389,8 +389,7 @@ class Send extends Component<Props, State> {
       apiGet(`coins/convert-from-fiat?from=${this.state.fiatUnit}&to=${coinCode}&amount=${value}`)
         .then(data => {
           if (data.success) {
-            this.setState({ amount: data.amount });
-            this.validateAndDisplayFee(false);
+            this.setState({ amount: data.amount }, () => this.validateAndDisplayFee(false));
           } else {
             this.setState({ amountError: this.props.t('send.error.invalidAmount') });
           }


### PR DESCRIPTION
Calling `validateAndDisplayFee` without waiting for `setState` to complete was causing the actual transaction proposal amount possibly not to be updated to the last inserted digit.