### PR TITLE
frontend/account: fix bitsurance badge on uninsured accounts

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -107,8 +107,8 @@ export function Account({
         checkUncoveredUTXOs();
         return;
       }
-      setInsured(false);
     }
+    setInsured(false);
   }, [t, account, code, checkUncoveredUTXOs]);
 
   useEffect(() => {


### PR DESCRIPTION
Bitsurance badge was not correctly removed navigating from an insured account to an uninsured one. This fixes the issue.