### PR TITLE
frontend: fix routing when removing account

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -83,8 +83,7 @@ class App extends Component<Props, State> {
         }));
       }),
       syncAccountsList(accounts => {
-        const oldAccountsLen = this.state.accounts.length;
-        this.setState({ accounts }, () => this.maybeRoute(oldAccountsLen));
+        this.setState({ accounts }, () => this.maybeRoute());
       }),
       syncDeviceList((devices) => {
         this.setStateWithDeviceList({ devices });
@@ -94,7 +93,6 @@ class App extends Component<Props, State> {
 
   private setStateWithDeviceList(newState: Partial<State>) {
     const oldDeviceIDList = Object.keys(this.state.devices);
-    const oldAccountsLen = this.state.accounts.length;
     this.setState(currentState => ({ ...currentState, ...newState }), () => {
       const newDeviceIDList: string[] = Object.keys(this.state.devices);
       // If a device is newly connected, we route to the settings.
@@ -114,7 +112,7 @@ class App extends Component<Props, State> {
           return;
         }
       }
-      this.maybeRoute(oldAccountsLen);
+      this.maybeRoute();
     });
   }
 
@@ -122,7 +120,7 @@ class App extends Component<Props, State> {
     unsubscribe(this.unsubscribeList);
   }
 
-  private maybeRoute = (oldAccountsLen: number) => {
+  private maybeRoute = () => {
     const currentURL = window.location.pathname;
     const isIndex = currentURL === '/' || currentURL === '/index.html' || currentURL === '/android_asset/web/index.html';
     const inAccounts = currentURL.startsWith('/account/');
@@ -149,13 +147,13 @@ class App extends Component<Props, State> {
       route('/', true);
       return;
     }
-    // if on an account that isnt registered route to /
+    // if on an account that isn't registered route to /
     if (inAccounts && !accounts.some(account => currentURL.startsWith('/account/' + account.code))) {
       route('/', true);
       return;
     }
-    // if on index page and we go from zero accounts to at least 1 account, route to /account-summary
-    if (isIndex && oldAccountsLen === 0 && accounts.length) {
+    // if on index page and have at least 1 account, route to /account-summary
+    if (isIndex && accounts.length) {
       route('/account-summary', true);
       return;
     }


### PR DESCRIPTION
If you are inside one account that is removed when the device/keystore is disconnected, it always routes to `/`, even if there are other watchonly accounts. This commit fixes it to route to the portfolio if there is at least one account.