### PR TITLE
Android system auth

### DIFF
--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -310,6 +310,8 @@ func (e environment) DetectDarkTheme() bool {
 	return false
 }
 
+func (e environment) Auth() {}
+
 func newBackend(t *testing.T, testing, regtest bool) *Backend {
 	t.Helper()
 	b, err := NewBackend(

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -117,6 +117,7 @@ type authEventType string
 const (
 	authRequired authEventType = "auth-required"
 	authForced   authEventType = "auth-forced"
+	authCanceled authEventType = "auth-canceled"
 	authOk       authEventType = "auth-ok"
 	authErr      authEventType = "auth-err"
 )
@@ -332,6 +333,17 @@ func (backend *Backend) TriggerAuth() {
 		Action:  action.Replace,
 		Object: authEventObject{
 			Typ: authRequired,
+		},
+	})
+}
+
+// CancelAuth triggers an auth-canceled notification.
+func (backend *Backend) CancelAuth() {
+	backend.Notify(observable.Event{
+		Subject: "auth",
+		Action:  action.Replace,
+		Object: authEventObject{
+			Typ: authCanceled,
 		},
 	})
 }

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -131,6 +131,16 @@ func TriggerAuth() {
 	globalBackend.TriggerAuth()
 }
 
+// CancelAuth triggers an authentication canceled notification.
+func CancelAuth() {
+	mu.Lock()
+	defer mu.Unlock()
+	if globalBackend == nil {
+		return
+	}
+	globalBackend.CancelAuth()
+}
+
 // AuthResult triggers an authentication result notification
 // on the base of the input value.
 func AuthResult(ok bool) {

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -121,6 +121,27 @@ func HandleURI(uri string) {
 	globalBackend.HandleURI(uri)
 }
 
+// TriggerAuth triggers an authentication request notification.
+func TriggerAuth() {
+	mu.Lock()
+	defer mu.Unlock()
+	if globalBackend == nil {
+		return
+	}
+	globalBackend.TriggerAuth()
+}
+
+// AuthResult triggers an authentication result notification
+// on the base of the input value.
+func AuthResult(ok bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	if globalBackend == nil {
+		return
+	}
+	globalBackend.AuthResult(ok)
+}
+
 // UsingMobileDataChanged should be called when the network connnection changed.
 func UsingMobileDataChanged() {
 	mu.RLock()
@@ -147,12 +168,20 @@ type BackendEnvironment struct {
 	GetSaveFilenameFunc func(string) string
 	SetDarkThemeFunc    func(bool)
 	DetectDarkThemeFunc func() bool
+	AuthFunc            func()
 }
 
 // NotifyUser implements backend.Environment.
 func (env *BackendEnvironment) NotifyUser(text string) {
 	if env.NotifyUserFunc != nil {
 		env.NotifyUserFunc(text)
+	}
+}
+
+// Auth implements backend.Environment.
+func (env *BackendEnvironment) Auth() {
+	if env.AuthFunc != nil {
+		env.AuthFunc()
 	}
 }
 

--- a/backend/bridgecommon/bridgecommon_test.go
+++ b/backend/bridgecommon/bridgecommon_test.go
@@ -69,6 +69,8 @@ func (e environment) DetectDarkTheme() bool {
 	return false
 }
 
+func (e environment) Auth() {}
+
 // TestServeShutdownServe checks that you can call Serve twice in a row.
 func TestServeShutdownServe(t *testing.T) {
 	bridgecommon.Serve(

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -74,6 +74,8 @@ type Backend struct {
 	DeprecatedLitecoinActive bool `json:"litecoinActive"`
 	DeprecatedEthereumActive bool `json:"ethereumActive"`
 
+	Authentication bool `json:"authentication"`
+
 	BTC  btcCoinConfig `json:"btc"`
 	TBTC btcCoinConfig `json:"tbtc"`
 	RBTC btcCoinConfig `json:"rbtc"`
@@ -155,6 +157,7 @@ func NewDefaultAppConfig() AppConfig {
 				UseProxy:     false,
 				ProxyAddress: "",
 			},
+			Authentication:           false,
 			DeprecatedBitcoinActive:  true,
 			DeprecatedLitecoinActive: true,
 			DeprecatedEthereumActive: true,

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -194,6 +194,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/update", handlers.getUpdateHandler).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/banners/{key}", handlers.getBannersHandler).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/using-mobile-data", handlers.getUsingMobileDataHandler).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/auth", handlers.getAuthHandler).Methods("GET")
 	getAPIRouter(apiRouter)("/set-dark-theme", handlers.postDarkThemeHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/detect-dark-theme", handlers.getDetectDarkThemeHandler).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/version", handlers.getVersionHandler).Methods("GET")
@@ -457,6 +458,12 @@ func (handlers *Handlers) getBannersHandler(r *http.Request) interface{} {
 
 func (handlers *Handlers) getUsingMobileDataHandler(r *http.Request) interface{} {
 	return handlers.backend.Environment().UsingMobileData()
+}
+
+func (handlers *Handlers) getAuthHandler(r *http.Request) interface{} {
+	handlers.log.Info("Auth requested")
+	handlers.backend.Environment().Auth()
+	return nil
 }
 
 func (handlers *Handlers) postDarkThemeHandler(r *http.Request) (interface{}, error) {

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -58,6 +58,7 @@ func (e *backendEnv) NativeLocale() string          { return e.Locale }
 func (e *backendEnv) GetSaveFilename(string) string { return "" }
 func (e *backendEnv) SetDarkTheme(bool)             {}
 func (e *backendEnv) DetectDarkTheme() bool         { return false }
+func (e *backendEnv) Auth()                         {}
 
 func TestGetNativeLocale(t *testing.T) {
 	const ptLocale = "pt"

--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -28,6 +28,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.biometric:biometric:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/BiometricAuthHelper.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/BiometricAuthHelper.java
@@ -1,0 +1,53 @@
+package ch.shiftcrypto.bitboxapp;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.annotation.NonNull;
+import androidx.biometric.BiometricManager;
+import androidx.biometric.BiometricPrompt;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.FragmentActivity;
+
+import java.util.concurrent.Executor;
+
+public class BiometricAuthHelper {
+
+    public interface AuthCallback {
+        void onSuccess();
+        void onFailure();
+    }
+
+    public static void showAuthenticationPrompt(FragmentActivity activity, AuthCallback callback) {
+        Executor executor = ContextCompat.getMainExecutor(activity);
+        BiometricPrompt biometricPrompt = new BiometricPrompt(activity, executor, new BiometricPrompt.AuthenticationCallback() {
+            @Override
+            public void onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult result) {
+                super.onAuthenticationSucceeded(result);
+                new Handler(Looper.getMainLooper()).post(callback::onSuccess);
+            }
+
+            @Override
+            public void onAuthenticationFailed() {
+                super.onAuthenticationFailed();
+                new Handler(Looper.getMainLooper()).post(callback::onFailure);
+            }
+
+            @Override
+            public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
+                Util.log("Authentication error: " + errorCode + " - " + errString);
+                super.onAuthenticationError(errorCode, errString);
+                new Handler(Looper.getMainLooper()).post(callback::onFailure);
+            }
+        });
+
+        BiometricPrompt.PromptInfo promptInfo = new BiometricPrompt.PromptInfo.Builder()
+                .setTitle("Authentication required")
+                .setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL |
+                                BiometricManager.Authenticators.BIOMETRIC_WEAK)
+                .setConfirmationRequired(false)
+                .build();
+
+        biometricPrompt.authenticate(promptInfo);
+    }
+}

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
@@ -121,6 +121,11 @@ public class GoViewModel extends AndroidViewModel {
             Util.systemOpen(getApplication(), url);
         }
 
+        public void auth() {
+            Util.log("Auth requested from backend");
+            requestAuth();
+        }
+
         public boolean usingMobileData() {
             // Adapted from https://stackoverflow.com/a/53243938
 
@@ -187,15 +192,29 @@ public class GoViewModel extends AndroidViewModel {
         }
     }
 
-     private MutableLiveData<Boolean> isDarkTheme = new MutableLiveData<>();
+    private MutableLiveData<Boolean> isDarkTheme = new MutableLiveData<>();
 
-     public MutableLiveData<Boolean> getIsDarkTheme() {
+    public MutableLiveData<Boolean> getIsDarkTheme() {
          return isDarkTheme;
      }
-
-     public void setIsDarkTheme(Boolean isDark) {
+    public void setIsDarkTheme(Boolean isDark) {
          this.isDarkTheme.postValue(isDark);
     }
+
+    private MutableLiveData<Boolean> authenticator = new MutableLiveData<>(false);
+
+    public MutableLiveData<Boolean> getAuthenticator() {
+        return authenticator;
+    }
+
+    public void requestAuth() {
+        this.authenticator.postValue(true);
+    }
+
+    public void closeAuth() {
+        this.authenticator.postValue(false);
+    }
+
     private GoEnvironment goEnvironment;
     private GoAPI goAPI;
 

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -358,12 +358,40 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
+        goViewModel.getAuthenticator().observe(this, new Observer<Boolean>() {
+            @Override
+            public void onChanged(Boolean requestAuth) {
+                if (!requestAuth) {
+                    return;
+                }
+                BiometricAuthHelper.showAuthenticationPrompt(MainActivity.this, new BiometricAuthHelper.AuthCallback() {
+                    @Override
+                    public void onSuccess() {
+                        // Authenticated successfully
+                        Util.log("Auth success");
+                        goViewModel.closeAuth();
+                        Goserver.authResult(true);
+                    }
+
+                    @Override
+                    public void onFailure() {
+                        // Failed or cancelled
+                        Util.log("Auth failed");
+                        goViewModel.closeAuth();;
+                        Goserver.authResult(false);
+                    }
+                });
+            }
+        });
+
     }
 
     @Override
     protected void onResume() {
         super.onResume();
         Util.log("lifecycle: onResume");
+        Goserver.triggerAuth();
+
         // This is only called reliably when USB is attached with android:launchMode="singleTop"
 
         // Usb device list is updated on ATTACHED / DETACHED intents.

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -375,10 +375,19 @@ public class MainActivity extends AppCompatActivity {
 
                     @Override
                     public void onFailure() {
-                        // Failed or cancelled
+                        // Failed
                         Util.log("Auth failed");
                         goViewModel.closeAuth();;
                         Goserver.authResult(false);
+                    }
+
+                    @Override
+                    public void onCancel() {
+                        // Canceled
+                        Util.log("Auth canceled");
+                        goViewModel.closeAuth();;
+                        Goserver.cancelAuth();
+
                     }
                 });
             }

--- a/frontends/android/goserver/goserver.go
+++ b/frontends/android/goserver/goserver.go
@@ -217,6 +217,11 @@ func TriggerAuth() {
 	bridgecommon.TriggerAuth()
 }
 
+// CancelAuth triggers an auth canceled notification towards the frontend.
+func CancelAuth() {
+	bridgecommon.CancelAuth()
+}
+
 // AuthResult triggers an auth feeedback notification (auth-ok/auth-err) towards the frontend,
 // depending on the input value.
 func AuthResult(ok bool) {

--- a/frontends/android/goserver/goserver.go
+++ b/frontends/android/goserver/goserver.go
@@ -92,6 +92,7 @@ type GoEnvironmentInterface interface {
 	NativeLocale() string
 	SetDarkTheme(bool)
 	DetectDarkTheme() bool
+	Auth()
 }
 
 // readWriteCloser implements io.ReadWriteCloser, translating from GoReadWriteCloserInterface. All methods
@@ -184,6 +185,7 @@ func Serve(dataDir string, environment GoEnvironmentInterface, goAPI GoAPIInterf
 		goAPI,
 		&bridgecommon.BackendEnvironment{
 			NotifyUserFunc: environment.NotifyUser,
+			AuthFunc:       environment.Auth,
 			DeviceInfosFunc: func() []usb.DeviceInfo {
 				i := environment.DeviceInfo()
 				if i == nil {
@@ -208,4 +210,15 @@ func Serve(dataDir string, environment GoEnvironmentInterface, goAPI GoAPIInterf
 // sleep.
 func Shutdown() {
 	bridgecommon.Shutdown()
+}
+
+// TriggerAuth triggers an auth required notification towards the frontend.
+func TriggerAuth() {
+	bridgecommon.TriggerAuth()
+}
+
+// AuthResult triggers an auth feeedback notification (auth-ok/auth-err) towards the frontend,
+// depending on the input value.
+func AuthResult(ok bool) {
+	bridgecommon.AuthResult(ok)
 }

--- a/frontends/qt/libserver.h
+++ b/frontends/qt/libserver.h
@@ -54,6 +54,8 @@ extern void serve(
 
 extern void systemOpen(cchar_t* url);
 
+extern void authResult(bool ok);
+
 extern void goLog(cchar_t* msg);
 
 #ifdef __cplusplus

--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -177,6 +177,10 @@ func serve(
 			},
 			SetDarkThemeFunc:    func(bool) {},
 			DetectDarkThemeFunc: detectDarkTheme,
+			AuthFunc: func() {
+				log.Info("Qt auth")
+				authResult(true)
+			},
 		},
 	)
 }
@@ -193,6 +197,10 @@ func systemOpen(url *C.cchar_t) {
 func goLog(msg *C.cchar_t) {
 	goMsg := C.GoString(msg)
 	logging.Get().WithGroup("qt-frontend").Info(goMsg)
+}
+
+func authResult(ok bool) {
+	bridgecommon.AuthResult(ok)
 }
 
 // Don't remove - needed for the C compilation.

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -108,3 +108,17 @@ export const cancelConnectKeystore = (): Promise<void> => {
 export const setWatchonly = (watchonly: boolean): Promise<ISuccess> => {
   return apiPost('set-watchonly', watchonly);
 };
+export const authenticate = (): Promise<void> => {
+  return apiGet('auth');
+};
+
+
+export type TAuthEventObject = {
+  typ: 'auth-required' | 'auth-ok' | 'auth-err';
+};
+
+export const subscribeAuth = (
+  cb: TSubscriptionCallback<TAuthEventObject>
+) => (
+  subscribeEndpoint('auth', cb)
+);

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -117,7 +117,7 @@ export const forceAuth = (): Promise<void> => {
 };
 
 export type TAuthEventObject = {
-  typ: 'auth-required' | 'auth-forced' | 'auth-ok' | 'auth-err' ;
+  typ: 'auth-required' | 'auth-forced' | 'auth-canceled' | 'auth-ok' | 'auth-err' ;
 };
 
 export const subscribeAuth = (

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -108,13 +108,16 @@ export const cancelConnectKeystore = (): Promise<void> => {
 export const setWatchonly = (watchonly: boolean): Promise<ISuccess> => {
   return apiPost('set-watchonly', watchonly);
 };
-export const authenticate = (): Promise<void> => {
-  return apiGet('auth');
+export const authenticate = (force: boolean = false): Promise<void> => {
+  return apiPost('authenticate', force);
 };
 
+export const forceAuth = (): Promise<void> => {
+  return apiPost('force-auth');
+};
 
 export type TAuthEventObject = {
-  typ: 'auth-required' | 'auth-ok' | 'auth-err';
+  typ: 'auth-required' | 'auth-forced' | 'auth-ok' | 'auth-err' ;
 };
 
 export const subscribeAuth = (

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -40,6 +40,7 @@ import { route, RouterWatcher } from './utils/route';
 import { Darkmode } from './components/darkmode/darkmode';
 import { DarkModeProvider } from './contexts/DarkmodeProvider';
 import { AppProvider } from './contexts/AppProvider';
+import { AuthRequired } from './components/auth/authrequired';
 
 type State = {
   accounts: IAccount[];
@@ -184,6 +185,7 @@ class App extends Component<Props, State> {
           <DarkModeProvider>
             <Darkmode />
             <div className="app">
+              <AuthRequired/>
               <Sidebar
                 accounts={activeAccounts}
                 deviceIDs={deviceIDs}

--- a/frontends/web/src/components/auth/authrequired.module.css
+++ b/frontends/web/src/components/auth/authrequired.module.css
@@ -1,0 +1,6 @@
+.auth {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: 9999;
+}

--- a/frontends/web/src/components/auth/authrequired.tsx
+++ b/frontends/web/src/components/auth/authrequired.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { View } from '../view/view';
+import style from './authrequired.module.css';
+import { useEffect, useState } from 'react';
+import { TAuthEventObject, authenticate, subscribeAuth } from '../../api/backend';
+
+export const AuthRequired = () => {
+  const [authRequired, setAuthRequired] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = subscribeAuth((data: TAuthEventObject) => {
+      switch (data.typ) {
+      case 'auth-required':
+        // It is a bit strange to call authenticate inside `setAuthRequired`,
+        // but doing so we avoid declaring `authRequired` as a useEffect's
+        // dependency, which would cause it to unsubscribe/subscribe every
+        // time the state changes.
+        setAuthRequired((prevAuthRequired) => {
+          if (!prevAuthRequired) {
+            authenticate();
+          }
+          return true;
+        });
+        break;
+      case 'auth-err':
+        authenticate();
+        break;
+      case 'auth-ok':
+        setAuthRequired(false);
+      }
+    });
+
+    // Perform initial authentication. If the auth config is disabled,
+    // the backend will immediately sent an auth-ok back.
+    setAuthRequired(true);
+    authenticate();
+
+    return unsubscribe;
+  }, []);
+
+  if (!authRequired) {
+    return null;
+  }
+
+  return (
+    <div className={style.auth}>
+      <View
+        fullscreen
+        verticallyCentered
+        width="100%"
+        withBottomBar>
+      </View>
+    </div>
+  );
+};

--- a/frontends/web/src/components/auth/authrequired.tsx
+++ b/frontends/web/src/components/auth/authrequired.tsx
@@ -44,6 +44,17 @@ export const AuthRequired = () => {
       case 'auth-err':
         authenticate(authForced.current);
         break;
+      case 'auth-canceled':
+        if (authForced.current) {
+          // forced auth can be dismissed and won't be repeated, as it is
+          // tied to a specific UI event (e.g. enabling the auth toggle in
+          // the advanced settings.
+          setAuthRequired(false);
+          authForced.current = false;
+        } else {
+          authenticate(authForced.current);
+        }
+        break;
       case 'auth-ok':
         setAuthRequired(false);
         authForced.current = false;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1059,6 +1059,10 @@
       }
     },
     "advancedSettings": {
+      "authentication": {
+        "description": "Lock access to the app with screen lock/fingerprint.",
+        "title": "Screen lock"
+      },
       "coinControl": {
         "description": "Select which UTXOs are part of a transaction to help improve privacy."
       },

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -29,6 +29,7 @@ import { getConfig } from '../../utils/config';
 import { MobileHeader } from './components/mobile-header';
 import { Guide } from '../../components/guide/guide';
 import { Entry } from '../../components/guide/entry';
+import { EnableAuthSetting } from './components/advanced-settings/enable-auth-setting';
 
 export type TProxyConfig = {
   proxyAddress: string;
@@ -40,8 +41,10 @@ export type TFrontendConfig = {
   coinControl?: boolean;
 }
 
-type TBackendConfig = {
+export type TBackendConfig = {
   proxy?: TProxyConfig
+  authentication?: boolean;
+
 }
 
 export type TConfig = {
@@ -55,6 +58,7 @@ export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetti
   const [config, setConfig] = useState<TConfig>();
 
   const frontendConfig = config?.frontend;
+  const backendConfig = config?.backend;
   const proxyConfig = config?.backend?.proxy;
 
   useEffect(() => {
@@ -82,6 +86,7 @@ export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetti
               >
                 <EnableCustomFeesToggleSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
                 <EnableCoinControlSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
+                <EnableAuthSetting backendConfig={backendConfig} onChangeConfig={setConfig} />
                 <EnableTorProxySetting proxyConfig={proxyConfig} onChangeConfig={setConfig} />
                 <ConnectFullNodeSetting />
               </WithSettingsTabs>

--- a/frontends/web/src/routes/settings/components/advanced-settings/enable-auth-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/enable-auth-setting.tsx
@@ -40,6 +40,10 @@ export const EnableAuthSetting = ({ backendConfig, onChangeConfig }: TProps) => 
         updateConfig(!e.target.checked);
         unsubscribe();
       }
+      if (data.typ === 'auth-canceled') {
+        // if the user canceled the auth, we leave everything as is.
+        unsubscribe();
+      }
     });
     forceAuth();
   };

--- a/frontends/web/src/routes/settings/components/advanced-settings/enable-auth-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/enable-auth-setting.tsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeEvent, Dispatch } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Toggle } from '../../../../components/toggle/toggle';
+import { SettingsItem } from '../settingsItem/settingsItem';
+import { TBackendConfig, TConfig } from '../../advanced-settings';
+import { setConfig } from '../../../../utils/config';
+import { TAuthEventObject, subscribeAuth, forceAuth } from '../../../../api/backend';
+import { runningInAndroid } from '../../../../utils/env';
+
+type TProps = {
+  backendConfig?: TBackendConfig;
+  onChangeConfig: Dispatch<TConfig>;
+}
+
+export const EnableAuthSetting = ({ backendConfig, onChangeConfig }: TProps) => {
+  const { t } = useTranslation();
+
+  const handleToggleAuth = async (e: ChangeEvent<HTMLInputElement>) => {
+    // Before updating the config we need the user to authenticate.
+    // The forceAuth is needed to force the backend to execute the
+    // authentication even if the auth config is disabled.
+    const unsubscribe = subscribeAuth((data: TAuthEventObject) => {
+      if (data.typ === 'auth-ok') {
+        updateConfig(!e.target.checked);
+        unsubscribe();
+      }
+    });
+    forceAuth();
+  };
+
+  const updateConfig = async (auth: boolean) => {
+    const config = await setConfig({
+      backend: { authentication: auth },
+    }) as TConfig;
+    onChangeConfig(config);
+  };
+
+  if (!runningInAndroid()) {
+    return null;
+  }
+
+  return (
+    <SettingsItem
+      settingName={t('newSettings.advancedSettings.authentication.title')}
+      secondaryText={t('newSettings.advancedSettings.authentication.description')}
+      extraComponent={
+        backendConfig !== undefined ?
+          <Toggle
+            checked={backendConfig?.authentication || false}
+            onChange={handleToggleAuth}
+          />
+          :
+          null
+      }
+    />
+  );
+};


### PR DESCRIPTION
Watch-only can benefit from a feature that allows the user to authenticate when opening the bitboxapp, to protect the privacy. This commit creates an Auth component in the frontend that can trigger an environment-based authentication.

On Qt and Webdev the authentication succeds automatically, while on Android it requires the user to complete the system biometric authentication every time the app is resumed (.i.e. at startup and when the app comes to foreground after being put in the background).

The authentication check can be requested by the frontend using the `auth` endpoint.

Authentication messages from backend to frontend are sent via three new notifications:
- 'auth-required': which triggers a new `authenticate` call from the frontend Auth component
- 'auth-ok': which means authentication completed successfully
- 'auth-err': which means authentication failed or has been canceled by the user.

There is also a `trigger-auth` endpoint that can be used by frontend components to trigger a new authentication flow (making the backend send a new `auth-required` notification).

NOTES: 
- the authentication screen is just a draft and will need some styling in a future PR