### PR TITLE
frontend: improve manage-accounts on small screen

### DIFF
--- a/frontends/web/src/routes/settings/components/manage-accounts/watchonlySetting.tsx
+++ b/frontends/web/src/routes/settings/components/manage-accounts/watchonlySetting.tsx
@@ -82,7 +82,7 @@ export const WatchonlySetting = ({ keystore }: Props) => {
         </DialogButtons>
       </Dialog>
       { watchonly !== undefined ? (
-        <Label>
+        <Label className={style.label}>
           <span className={style.labelText}>
             {t('newSettings.appearance.remebmerWallet.name')}
           </span>


### PR DESCRIPTION
Remember  toggle can break onto 2 lines on small screen, the CSS to prevent this was committed but the className was not used.

Should have been part of d066864ce60528b0fe2bb443cab97e2fe1c131a9