### PR TITLE
frontend/account: prompt keystore for ETH before going to send screen

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -190,6 +190,7 @@ export function Account({
 
   const actionButtonsProps = {
     code,
+    coinCode: account.coinCode,
     canSend,
     exchangeBuySupported,
     account


### PR DESCRIPTION
BitBox02 fw <9.15.0 can only sign legacy ETH
transactions (EIP155). After 9.15.0, it can also sign EIP1559 transactions. The app decides which one to create in the send screen depending on which keystore is used, so we need to already have it connected when entering the send screen.

We do this only for Ethereum, as for Bitcoin/Litecoin, this is not needed.

Alternaties dismissed:
- Prompt keystore on first send form modification - bad UX
- Force fw upgrade when sending ETH and only do EIP1559 - bad UX