### PR TITLE
backend/accounts: fix race conditions for backend.accounts

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -46,9 +46,10 @@ const hardenedKeystart uint32 = hdkeychain.HardenedKeyStart
 // limit, but simply use a hard limit for simplicity.
 const accountsHardLimit = 5
 
-type accountsList []accounts.Interface
+// AccountsList is an accounts.Interface slice which implements a lookup method.
+type AccountsList []accounts.Interface
 
-func (a accountsList) lookup(code accountsTypes.Code) accounts.Interface {
+func (a AccountsList) lookup(code accountsTypes.Code) accounts.Interface {
 	for _, acct := range a {
 		if acct.Config().Config.Code == code {
 			return acct

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -924,7 +924,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 	defer b.Close()
 	fingerprint := []byte{0x55, 0x55, 0x55, 0x55}
 
-	require.Equal(t, accountsList{}, b.accounts)
+	require.Equal(t, AccountsList{}, b.Accounts())
 
 	// Add a Bitcoin account.
 	coin, err := b.Coin(coinpkg.CodeBTC)
@@ -939,9 +939,9 @@ func TestCreateAndAddAccount(t *testing.T) {
 			},
 		},
 	)
-	require.Len(t, b.accounts, 1)
+	require.Len(t, b.Accounts(), 1)
 	// Check some properties of the newly added account.
-	acct := b.accounts[0]
+	acct := b.Accounts()[0]
 	require.Equal(t, accountsTypes.Code("test-btc-account-code"), acct.Config().Config.Code)
 	require.Equal(t, coin, acct.Coin())
 	require.Equal(t, "Bitcoin account name", acct.Config().Config.Name)
@@ -958,9 +958,9 @@ func TestCreateAndAddAccount(t *testing.T) {
 			},
 		},
 	)
-	require.Len(t, b.accounts, 2)
+	require.Len(t, b.Accounts(), 2)
 	// Check some properties of the newly added account.
-	acct = b.accounts[1]
+	acct = b.Accounts()[1]
 	require.Equal(t, accountsTypes.Code("test-ltc-account-code"), acct.Config().Config.Code)
 	require.Equal(t, coin, acct.Coin())
 	require.Equal(t, "Litecoin account name", acct.Config().Config.Name)
@@ -979,14 +979,14 @@ func TestCreateAndAddAccount(t *testing.T) {
 		},
 	)
 	// 2 more accounts: the added ETH account plus the active token for the ETH account.
-	require.Len(t, b.accounts, 4)
+	require.Len(t, b.Accounts(), 4)
 	// Check some properties of the newly added account.
-	acct = b.accounts[2]
+	acct = b.Accounts()[2]
 	require.Nil(t, acct.Coin().(*eth.Coin).ERC20Token())
 	require.Equal(t, accountsTypes.Code("test-eth-account-code"), acct.Config().Config.Code)
 	require.Equal(t, coin, acct.Coin())
 	require.Equal(t, "Ethereum account name", acct.Config().Config.Name)
-	acct = b.accounts[3]
+	acct = b.Accounts()[3]
 	require.NotNil(t, acct.Coin().(*eth.Coin).ERC20Token())
 	require.Equal(t, accountsTypes.Code("test-eth-account-code-eth-erc20-mkr"), acct.Config().Config.Code)
 	require.Equal(t, "Maker", acct.Config().Config.Name)
@@ -1006,18 +1006,18 @@ func TestCreateAndAddAccount(t *testing.T) {
 		},
 	)
 	// 3 more accounts: the added ETH account plus the two active tokens for the ETH account.
-	require.Len(t, b.accounts, 7)
+	require.Len(t, b.Accounts(), 7)
 	// Check some properties of the newly added accounts.
-	acct = b.accounts[4]
+	acct = b.Accounts()[4]
 	require.Nil(t, acct.Coin().(*eth.Coin).ERC20Token())
 	require.Equal(t, accountsTypes.Code("test-eth-account-code-2"), acct.Config().Config.Code)
 	require.Equal(t, coin, acct.Coin())
 	require.Equal(t, "Ethereum account name 2", acct.Config().Config.Name)
-	acct = b.accounts[5]
+	acct = b.Accounts()[5]
 	require.NotNil(t, acct.Coin().(*eth.Coin).ERC20Token())
 	require.Equal(t, accountsTypes.Code("test-eth-account-code-2-eth-erc20-bat"), acct.Config().Config.Code)
 	require.Equal(t, "Basic Attention Token 2", acct.Config().Config.Name)
-	acct = b.accounts[6]
+	acct = b.Accounts()[6]
 	require.NotNil(t, acct.Coin().(*eth.Coin).ERC20Token())
 	require.Equal(t, accountsTypes.Code("test-eth-account-code-2-eth-erc20-usdt"), acct.Config().Config.Code)
 	require.Equal(t, "Tether USD 2", acct.Config().Config.Name)
@@ -1231,7 +1231,7 @@ func TestRenameAccount(t *testing.T) {
 	b.registerKeystore(makeBitBox02Multi())
 
 	require.NoError(t, b.RenameAccount("v0-55555555-btc-0", "renamed"))
-	require.Equal(t, "renamed", b.accounts.lookup("v0-55555555-btc-0").Config().Config.Name)
+	require.Equal(t, "renamed", b.Accounts().lookup("v0-55555555-btc-0").Config().Config.Name)
 	require.Equal(t, "renamed", b.config.AccountsConfig().Lookup("v0-55555555-btc-0").Name)
 }
 
@@ -1250,7 +1250,7 @@ func TestMaybeAddHiddenUnusedAccounts(t *testing.T) {
 		b.maybeAddHiddenUnusedAccounts()
 	}
 
-	require.Len(t, b.accounts, 3+2*5)
+	require.Len(t, b.Accounts(), 3+2*5)
 	require.Len(t, b.config.AccountsConfig().Accounts, 3+2*5)
 
 	for i := 1; i <= 5; i++ {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -180,7 +180,7 @@ type Backend struct {
 	devices map[string]device.Interface
 
 	accountsAndKeystoreLock locker.Locker
-	accounts                accountsList
+	accounts                AccountsList
 	// keystore is nil if no keystore is connected.
 	keystore keystore.Keystore
 
@@ -527,7 +527,7 @@ func (backend *Backend) Testing() bool {
 }
 
 // Accounts returns the current accounts of the backend.
-func (backend *Backend) Accounts() []accounts.Interface {
+func (backend *Backend) Accounts() AccountsList {
 	defer backend.accountsAndKeystoreLock.RLock()()
 	return backend.accounts
 }
@@ -911,7 +911,7 @@ func (backend *Backend) SetWatchonly(watchonly bool) error {
 		)
 	}
 
-	accounts := accountsList(backend.Accounts())
+	accounts := backend.Accounts()
 	// When enabling watchonly, we turn the currently loaded accounts into watch-only accounts.
 	t := true
 	return backend.AccountSetWatch(

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -68,7 +68,7 @@ type Backend interface {
 	DefaultAppConfig() config.AppConfig
 	Coin(coinpkg.Code) (coinpkg.Coin, error)
 	Testing() bool
-	Accounts() []accounts.Interface
+	Accounts() backend.AccountsList
 	Keystore() keystore.Keystore
 	OnAccountInit(f func(accounts.Interface))
 	OnAccountUninit(f func(accounts.Interface))


### PR DESCRIPTION
`backend.accounts` was accessed in several places without locking a read locker before, causing several possible race conditions.

This commit exports the backend.Accounts() method, which locks correctly before returning the accounts, and fixes the unlocked calls.