### PR TITLE
frontend: fix route after passphrase device settings changed

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -139,7 +139,6 @@ class App extends Component<Props, State> {
       currentURL.startsWith('/account-summary')
       || currentURL.startsWith('/add-account')
       || currentURL.startsWith('/settings/manage-accounts')
-      || currentURL.startsWith('/passphrase')
     )) {
       route('/', true);
       return;

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -192,7 +192,6 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
         <Route path="pocket/:code" element={PocketEl} />
         <Route path="exchange/:code" element={ExchangeEl} />
       </Route>
-      <Route path="passphrase/:deviceID" element={PassphraseEl} />
       <Route path="manage-backups/:deviceID" element={ManageBackupsEl} />
       <Route path="accounts/select-receive" element={ReceiveAccountsSelectorEl} />
       <Route path="settings">
@@ -200,6 +199,7 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
         <Route path="appearance" element={AppearanceEl} />
         <Route path="about" element={AboutEl} />
         <Route path="device-settings/:deviceID" element={Device} />
+        <Route path="device-settings/passphrase/:deviceID" element={PassphraseEl} />
         <Route path="advanced-settings" element={AdvancedSettingsEl} />
         <Route path="electrum" element={<ElectrumSettings />} />
         <Route path="manage-accounts" element={<ManageAccounts key={'manage-accounts'} deviceIDs={deviceIDs} hasAccounts={hasAccounts}/>} />

--- a/frontends/web/src/routes/settings/components/device-settings/passphrase-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/passphrase-setting.tsx
@@ -28,7 +28,7 @@ const PassphraseSetting = ({ deviceID, passphraseEnabled }: TProps) => {
   const { t } = useTranslation();
   return (
     <SettingsItem
-      onClick={() => route(`/passphrase/${deviceID}`)}
+      onClick={() => route(`/settings/device-settings/passphrase/${deviceID}`)}
       settingName={t('deviceSettings.expert.passphrase.title')}
       secondaryText={t('deviceSettings.expert.passphrase.description')}
       displayedValue={ passphraseEnabled


### PR DESCRIPTION
After enabling the passphrase option (watch-only enabled) the app says "Please replug the BitBox02 now", but the app just keeps showing that view.

Without watch-only the unlock device view shows as expected.

Reason was that the /passphrase route was not under /settings and had some special condition which including testing accounts. But with watch-only there might be always accounts, so this failed.

Moved the /passphrase router under /settings/device-settings, so that it is covered by another condition in app.tsx routing logic. With this there is no need to check for /passphrase directly, as it is now under /settings.

Alternative would have been to explicitly test for /passphrase.