### PR TITLE
frontend: bring back download button on android

### DIFF
--- a/frontends/web/src/components/update/update.tsx
+++ b/frontends/web/src/components/update/update.tsx
@@ -16,7 +16,6 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { runningInAndroid } from '../../utils/env';
 import { getUpdate } from '../../api/version';
 import { Status } from '../status/status';
 import { AppDownloadLink } from '../appdownloadlink/appdownloadlink';
@@ -37,8 +36,7 @@ export const Update = () => {
       })}
       {file.description}
       {' '}
-      {/* Don't show download link on Android because they should update from stores */}
-      {!runningInAndroid() && <AppDownloadLink className={style.link} />}
+      <AppDownloadLink className={style.link} />
     </Status>
   );
 };


### PR DESCRIPTION
The download button in the update banner was removed in:
- aa8a016b322c84e5ad81f92b137c103e3fa8fa38

Reason given was: because Android users usually auto-update their app through a store. This should be added again with a download button that opens up the store where the app has been downloaded.

Adding it back for the following reasons:
- the update banner should have an actionable item and not just information that there is a newer version
- the download page on the website will be improved and will try to show the platform specific download button instead of all downloads
- linking to play store would probably be ok for most users, but some users install the apk directly from GitHub or own build, in these cases it makes sense to just link to the downloads page