### PR TITLE
frontend: fix empty element

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/wizard.tsx
+++ b/frontends/web/src/routes/device/bitbox02/wizard.tsx
@@ -152,7 +152,10 @@ export class Wizard extends Component<Props, State> {
           text={waitDialog.text} />
       );
     }
-
+    // fixes empty main element, happens when after unlocking the device, reason wizard is now always mounted in app.tsx
+    if (appStatus === '' && status === 'initialized') {
+      return null;
+    }
     return (
       <Main>
         { (status === 'connected') ? (


### PR DESCRIPTION
Unlocking a device renders an empty main element. This is only visible in some views (i.e. settings) as a large empty space on top of the view.

Reason is that the setup wizard is now always mounted since watch-only as the device can be unlocked at any time.