### PR TITLE
frontend: fix flickering dialog on close

### DIFF
--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -156,12 +156,25 @@ class Dialog extends Component<Props, State> {
       clearTimeout(this.timerId);
     }
 
-    this.modal.current?.classList.remove(style.open);
     this.overlay.current.classList.remove(style.activeOverlay);
     this.overlay.current.classList.add(style.closingOverlay);
-    this.timerId = setTimeout(() => {
+    this.modal.current?.classList.remove(style.open);
+
+    const onTransitionEnd = (event: TransitionEvent) => {
+      if (event.target === this.modal.current) {
+        this.deactivateModal(fireOnCloseProp);
+        this.modal.current?.removeEventListener('transitionend', onTransitionEnd);
+      }
+    };
+
+    const hasTransition = parseFloat(window.getComputedStyle(this.modal.current).transitionDuration) > 0;
+    if (hasTransition) {
+      this.modal.current.addEventListener('transitionend', onTransitionEnd);
+      // fallback in-case the 'transitionend' event didn't fire
+      this.timerId = setTimeout(() => this.deactivateModal(fireOnCloseProp), 400);
+    } else {
       this.deactivateModal(fireOnCloseProp);
-    }, 300);
+    }
   };
 
   private activate = () => {
@@ -180,7 +193,6 @@ class Dialog extends Component<Props, State> {
       this.timerId = setTimeout(() => {
         this.modal.current?.classList.add(style.open);
       }, 10);
-
 
       this.focusWithin();
       this.focusFirst();


### PR DESCRIPTION
When closing the `dialog.tsx` (either by pressing `esc`,  or clicking the update / close button), **sometimes** the dialog flickers. This only happens on desktop. The reason for this is because we previously fire `deactivateModal()` inside a timeout (300ms) to await for transitions to finish.

This is working fine on mobile, but not on desktop. On desktop we should call the `deactivateModal` with no delay to prevent unnecessary re-render, and only wait for animation (css transition) when there is one (such as on mobile).

To achieve this, we're using `transitionend` event listener to more accurately wait for the transition to end and fire `deactivateModal`, or not wait at all when there's no transition which ultimately fixes the flickering issue.

Preview (before, **sometimes** it flickers):

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/fccf669e-7cc8-4b84-bd6d-9f1d94603280

After:

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/3ed68a05-5963-4017-ba05-db28a4acdfeb

After (mobile, transition/animation still occurs normally):

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/1a0b2d2a-4a72-4046-a943-75b281f0a80a


