### PR TITLE
frontend/qt: link breez to the Windows build

### DIFF
--- a/breeztest/breeztest_disabled.go
+++ b/breeztest/breeztest_disabled.go
@@ -1,3 +1,3 @@
-//go:build !linux
+//go:build !linux && !windows
 
 package breeztest

--- a/breeztest/breeztest_enabled.go
+++ b/breeztest/breeztest_enabled.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || windows
 
 package breeztest
 

--- a/frontends/qt/make_windows.sh
+++ b/frontends/qt/make_windows.sh
@@ -20,5 +20,6 @@ make -C server/ windows-legacy
 env -u MAKE -u MAKEFLAGS cmd "/C compile_windows.bat"
 cp build/assets.rcc build/windows/
 cp server/libserver.dll build/windows/
+cp ../../vendor/github.com/breez/breez-sdk-go/breez_sdk/lib/windows-amd64/breez_sdk_bindings.dll build/windows/
 windeployqt build/windows/BitBox.exe
 cp "$MINGW_BIN/libssp-0.dll" build/windows/

--- a/frontends/qt/server/Makefile.windows
+++ b/frontends/qt/server/Makefile.windows
@@ -4,6 +4,7 @@ CGO=1
 BUILDMODE=c-shared
 GOARCH=amd64
 GOOS=windows
+BREEZ_LIB_DIR=../../../vendor/github.com/breez/breez-sdk-go/breez_sdk/lib/windows-amd64/
 
 windows:
 	CGO_CFLAGS="${GOWINSECFLAGS} ${CFLAGS}" \
@@ -25,6 +26,7 @@ windows-legacy:
 	CGO_ENABLED=1 go build -mod=vendor -ldflags="-s -w" -buildmode=c-archive \
 		-o libserver.a
 	gcc server.def libserver.a -shared -lwinmm -lhid -lsetupapi -lWs2_32 \
+		-L${BREEZ_LIB_DIR} -lbreez_sdk_bindings \
 		-o libserver.dll -Wl,--out-implib,libserver.lib
 
 clean:


### PR DESCRIPTION
In Windows, DLLs in the same folderas the binary referencing are
automatically found, so we just need to copy the DLL to the same
folder as libserver.dll (which references libbreez).

Builds on https://github.com/digitalbitbox/bitbox-wallet-app/pull/2373/