### PR TITLE
frontend: subscribe to accounts in manage-accounts view

### DIFF
--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -202,7 +202,13 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
         <Route path="device-settings/:deviceID" element={Device} />
         <Route path="advanced-settings" element={AdvancedSettingsEl} />
         <Route path="electrum" element={<ElectrumSettings />} />
-        <Route path="manage-accounts" element={<ManageAccounts key={'manage-accounts'} deviceIDs={deviceIDs} hasAccounts={hasAccounts}/>} />
+        <Route path="manage-accounts" element={
+          <ManageAccounts
+            accounts={accounts}
+            key="manage-accounts"
+            deviceIDs={deviceIDs}
+            hasAccounts={hasAccounts} />
+        } />
       </Route>
     </Route>
   </Routes>;


### PR DESCRIPTION
Without watch-only manage-accounts view could load accounts once and did not need to update the state anymore. This changed as with watch-only the accounts should update, i.e. when the device is unplugged but not remembered.

App component already subscribed to accounts, so this commit only passes the accounts to manage-accounts component, and changes accounts from state to props.