### PR TITLE
frontend: only show closebutton in a watchonly receive dialog

### DIFF
--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -261,11 +261,9 @@ export const Receive = ({
                     // disable escape for secure outputs like the BitBox02, where the dialog is
                     // dimissed by tapping the device
                     disableEscape={verifying === 'secure'}
-                    onClose={() => {
-                      if (verifying === 'insecure') {
-                        setVerifying(false);
-                      }
-                    }}
+                    onClose={verifying === 'insecure' ? () => {
+                      setVerifying(false);
+                    } : undefined}
                     medium centered>
                     {account && <>
                       <div className="text-center">


### PR DESCRIPTION
With watch-only the verify receive address can show a connect the correct wallet dialog, introduced in 61a9322a5a1877f518d50e8dfe68e0a9e09953ad

This introduced a minor regression that shows a close button when the dialog should be blocking.