### PR TITLE
frontend: add warning when disabling watch-only from settings

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1103,7 +1103,9 @@
       },
       "watchonly": {
         "description": "Let's you see your accounts and portfolio without the BitBox02. The BitBox02 is still needed for signing.",
-        "title": "Watch-only"
+        "title": "Watch-only",
+        "warning": "This will remove all your watch-only accounts. To see them again, you will need to plug in your BitBox02. Do you want to continue?",
+        "warningTitle": "Disable watch-only"
       }
     }
   },

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -171,10 +171,6 @@ class ManageAccounts extends Component<Props, State> {
   };
 
   private setWatch = async (accountCode: string, watch: boolean) => {
-    // TODO: ask user if they really want to proceed if they disable watch-only, if its keystore is
-    // not currently loaded. Disabling watch-only in this case immediately removes the account from
-    // the sidebar and manage accounts and cannot be brought back without connecting the keystore.
-
     const result = await backendAPI.accountSetWatch(accountCode, watch);
     if (result.success) {
       await this.fetchAccounts();


### PR DESCRIPTION
Displays a warning/confirmation dialog when disabling watch-only from settings page. Text is subject to change.

Preview: 

![ow2](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/5fba5ed6-3338-46bc-8854-61ef740a657a)
