### PR TITLE
frontend: extracted txProposal error handling into a function

### DIFF
--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -1,0 +1,34 @@
+import { alertUser } from '../../../components/alert/Alert';
+import { i18n } from '../../../i18n/i18n';
+
+export type TProposalError = {
+    addressError: string;
+    amountError: string;
+    feeError: string;
+}
+
+type TProposalErrorHandling = TProposalError | {proposedFee: undefined}
+
+export const txProposalErrorHandling = (registerEvents: () => void, unregisterEvents: () => void, errorCode?: string) => {
+  const { t } = i18n;
+  let errorHandling = {} as Partial<TProposalErrorHandling>;
+  switch (errorCode) {
+  case 'invalidAddress':
+    errorHandling = { addressError: t('send.error.invalidAddress') };
+    break;
+  case 'invalidAmount':
+  case 'insufficientFunds':
+    errorHandling = { amountError: t(`send.error.${errorCode}`), proposedFee: undefined };
+    break;
+  case 'feeTooLow':
+  case 'feesNotAvailable':
+    errorHandling = { feeError: t(`send.error.${errorCode}`) };
+    break;
+  default:
+    if (errorCode) {
+      unregisterEvents();
+      alertUser(errorCode, { callback: registerEvents });
+    }
+  }
+  return errorHandling;
+};


### PR DESCRIPTION
To reduce the amount of logic and as a part of the refactoring of `send.tsx`, we create a new service file to place more logic-heavy codes outside of the `send` component.

This commit moves a lengthy switch case into the service and called it `txProposalErrorHandling`.