### PR TITLE
frontend/bitsurance: localize bitsurance terms privacy link

### DIFF
--- a/frontends/web/src/components/terms/bitsurance-terms.tsx
+++ b/frontends/web/src/components/terms/bitsurance-terms.tsx
@@ -20,6 +20,7 @@ import { Button, Checkbox } from '../forms';
 import { setConfig } from '../../utils/config';
 import { A } from '../anchor/anchor';
 import style from './terms.module.css';
+import { i18n } from '../../i18n/i18n';
 
 type TProps = {
   onAgreedTerms: () => void;
@@ -30,6 +31,15 @@ export const BitsuranceTerms = ({ onAgreedTerms }: TProps) => {
   const handleSkipDisclaimer = (e: ChangeEvent<HTMLInputElement>) => {
     setConfig({ frontend: { skipBitsuranceDisclaimer: e.target.checked } });
   };
+  const getPrivacyLink = (): string => {
+    switch (i18n.resolvedLanguage) {
+    case 'de':
+      return 'https://www.bitsurance.eu/datenschutz';
+    default:
+      return 'https://www.bitsurance.eu/en/dataprotection/';
+    }
+  };
+
 
   return (
     <div className={style.disclaimerContainer}>
@@ -41,7 +51,7 @@ export const BitsuranceTerms = ({ onAgreedTerms }: TProps) => {
         <p>
           {t('bitsurance.terms.text5')}
           {' '}
-          <A href="https://www.bitsurance.eu/datenschutz">
+          <A href={getPrivacyLink()}>
             {t('bitsurance.terms.link')}.
           </A>
         </p>

--- a/frontends/web/src/routes/bitsurance/bitsurance.tsx
+++ b/frontends/web/src/routes/bitsurance/bitsurance.tsx
@@ -29,8 +29,6 @@ import { useDarkmode } from '../../hooks/darkmode';
 import { route } from '../../utils/route';
 import { BitsuranceGuide } from './guide';
 import style from './bitsurance.module.css';
-import { defaultLanguages } from '../../components/language/types';
-import { getSelectedIndex } from '../../utils/language';
 import { i18n } from '../../i18n/i18n';
 
 type TProps = {
@@ -73,11 +71,12 @@ export const Bitsurance = ({ accounts }: TProps) => {
   };
 
   const getBitsurancePageLink = (): string => {
-    const selectedLanguage = defaultLanguages[getSelectedIndex(defaultLanguages, i18n)];
-    if (selectedLanguage.code === 'de') {
+    switch (i18n.resolvedLanguage) {
+    case 'de':
       return 'https://www.bitsurance.eu/de/bitbox/';
+    default:
+      return 'https://www.bitsurance.eu/en/bitbox/';
     }
-    return 'https://www.bitsurance.eu/en/bitbox/';
   };
 
   const maybeProceed = async () => {


### PR DESCRIPTION
Bitsurance terms and conditions page contains an external link towards the bitsurance website. This commit introduces different links for german and non german languages.