### PR TITLE
ci: remove macOS caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Enable caching
-        uses: actions/cache@v2
-        with:
-          # The key version is just an incremental number.
-          # Bump it every time there are changes in CI scripts.
-          key: ${{runner.os}}-qt-osx-v2
-          path: |
-            ~/Library/Caches/Homebrew
       - name: Install Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Recently, half of the PRs fail CI because macOS cache downloading gets
stuck at 99.9%.

We simply remove it, it does not seem to have a performance
downside. Downloading from brew seems to take more or less the same
amount of time as downloading the cache. It may even be faster - CI
with this commit ran in 6min while a previous one with the cache ran
in 7min.
