### PR TITLE
frontend: fix overlapping text in status component

### DIFF
--- a/frontends/web/src/components/status/status.module.css
+++ b/frontends/web/src/components/status/status.module.css
@@ -4,6 +4,9 @@
     padding: calc(var(--space-default) * 1.5);
     width: 100%;
 }
+.container.withCloseBtn {
+    padding-right: 60px;
+}
 
 :global(.padded) .container {
     max-width: var(--content-width);


### PR DESCRIPTION
On small screen the close button of status component sometimes overlaps with the text of the status message.