### PR TITLE
backend: avoid deadlock

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -910,13 +910,14 @@ func (backend *Backend) SetWatchonly(watchonly bool) error {
 			nil,
 		)
 	}
+
+	accounts := accountsList(backend.Accounts())
 	// When enabling watchonly, we turn the currently loaded accounts into watch-only accounts.
 	t := true
 	return backend.AccountSetWatch(
 		func(account *config.Account) bool {
 			// Apply to each currently loaded account.
-			defer backend.accountsAndKeystoreLock.RLock()()
-			return backend.accounts.lookup(account.Code) != nil
+			return accounts.lookup(account.Code) != nil
 		},
 		&t,
 	)


### PR DESCRIPTION
backend.AccountSetWatch holds the accounts config lock while it is modifying the config, and while it holds the config lock it tries to acquire the accountsAndKeystoreLock in the filter function. This can deadlock if the accountsAndKeystoreLock is held already.