### PR TITLE
frontend: amend CSS to fix manage accounts UI on smaller screens

### DIFF
--- a/frontends/web/src/routes/settings/components/manage-accounts/watchonlySetting.tsx
+++ b/frontends/web/src/routes/settings/components/manage-accounts/watchonlySetting.tsx
@@ -82,7 +82,7 @@ export const WatchonlySetting = ({ keystore }: Props) => {
         </DialogButtons>
       </Dialog>
       { watchonly !== undefined ? (
-        <Label>
+        <Label className={style.label}>
           <span className={style.labelText}>
             {t('newSettings.appearance.remebmerWallet.name')}
           </span>

--- a/frontends/web/src/routes/settings/components/manage-accounts/watchonlySettings.module.css
+++ b/frontends/web/src/routes/settings/components/manage-accounts/watchonlySettings.module.css
@@ -7,6 +7,5 @@
   font-size: 14px;
   line-height: 1;
   margin-right: 8px;
-  padding-left: var(--space-quarter);
   vertical-align: sub;
 }

--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -26,7 +26,6 @@
     align-items: center;
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
     justify-content: space-between;
     min-height: var(--item-height);
     padding: var(--space-quarter) 0;
@@ -44,7 +43,7 @@
 .acccountLink {
     align-items: center;
     display: flex;
-    flex-basis: calc(100% - 100px);
+    flex-basis: 0;
     flex-grow: 1;
     flex-shrink: 1;
 }

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -84,7 +84,9 @@ class ManageAccounts extends Component<Props, State> {
             onClick={() => this.setState({ currentlyEditedAccount: account })}
             transparent>
             <EditActive />
-            {t('manageAccounts.editAccount')}
+            <span className="hide-on-small">
+              {t('manageAccounts.editAccount')}
+            </span>
           </Button>
           {active && account.coinCode === 'eth' ? (
             <div className={style.tokenSection}>
@@ -293,6 +295,7 @@ class ManageAccounts extends Component<Props, State> {
                             </span>
                             {keystore.keystore.connected ? (
                               <Badge
+                                className="m-right-quarter"
                                 icon={props => <USBSuccess {...props} />}
                                 type="success">
                                 {t('device.keystoreConnected')}


### PR DESCRIPTION
amend CSS to fix manage accounts UI on smaller screens.

The "Edit" button collapses on smaller screens. This PR aims to fix that.

Before:

<img width="348" alt="Screenshot 2023-12-18 at 06 43 01" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/1223002b-a08b-4293-ac47-87b3fd7d7c5e">

After:

![Screenshot 2023-12-18 at 12 49 47](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/aa02bf1b-2388-45f0-8380-f7996bd1a471)
