### PR TITLE
Frontend fix sidebar connected icon

### DIFF
--- a/frontends/web/src/components/badge/badge.module.css
+++ b/frontends/web/src/components/badge/badge.module.css
@@ -18,7 +18,7 @@
 }
 
 .badgeIcon {
-  max-width: 9px;
+  max-width: 10px;
 }
 
 .withChildren .badgeIcon {

--- a/frontends/web/src/components/sidebar/sidebar.module.css
+++ b/frontends/web/src/components/sidebar/sidebar.module.css
@@ -92,6 +92,14 @@
     color: var(--color-secondary);
 }
 
+.sidebarIconVisible {
+    visibility: visible;
+}
+
+.sidebarIconHidden {
+    visibility: hidden;
+}
+
 .sidebarItem {
     display: block;
 }

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -226,12 +226,11 @@ class Sidebar extends Component<Props> {
                       <> ({keystore.keystore.rootFingerprint})</>
                     ) : null }
                   </span>
-                  {keystore.keystore.connected ? (
-                    <Badge
-                      icon={props => <USBSuccess {...props} />}
-                      type="success"
-                      title={t('device.keystoreConnected')} />
-                  ) : null}
+                  <Badge
+                    className={keystore.keystore.connected ? style.sidebarIconVisible : style.sidebarIconHidden}
+                    icon={props => <USBSuccess {...props} />}
+                    type="success"
+                    title={t('device.keystoreConnected')} />
                 </span>
               </div>
 


### PR DESCRIPTION
### prevent jumping icon when device is unplugged

The connected icon is slightly bigger than the small text fontsize.
This caused a tiny jump, when the device is disconnected.

Fixed by having the icon always in place and just turn on and off
the visibility.


### fix centered badge icon

The icon in the badge was not perfectly centered. Reason is
that the icon has an uneven width (9px) so it rounds the
position to be 1px off.

Changed so that the icon is now a max of 10px wide. Ideally
all icons in the future that are used in badges should have
an even width.



