### PR TITLE
frontend: use normal font-size in account edit dialog

### DIFF
--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -156,7 +156,6 @@
 }
 
 .watchOnlyNote {
-    font-size: var(--size-small);
     margin: 0;
     margin-top: var(--space-half);
 }


### PR DESCRIPTION
Whenever possible always use regular font-size. In the edit account dialog there is a small description about watch-only this can just use normal font-size.