### PR TITLE
frontend: show actual account name in sidebar

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.module.css
+++ b/frontends/web/src/components/sidebar/sidebar.module.css
@@ -86,7 +86,6 @@
     font-size: var(--sidebar-header-size);
     line-height: var(--sidebar-header-line-height);
     color: var(--color-secondary);
-    text-transform: uppercase;
 }
 
 .sidebarItem {


### PR DESCRIPTION
The sidebar header used to display ACCOUNTS (uppercase) but with watch-only this now includes the wallet name (user input).

Removed uppercase styling so that the BitBoxApp shows the exact name that the user has choosen. The user can decide to use a name that is all uppercase. The app should just display the name as choosen and not transform to uppercase.