### PR TITLE
frontend/qt: deploy and link breez to the macOS build

### DIFF
--- a/breeztest/breeztest_disabled.go
+++ b/breeztest/breeztest_disabled.go
@@ -1,3 +1,3 @@
-//go:build !linux && !windows
+//go:build !linux && !windows && !darwin
 
 package breeztest

--- a/breeztest/breeztest_enabled.go
+++ b/breeztest/breeztest_enabled.go
@@ -1,4 +1,4 @@
-//go:build linux || windows
+//go:build linux || windows || darwin
 
 package breeztest
 

--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -52,10 +52,15 @@ osx:
 	mv build/BitBox.app build/osx/
 	cp resources/MacOS/Info.plist build/osx/BitBox.app/Contents/
 	cp resources/MacOS/icon.icns build/osx/BitBox.app/Contents/Resources/
-	# The `-executable` flag is needed to make the macOS build work when Qt is installed from homebrew.
-	# It works without it when Qt is installed using the official installer.
-	cd build/osx/ && macdeployqt BitBox.app -executable=BitBox.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
+	mkdir -p build/osx/BitBox.app/Contents/Frameworks
 	cp server/libserver.so build/osx/BitBox.app/Contents/Frameworks
+	cp ../../vendor/github.com/breez/breez-sdk-go/breez_sdk/lib/darwin-amd64/libbreez_sdk_bindings.dylib build/osx/BitBox.app/Contents/Frameworks
+	# The first `-executable` flag is needed to make the macOS build work when Qt is installed from homebrew.
+	# It works without it when Qt is installed using the official installer.
+	# The second one is needed to have libserver.so resolve libbreez_sdk_bindings by rewiring the LC_RPATH and path to libbreez.
+	cd build/osx/ && macdeployqt BitBox.app \
+		-executable=BitBox.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess \
+		-executable=BitBox.app/Contents/Frameworks/libserver.so
 	cp build/assets.rcc build/osx/BitBox.app/Contents/MacOS/
 	install_name_tool -change libserver.so @executable_path/../Frameworks/libserver.so build/osx/BitBox.app/Contents/MacOS/BitBox
 	cp -r resources/MacOS/Testnet.app build/osx/Testnet.app


### PR DESCRIPTION
Similar to the commit that links the breez lib in linux, libserver.so
ends up having an absolute path to libbreez_sdk_bindings becaus of the
rpath linker flag set here:

```
cgo darwin,amd64 LDFLAGS: -Wl,-rpath,${SRCDIR}/lib/darwin-amd64 -L${SRCDIR}/lib/darwin-amd64
```

(https://github.com/breez/breez-sdk-go/blob/7b566724daae0fa539f622b301fe840a3e5cbd59/breez_sdk/cgo.go)

`SRCDIR` is an absolute path and it ends up in the libserver.so
binary (check with `otool -l libserver.so`).

By adding libserver.so to the executables to rewire by macdepoyqt, we
fix its rpath and path to libbreez.

Builds on #2377