### PR TITLE
frontend: apply `displayedValue` class conditionally to rm space

### DIFF
--- a/frontends/web/src/routes/settings/components/settingsItem/settingsItem.tsx
+++ b/frontends/web/src/routes/settings/components/settingsItem/settingsItem.tsx
@@ -44,7 +44,7 @@ export const SettingsItem = ({
     <div className={styles.rightContentContainer}>
       <p className={
         `
-        ${styles.displayedValue}
+        ${displayedValue ? styles.displayedValue : ''}
         ${extraComponent ? styles.withMargin : ''}
         ${hideDisplayedValueOnSmall ? styles.hideDisplayedValueOnSmall : ''}
        `}


### PR DESCRIPTION
Unuseful space was added due to always having `.displayedValue` class regardless when there's displayed value or not for `SettingsItem` (visible on mobile). We should only add it if there's a displayed value.

Before:
<img width="227" alt="CKGM" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/31ba0f78-e465-4d53-a41f-3deb795f6695">


After:

<img width="369" alt="jkaem" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/5250d8d5-ee33-44a2-9612-8f5f5d9bb463">

After for stuff with "displayed value" (no change):
<img width="359" alt="x" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/9deb56f9-fd55-4240-8246-719d6e4c7673">

