### PR TITLE
frontend: migrate rates store to context API

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -42,6 +42,7 @@ import { DarkModeProvider } from './contexts/DarkmodeProvider';
 import { AppProvider } from './contexts/AppProvider';
 import { AuthRequired } from './components/auth/authrequired';
 import { WCWeb3WalletProvider } from './contexts/WCWeb3WalletProvider';
+import { RatesProvider } from './contexts/RatesProvider';
 import { WCSigningRequest } from './components/wallet-connect/incoming-signing-request';
 
 type State = {
@@ -182,49 +183,51 @@ class App extends Component<Props, State> {
       <ConnectedApp>
         <AppProvider>
           <DarkModeProvider>
-            <WCWeb3WalletProvider>
-              <Darkmode />
-              <div className="app">
-                <AuthRequired/>
-                <Sidebar
-                  accounts={activeAccounts}
-                  deviceIDs={deviceIDs}
-                />
-                <div className="appContent flex flex-column flex-1" style={{ minWidth: 0 }}>
-                  <Update />
-                  <Banner msgKey="bitbox01" />
-                  <Banner msgKey="bitbox02" />
-                  <MobileDataWarning />
-                  <WCSigningRequest />
-                  <Aopp />
-                  <KeystoreConnectPrompt />
-                  {
-                    Object.entries(devices).map(([deviceID, productName]) => {
-                      if (productName === 'bitbox02') {
-                        return (
-                          <Fragment key={deviceID}>
-                            <BitBox02Wizard
-                              deviceID={deviceID}
-                            />
-                          </Fragment>
-                        );
-                      }
-                      return null;
-                    })
-                  }
-                  <AppRouter
-                    accounts={accounts}
-                    activeAccounts={activeAccounts}
+            <RatesProvider>
+              <WCWeb3WalletProvider>
+                <Darkmode />
+                <div className="app">
+                  <AuthRequired/>
+                  <Sidebar
+                    accounts={activeAccounts}
                     deviceIDs={deviceIDs}
-                    devices={devices}
-                    devicesKey={this.devicesKey}
                   />
-                  <RouterWatcher onChange={this.handleRoute} />
+                  <div className="appContent flex flex-column flex-1" style={{ minWidth: 0 }}>
+                    <Update />
+                    <Banner msgKey="bitbox01" />
+                    <Banner msgKey="bitbox02" />
+                    <MobileDataWarning />
+                    <WCSigningRequest />
+                    <Aopp />
+                    <KeystoreConnectPrompt />
+                    {
+                      Object.entries(devices).map(([deviceID, productName]) => {
+                        if (productName === 'bitbox02') {
+                          return (
+                            <Fragment key={deviceID}>
+                              <BitBox02Wizard
+                                deviceID={deviceID}
+                              />
+                            </Fragment>
+                          );
+                        }
+                        return null;
+                      })
+                    }
+                    <AppRouter
+                      accounts={accounts}
+                      activeAccounts={activeAccounts}
+                      deviceIDs={deviceIDs}
+                      devices={devices}
+                      devicesKey={this.devicesKey}
+                    />
+                    <RouterWatcher onChange={this.handleRoute} />
+                  </div>
+                  <Alert />
+                  <Confirm />
                 </div>
-                <Alert />
-                <Confirm />
-              </div>
-            </WCWeb3WalletProvider>
+              </WCWeb3WalletProvider>
+            </RatesProvider>
           </DarkModeProvider>
         </AppProvider>
       </ConnectedApp>

--- a/frontends/web/src/components/balance/balance.test.tsx
+++ b/frontends/web/src/components/balance/balance.test.tsx
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { describe, expect, it, vi } from 'vitest';
+import { useContext } from 'react';
+import { Mock, describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { IBalance } from '../../api/account';
 import I18NWrapper from '../../i18n/forTests/i18nwrapper';
@@ -24,8 +24,15 @@ vi.mock('../../utils/request', () => ({
   apiGet: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock('react', () => ({
+  ...vi.importActual('react'),
+  useContext: vi.fn(),
+  createContext: vi.fn()
+}));
+
 describe('components/balance/balance', () => {
   it('renders balance properly', () => {
+    (useContext as Mock).mockReturnValue({ btcUnit: 'default', defaultCurrency: 'USD' });
     const MOCK_BALANCE: IBalance = {
       hasAvailable: true,
       hasIncoming: true,
@@ -60,7 +67,7 @@ describe('components/balance/balance', () => {
       }
     };
     const { getByTestId } = render(<Balance balance={MOCK_BALANCE} />, { wrapper: I18NWrapper });
-    expect(getByTestId('availableBalance')).toHaveTextContent('0.005BTC');
-    expect(getByTestId('incomingBalance').textContent).toContain('+0.003 BTC / 512');
+    expect(getByTestId('availableBalance').textContent).toBe('0.005BTC');
+    expect(getByTestId('incomingBalance').textContent).toBe('+0.003 BTC / 512 USD');
   });
 });

--- a/frontends/web/src/contexts/RatesContext.tsx
+++ b/frontends/web/src/contexts/RatesContext.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+*
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext } from 'react';
+import { Fiat } from '../api/account';
+import { BtcUnit } from '../api/coins';
+
+type RatesContextProps = {
+    defaultCurrency: Fiat;
+    activeCurrencies: Fiat[];
+    btcUnit?: BtcUnit;
+    rotateFiat: () => void;
+    selectFiat: (fiat: Fiat) => Promise<void>;
+    updateDefaultFiat: (fiat: Fiat) => void;
+    updateRatesConfig: () => Promise<void>;
+    unselectFiat: (fiat: Fiat) => Promise<void>;
+}
+
+const RatesContext = createContext<RatesContextProps>({} as RatesContextProps);
+
+export { RatesContext };

--- a/frontends/web/src/contexts/RatesProvider.tsx
+++ b/frontends/web/src/contexts/RatesProvider.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode, useEffect, useState } from 'react';
+import { RatesContext } from './RatesContext';
+import { Fiat } from '../api/account';
+import { BtcUnit } from '../api/coins';
+import { getConfig, setConfig } from '../utils/config';
+import { reinitializeAccounts } from '../api/backend';
+import { equal } from '../utils/equal';
+
+type TProps = {
+    children: ReactNode;
+}
+
+export const RatesProvider = ({ children }: TProps) => {
+  const [defaultCurrency, setDefaultCurrency] = useState<Fiat>('USD');
+  const [activeCurrencies, setActiveCurrencies] = useState<Fiat[]>(['USD', 'EUR', 'CHF']);
+  const [btcUnit, setBtcUnit] = useState<BtcUnit>('default');
+
+  useEffect(() => {
+    updateRatesConfig();
+  }, []);
+
+  const updateRatesConfig = async () => {
+    const appConf = await getConfig();
+
+    if (appConf.backend?.mainFiat) {
+      setDefaultCurrency(appConf.backend.mainFiat);
+    }
+
+    if (appConf.backend?.fiatList && appConf.backend?.btcUnit) {
+      setActiveCurrencies(appConf.backend.fiatList);
+      setBtcUnit(appConf.backend.btcUnit);
+    }
+  };
+
+  const rotateFiat = () => {
+    const index = activeCurrencies.indexOf(defaultCurrency);
+    const fiat = activeCurrencies[(index + 1) % activeCurrencies.length];
+    setDefaultCurrency(fiat);
+  };
+
+  const updateDefaultFiat = (fiat: Fiat) => {
+    if (!activeCurrencies.includes(fiat)) {
+      selectFiat(fiat);
+    }
+    setDefaultCurrency(fiat);
+    setConfig({ backend: { mainFiat: fiat } });
+  };
+
+  //this is a method to select a fiat to be
+  //added into the selected fiat list
+  const selectFiat = async (fiat: Fiat) => {
+    const selected = [...activeCurrencies, fiat];
+    await setConfig({ backend: { fiatList: selected } });
+    handleChangeSelectedFiat(selected);
+  };
+
+  //this is a method to unselect a fiat to be
+  //removed from the selected fiat list
+  const unselectFiat = async (fiat: Fiat) => {
+    const selected = activeCurrencies.filter(item => !equal(item, fiat));
+    await setConfig({ backend: { fiatList: selected } });
+    handleChangeSelectedFiat(selected);
+  };
+
+  const handleChangeSelectedFiat = (selected: Fiat[]) => {
+    setActiveCurrencies(selected);
+    // Need to reconfigure currency exchange rates updater
+    // which is done during accounts reset.
+    reinitializeAccounts();
+  };
+
+  return (
+    <RatesContext.Provider
+      value={{
+        defaultCurrency,
+        activeCurrencies,
+        btcUnit,
+        rotateFiat,
+        selectFiat,
+        updateDefaultFiat,
+        updateRatesConfig,
+        unselectFiat
+      }}
+    >
+      {children}
+    </RatesContext.Provider>
+  );
+};

--- a/frontends/web/src/routes/account/send/send-wrapper.tsx
+++ b/frontends/web/src/routes/account/send/send-wrapper.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2023 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext } from 'react';
+import { IAccount } from '../../../api/account';
+import { TDevices } from '../../../api/devices';
+import { RatesContext } from '../../../contexts/RatesContext';
+import { Send } from './send';
+
+type TSendProps = {
+    accounts: IAccount[];
+    code: string;
+    devices: TDevices;
+    deviceIDs: string[];
+}
+
+export const SendWrapper = ({ accounts, code, deviceIDs, devices }: TSendProps) => {
+  const { defaultCurrency } = useContext(RatesContext);
+  return (
+    <Send
+      accounts={accounts}
+      code={code}
+      devices={devices}
+      deviceIDs={deviceIDs}
+      activeCurrency={defaultCurrency}
+    />
+  );
+};

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -27,7 +27,6 @@ import { Balance } from '../../../components/balance/balance';
 import { HideAmountsButton } from '../../../components/hideamountsbutton/hideamountsbutton';
 import { Button, ButtonLink } from '../../../components/forms';
 import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
-import { store as fiat } from '../../../components/rates/rates';
 import { Status } from '../../../components/status/status';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiGet, apiPost } from '../../../utils/request';
@@ -51,6 +50,7 @@ interface SendProps {
     code: string;
     devices: TDevices;
     deviceIDs: string[];
+    activeCurrency: accountApi.Fiat;
 }
 
 interface SignProgress {
@@ -115,7 +115,7 @@ class Send extends Component<Props, State> {
     isAborted: false,
     isUpdatingProposal: false,
     noMobileChannelError: false,
-    fiatUnit: fiat.state.active,
+    fiatUnit: this.props.activeCurrency,
     coinControl: false,
     btcUnit : 'default',
     activeCoinControl: false,

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -9,7 +9,7 @@ import { Exchange } from './buy/exchange';
 import { Pocket } from './buy/pocket';
 import { Info } from './account/info/info';
 import { Receive } from './account/receive';
-import { Send } from './account/send/send';
+import { SendWrapper } from './account/send/send-wrapper';
 import { AccountsSummary } from './account/summary/accountssummary';
 import { DeviceSwitch } from './device/deviceswitch';
 import ManageBackups from './device/manage-backups/manage-backups';
@@ -74,7 +74,7 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
   </InjectParams>;
 
   const AccSend = <InjectParams>
-    <Send
+    <SendWrapper
       code={'' /* dummy to satisfy TS */}
       devices={devices}
       deviceIDs={deviceIDs}

--- a/frontends/web/src/routes/settings/appearance.tsx
+++ b/frontends/web/src/routes/settings/appearance.tsx
@@ -21,7 +21,7 @@ import { DarkmodeToggleSetting } from './components/appearance/darkmodeToggleSet
 import { DefaultCurrencyDropdownSetting } from './components/appearance/defaultCurrencyDropdownSetting';
 import { DisplaySatsToggleSetting } from './components/appearance/displaySatsToggleSetting';
 import { LanguageDropdownSetting } from './components/appearance/languageDropdownSetting';
-import { ActiveCurrenciesDropdownSettingWithStore } from './components/appearance/activeCurrenciesDropdownSetting';
+import { ActiveCurrenciesDropdownSetting } from './components/appearance/activeCurrenciesDropdownSetting';
 import { HideAmountsSetting } from './components/appearance/hideAmountsSetting';
 import { WithSettingsTabs } from './components/tabs';
 import { MobileHeader } from './components/mobile-header';
@@ -47,7 +47,7 @@ export const Appearance = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTab
             <ViewContent>
               <WithSettingsTabs hasAccounts={hasAccounts} hideMobileMenu deviceIDs={deviceIDs}>
                 <DefaultCurrencyDropdownSetting />
-                <ActiveCurrenciesDropdownSettingWithStore />
+                <ActiveCurrenciesDropdownSetting />
                 <LanguageDropdownSetting />
                 <DarkmodeToggleSetting />
                 <DisplaySatsToggleSetting />

--- a/frontends/web/src/routes/settings/components/appearance/activeCurrenciesDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/activeCurrenciesDropdownSetting.tsx
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-import { store, SharedProps, formattedCurrencies } from '../../../../components/rates/rates';
-import { SettingsItem } from '../settingsItem/settingsItem';
-import { share } from '../../../../decorators/share';
-import { ActiveCurrenciesDropdown } from '../dropdowns/activecurrenciesdropdown';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
+import { formattedCurrencies } from '../../../../components/rates/rates';
+import { SettingsItem } from '../settingsItem/settingsItem';
+import { ActiveCurrenciesDropdown } from '../dropdowns/activecurrenciesdropdown';
+import { RatesContext } from '../../../../contexts/RatesContext';
 
-const ActiveCurrenciesDropdownSetting = ({ selected, active }: SharedProps) => {
+const ActiveCurrenciesDropdownSetting = () => {
   const { t } = useTranslation();
+  const { activeCurrencies, defaultCurrency } = useContext(RatesContext);
   return (
     <SettingsItem
       collapseOnSmall
@@ -30,12 +32,12 @@ const ActiveCurrenciesDropdownSetting = ({ selected, active }: SharedProps) => {
       extraComponent={
         <ActiveCurrenciesDropdown
           options={formattedCurrencies}
-          active={active}
-          selected={selected}
+          defaultCurrency={defaultCurrency}
+          activeCurrencies={activeCurrencies}
         />
       }
     />
   );
 };
 
-export const ActiveCurrenciesDropdownSettingWithStore = share<SharedProps>(store)(ActiveCurrenciesDropdownSetting);
+export { ActiveCurrenciesDropdownSetting };

--- a/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-import { currenciesWithDisplayName, formattedCurrencies, selectFiat, setActiveFiat, store } from '../../../../components/rates/rates';
+import { currenciesWithDisplayName, formattedCurrencies } from '../../../../components/rates/rates';
 import { SingleDropdown } from '../dropdowns/singledropdown';
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { Fiat } from '../../../../api/account';
 import { useTranslation } from 'react-i18next';
+import { useContext } from 'react';
+import { RatesContext } from '../../../../contexts/RatesContext';
 
 export const DefaultCurrencyDropdownSetting = () => {
   const { t } = useTranslation();
-  const valueLabel = currenciesWithDisplayName.find(fiat => fiat.currency === store.state.active)?.displayName;
-  const defaultValueLabel = valueLabel ? `${valueLabel} (${store.state.active})` : store.state.active;
+  const { selectFiat, updateDefaultFiat, defaultCurrency, activeCurrencies } = useContext(RatesContext);
+  const valueLabel = currenciesWithDisplayName.find(fiat => fiat.currency === defaultCurrency)?.displayName;
+  const defaultValueLabel = valueLabel ? `${valueLabel} (${defaultCurrency})` : defaultCurrency;
   return (
     <SettingsItem
       settingName={t('newSettings.appearance.defaultCurrency.title')}
@@ -32,15 +35,15 @@ export const DefaultCurrencyDropdownSetting = () => {
       extraComponent={
         <SingleDropdown
           options={formattedCurrencies}
-          handleChange={(fiat: Fiat) => {
-            setActiveFiat(fiat);
-            if (!store.state.selected.includes(fiat)) {
-              selectFiat(fiat);
+          handleChange={async (fiat: Fiat) => {
+            updateDefaultFiat(fiat);
+            if (!activeCurrencies.includes(fiat)) {
+              await selectFiat(fiat);
             }
           }}
           defaultValue={{
             label: defaultValueLabel,
-            value: store.state.active
+            value: defaultCurrency
           }}
         />
       }

--- a/frontends/web/src/routes/settings/components/appearance/displaySatsToggleSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/displaySatsToggleSetting.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Toggle } from '../../../../components/toggle/toggle';
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { useLoad } from '../../../../hooks/api';
 import { getConfig, setConfig } from '../../../../utils/config';
-import { updateRatesConfig } from '../../../../components/rates/rates';
+import { RatesContext } from '../../../../contexts/RatesContext';
 import { BtcUnit, setBtcUnit } from '../../../../api/coins';
 import { alertUser } from '../../../../components/alert/Alert';
 
@@ -28,6 +28,8 @@ export const DisplaySatsToggleSetting = () => {
   const { t } = useTranslation();
   const fetchedConfig = useLoad(getConfig);
   const [displayAsSAT, setDisplayAsSAT] = useState<boolean>();
+
+  const { updateRatesConfig } = useContext(RatesContext);
 
   useEffect(() => {
     if (fetchedConfig) {
@@ -52,7 +54,6 @@ export const DisplaySatsToggleSetting = () => {
       alertUser(t('genericError'));
     }
   };
-
 
   return (
     <>


### PR DESCRIPTION
We'd like to move away from our self-made `store` HoC & decorator
and use React's Context API instead.

This commit migrates rates store to context API. We created RatesProvider to provide "global" rates data/state & methods for the whole app and we can get them from anywhere within the app using RatesContext.

Also renamed these method & states/variables from the store for
better consistency & clarity:
1. `setActiveFiat()` -> `updateDefaultFiat()`
2. `active` -> `defaultCurrency`
3. `selected` -> `activeCurrencies`
