### PR TITLE
frontend/utils: sort getAccountsByKeystore map

### DIFF
--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -112,7 +112,13 @@ export function getAccountsByKeystore(accounts: IAccount[]): TAccountsByKeystore
     }
     acc[key].accounts.push(account);
     return acc;
-  }, {} as Record<string, TAccountsByKeystore>));
+  }, {} as Record<string, TAccountsByKeystore>))
+    // sort the output array as we noticed that somehow the input accounts
+    // list seems to be possibly ordered differently in different places
+    // in the code (e.g. sidebar vs manage account page)
+    .sort((ac1, ac2) => {
+      return ac1.keystore.name.localeCompare(ac2.keystore.name);
+    });
 }
 
 // Returns true if more than one keystore has the given name.


### PR DESCRIPTION
The input accounts list seems to be possibly ordered differently in different places in the code (e.g. sidebar vs manage account page). This ensures that the list of accounts grouped by keystore always has a consistent order, and also keeps keystores with same name (e.g. create using different passphrases) to be close to each other in the list.