### PR TITLE
backend: fix regression related to updating persisted accounts

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1073,35 +1073,9 @@ func (backend *Backend) maybeAddP2TR(keystore keystore.Keystore, accounts []*con
 // perform migrations, updates etc. We use it to add taproot subaccounts to Bitcoin accounts that
 // were created (persisted) before the introduction of taproot support.
 func (backend *Backend) updatePersistedAccounts(
-	keystore keystore.Keystore, accountsConfig *config.AccountsConfig) error {
+	keystore keystore.Keystore, accounts []*config.Account) error {
 
-	// setWatch, if the keystore Watchonly flag is enabled, sets the `Watch`
-	// flag to `true`, turning this account into a watch-only account.
-	setWatch := func() error {
-		rootFingerprint, err := keystore.RootFingerprint()
-		if err != nil {
-			return err
-		}
-		if !accountsConfig.IsKeystoreWatchonly(rootFingerprint) {
-			return nil
-		}
-		for _, account := range accountsConfig.Accounts {
-			// If the account was added in the background as part of scanning, we don't mark it
-			// watchonly. Otherwise the account would appear automatically once it received funds,
-			// even if it was not visible before and the keystore is never connected again.
-			if !account.HiddenBecauseUnused && account.Watch == nil {
-				t := true
-				account.Watch = &t
-			}
-		}
-		return nil
-	}
-
-	if err := setWatch(); err != nil {
-		return err
-	}
-
-	return backend.maybeAddP2TR(keystore, accountsConfig.Accounts)
+	return backend.maybeAddP2TR(keystore, accounts)
 }
 
 // The accountsAndKeystoreLock must be held when calling this function.

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -1381,16 +1381,6 @@ func TestWatchonly(t *testing.T) {
 		// Disable watchonly, all accounts disappear.
 		require.NoError(t, b.SetWatchonly(rootFingerprint, false))
 		checkShownAccountsLen(t, b, 0, 3)
-
-		// Re-enable watchonly - accounts do not show up yet.
-		require.NoError(t, b.SetWatchonly(rootFingerprint, true))
-		checkShownAccountsLen(t, b, 0, 3)
-
-		// Reconnecting the keystore brings back the watched accounts.
-		b.registerKeystore(ks)
-		checkShownAccountsLen(t, b, 3, 3)
-		b.DeregisterKeystore()
-		checkShownAccountsLen(t, b, 3, 3)
 	})
 
 	// Disable keystore's watchonly setting while keystore is connected does not make the accounts

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -920,7 +920,7 @@ func (backend *Backend) SetWatchonly(rootFingerprint []byte, watchonly bool) err
 	return backend.AccountSetWatch(
 		func(account *config.Account) bool {
 			// Apply to each currently loaded account.
-			return accounts.lookup(account.Code) != nil
+			return !account.HiddenBecauseUnused && accounts.lookup(account.Code) != nil
 		},
 		&t,
 	)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -640,7 +640,7 @@ func (backend *Backend) registerKeystore(keystore keystore.Keystore) {
 		// needed on the persisted accounts.
 		accounts := backend.filterAccounts(accountsConfig, belongsToKeystore)
 		if len(accounts) != 0 {
-			return backend.updatePersistedAccounts(keystore, accountsConfig)
+			return backend.updatePersistedAccounts(keystore, accounts)
 		}
 		return backend.persistDefaultAccountConfigs(keystore, accountsConfig)
 	})


### PR DESCRIPTION
It was supposed to only be applied to the accounts that belong to the current keystore, but 52bf446c7e1d09ac95c7c4d61e9f784fe028e1c1 added a regression and it was applied to all persisted accounts.

The `setWatch()` thing can be removed - it was there before when the watchonly setting was global and accounts would need to be marked as `Watch` when the keystore is connected. After we moved it to be a keystore setting, it can only be enabled after connecting the keystore anyway in 'Manage accounts'.