### PR TITLE
watchonly: add global watchonly setting

### DIFF
--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -1046,18 +1046,12 @@ func TestAccountSupported(t *testing.T) {
 	b := newBackend(t, testnetDisabled, regtestDisabled)
 	defer b.Close()
 
+	require.NoError(t, b.SetWatchonly(true))
+
 	// Registering a new keystore persists a set of initial default accounts.
 	b.registerKeystore(bb02Multi)
 	require.Len(t, b.Accounts(), 3)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
-	// Mark all as watch-only.
-	require.NoError(t, b.config.ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
-		for _, acct := range cfg.Accounts {
-			f := true
-			acct.Watch = &f
-		}
-		return nil
-	}))
 
 	b.DeregisterKeystore()
 	// Registering a Bitcoin-only like keystore loads also the altcoins that were persisted
@@ -1066,15 +1060,10 @@ func TestAccountSupported(t *testing.T) {
 	require.Len(t, b.Accounts(), 3)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
 
-	b.DeregisterKeystore()
 	// If watch-only is disabled, then these will not be loaded if not supported by the keystore.
-	require.NoError(t, b.config.ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
-		for _, acct := range cfg.Accounts {
-			f := false
-			acct.Watch = &f
-		}
-		return nil
-	}))
+	require.NoError(t, b.SetWatchonly(false))
+	b.DeregisterKeystore()
+
 	// Registering a Bitcoin-only like keystore loads only the Bitcoin account, even though altcoins
 	// were persisted previously.
 	b.registerKeystore(bb02BtcOnly)

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -120,13 +120,8 @@ func TestRegisterKeystore(t *testing.T) {
 	// Deregistering the keystore leaves the loaded accounts (watchonly), and leaves the persisted
 	// accounts and keystores.
 	// Mark accounts as watch-only.
-	require.NoError(t, b.config.ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
-		for _, acct := range cfg.Accounts {
-			f := true
-			acct.Watch = &f
-		}
-		return nil
-	}))
+	require.NoError(t, b.SetWatchonly(true))
+
 	b.DeregisterKeystore()
 	require.Len(t, b.Accounts(), 3)
 	require.Len(t, b.Config().AccountsConfig().Accounts, 3)
@@ -156,14 +151,10 @@ func TestRegisterKeystore(t *testing.T) {
 	require.Equal(t, rootFingerprint2, []byte(b.Config().AccountsConfig().Keystores[1].RootFingerprint))
 
 	b.DeregisterKeystore()
-	// Enable watch-only for all but two accounts, one of each keystore. Now, all watch-only
-	// accounts plus the non-watch only accounts of the connected keystore will be loaded.
-	require.NoError(t, b.config.ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
-		for _, acct := range cfg.Accounts {
-			t := true
-			acct.Watch = &t
-		}
 
+	// Disable watch-only for two accounts, one of each keystore. Now, all accounts plus the
+	// non-watch only accounts of the connected keystore will be loaded.
+	require.NoError(t, b.config.ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
 		f := false
 		cfg.Lookup("v0-55555555-btc-0").Watch = &f
 		cfg.Lookup("v0-66666666-ltc-0").Watch = &f

--- a/backend/config/accounts.go
+++ b/backend/config/accounts.go
@@ -42,7 +42,9 @@ type Account struct {
 	// If false, the account is only displayed if the keystore is connected. If true, it is loaded
 	// and displayed when the app launches.
 	//
-	// If nil, it is considered false.
+	// If nil, it is considered false.  The reason for this is that we don't want to suddenly show
+	// all persisted accounts when the Watchonly setting is enabled - only accounts that are loaded
+	// when Watchonly is enabled should do this.
 	Watch                 *bool                  `json:"watch"`
 	CoinCode              coin.Code              `json:"coinCode"`
 	Name                  string                 `json:"name"`
@@ -73,9 +75,10 @@ func (acct *Account) SetTokenActive(tokenCode string, active bool) error {
 	return nil
 }
 
-// IsWatchOnly returns true if the `Watch` setting is set to true.
-func (acct *Account) IsWatch() bool {
-	return acct.Watch != nil && *acct.Watch
+// IsWatch returns true if the `Watch` setting is set to true and `defaultWatchonly` is true. For
+// `defaultWatchonly`, you should provide the global watchonly setting from the backend config.
+func (acct *Account) IsWatch(defaultWatchonly bool) bool {
+	return defaultWatchonly && acct.Watch != nil && *acct.Watch
 }
 
 // Keystore holds information related to keystores such as the BitBox02.

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -234,7 +234,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/aopp/cancel", handlers.postAOPPCancelHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/aopp/approve", handlers.postAOPPApproveHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/aopp/choose-account", handlers.postAOPPChooseAccountHandler).Methods("POST")
-	getAPIRouter(apiRouter)("/cancel-connect-keystore", handlers.postCancelConnectKeystoreHandler).Methods("POST")
+	getAPIRouterNoError(apiRouter)("/cancel-connect-keystore", handlers.postCancelConnectKeystoreHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/set-watchonly", handlers.postSetWatchonlyHandler).Methods("POST")
 
 	devicesRouter := getAPIRouterNoError(apiRouter.PathPrefix("/devices").Subrouter())
@@ -1286,9 +1286,9 @@ func (handlers *Handlers) postAOPPApproveHandler(r *http.Request) interface{} {
 	return nil
 }
 
-func (handlers *Handlers) postCancelConnectKeystoreHandler(r *http.Request) (interface{}, error) {
+func (handlers *Handlers) postCancelConnectKeystoreHandler(r *http.Request) interface{} {
 	handlers.backend.CancelConnectKeystore()
-	return nil, nil
+	return nil
 }
 
 func (handlers *Handlers) postSetWatchonlyHandler(r *http.Request) interface{} {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -96,7 +96,7 @@ type Backend interface {
 	SetAccountActive(accountCode accountsTypes.Code, active bool) error
 	SetTokenActive(accountCode accountsTypes.Code, tokenCode string, active bool) error
 	RenameAccount(accountCode accountsTypes.Code, name string) error
-	AccountSetWatch(accountCode accountsTypes.Code, watch bool) error
+	AccountSetWatch(filter func(*config.Account) bool, watch *bool) error
 	AOPP() backend.AOPP
 	AOPPCancel()
 	AOPPApprove()
@@ -104,6 +104,7 @@ type Backend interface {
 	GetAccountFromCode(code string) (accounts.Interface, error)
 	HTTPClient() *http.Client
 	CancelConnectKeystore()
+	SetWatchonly(watchonly bool) error
 }
 
 // Handlers provides a web api to the backend.
@@ -234,6 +235,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/aopp/approve", handlers.postAOPPApproveHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/aopp/choose-account", handlers.postAOPPChooseAccountHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/cancel-connect-keystore", handlers.postCancelConnectKeystoreHandler).Methods("POST")
+	getAPIRouterNoError(apiRouter)("/set-watchonly", handlers.postSetWatchonlyHandler).Methods("POST")
 
 	devicesRouter := getAPIRouterNoError(apiRouter.PathPrefix("/devices").Subrouter())
 	devicesRouter("/registered", handlers.getDevicesRegisteredHandler).Methods("GET")
@@ -364,10 +366,11 @@ type accountJSON struct {
 func newAccountJSON(keystore config.Keystore, account accounts.Interface, activeTokens []activeToken) *accountJSON {
 	eth, ok := account.Coin().(*eth.Coin)
 	isToken := ok && eth.ERC20Token() != nil
+	watch := account.Config().Config.Watch
 	return &accountJSON{
 		Keystore:              keystore,
 		Active:                !account.Config().Config.Inactive,
-		Watch:                 account.Config().Config.IsWatch(),
+		Watch:                 watch != nil && *watch,
 		CoinCode:              account.Coin().Code(),
 		CoinUnit:              account.Coin().Unit(false),
 		CoinName:              account.Coin().Name(),
@@ -729,7 +732,11 @@ func (handlers *Handlers) postAccountSetWatchHandler(r *http.Request) interface{
 	if err := json.NewDecoder(r.Body).Decode(&jsonBody); err != nil {
 		return response{Success: false, ErrorMessage: err.Error()}
 	}
-	if err := handlers.backend.AccountSetWatch(jsonBody.AccountCode, jsonBody.Watch); err != nil {
+
+	filter := func(account *config.Account) bool {
+		return account.Code == jsonBody.AccountCode
+	}
+	if err := handlers.backend.AccountSetWatch(filter, &jsonBody.Watch); err != nil {
 		return response{Success: false, ErrorMessage: err.Error()}
 	}
 	return response{Success: true}
@@ -1282,4 +1289,18 @@ func (handlers *Handlers) postAOPPApproveHandler(r *http.Request) interface{} {
 func (handlers *Handlers) postCancelConnectKeystoreHandler(r *http.Request) (interface{}, error) {
 	handlers.backend.CancelConnectKeystore()
 	return nil, nil
+}
+
+func (handlers *Handlers) postSetWatchonlyHandler(r *http.Request) interface{} {
+	type response struct {
+		Success bool `json:"success"`
+	}
+	var watchonly bool
+	if err := json.NewDecoder(r.Body).Decode(&watchonly); err != nil {
+		return response{Success: false}
+	}
+	if err := handlers.backend.SetWatchonly(watchonly); err != nil {
+		return response{Success: false}
+	}
+	return response{Success: true}
 }

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -104,3 +104,7 @@ export const syncConnectKeystore = () => {
 export const cancelConnectKeystore = (): Promise<void> => {
   return apiPost('cancel-connect-keystore');
 };
+
+export const setWatchonly = (watchonly: boolean): Promise<ISuccess> => {
+  return apiPost('set-watchonly', watchonly);
+};

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1093,6 +1093,10 @@
       },
       "toggleSats": {
         "description": "Enable or disable Satoshis."
+      },
+      "watchonly": {
+        "description": "Let's you see your accounts and portfolio without the BitBox02. The BitBox02 is still needed for signing.",
+        "title": "Watch-only"
       }
     }
   },

--- a/frontends/web/src/routes/settings/appearance.tsx
+++ b/frontends/web/src/routes/settings/appearance.tsx
@@ -23,6 +23,7 @@ import { DisplaySatsToggleSetting } from './components/appearance/displaySatsTog
 import { LanguageDropdownSetting } from './components/appearance/languageDropdownSetting';
 import { ActiveCurrenciesDropdownSettingWithStore } from './components/appearance/activeCurrenciesDropdownSetting';
 import { HideAmountsSetting } from './components/appearance/hideAmountsSetting';
+import { WatchonlySetting } from './components/appearance/watchonlySetting';
 import { WithSettingsTabs } from './components/tabs';
 import { MobileHeader } from './components/mobile-header';
 import { Guide } from '../../components/guide/guide';
@@ -52,6 +53,7 @@ export const Appearance = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTab
                 <DarkmodeToggleSetting />
                 <DisplaySatsToggleSetting />
                 <HideAmountsSetting />
+                <WatchonlySetting />
               </WithSettingsTabs>
             </ViewContent>
           </View>

--- a/frontends/web/src/routes/settings/components/appearance/watchonlySetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/watchonlySetting.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Toggle } from '../../../../components/toggle/toggle';
+import { SettingsItem } from '../settingsItem/settingsItem';
+import * as backendAPI from '../../../../api/backend';
+import { useLoad } from '../../../../hooks/api';
+import { getConfig } from '../../../../utils/config';
+
+export const WatchonlySetting = () => {
+  const { t } = useTranslation();
+  const [disabled, setDisabled] = useState<boolean>(false);
+  const [watchonly, setWatchonly] = useState<boolean>();
+  const config = useLoad(getConfig);
+
+  useEffect(() => {
+    if (config) {
+      setWatchonly(config.backend.watchonly);
+    }
+  }, [config]);
+
+  const toggleWatchonly = async () => {
+    // TODO: ask user if they really want to proceed if they disable watch-only.
+    // Disabling watch-only immediately removes all accounts from
+    // the sidebar and manage accounts and cannot be brought back without connecting the keystore.
+
+    setDisabled(true);
+    const { success } = await backendAPI.setWatchonly(!watchonly);
+    if (success) {
+      setWatchonly(!watchonly);
+    }
+    setDisabled(false);
+  };
+
+  return (
+    <SettingsItem
+      settingName={t('newSettings.appearance.watchonly.title')}
+      secondaryText={t('newSettings.appearance.watchonly.description')}
+      extraComponent={
+        <>
+          {
+            watchonly !== undefined ?
+              (
+                <Toggle
+                  checked={watchonly}
+                  disabled={disabled}
+                  onChange={toggleWatchonly}
+                />
+              ) :
+              null
+          }
+        </>
+      }
+    />
+  );
+};

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -29,6 +29,7 @@ import { Message } from '../../components/message/message';
 import { translate, TranslateProps } from '../../decorators/translate';
 import { WithSettingsTabs } from './components/tabs';
 import { View, ViewContent } from '../../components/view/view';
+import { getConfig } from '../../utils/config';
 import { MobileHeader } from '../settings/components/mobile-header';
 import Guide from './manage-account-guide';
 import style from './manage-accounts.module.css';
@@ -42,15 +43,16 @@ interface ManageAccountsProps {
 type Props = ManageAccountsProps & TranslateProps;
 
 type TShowTokens = {
-    readonly [key in string]: boolean;
+  readonly [key in string]: boolean;
 }
 
 interface State {
-    editAccountCode?: string;
-    editAccountNewName: string;
-    editErrorMessage?: string;
-    accounts: accountAPI.IAccount[];
-    showTokens: TShowTokens;
+  editAccountCode?: string;
+  editAccountNewName: string;
+  editErrorMessage?: string;
+  accounts: accountAPI.IAccount[];
+  showTokens: TShowTokens;
+  watchonly?: boolean;
 }
 
 class ManageAccounts extends Component<Props, State> {
@@ -58,7 +60,8 @@ class ManageAccounts extends Component<Props, State> {
     editAccountNewName: '',
     editErrorMessage: undefined,
     accounts: [],
-    showTokens: {}
+    showTokens: {},
+    watchonly: undefined,
   };
 
   private fetchAccounts = () => {
@@ -67,10 +70,11 @@ class ManageAccounts extends Component<Props, State> {
 
   public componentDidMount() {
     this.fetchAccounts();
+    getConfig().then(config => this.setState({ watchonly: config!.backend!.watchonly }));
   }
 
   private renderAccounts = (accounts: accountAPI.IAccount[]) => {
-    const { showTokens } = this.state;
+    const { watchonly, showTokens } = this.state;
     const { t } = this.props;
     return accounts.filter(account => !account.isToken).map(account => {
       const active = account.active;
@@ -101,16 +105,19 @@ class ManageAccounts extends Component<Props, State> {
               this.toggleAccount(account.code, !active)
                 .then(() => event.target.disabled = false);
             }} />
-          Watchonly:
-          <Toggle
-            checked={account.watch}
-            className={style.toggle}
-            id={account.code}
-            onChange={async (event) => {
-              event.target.disabled = true;
-              await this.setWatch(account.code, !account.watch);
-              event.target.disabled = false;
-            }} />
+          { watchonly ? (<>
+            Hide account:
+            <Toggle
+              checked={!account.watch}
+              className={style.toggle}
+              id={account.code}
+              onChange={async (event) => {
+                event.target.disabled = true;
+                await this.setWatch(account.code, !account.watch);
+                event.target.disabled = false;
+              }} />
+          </>
+          ) : null }
           {active && account.coinCode === 'eth' ? (
             <div className={style.tokenSection}>
               <div className={`${style.tokenContainer} ${tokensVisible ? style.tokenContainerOpen : ''}`}>

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -106,7 +106,7 @@ class ManageAccounts extends Component<Props, State> {
                 .then(() => event.target.disabled = false);
             }} />
           { watchonly ? (<>
-            Hide account:
+            Hide account (TODO: move this to the edit dialog):
             <Toggle
               checked={!account.watch}
               className={style.toggle}


### PR DESCRIPTION
With option to exempt individual accounts.

- When global watchonly is enabled, all currently loaded accounts and
accounts loaded in the future will be set to watchonly. Accounts that
had been persisted beforehand are not automatically set to watch-only.
- When global watchonly is disabled, all persisted accounts' watchonly
status is reset. This way, when one enables watchonly again, accounts
that are already persisted don't immediately appear - one has to first
load them with a keystore.

**Test cases**:

With a deleted/fresh accounts.json before every test

- Unlock BB02, remove BB02 - accounts will be loaded and unloaded, no accounts after app restart
- Enable watchonly, insert BB02, remove BB02: accounts remain, also after app restart
- Unlock BB02, enable watchonly, remove BB02: accounts remain, also after app restart
- Unlock BB02, enable watchonly, check "hide account" for an account, remove BB02: all accounts except the hidden one remain, also after app restart
- Unlock BB02, enable watchonly, disable watchonly. remove BB02: no accounts remain
- Enable watchonly, unlock BB02 with passphrase `a`, remove, unlock BB02 with passphrase `b`, remove
  - Accounts from both keystores remain
  - Disable watchonly: all accounts disappear
  - Enable watchonly again: nothing happens - must insert BB02 again to get back the accounts