### PR TITLE
frontend: invert watch account option

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1057,18 +1057,18 @@
   },
   "loading": "loading…",
   "manageAccounts": {
-    "accountHidden": "This account has been hidden from your watch-only accounts. To see it again, please plug in your BitBox02.",
+    "accountHidden": "This account will now be hidden from your watch-only accounts. To see it again, please plug in your BitBox02.",
     "editAccount": "Edit",
     "editAccountNameTitle": "Edit account name",
-    "hideAccount": "Hide account",
-    "hideAccountDescription": "Hide your account so next time you open the BitBoxApp, it won't show up in your list of accounts. You can always add it again later.",
     "noAccounts": "no accounts found",
     "settings": {
       "hideTokens": "Hide tokens",
       "showTokens": "Show tokens ({{activeTokenCount}})"
     },
     "settingsButtonDescription": "Add and show/hide accounts",
-    "title": "Manage accounts"
+    "title": "Manage accounts",
+    "watchAccount": "Watch account",
+    "watchAccountDescription": "This account is part of your watch-only accounts. You can hide it from your watch-only accounts using the toggle."
   },
   "mobile": {
     "usingMobileDataWarning": "Mobile data usage: this app may download up to a few hundred megabytes of blockchain header data after unlocking an account. Please connect to Wi-Fi to avoid using mobile data. After dismissing it, this message won't be shown again."

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -137,10 +137,10 @@ class ManageAccounts extends Component<Props, State> {
         <div className={style.watchOnlyContainer}>
           <div className="flex">
             <EyeOpenedDark width={18} height={18} />
-            <p className={style.watchOnlyTitle}>{t('manageAccounts.hideAccount')}</p>
+            <p className={style.watchOnlyTitle}>{t('manageAccounts.watchAccount')}</p>
           </div>
           <Toggle
-            checked={!currentlyEditedAccount.watch}
+            checked={currentlyEditedAccount.watch}
             className={style.toggle}
             id={currentlyEditedAccount.code}
             onChange={async (event) => {
@@ -151,7 +151,7 @@ class ManageAccounts extends Component<Props, State> {
             }}
           />
         </div>
-        <p className={style.watchOnlyNote}>{t('manageAccounts.hideAccountDescription')}</p>
+        <p className={style.watchOnlyNote}>{t('manageAccounts.watchAccountDescription')}</p>
         {
           !currentlyEditedAccount.watch && <div className={style.watchOnlyAccountHidden}>
             <p>{t('manageAccounts.accountHidden')}</p>


### PR DESCRIPTION
The BitBoxApp already has an enable option in the manage-accounts view. Adding a similar 'hide' option in the edit-account dialog is confusing.

This commit changes the wording and flips the toggle, from hide account to watch account. The verb 'watch' is more naturally associable with the feature watch-only.