### PR TITLE
backend/accounts_test: fix race condition

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1163,6 +1163,9 @@ func (backend *Backend) uninitAccounts(force bool) {
 //     and still be able to receive to P2TR in the highest account. Such a P2TR
 //     account would not be discovered by other BIP44-compatible software.
 func (backend *Backend) maybeAddHiddenUnusedAccounts() {
+	if backend.tstMaybeAddHiddenUnusedAccounts != nil {
+		defer backend.tstMaybeAddHiddenUnusedAccounts()
+	}
 	defer backend.accountsAndKeystoreLock.Lock()()
 	if backend.keystore == nil {
 		return

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -214,6 +214,8 @@ type Backend struct {
 
 	// For unit tests, called when `backend.checkAccountUsed()` is called.
 	tstCheckAccountUsed func(accounts.Interface) bool
+	// For unit tests, called when `backend.maybeAddHiddenUnusedAccounts()` has run.
+	tstMaybeAddHiddenUnusedAccounts func()
 }
 
 // NewBackend creates a new backend with the given arguments.


### PR DESCRIPTION
The `go backend.maybeAddHiddenunusedAccounts()` call in `registerKeystore()` could execute before or after the first `CreateAndPersistAccountConfig()` in that Watchonly unit test. If it happened after, then there would already be two accounts and we would fail at

    require.Nil(t, b.Config().AccountsConfig().Lookup(expectedNewAccountCode2))