### PR TITLE
fix: use flex-wrap to wrap "Show tokens" button on manage accs

### DIFF
--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -26,6 +26,7 @@
     align-items: center;
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     justify-content: space-between;
     min-height: var(--item-height);
     padding: var(--space-quarter) 0;


### PR DESCRIPTION
Preview:

![Screenshot 2023-12-18 at 16 23 11](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/d8d01b59-5b9e-4cec-bc4c-7e594d902c69)

![Screenshot 2023-12-18 at 16 22 43](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/84cb5f45-98ba-4b35-9564-70dda54549c1)

