### PR TITLE
frontend: extracted txProposal error handling into a function

### DIFF
--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -38,6 +38,7 @@ import { route } from '../../../utils/route';
 import { UnsubscribeList, unsubscribe } from '../../../utils/subscriptions';
 import { ConfirmingWaitDialog } from './components/dialogs/confirm-wait-dialog';
 import { SendGuide } from './send-guide';
+import { TProposalError, txProposalErrorHandling } from './services';
 import { MessageWaitDialog } from './components/dialogs/message-wait-dialog';
 import { ReceiverAddressInput } from './components/inputs/receiver-address-input';
 import { CoinInput } from './components/inputs/coin-input';
@@ -60,7 +61,7 @@ interface SignProgress {
 
 type Props = SendProps & TranslateProps;
 
-interface State {
+export type State = {
     account?: accountApi.IAccount;
     balance?: accountApi.IBalance;
     proposedFee?: accountApi.IAmount;
@@ -78,9 +79,9 @@ interface State {
     isSent: boolean;
     isAborted: boolean;
     isUpdatingProposal: boolean;
-    addressError?: string;
-    amountError?: string;
-    feeError?: string;
+    addressError?: TProposalError['addressError'];
+    amountError?: TProposalError['amountError'];
+    feeError?: TProposalError['feeError'];
     paired?: boolean;
     noMobileChannelError?: boolean;
     signProgress?: SignProgress;
@@ -339,32 +340,8 @@ class Send extends Component<Props, State> {
         this.convertToFiat(result.amount.amount);
       }
     } else {
-      const errorCode = result.errorCode;
-      switch (errorCode) {
-      case 'invalidAddress':
-        this.setState({ addressError: this.props.t('send.error.invalidAddress') });
-        break;
-      case 'invalidAmount':
-      case 'insufficientFunds':
-        this.setState({
-          amountError: this.props.t(`send.error.${errorCode}`),
-          proposedFee: undefined,
-        });
-        break;
-      case 'feeTooLow':
-        this.setState({ feeError: this.props.t('send.error.feeTooLow') });
-        break;
-      case 'feesNotAvailable':
-        this.setState({ feeError: this.props.t('send.error.feesNotAvailable') });
-        break;
-      default:
-        this.setState({ proposedFee: undefined });
-        if (errorCode) {
-          this.unregisterEvents();
-          alertUser(errorCode, { callback: this.registerEvents });
-        }
-      }
-      this.setState({ isUpdatingProposal: false });
+      const errorHandling = txProposalErrorHandling(this.registerEvents, this.unregisterEvents, result.errorCode);
+      this.setState({ ...errorHandling, isUpdatingProposal: false });
     }
   };
 

--- a/frontends/web/src/routes/account/send/services.test.ts
+++ b/frontends/web/src/routes/account/send/services.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { i18n as interfacei18n } from 'i18next';
+import { txProposalErrorHandling } from './services';
+import { alertUser } from '../../../components/alert/Alert';
+
+vi.mock('i18next', async () => {
+  const actualI18next: { default: interfacei18n } = await vi.importActual('i18next') as { default: interfacei18n };
+  return {
+    default: {
+      ...actualI18next.default,
+      use: vi.fn().mockReturnThis(),
+      init: vi.fn(),
+      addResourceBundle: vi.fn(),
+      on: vi.fn(),
+      t: vi.fn().mockImplementation((key: string) => key)
+    },
+  };
+});
+
+vi.mock('../../../components/alert/Alert', () => ({
+  ...vi.importActual('../../../components/alert/Alert'),
+  alertUser: vi.fn()
+}));
+
+describe('send services', () => {
+  describe('txProposalErrorHandling', () => {
+
+    const mockRegisterEvents = vi.fn();
+    const mockUnregisterEvents = vi.fn();
+
+    it('returns invalid address message on invalidAddress error', () => {
+      const result = txProposalErrorHandling(mockRegisterEvents, mockUnregisterEvents, 'invalidAddress');
+      expect(result).toEqual({ addressError: 'send.error.invalidAddress' });
+    });
+
+    it('returns invalid amount message on invalidAmount error', () => {
+      const result = txProposalErrorHandling(mockRegisterEvents, mockUnregisterEvents, 'invalidAmount');
+      expect(result).toEqual({ amountError: 'send.error.invalidAmount', proposedFee: undefined });
+    });
+
+    it('returns insufficient funds message on insufficientFunds error', () => {
+      const result = txProposalErrorHandling(mockRegisterEvents, mockUnregisterEvents, 'insufficientFunds');
+      expect(result).toEqual({ amountError: 'send.error.insufficientFunds', proposedFee: undefined });
+    });
+
+    it('returns fee too low message on feeTooLow error', () => {
+      const result = txProposalErrorHandling(mockRegisterEvents, mockUnregisterEvents, 'feeTooLow');
+      expect(result).toEqual({ feeError: 'send.error.feeTooLow' });
+    });
+
+    it('returns fees not available message on feesNotAvailable error', () => {
+      const result = txProposalErrorHandling(mockRegisterEvents, mockUnregisterEvents, 'feesNotAvailable');
+      expect(result).toEqual({ feeError: 'send.error.feesNotAvailable' });
+    });
+
+    it('returns proposed fee undefined and alerts the user when error is unknown', () => {
+      const result = txProposalErrorHandling(mockRegisterEvents, mockUnregisterEvents, 'unknownError');
+      expect(result).toEqual({ proposedFee: undefined });
+      expect(alertUser).toHaveBeenCalledWith('unknownError', { callback: mockRegisterEvents });
+    });
+
+  });
+});

--- a/frontends/web/src/routes/account/send/services.ts
+++ b/frontends/web/src/routes/account/send/services.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2018 Shift Devices AG
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { alertUser } from '../../../components/alert/Alert';
+import { i18n } from '../../../i18n/i18n';
+
+export type TProposalError = {
+    addressError: string;
+    amountError: string;
+    feeError: string;
+}
+
+export const txProposalErrorHandling = (registerEvents: () => void, unregisterEvents: () => void, errorCode?: string) => {
+  const { t } = i18n;
+  switch (errorCode) {
+  case 'invalidAddress':
+    return { addressError: t('send.error.invalidAddress') };
+  case 'invalidAmount':
+  case 'insufficientFunds':
+    return { amountError: t(`send.error.${errorCode}`), proposedFee: undefined };
+  case 'feeTooLow':
+  case 'feesNotAvailable':
+    return { feeError: t(`send.error.${errorCode}`) };
+  default:
+    if (errorCode) {
+      unregisterEvents();
+      alertUser(errorCode, { callback: registerEvents });
+    }
+    return { proposedFee: undefined };
+  }
+};


### PR DESCRIPTION
To reduce the amount of logic and as a part of the refactoring of `send.tsx`, we create a new service file to place more logic-heavy codes outside of the `send` component.

This commit moves a lengthy switch case into the service and called it `txProposalErrorHandling`.