### PR TITLE
build/os-x: fix build errors for M-based Apple machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix build on M-processor Apple machines
 
 ## 4.40.0
 - Add support for watch-only - see your accounts and portfolio without connecting your BitBox02

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,7 @@ envinit:
 #  - additional dependencies: Qt 5.15 & Xcode command line tools
 #  - add to $PATH: /usr/local/opt/go@1.20/bin
 osx-init:
-	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-	brew install go@1.20
-	brew install qt@5
+	./scripts/osx-brew.sh
 	$(MAKE) envinit
 servewallet:
 	go run -mod=vendor ./cmd/servewallet

--- a/scripts/osx-brew.sh
+++ b/scripts/osx-brew.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ $(arch) = "arm64" ]; then
+  # recent M-based apple machines have an arm64 arch, but we need to install x86_64 deps
+  arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+  /usr/local/Homebrew/bin/brew install go@1.20
+  /usr/local/Homebrew/bin/brew instal qt@5
+else
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+  brew install go@1.20
+  brew install qt@5
+fi


### PR DESCRIPTION
Apple machines with M processor have an arm64 architecture with a compatiblity layer for x86_64 software. Brew packages are installed with an arm64 architecture by default on these machines.

BitBoxApp is compiled for x86_64 arch, and the arm64 Qt was causing errors in the build process.

This commit introduces an osx-brew.sh script that forces the installation of x86_64 deps even on arm64 machines, fixing the error.

**NOTE: this is untested on Intel machines!**