### PR TITLE
frontend: remove 'Back' text on MobileHeader

### DIFF
--- a/frontends/web/src/routes/settings/components/mobile-header.module.css
+++ b/frontends/web/src/routes/settings/components/mobile-header.module.css
@@ -38,7 +38,7 @@
 }
 
 .withGuide .headerText {
-    left: calc(50% + 37px);
+    left: calc(50% + 22px);
 }
 
 @media (max-width: 768px) {

--- a/frontends/web/src/routes/settings/components/mobile-header.tsx
+++ b/frontends/web/src/routes/settings/components/mobile-header.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { useTranslation } from 'react-i18next';
 import { ChevronLeftDark } from '../../../components/icon';
 import { route } from '../../../utils/route';
 import styles from './mobile-header.module.css';
@@ -25,14 +24,13 @@ type TProps = {
 }
 
 export const MobileHeader = ({ title, withGuide = false }: TProps) => {
-  const { t } = useTranslation();
   const handleClick = () => {
     //goes to the 'general settings' page
     route('/settings');
   };
   return (
     <div className={`${styles.container} ${withGuide ? `${styles.withGuide}` : ''}`}>
-      <button onClick={handleClick} className={styles.backButton}><ChevronLeftDark /> {t('button.back')}</button>
+      <button onClick={handleClick} className={styles.backButton}><ChevronLeftDark /></button>
       <h1 className={styles.headerText}>{title}</h1>
     </div>
   );


### PR DESCRIPTION
the "Back" text sometimes crashed into the page's title/header text causing unclarity in the UI, so we'd like to remove it.

Also adjusted the position of the header text so it centres better.

Before:
<img width="338" alt="Screenshot 2023-12-19 at 12 42 51" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/62e21cda-fa08-432a-be8f-602dd28a38e6">

After:
<img width="338" alt="Screenshot 2023-12-19 at 12 46 33" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/fe3f78e1-9716-488e-a94c-5500735f38bf">
