### PR TITLE
frontend: fix a typo in 'Unlock software keystore'

### DIFF
--- a/frontends/web/src/routes/device/components/skipfortesting.tsx
+++ b/frontends/web/src/routes/device/components/skipfortesting.tsx
@@ -36,7 +36,7 @@ export const SkipForTesting = () => {
   if (!show) {
     return null;
   }
-  const title = 'Unlock software kestore';
+  const title = 'Unlock software keystore';
   return (
     <>
       <button onClick={() => setDialog(true)}>{title}</button>


### PR DESCRIPTION
Small spelling change from `kestore` to `keystore`.