### PR TITLE
frontend/summary,account: sdcard check false positive

### DIFF
--- a/backend/devices/bitbox02/handlers/handlers.go
+++ b/backend/devices/bitbox02/handlers/handlers.go
@@ -261,7 +261,7 @@ func (handlers *Handlers) getCheckSDCard(_ *http.Request) interface{} {
 	handlers.log.Debug("Checking if SD Card is inserted")
 	sdCardInserted, err := handlers.device.CheckSDCard()
 	if err != nil {
-		return maybeBB02Err(err, handlers.log)
+		return false
 	}
 	return sdCardInserted
 }


### PR DESCRIPTION
If one inserts a BitBox02 while in the account summary or account, `useSDCard(devices);` returns true even if there is no sdcard, because:

1. It is called before the BitBox02 has established the communication (paired channel)
2. The checkSDCard endpoints returns an error
3. The `useSDCard()` assumes the result is `boolean` always, so it interprets the non-zero error as `true`, which leads to the warning banner being shown even if the sdcard is not inserted.

This is a quick fix to not show the banner in this case by returning `false` instead of an error.

The proper fix is postponed, and involes rewriting `useSDCard` to listen on the `statusChanged` event of the BitBox02 to only chekc the sdcard once the device is paired (or do something similar in the backend and make an `sdcard` event).