### PR TITLE
frontend: fix pasting wc address in qt app

### DIFF
--- a/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
@@ -82,7 +82,7 @@ export const WCConnectForm = ({
           className={showQRButton ? styles.inputWithIcon : ''}
           value={uri}
           readOnly={connectLoading}
-          onInput={(e) => onInputChange(e.target.value.replaceAll(' ', ''))}>
+          onInput={(e) => onInputChange(e.target.value.replace(/\s/g, ''))}>
           {(showQRButton && !connectLoading) && <ScanQRButton onClick={toggleScanQR} />}
         </Input>
         <ScanQRDialog


### PR DESCRIPTION
This fixes a JavaScript error that occured by useing replaceAll, which is only supported from chrome version 85 on. But the WebView currently is based on chrome version 83.

Changed to use replace + regex, to filter out white-spaces etc.