### PR TITLE
backend/bitbox02: mark recipient address as ours if they are ours

### DIFF
--- a/backend/coins/btc/transaction.go
+++ b/backend/coins/btc/transaction.go
@@ -213,7 +213,7 @@ func (account *Account) newTx(args *accounts.TxProposalArgs) (
 	return utxo, txProposal, nil
 }
 
-// getAddress returns the address in the account with the given `scriptHashHex`. Panics if the
+// getAddress returns the address in the account with the given `scriptHashHex`. Returns nil if the
 // address does not exist in the account.
 func (account *Account) getAddress(scriptHashHex blockchain.ScriptHashHex) *addresses.AccountAddress {
 	for _, subacc := range account.subaccounts {
@@ -224,7 +224,7 @@ func (account *Account) getAddress(scriptHashHex blockchain.ScriptHashHex) *addr
 			return address
 		}
 	}
-	panic("address must be present")
+	return nil
 }
 
 // SendTx implements accounts.Interface.


### PR DESCRIPTION
This will make the BitBox02 show 'This BitBox02' before the address verification when making a self-send transaction.

There is a annoying edge case that is fixed by moving the `firmware.BTCSignNeedsPrevTxs()` check below processing the outputs:

- Previous transactions are not needed if all inputs are Taproot.
- The firmware determines this by checking if all provided script configs are Taproot - if it is, it does not require the previous transcations, otherwise it does.
- Unfortunately, change outputs and now also recpient outputs can add a script config for its own type. For changes it didn't change anything as we only added Taproot changes if all inputs were Taproot.
- This means that if you send-to-self using only Taproot inputs but send to a non-taproot (native segwit) recipient address of the same account, the non-taproot script config is added to the list and the BB02 will require previous transactions, even though they are not technically needed.

We just live with this edge case (send from taproot to a native segwit recipient address of the same account) - it works, but just performs more work by sending the previous transactions.

In all other cases it works as expected.