### PR TITLE
qt: fix macOS build when using Qt from homebrew

### DIFF
--- a/frontends/qt/BitBox.pro
+++ b/frontends/qt/BitBox.pro
@@ -62,7 +62,6 @@ unix:macx {
     # Those frameworks are needed for Go's http/net packages.
     # Waiting for https://github.com/golang/go/issues/11258 to be able to automatically capture link flags.
     LIBS += -framework CoreFoundation -framework Security
-    # QMAKE_RPATHDIR = @executable_path/../Frameworks
     QMAKE_LFLAGS += "-pie -s -w"
     QMAKE_MACOSX_DEPLOYMENT_TARGET = $$[MACOS_MIN_VERSION]
 }

--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -52,7 +52,9 @@ osx:
 	mv build/BitBox.app build/osx/
 	cp resources/MacOS/Info.plist build/osx/BitBox.app/Contents/
 	cp resources/MacOS/icon.icns build/osx/BitBox.app/Contents/Resources/
-	macdeployqt build/osx/BitBox.app
+	# The `-executable` flag is needed to make the macOS build work when Qt is installed from homebrew.
+	# It works without it when Qt is installed using the official installer.
+	cd build/osx/ && macdeployqt BitBox.app -executable=BitBox.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
 	cp server/libserver.so build/osx/BitBox.app/Contents/Frameworks
 	cp build/assets.rcc build/osx/BitBox.app/Contents/MacOS/
 	install_name_tool -change libserver.so @executable_path/../Frameworks/libserver.so build/osx/BitBox.app/Contents/MacOS/BitBox


### PR DESCRIPTION
There is a official Qt installer, with which the macOS build works
fine.

When installing Qt from homebrew, as done in the CI and in the build
docs of this repo, the resulting build has invalid library references
in the QtWebEngineProcess. The QtWebEngine executable resides in

    BitBox.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess

Instead of referencing the Qt library (frameworks) by path relative to
the BitBox.app folder to point to the local frameworks in
BitBox.app/Contents/Frameworks (using `@rpath` or `@loader_path`), it uses
absolute paths like

    /usr/local/Cellar/qt@5/5.15.10_1/lib/QtGui.framework/...

The reason for this difference is unclear, most likely the macdeployqt
has a different version or a different configuration and fails to
rewire the library references in the QtWebEngineProcess.

One can see the library references with:

    otool -L BitBox.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess

and the `@rpath` (`RC_RPATH` and other vars) using `otool -l ...`.

By using the `-executable` flag, we can instruct macdeployqt to also
use the deployed frameworks for QtWebEngineProcess, so the resulting
QtWebEngineProcess executable is wired correctly to the local
frameworks using references like:

    @loader_path/../../../../../../../QtGui.framework/...

It also changes the references inside
e.g. BitBox.app/Contents/Frameworks/QtGui.framework/Versions/Current/QtGui,
which before were using refs like

    @executable_path/../Frameworks/QtCore.framework/...

which didn't work as one executable is in `Contents/MacOS/BitBox` and
the other in
`BitBox.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess`.

(This is why the OP in
https://stackoverflow.com/questions/46430930/how-to-make-macdeployqt-change-the-library-names-inside-qtwebengineprocess-app-w
failed even after manually rewiring the QtWebEngineProcess library references).

With this fix is now uses paths like:

    @loader_path/../../../QtCore.framework/...

The `@loader_path` is the folder the library binary is located at, so it
works regardless of which process (BitBox or QtWebEngineProcess) loads
it.

I tested that this change does not negatively impact the macOS build
using Qt from the official installer.
