### PR TITLE
Frontend fix langauge

### DIFF
--- a/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
+++ b/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
@@ -24,6 +24,8 @@ export const downloadLinkByLanguage = () => {
   switch (i18n.resolvedLanguage) {
   case 'de':
     return URL_CONSTANTS.DOWNLOAD_LINK_DE;
+  case 'es':
+    return URL_CONSTANTS.DOWNLOAD_LINK_ES;
   default:
     return URL_CONSTANTS.DOWNLOAD_LINK_GLOBAL;
   }

--- a/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
+++ b/frontends/web/src/components/appdownloadlink/appdownloadlink.tsx
@@ -21,8 +21,7 @@ import { Button } from '../forms';
 import { A } from '../anchor/anchor';
 
 export const downloadLinkByLanguage = () => {
-  const language = i18n.language;
-  switch (language) {
+  switch (i18n.resolvedLanguage) {
   case 'de':
     return URL_CONSTANTS.DOWNLOAD_LINK_DE;
   default:

--- a/frontends/web/src/components/banner/banner.tsx
+++ b/frontends/web/src/components/banner/banner.tsx
@@ -44,7 +44,7 @@ export const Banner = ({ msgKey }: TBannerProps) => {
     <Status
       dismissible={banner.dismissible ? `banner-${msgKey}-${banner.id}` : ''}
       type={banner.type ? banner.type : 'warning'}>
-      { message[i18n.language] || message[(i18n.options.fallbackLng as string[])[0]] }
+      { message[i18n.resolvedLanguage] || message[(i18n.options.fallbackLng as string[])[0]] }
       &nbsp;
       { link && (
         <A href={link.href} className={style.link}>

--- a/frontends/web/src/routes/device/bitbox02/settings-guide.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings-guide.tsx
@@ -35,7 +35,7 @@ export const ManageDeviceGuide = () => {
       <Entry key="guide.device.attestation" entry={{
         link: {
           text: t('guide.device.attestation.link.text'),
-          url: (i18n.language === 'de')
+          url: (i18n.resolvedLanguage === 'de')
             ? 'https://bitbox.swiss/de/bitbox02/sicherheit/#device-authenticity-check'
             : 'https://bitbox.swiss/bitbox02/security-features/#device-authenticity-check'
         },

--- a/frontends/web/src/routes/device/bitbox02/settings-guide.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings-guide.tsx
@@ -19,6 +19,17 @@ import { i18n } from '../../../i18n/i18n';
 import { Entry } from '../../../components/guide/entry';
 import { Guide } from '../../../components/guide/guide';
 
+const getLink = () => {
+  switch (i18n.resolvedLanguage) {
+  case 'de':
+    return 'https://bitbox.swiss/de/bitbox02/sicherheit/#device-authenticity-check';
+  case 'es':
+    return 'https://bitbox.swiss/es/bitbox02/seguridad/#device-authenticity-check';
+  default:
+    return 'https://bitbox.swiss/bitbox02/security-features/#device-authenticity-check';
+  }
+};
+
 export const ManageDeviceGuide = () => {
   const { t } = useTranslation();
   return (
@@ -35,9 +46,7 @@ export const ManageDeviceGuide = () => {
       <Entry key="guide.device.attestation" entry={{
         link: {
           text: t('guide.device.attestation.link.text'),
-          url: (i18n.resolvedLanguage === 'de')
-            ? 'https://bitbox.swiss/de/bitbox02/sicherheit/#device-authenticity-check'
-            : 'https://bitbox.swiss/bitbox02/security-features/#device-authenticity-check'
+          url: getLink(),
         },
         text: t('guide.device.attestation.text'),
         title: t('guide.device.attestation.title')

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -69,7 +69,7 @@ export const Waiting = () => {
         <Entry entry={{
           link: {
             text: t('guide.waiting.lostDevice.link.text'),
-            url: (i18n.language === 'de')
+            url: (i18n.resolvedLanguage === 'de')
               ? 'https://shiftcrypto.support/help/de-de/5-backup/8-wie-kann-ich-ein-bitbox02-wallet-in-ein-drittanbieter-wallet-importieren'
               : 'https://shiftcrypto.support/help/en-us/5-backup/8-how-do-i-restore-my-wallet-if-my-bitbox02-is-lost',
           },

--- a/frontends/web/src/routes/settings/electrum.tsx
+++ b/frontends/web/src/routes/settings/electrum.tsx
@@ -89,7 +89,7 @@ export const ElectrumSettings = () => {
         <Entry key="guide.settings-electrum.instructions" entry={{
           link: {
             text: t('guide.settings-electrum.instructions.link.text'),
-            url: (i18n.language === 'de')
+            url: (i18n.resolvedLanguage === 'de')
               ? 'https://shiftcrypto.support/help/de-de/14-privatsphare/29-verbindung-der-bitboxapp-zu-meinem-bitcoin-full-node'
               : 'https://shiftcrypto.support/help/en-us/14-privacy/29-how-to-connect-the-bitboxapp-to-my-own-full-node'
           },

--- a/frontends/web/src/utils/url_constants.ts
+++ b/frontends/web/src/utils/url_constants.ts
@@ -16,5 +16,6 @@
 
 export const URL_CONSTANTS = {
   DOWNLOAD_LINK_GLOBAL: 'https://bitbox.swiss/download/?source=bitboxapp',
-  DOWNLOAD_LINK_DE: 'https://bitbox.swiss/de/download/?source=bitboxapp'
+  DOWNLOAD_LINK_DE: 'https://bitbox.swiss/de/download/?source=bitboxapp',
+  DOWNLOAD_LINK_ES: 'https://bitbox.swiss/es/descargar/?source=bitboxapp'
 };


### PR DESCRIPTION
A locale may contain region and other sub tags, in which case it would fallback to English.

I.e. if i18n.language is 'de-ch' instead of 'de' download link would point to english page.

i18next added resolvedLanguage in v21, see:
- https://www.i18next.com/overview/api#resolvedlanguage

The app should keep using i18n.language (with region information) if used for: Date formatting, country display names or internationalized number formatting.

In 2nd commit:

Link to pages that are available in Spanish, i.e the downloads page or the BitBox02 security page.


