### PR TITLE
frontend: update manage-accounts ui with remember account

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -97,7 +97,8 @@ type Backend interface {
 	SetAccountActive(accountCode accountsTypes.Code, active bool) error
 	SetTokenActive(accountCode accountsTypes.Code, tokenCode string, active bool) error
 	RenameAccount(accountCode accountsTypes.Code, name string) error
-	AccountSetWatch(filter func(*config.Account) bool, watch *bool) error
+	// disabling for now, we'll either bring this back (if user request it) or remove for good
+	// AccountSetWatch(filter func(*config.Account) bool, watch *bool) error
 	AOPP() backend.AOPP
 	AOPPCancel()
 	AOPPApprove()
@@ -213,7 +214,8 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/set-account-active", handlers.postSetAccountActiveHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/set-token-active", handlers.postSetTokenActiveHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/rename-account", handlers.postRenameAccountHandler).Methods("POST")
-	getAPIRouterNoError(apiRouter)("/account-set-watch", handlers.postAccountSetWatchHandler).Methods("POST")
+	// disabling for now, we'll either bring this back (if user request it) or remove for good
+	// getAPIRouterNoError(apiRouter)("/account-set-watch", handlers.postAccountSetWatchHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/accounts/reinitialize", handlers.postAccountsReinitializeHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/account-summary", handlers.getAccountSummary).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/supported-coins", handlers.getSupportedCoinsHandler).Methods("GET")
@@ -800,6 +802,8 @@ func (handlers *Handlers) postRenameAccountHandler(r *http.Request) interface{} 
 	return response{Success: true}
 }
 
+// disabling for now, we'll either bring this back (if user request it) or remove for good
+/*
 func (handlers *Handlers) postAccountSetWatchHandler(r *http.Request) interface{} {
 	var jsonBody struct {
 		AccountCode accountsTypes.Code `json:"accountCode"`
@@ -823,6 +827,7 @@ func (handlers *Handlers) postAccountSetWatchHandler(r *http.Request) interface{
 	}
 	return response{Success: true}
 }
+*/
 
 func (handlers *Handlers) postAccountsReinitializeHandler(_ *http.Request) interface{} {
 	handlers.backend.ReinitializeAccounts()

--- a/frontends/web/src/components/icon/assets/icons/edit-active.svg
+++ b/frontends/web/src/components/icon/assets/icons/edit-active.svg
@@ -1,0 +1,13 @@
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="#5e94bf"
+    stroke-width="1.8"
+    stroke-linecap="round"
+    stroke-linejoin="round">
+    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+  </svg>

--- a/frontends/web/src/components/icon/icon.tsx
+++ b/frontends/web/src/components/icon/icon.tsx
@@ -36,6 +36,7 @@ import creditCardDarkSVG from './assets/icons/credit-card.svg';
 import creditCardLightSVG from './assets/icons/credit-card-light.svg';
 import editSVG from './assets/icons/edit.svg';
 import editLightSVG from './assets/icons/edit-light.svg';
+import editActiveSVG from './assets/icons/edit-active.svg';
 import ethColorSVG from './assets//eth-color.svg';
 import redDotSVG from './assets/icons/red-dot.svg';
 import copySVG from './assets/icons/copy.svg';
@@ -157,6 +158,7 @@ export const CloseXWhite = (props: ImgProps) => (<img src={closeXWhiteSVG} dragg
 export const CloseXDark = (props: ImgProps) => (<img src={closeXDarkSVG} draggable={false} {...props} />);
 export const Edit = (props: ImgProps) => (<img src={editSVG} draggable={false} {...props} />);
 export const EditLight = (props: ImgProps) => (<img src={editLightSVG} draggable={false} {...props} />);
+export const EditActive = (props: ImgProps) => (<img src={editActiveSVG} draggable={false} {...props} />);
 export const ETHLogo = (props: ImgProps) => (<img src={ethColorSVG} draggable={false} {...props} />);
 export const ExternalLink = (props: ImgProps) => (<img src={externalLink} draggable={false} {...props} />);
 export const EyeClosed = (props: ImgProps) => (<img src={eyeClosedSVG} draggable={false} {...props} />);

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1111,6 +1111,10 @@
         "description": "Select your default currency",
         "title": "Default currency"
       },
+      "enableWallet": {
+        "description": "Disabling your account means it will not appear in the sidebar or the portfolio. You can always enable it again from here. Coins on this account will not be affected and will remain safe.",
+        "title": "Enable/disable wallet"
+      },
       "hideAmounts": {
         "description": "Displays a toggle to hide your balance and amounts to improve your privacy when using the app in public.",
         "hideAmounts": "Hide amounts",
@@ -1121,14 +1125,13 @@
         "description": "Which language you want the BitBoxApp to use.",
         "title": "Language"
       },
+      "remebmerWallet": {
+        "name": "Remember wallet",
+        "warning": "This will remove your remembered wallet. To see it again, you will need to plug in the BitBox02 for this wallet. Any coins on this wallet are not affected. Do you want to continue?",
+        "warningTitle": "Disable remember wallet"
+      },
       "toggleSats": {
         "description": "Enable or disable Satoshis."
-      },
-      "watchonly": {
-        "description": "Let's you see your accounts and portfolio without the BitBox02. The BitBox02 is still needed for signing.",
-        "title": "Watch-only",
-        "warning": "This will remove all your watch-only accounts. To see them again, you will need to plug in your BitBox02. Do you want to continue?",
-        "warningTitle": "Disable watch-only"
       }
     }
   },

--- a/frontends/web/src/routes/settings/components/manage-accounts/watchonlySetting.tsx
+++ b/frontends/web/src/routes/settings/components/manage-accounts/watchonlySetting.tsx
@@ -17,13 +17,13 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Toggle } from '../../../../components/toggle/toggle';
-import { SettingsItem } from '../settingsItem/settingsItem';
 import * as backendAPI from '../../../../api/backend';
 import * as accountAPI from '../../../../api/account';
 import { useLoad } from '../../../../hooks/api';
 import { getConfig } from '../../../../utils/config';
 import { Dialog, DialogButtons } from '../../../../components/dialog/dialog';
-import { Button } from '../../../../components/forms';
+import { Button, Label } from '../../../../components/forms';
+import style from './watchonlySettings.module.css';
 
 type Props = {
   keystore: accountAPI.TKeystore;
@@ -74,32 +74,25 @@ export const WatchonlySetting = ({ keystore }: Props) => {
 
   return (
     <>
-      <Dialog title={t('newSettings.appearance.watchonly.warningTitle')} medium onClose={handleCloseDialog} open={warningDialogOpen}>
-        <p>{t('newSettings.appearance.watchonly.warning')}</p>
+      <Dialog title={t('newSettings.appearance.remebmerWallet.warningTitle')} medium onClose={handleCloseDialog} open={warningDialogOpen}>
+        <p>{t('newSettings.appearance.remebmerWallet.warning')}</p>
         <DialogButtons>
           <Button primary onClick={handleConfirmDisableWatchonly}>{t('dialog.confirm')}</Button>
           <Button secondary onClick={handleCloseDialog}>{t('dialog.cancel')}</Button>
         </DialogButtons>
       </Dialog>
-      <SettingsItem
-        settingName={t('newSettings.appearance.watchonly.title')}
-        secondaryText={t('newSettings.appearance.watchonly.description')}
-        extraComponent={
-          <>
-            {
-              watchonly !== undefined ?
-                (
-                  <Toggle
-                    checked={watchonly}
-                    disabled={disabled}
-                    onChange={toggleWatchonly}
-                  />
-                ) :
-                null
-            }
-          </>
-        }
-      />
+      { watchonly !== undefined ? (
+        <Label>
+          <span className={style.labelText}>
+            {t('newSettings.appearance.remebmerWallet.name')}
+          </span>
+          <Toggle
+            checked={watchonly}
+            disabled={disabled}
+            onChange={toggleWatchonly}
+          />
+        </Label>
+      ) : null}
     </>
   );
 };

--- a/frontends/web/src/routes/settings/components/manage-accounts/watchonlySettings.module.css
+++ b/frontends/web/src/routes/settings/components/manage-accounts/watchonlySettings.module.css
@@ -1,0 +1,6 @@
+.labelText {
+  font-size: 14px;
+  line-height: 1;
+  margin-right: 8px;
+  vertical-align: sub;
+}

--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -3,14 +3,31 @@
     margin-bottom: var(--spacing-default);
 }
 
+.walletHeader {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-bottom: var(--space-eight);
+}
+
+.walletTitle {
+    font-size: 20px;
+    font-weight: 400;
+    margin: 0;
+}
+
 .setting {
     align-items: center;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    justify-content: flex-end;
+    justify-content: space-between;
     min-height: var(--item-height);
-    padding: 10px var(--space-half);
+    padding: var(--space-quarter) 0;
+}
+
+.setting:not(:last-child) {
+    border-bottom: solid 1px var(--background);
 }
 
 .coinLogo {
@@ -21,20 +38,38 @@
 .acccountLink {
     align-items: center;
     display: flex;
-    flex-basis: calc(100% - 180px);
-    flex-grow: 0;
+    flex-basis: calc(100% - 100px);
+    flex-grow: 1;
     flex-shrink: 1;
 }
 
 .editBtn {
-    background: transparent;
-    border: none;
-    color: var(--color-primary);
-    flex-basis: content;
-    flex-grow: 1;
-    flex-shrink: 1;
-    line-height: 2;
-    text-align: right;
+    min-width: 0;
+    padding: 0 0 0 var(--space-quarter);
+}
+
+.editBtn img {
+    margin-right: var(--space-quarter);
+    max-width: 18px;
+    height: auto;
+    vertical-align: text-bottom;
+}
+
+.toggleLabel {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+}
+
+.toggleLabelText {
+    color: var(--color-secondary);
+}
+
+.toggleLabelText img {
+    color: var(--color-secondary);
+    margin-right: var(--space-quarter);
+    max-width: 18px;
+    vertical-align: bottom;
 }
 
 .toggle {
@@ -147,12 +182,6 @@
     display: flex;
     justify-content: space-between;
     margin-top: var(--space-half);
-}
-
-.watchOnlyTitle {
-    color: var(--color-secondary);   
-    margin: 0;
-    margin-left: var(--space-quarter);
 }
 
 .watchOnlyNote {

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -20,10 +20,10 @@ import { route } from '../../utils/route';
 import * as accountAPI from '../../api/account';
 import * as backendAPI from '../../api/backend';
 import { alertUser } from '../../components/alert/Alert';
-import { Button, Input } from '../../components/forms';
+import { Button, Input, Label } from '../../components/forms';
 import Logo from '../../components/icon/logo';
-import { EyeOpenedDark } from '../../components/icon';
-import { GuideWrapper, GuidedContent, Header, Main } from '../../components/layout';
+import { EditActive, EyeOpenedDark } from '../../components/icon';
+import { Column, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../components/layout';
 import { Toggle } from '../../components/toggle/toggle';
 import { Dialog, DialogButtons } from '../../components/dialog/dialog';
 import { Message } from '../../components/message/message';
@@ -32,8 +32,8 @@ import { WithSettingsTabs } from './components/tabs';
 import { View, ViewContent } from '../../components/view/view';
 import { MobileHeader } from '../settings/components/mobile-header';
 import { AccountGuide } from './manage-account-guide';
-import style from './manage-accounts.module.css';
 import { WatchonlySetting } from './components/manage-accounts/watchonlySetting';
+import style from './manage-accounts.module.css';
 
 interface ManageAccountsProps {
   deviceIDs: string[];
@@ -50,7 +50,7 @@ interface State {
   editErrorMessage?: string;
   accounts: accountAPI.IAccount[];
   showTokens: TShowTokens;
-  currentlyEditedAccount?: accountAPI.IAccount
+  currentlyEditedAccount?: accountAPI.IAccount;
 }
 
 class ManageAccounts extends Component<Props, State> {
@@ -58,7 +58,7 @@ class ManageAccounts extends Component<Props, State> {
     editErrorMessage: undefined,
     accounts: [],
     showTokens: {},
-    currentlyEditedAccount: undefined
+    currentlyEditedAccount: undefined,
   };
 
   private fetchAccounts = () => {
@@ -87,21 +87,13 @@ class ManageAccounts extends Component<Props, State> {
               <span className="unit">({account.coinUnit})</span>
             </span>
           </div>
-          <button
+          <Button
             className={style.editBtn}
             onClick={() => this.setState({ currentlyEditedAccount: account })}
-          >
+            transparent>
+            <EditActive />
             {t('manageAccounts.editAccount')}
-          </button>
-          <Toggle
-            checked={active}
-            className={style.toggle}
-            id={account.code}
-            onChange={(event) => {
-              event.target.disabled = true;
-              this.toggleAccount(account.code, !active)
-                .then(() => event.target.disabled = false);
-            }} />
+          </Button>
           {active && account.coinCode === 'eth' ? (
             <div className={style.tokenSection}>
               <div className={`${style.tokenContainer} ${tokensVisible ? style.tokenContainerOpen : ''}`}>
@@ -123,7 +115,7 @@ class ManageAccounts extends Component<Props, State> {
   };
 
   private renderWatchOnlyToggle = () => {
-    const { t } = this.props;
+    // const { t } = this.props;
     const { currentlyEditedAccount } = this.state;
     if (!currentlyEditedAccount) {
       return;
@@ -131,33 +123,34 @@ class ManageAccounts extends Component<Props, State> {
     if (!currentlyEditedAccount.keystore.watchonly) {
       return;
     }
-
-    return (
-      <div className="flex flex-column">
-        <div className={style.watchOnlyContainer}>
-          <div className="flex">
-            <EyeOpenedDark width={18} height={18} />
-            <p className={style.watchOnlyTitle}>{t('manageAccounts.watchAccount')}</p>
-          </div>
-          <Toggle
-            checked={currentlyEditedAccount.watch}
-            className={style.toggle}
-            id={currentlyEditedAccount.code}
-            onChange={async (event) => {
-              event.target.disabled = true;
-              await this.setWatch(currentlyEditedAccount.code, !currentlyEditedAccount.watch);
-              this.setState({ currentlyEditedAccount: { ...currentlyEditedAccount, watch: !currentlyEditedAccount.watch } });
-              event.target.disabled = false;
-            }}
-          />
-        </div>
-        <p className={style.watchOnlyNote}>{t('manageAccounts.watchAccountDescription')}</p>
-        {
-          !currentlyEditedAccount.watch && <div className={style.watchOnlyAccountHidden}>
-            <p>{t('manageAccounts.accountHidden')}</p>
-          </div>
-        }
-      </div>);
+    return null;
+    // disabling for now, we'll either bring this back (if user request it) or remove for good
+    // return (
+    //   <div className="flex flex-column">
+    //     <div className={style.watchOnlyContainer}>
+    //       <div className="flex">
+    //         <EyeOpenedDark width={18} height={18} />
+    //         <p className={style.watchOnlyTitle}>{t('manageAccounts.watchAccount')}</p>
+    //       </div>
+    //       <Toggle
+    //         checked={currentlyEditedAccount.watch}
+    //         className={style.toggle}
+    //         id={currentlyEditedAccount.code}
+    //         onChange={async (event) => {
+    //           event.target.disabled = true;
+    //           await this.setWatch(currentlyEditedAccount.code, !currentlyEditedAccount.watch);
+    //           this.setState({ currentlyEditedAccount: { ...currentlyEditedAccount, watch: !currentlyEditedAccount.watch } });
+    //           event.target.disabled = false;
+    //         }}
+    //       />
+    //     </div>
+    //     <p className={style.watchOnlyNote}>{t('manageAccounts.watchAccountDescription')}</p>
+    //     {
+    //       !currentlyEditedAccount.watch && <div className={style.watchOnlyAccountHidden}>
+    //         <p>{t('manageAccounts.accountHidden')}</p>
+    //       </div>
+    //     }
+    //   </div>);
   };
 
   private toggleAccount = (accountCode: string, active: boolean) => {
@@ -170,14 +163,15 @@ class ManageAccounts extends Component<Props, State> {
     });
   };
 
-  private setWatch = async (accountCode: string, watch: boolean) => {
-    const result = await backendAPI.accountSetWatch(accountCode, watch);
-    if (result.success) {
-      await this.fetchAccounts();
-    } else if (result.errorMessage) {
-      alertUser(result.errorMessage);
-    }
-  };
+  // disabling for now, we'll either bring this back (if user request it) or remove for good
+  // private setWatch = async (accountCode: string, watch: boolean) => {
+  //   const result = await backendAPI.accountSetWatch(accountCode, watch);
+  //   if (result.success) {
+  //     await this.fetchAccounts();
+  //   } else if (result.errorMessage) {
+  //     alertUser(result.errorMessage);
+  //   }
+  // };
 
   private toggleShowTokens = (accountCode: string) => {
     this.setState(({ showTokens }) => ({
@@ -240,9 +234,9 @@ class ManageAccounts extends Component<Props, State> {
     });
   };
 
-  private updateAccountName = (event: React.SyntheticEvent) => {
+  private updateAccount = (event: React.SyntheticEvent) => {
     event.preventDefault();
-    const { currentlyEditedAccount } = this.state;
+    const { accounts, currentlyEditedAccount } = this.state;
 
     if (!currentlyEditedAccount) {
       return;
@@ -257,6 +251,10 @@ class ManageAccounts extends Component<Props, State> {
             this.setState({ editErrorMessage: result.errorMessage });
           }
           return;
+        }
+        const account = accounts.find(({ code }) => currentlyEditedAccount.code === code);
+        if (currentlyEditedAccount.active !== account?.active) {
+          this.toggleAccount(currentlyEditedAccount.code, currentlyEditedAccount.active);
         }
         this.fetchAccounts();
         this.setState({
@@ -291,23 +289,27 @@ class ManageAccounts extends Component<Props, State> {
                     onClick={() => route('/add-account', true)}>
                     {t('addAccount.title')}
                   </Button>
-                  {
-                    accountsByKeystore.map(keystore => (
-                      <React.Fragment key={keystore.keystore.rootFingerprint}>
-                        <p>{keystore.keystore.name}</p>
-                        <WatchonlySetting keystore={keystore.keystore} />
-                        <div className="box slim divide m-bottom-large">
-                          {this.renderAccounts(keystore.accounts)}
+                  <Grid col="1">
+                    { accountsByKeystore.map(keystore => (
+                      <Column
+                        key={keystore.keystore.rootFingerprint}
+                        asCard>
+                        <div className={style.walletHeader}>
+                          <h2 className={style.walletTitle}>
+                            {keystore.keystore.name}
+                          </h2>
+                          <WatchonlySetting keystore={keystore.keystore} />
                         </div>
-                      </React.Fragment>
-                    ))
-                  }
+                        {this.renderAccounts(keystore.accounts)}
+                      </Column>
+                    )) }
+                  </Grid>
                   {currentlyEditedAccount && (
                     <Dialog
                       open={!!(currentlyEditedAccount)}
                       onClose={() => this.setState({ currentlyEditedAccount: undefined })}
                       title={t('manageAccounts.editAccountNameTitle')}>
-                      <form onSubmit={this.updateAccountName}>
+                      <form onSubmit={this.updateAccount}>
                         <Message type="error" hidden={!editErrorMessage}>
                           {editErrorMessage}
                         </Message>
@@ -315,6 +317,28 @@ class ManageAccounts extends Component<Props, State> {
                           onInput={e => this.setState({ currentlyEditedAccount: { ...currentlyEditedAccount, name: e.target.value } })}
                           value={currentlyEditedAccount.name}
                         />
+                        <Label
+                          className={style.toggleLabel}
+                          htmlFor={currentlyEditedAccount.code}>
+                          <span className={style.toggleLabelText}>
+                            <EyeOpenedDark />
+                            {t('newSettings.appearance.enableWallet.title')}
+                          </span>
+                          <Toggle
+                            checked={currentlyEditedAccount.active}
+                            className={style.toggle}
+                            id={currentlyEditedAccount.code}
+                            onChange={(event) => {
+                              event.target.disabled = true;
+                              this.setState({
+                                currentlyEditedAccount: {
+                                  ...currentlyEditedAccount,
+                                  active: event.target.checked,
+                                }
+                              }, () => event.target.disabled = false);
+                            }} />
+                        </Label>
+                        <p>{t('newSettings.appearance.enableWallet.description')}</p>
                         {this.renderWatchOnlyToggle()}
                         <DialogButtons>
                           <Button


### PR DESCRIPTION
- chanage from watch wallet to remember wallet
- removed outdated translations and replaced with rememberWallet
- moved enable/disable account to edit dialog
- comment code that allowed to enable watching one account, if many users request this we might bring it back
- changed manage-accounts ui to use Grid/Column component