### PR TITLE
frontend: apply 2 space indentation also to TypeScript

### DIFF
--- a/frontends/web/.eslintrc.json
+++ b/frontends/web/.eslintrc.json
@@ -17,6 +17,7 @@
     "space-before-blocks": ["error", "always"],
     "space-in-parens": ["error", "never"],
     "no-extra-semi": "error",
+    "@typescript-eslint/indent": ["error", 2, { "SwitchCase": 0 }],
     "@typescript-eslint/type-annotation-spacing": "error",
     "arrow-spacing": "error",
     "space-infix-ops": "error",

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -67,7 +67,7 @@ export const getAccounts = (): Promise<IAccount[]> => {
 };
 
 export interface ITotalBalance {
-    [key: string]: IAmount;
+  [key: string]: IAmount;
 
 }
 
@@ -85,10 +85,10 @@ export const getEthAccountCodeAndNameByAddress = (address: string): Promise<TEth
 };
 
 export interface IStatus {
-    disabled: boolean;
-    synced: boolean;
-    fatalError: boolean;
-    offlineError: string | null;
+  disabled: boolean;
+  synced: boolean;
+  fatalError: boolean;
+  offlineError: string | null;
 }
 
 export const getStatus = (code: AccountCode): Promise<IStatus> => {
@@ -100,30 +100,30 @@ export type ScriptType = 'p2pkh' | 'p2wpkh-p2sh' | 'p2wpkh' | 'p2tr';
 export const allScriptTypes: ScriptType[] = ['p2pkh', 'p2wpkh-p2sh', 'p2wpkh', 'p2tr'];
 
 export interface IKeyInfo {
-    keypath: string;
-    rootFingerprint: string;
-    xpub: string;
+  keypath: string;
+  rootFingerprint: string;
+  xpub: string;
 }
 
 export type TBitcoinSimple = {
-    keyInfo: IKeyInfo;
-    scriptType: ScriptType;
+  keyInfo: IKeyInfo;
+  scriptType: ScriptType;
 }
 
 export type TEthereumSimple = {
-    keyInfo: IKeyInfo;
+  keyInfo: IKeyInfo;
 }
 
 export type TSigningConfiguration = {
-    bitcoinSimple: TBitcoinSimple;
-    ethereumSimple?: never;
+  bitcoinSimple: TBitcoinSimple;
+  ethereumSimple?: never;
 } | {
-    bitcoinSimple?: never;
-    ethereumSimple: TEthereumSimple;
+  bitcoinSimple?: never;
+  ethereumSimple: TEthereumSimple;
 }
 
 export type TSigningConfigurationList = null | {
-    signingConfigurations: TSigningConfiguration[];
+  signingConfigurations: TSigningConfiguration[];
 }
 
 export const getInfo = (code: AccountCode) => {
@@ -137,14 +137,14 @@ export const init = (code: AccountCode): Promise<null> => {
 };
 
 export interface ISummary {
-    chartDataMissing: boolean;
-    chartDataDaily: ChartData;
-    chartDataHourly: ChartData;
-    chartFiat: ConversionUnit;
-    chartTotal: number | null;
-    formattedChartTotal: string | null;
-    chartIsUpToDate: boolean; // only valid if chartDataMissing is false
-    lastTimestamp: number;
+  chartDataMissing: boolean;
+  chartDataDaily: ChartData;
+  chartDataHourly: ChartData;
+  chartFiat: ConversionUnit;
+  chartTotal: number | null;
+  formattedChartTotal: string | null;
+  chartIsUpToDate: boolean; // only valid if chartDataMissing is false
+  lastTimestamp: number;
 }
 
 export const getSummary = (): Promise<ISummary> => {
@@ -152,20 +152,20 @@ export const getSummary = (): Promise<ISummary> => {
 };
 
 export type Conversions = {
-    [key in Fiat]: string;
+  [key in Fiat]: string;
 }
 
 export interface IAmount {
-    amount: string;
-    conversions?: Conversions;
-    unit: CoinUnit;
+  amount: string;
+  conversions?: Conversions;
+  unit: CoinUnit;
 }
 
 export interface IBalance {
-    hasAvailable: boolean;
-    available: IAmount;
-    hasIncoming: boolean;
-    incoming: IAmount;
+  hasAvailable: boolean;
+  available: IAmount;
+  hasIncoming: boolean;
+  incoming: IAmount;
 }
 
 export const getBalance = (code: AccountCode): Promise<IBalance> => {
@@ -173,31 +173,31 @@ export const getBalance = (code: AccountCode): Promise<IBalance> => {
 };
 
 export interface ITransaction {
-    addresses: string[];
-    amount: IAmount;
-    amountAtTime: IAmount | null;
-    fee: IAmount;
-    feeRatePerKb: IAmount;
-    gas: number;
-    nonce: number | null;
-    internalID: string;
-    note: string;
-    numConfirmations: number;
-    numConfirmationsComplete: number;
-    size: number;
-    status: 'complete' | 'pending' | 'failed';
-    time: string | null;
-    type: 'send' | 'receive' | 'self';
-    txID: string;
-    vsize: number;
-    weight: number;
+  addresses: string[];
+  amount: IAmount;
+  amountAtTime: IAmount | null;
+  fee: IAmount;
+  feeRatePerKb: IAmount;
+  gas: number;
+  nonce: number | null;
+  internalID: string;
+  note: string;
+  numConfirmations: number;
+  numConfirmationsComplete: number;
+  size: number;
+  status: 'complete' | 'pending' | 'failed';
+  time: string | null;
+  type: 'send' | 'receive' | 'self';
+  txID: string;
+  vsize: number;
+  weight: number;
 }
 
 export type TTransactions = { success: false } | { success: true; list: ITransaction[]; };
 
 export interface INoteTx {
-    internalTxID: string;
-    note: string;
+  internalTxID: string;
+  note: string;
 }
 
 export const postNotesTx = (code: AccountCode, {
@@ -220,9 +220,9 @@ export const getTransaction = (code: AccountCode, id: ITransaction['internalID']
 };
 
 export interface IExport {
-    success: boolean;
-    path: string;
-    errorMessage: string;
+  success: boolean;
+  path: string;
+  errorMessage: string;
 }
 
 export const exportAccount = (code: AccountCode): Promise<IExport | null> => {
@@ -237,13 +237,13 @@ export const verifyXPub = (
 };
 
 export interface IReceiveAddress {
-    addressID: string;
-    address: string;
+  addressID: string;
+  address: string;
 }
 
 export interface ReceiveAddressList {
-    scriptType: ScriptType | null;
-    addresses: IReceiveAddress[];
+  scriptType: ScriptType | null;
+  addresses: IReceiveAddress[];
 }
 
 export const getReceiveAddressList = (code: AccountCode) => {
@@ -253,10 +253,10 @@ export const getReceiveAddressList = (code: AccountCode) => {
 };
 
 export interface ISendTx {
-    aborted?: boolean;
-    success?: boolean;
-    errorMessage?: string;
-    errorCode?: string;
+  aborted?: boolean;
+  success?: boolean;
+  errorMessage?: string;
+  errorCode?: string;
 }
 
 export const sendTx = (code: AccountCode): Promise<ISendTx> => {
@@ -266,29 +266,29 @@ export const sendTx = (code: AccountCode): Promise<ISendTx> => {
 export type FeeTargetCode = 'custom' | 'low' | 'economy' | 'normal' | 'high';
 
 export interface IProposeTxData {
-    address?: string;
-    amount?: number;
-    // data?: string;
-    feePerByte: string;
-    feeTarget: FeeTargetCode;
-    selectedUTXOs: string[];
-    sendAll: 'yes' | 'no';
+  address?: string;
+  amount?: number;
+  // data?: string;
+  feePerByte: string;
+  feeTarget: FeeTargetCode;
+  selectedUTXOs: string[];
+  sendAll: 'yes' | 'no';
 }
 
 export interface IProposeTx {
-    aborted?: boolean;
-    success?: boolean;
-    errorMessage?: string;
+  aborted?: boolean;
+  success?: boolean;
+  errorMessage?: string;
 }
 
 export interface IFeeTarget {
-    code: FeeTargetCode;
-    feeRateInfo: string;
+  code: FeeTargetCode;
+  feeRateInfo: string;
 }
 
 export interface IFeeTargetList {
-    feeTargets: IFeeTarget[],
-    defaultFeeTarget: FeeTargetCode
+  feeTargets: IFeeTarget[],
+  defaultFeeTarget: FeeTargetCode
 }
 
 export const getFeeTargetList = (code: AccountCode): Promise<IFeeTargetList> => {
@@ -314,8 +314,8 @@ export const getUTXOs = (code: AccountCode): Promise<TUTXO[]> => {
 };
 
 type TSecureOutput = {
-    hasSecureOutput: boolean;
-    optional: boolean;
+  hasSecureOutput: boolean;
+  optional: boolean;
 };
 
 export const hasSecureOutput = (code: AccountCode) => {

--- a/frontends/web/src/api/aopp.ts
+++ b/frontends/web/src/api/aopp.ts
@@ -18,36 +18,36 @@ import { AccountCode } from './account';
 import { apiPost } from '../utils/request';
 
 export interface Account {
-    name: string;
-    code: AccountCode;
+  name: string;
+  code: AccountCode;
 }
 
 interface Accounts extends Array<Account> {
-    0: Account,
+  0: Account,
 }
 
 export type Aopp = {
-    state: 'error';
-    errorCode: 'aoppUnsupportedAsset' | 'aoppVersion' | 'aoppInvalidRequest' | 'aoppNoAccounts' | 'aoppUnsupportedKeystore' | 'aoppUnknown' | 'aoppSigningAborted' | 'aoppCallback';
-    callback: string;
+  state: 'error';
+  errorCode: 'aoppUnsupportedAsset' | 'aoppVersion' | 'aoppInvalidRequest' | 'aoppNoAccounts' | 'aoppUnsupportedKeystore' | 'aoppUnknown' | 'aoppSigningAborted' | 'aoppCallback';
+  callback: string;
 } | {
-    state: 'inactive';
+  state: 'inactive';
 } | {
-    state: 'user-approval' | 'awaiting-keystore' | 'syncing';
-    message: string;
-    callback: string;
+  state: 'user-approval' | 'awaiting-keystore' | 'syncing';
+  message: string;
+  callback: string;
 } | {
-    state: 'choosing-account';
-    accounts: Accounts;
-    message: string;
-    callback: string;
+  state: 'choosing-account';
+  accounts: Accounts;
+  message: string;
+  callback: string;
 } | {
-    state: 'signing' | 'success';
-    address: string;
-    addressID: string;
-    message: string;
-    callback: string;
-    accountCode: AccountCode;
+  state: 'signing' | 'success';
+  address: string;
+  addressID: string;
+  message: string;
+  callback: string;
+  accountCode: AccountCode;
 };
 
 export const cancel = (): Promise<null> => {

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -20,16 +20,16 @@ import { FailResponse, SuccessResponse } from './response';
 import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
 
 export interface ICoin {
-    coinCode: CoinCode;
-    name: string;
-    canAddAccount: boolean;
-    suggestedAccountName: string;
+  coinCode: CoinCode;
+  name: string;
+  canAddAccount: boolean;
+  suggestedAccountName: string;
 }
 
 export interface ISuccess {
-    success: boolean;
-    errorMessage?: string;
-    errorCode?: string;
+  success: boolean;
+  errorMessage?: string;
+  errorCode?: string;
 }
 
 export const getSupportedCoins = (): Promise<ICoin[]> => {

--- a/frontends/web/src/api/backup.ts
+++ b/frontends/web/src/api/backup.ts
@@ -3,14 +3,14 @@ import { FailResponse } from './response';
 import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
 
 export type Backup = {
-    id: string;
-    date: string;
-    name: string;
+  id: string;
+  date: string;
+  name: string;
 };
 
 type BackupResponse = {
-    success: true;
-    backups: Backup[];
+  success: true;
+  backups: Backup[];
 }
 
 export const getBackupList = (

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -21,15 +21,15 @@ import { SuccessResponse, FailResponse } from './response';
 export const errUserAbort = 104;
 
 export type DeviceInfo = {
-    initialized: boolean;
-    mnemonicPassphraseEnabled: boolean;
-    name: string;
-    securechipModel: string;
-    version: string;
+  initialized: boolean;
+  mnemonicPassphraseEnabled: boolean;
+  name: string;
+  securechipModel: string;
+  version: string;
 }
 
 type DeviceInfoResponse = SuccessResponse & {
-    deviceInfo: DeviceInfo;
+  deviceInfo: DeviceInfo;
 };
 
 export const resetDevice = (deviceID: string): Promise<SuccessResponse | FailResponse> => {
@@ -64,19 +64,19 @@ export const setDeviceName = (
 };
 
 export type VersionInfo = {
-    newVersion: string;
-    currentVersion: string;
-    canUpgrade: boolean;
-    canGotoStartupSettings: boolean;
-    // If true, creating a backup using the mnemonic recovery words instead of the microSD card
-    // is supported in the initial setup.
-    //
-    // If false, the backup must be performed using the microSD card in the initial setup.
-    //
-    // This has no influence over whether one can display the recovery words after the initial
-    // setup - that is always possible regardless of this value.
-    canBackupWithRecoveryWords: boolean;
-    canCreate12Words: boolean;
+  newVersion: string;
+  currentVersion: string;
+  canUpgrade: boolean;
+  canGotoStartupSettings: boolean;
+  // If true, creating a backup using the mnemonic recovery words instead of the microSD card
+  // is supported in the initial setup.
+  //
+  // If false, the backup must be performed using the microSD card in the initial setup.
+  //
+  // This has no influence over whether one can display the recovery words after the initial
+  // setup - that is always possible regardless of this value.
+  canBackupWithRecoveryWords: boolean;
+  canCreate12Words: boolean;
 }
 
 export const getVersion = (
@@ -136,13 +136,13 @@ export const restoreFromMnemonic = (
 };
 
 export type TStatus = 'connected'
-  | 'initialized'
-  | 'pairingFailed'
-  | 'require_firmware_upgrade'
-  | 'require_app_upgrade'
-  | 'seeded'
-  | 'unpaired'
-  | 'uninitialized';
+| 'initialized'
+| 'pairingFailed'
+| 'require_firmware_upgrade'
+| 'require_app_upgrade'
+| 'seeded'
+| 'unpaired'
+| 'uninitialized';
 
 export const getStatus = (deviceID: string): Promise<TStatus> => {
   return apiGet(`devices/bitbox02/${deviceID}/status`);

--- a/frontends/web/src/api/coins.ts
+++ b/frontends/web/src/api/coins.ts
@@ -22,10 +22,10 @@ import { apiPost, apiGet } from '../utils/request';
 export type BtcUnit = 'default' | 'sat';
 
 export type TStatus = {
-    targetHeight: number;
-    tip: number;
-    tipAtInitTime: number;
-    tipHashHex: string;
+  targetHeight: number;
+  tip: number;
+  tipAtInitTime: number;
+  tipHashHex: string;
 }
 
 export const subscribeCoinHeaders = (coinCode: CoinCode) => (

--- a/frontends/web/src/api/devices.ts
+++ b/frontends/web/src/api/devices.ts
@@ -19,7 +19,7 @@ import { apiGet } from '../utils/request';
 export type TProductName = 'bitbox' | 'bitbox02' | 'bitbox02-bootloader';
 
 export type TDevices = {
-    readonly [key in string]: TProductName;
+  readonly [key in string]: TProductName;
 };
 
 export const getDeviceList = (): Promise<TDevices> => {

--- a/frontends/web/src/api/response.ts
+++ b/frontends/web/src/api/response.ts
@@ -15,12 +15,12 @@
  */
 
 export type SuccessResponse = {
-    success: true;
+  success: true;
 }
 
 // if the backend uses maybeBB02Err
 export type FailResponse = {
-    code?: number;
-    message?: string;
-    success: false;
+  code?: number;
+  message?: string;
+  success: false;
 }

--- a/frontends/web/src/api/version.ts
+++ b/frontends/web/src/api/version.ts
@@ -20,9 +20,9 @@ import { apiGet } from '../utils/request';
  * Describes the file that is loaded from 'https://bitbox.swiss/updates/desktop.json'.
  */
 export type TUpdateFile = {
-    current: string;
-    version: string;
-    description: string;
+  current: string;
+  version: string;
+  description: string;
 }
 
 export const getVersion = (): Promise<string> => {

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -39,14 +39,14 @@ const Banner = ({ children }: TProps) => (
 );
 
 interface State {
-    accountCode: accountAPI.AccountCode;
+  accountCode: accountAPI.AccountCode;
 }
 
 interface AoppProps {
 }
 
 interface SubscribedProps {
-    aopp?: aoppAPI.Aopp;
+  aopp?: aoppAPI.Aopp;
 }
 
 type Props = SubscribedProps & AoppProps & TranslateProps;

--- a/frontends/web/src/components/aopp/vasp.tsx
+++ b/frontends/web/src/components/aopp/vasp.tsx
@@ -22,14 +22,14 @@ import BityLogo from '../../assets/exchanges/logos/bity.png';
 import PocketBitcoinLogo from '../../assets/exchanges/logos/pocketbitcoin.svg';
 
 type TVASPProps = {
-    fallback?: JSX.Element;
-    hostname: string;
-    prominent?: boolean;
-    withLogoText?: string;
+  fallback?: JSX.Element;
+  hostname: string;
+  prominent?: boolean;
+  withLogoText?: string;
 }
 
 type TVASPMap = {
-    [hostname: string]: string
+  [hostname: string]: string
 }
 
 const VASPLogoMap: TVASPMap = {

--- a/frontends/web/src/components/aopp/verifyaddress.tsx
+++ b/frontends/web/src/components/aopp/verifyaddress.tsx
@@ -21,9 +21,9 @@ import { Button } from '../forms';
 import { WaitDialog } from '../wait-dialog/wait-dialog';
 
 type TProps = {
-    accountCode: string;
-    address: string;
-    addressID: string;
+  accountCode: string;
+  address: string;
+  addressID: string;
 }
 
 export const VerifyAddress = ({ accountCode, address, addressID }: TProps) => {

--- a/frontends/web/src/components/confirm/Confirm.tsx
+++ b/frontends/web/src/components/confirm/Confirm.tsx
@@ -29,9 +29,9 @@ type TCallback = (response: boolean) => void;
 export let confirmation: (message: string, callback: TCallback, customButtonText?: string) => void;
 
 interface State {
-    active: boolean;
-    message?: string;
-    customButtonText?: string;
+  active: boolean;
+  message?: string;
+  customButtonText?: string;
 }
 
 /**

--- a/frontends/web/src/components/copy/Copy.tsx
+++ b/frontends/web/src/components/copy/Copy.tsx
@@ -21,13 +21,13 @@ import { Check, Copy } from '../icon/icon';
 import style from './Copy.module.css';
 
 type TProps = {
-    alignLeft?: boolean;
-    alignRight?: boolean;
-    borderLess?: boolean;
-    className?: string;
-    disabled?: boolean;
-    flexibleHeight?: boolean;
-    value: string;
+  alignLeft?: boolean;
+  alignRight?: boolean;
+  borderLess?: boolean;
+  className?: string;
+  disabled?: boolean;
+  flexibleHeight?: boolean;
+  value: string;
 }
 
 export const CopyableInput = ({ alignLeft, alignRight, borderLess, value, className, disabled, flexibleHeight }: TProps) => {

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -27,30 +27,30 @@ import { ToggleShowFirmwareHash } from './toggleshowfirmwarehash';
 import { getDarkmode } from '../../darkmode/darkmode';
 
 interface BitBox02BootloaderProps {
-    deviceID: string;
+  deviceID: string;
 }
 
 interface LoadedProps {
-    versionInfo: {
-        // Indicates whether the device has any firmware already installed on it.
-        // It is considered "erased" if there's no firmware, and it also happens
-        // to be the state in which BitBox02 is shipped to customers.
-        erased: boolean;
-        // Indicates whether the user can install/upgrade firmware.
-        canUpgrade: boolean;
-    };
+  versionInfo: {
+    // Indicates whether the device has any firmware already installed on it.
+    // It is considered "erased" if there's no firmware, and it also happens
+    // to be the state in which BitBox02 is shipped to customers.
+    erased: boolean;
+    // Indicates whether the user can install/upgrade firmware.
+    canUpgrade: boolean;
+  };
 }
 
 type Props = BitBox02BootloaderProps & LoadedProps & TranslateProps;
 
 interface State {
-    status: {
-        upgrading: boolean;
-        errMsg?: string;
-        progress: number;
-        upgradeSuccessful: boolean;
-        rebootSeconds: number;
-    };
+  status: {
+    upgrading: boolean;
+    errMsg?: string;
+    progress: number;
+    upgradeSuccessful: boolean;
+    rebootSeconds: number;
+  };
 }
 
 class BitBox02Bootloader extends Component<Props, State> {

--- a/frontends/web/src/components/dialog/dialog-legacy.tsx
+++ b/frontends/web/src/components/dialog/dialog-legacy.tsx
@@ -19,21 +19,21 @@ import React, { Component, createRef } from 'react';
 import { CloseXDark, CloseXWhite } from '../icon';
 import style from './dialog-legacy.module.css';
 interface Props {
-    title?: string;
-    small?: boolean;
-    medium?: boolean;
-    large?: boolean;
-    slim?: boolean;
-    centered?: boolean;
-    disableEscape?: boolean;
-    onClose?: (e?: Event) => void;
-    disabledClose?: boolean;
-    children: React.ReactNode;
+  title?: string;
+  small?: boolean;
+  medium?: boolean;
+  large?: boolean;
+  slim?: boolean;
+  centered?: boolean;
+  disableEscape?: boolean;
+  onClose?: (e?: Event) => void;
+  disabledClose?: boolean;
+  children: React.ReactNode;
 }
 
 interface State {
-    active: boolean;
-    currentTab: number;
+  active: boolean;
+  currentTab: number;
 }
 
 class DialogLegacy extends Component<Props, State> {
@@ -209,7 +209,7 @@ class DialogLegacy extends Component<Props, State> {
  */
 
 interface DialogButtonsProps {
-    children: React.ReactNode;
+  children: React.ReactNode;
 }
 
 function DialogButtons({ children }: DialogButtonsProps) {

--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -19,17 +19,17 @@ import React, { Component, createRef } from 'react';
 import { CloseXDark, CloseXWhite } from '../icon';
 import style from './dialog.module.css';
 interface Props {
-    title?: string;
-    small?: boolean;
-    medium?: boolean;
-    large?: boolean;
-    slim?: boolean;
-    centered?: boolean;
-    disableEscape?: boolean;
-    onClose?: (e?: Event) => void;
-    disabledClose?: boolean;
-    children: React.ReactNode;
-    open: boolean;
+  title?: string;
+  small?: boolean;
+  medium?: boolean;
+  large?: boolean;
+  slim?: boolean;
+  centered?: boolean;
+  disableEscape?: boolean;
+  onClose?: (e?: Event) => void;
+  disabledClose?: boolean;
+  children: React.ReactNode;
+  open: boolean;
 }
 
 interface State {
@@ -275,7 +275,7 @@ class Dialog extends Component<Props, State> {
  */
 
 interface DialogButtonsProps {
-    children: React.ReactNode;
+  children: React.ReactNode;
 }
 
 function DialogButtons({ children }: DialogButtonsProps) {

--- a/frontends/web/src/components/forms/checkbox.tsx
+++ b/frontends/web/src/components/forms/checkbox.tsx
@@ -19,9 +19,9 @@ import { FunctionComponent } from 'react';
 import styles from './checkbox.module.css';
 
 type CheckboxProps = JSX.IntrinsicElements['input'] & {
-    label?: string;
-    id: string;
-    checkboxStyle?: 'default' | 'info' | 'warning' | 'success';
+  label?: string;
+  id: string;
+  checkboxStyle?: 'default' | 'info' | 'warning' | 'success';
 }
 
 const Checkbox: FunctionComponent<CheckboxProps> = ({

--- a/frontends/web/src/components/forms/input.tsx
+++ b/frontends/web/src/components/forms/input.tsx
@@ -26,27 +26,27 @@ type withValue = {
 }
 
 export type Props = withValue & {
-    align?: 'left' | 'right';
-    autoFocus?: boolean;
-    children?: React.ReactNode;
-    className?: string;
-    disabled?: boolean;
-    error?: string | object;
-    id?: string;
-    label?: string;
-    min?: string;
-    name?: string;
-    onInput?: (e: any) => void;
-    onPaste?: (e: any) => void;
-    pattern?: string;
-    placeholder?: string;
-    readOnly?: boolean;
-    step?: string;
-    title?: string;
-    transparent?: boolean;
-    type?: 'text' | 'password' | 'number';
-    maxLength?: number;
-    labelSection?: JSX.Element | undefined;
+  align?: 'left' | 'right';
+  autoFocus?: boolean;
+  children?: React.ReactNode;
+  className?: string;
+  disabled?: boolean;
+  error?: string | object;
+  id?: string;
+  label?: string;
+  min?: string;
+  name?: string;
+  onInput?: (e: any) => void;
+  onPaste?: (e: any) => void;
+  pattern?: string;
+  placeholder?: string;
+  readOnly?: boolean;
+  step?: string;
+  title?: string;
+  transparent?: boolean;
+  type?: 'text' | 'password' | 'number';
+  maxLength?: number;
+  labelSection?: JSX.Element | undefined;
 }
 
 export default forwardRef<HTMLInputElement, Props>(function Input({

--- a/frontends/web/src/components/forms/radio.tsx
+++ b/frontends/web/src/components/forms/radio.tsx
@@ -18,7 +18,7 @@
 import style from './radio.module.css';
 
 interface IRadioProps {
-    label?: string;
+  label?: string;
 }
 
 type TRadioProps = IRadioProps & JSX.IntrinsicElements['input']

--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -20,18 +20,18 @@ import { A } from '../anchor/anchor';
 import style from './guide.module.css';
 
 export type TEntryProp = {
-    title: string;
+  title: string;
+  text: string;
+  link?: {
+    url: string;
     text: string;
-    link?: {
-        url: string;
-        text: string;
-    };
+  };
 }
 
 type TEntryProps = {
-    entry: TEntryProp;
-    shown?: boolean;
-    children?: ReactNode;
+  entry: TEntryProp;
+  shown?: boolean;
+  children?: ReactNode;
 }
 
 type TProps = TEntryProps;

--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -22,7 +22,7 @@ import AppContext from '../../contexts/AppContext';
 import style from './guide.module.css';
 
 export type TProps = {
-    children?: ReactNode;
+  children?: ReactNode;
 }
 
 const Guide = ({ children }: TProps) => {

--- a/frontends/web/src/components/headerssync/headerssync.tsx
+++ b/frontends/web/src/components/headerssync/headerssync.tsx
@@ -25,7 +25,7 @@ import Spinner from '../spinner/ascii';
 import style from './headerssync.module.css';
 
 export type TProps = {
-    coinCode: CoinCode;
+  coinCode: CoinCode;
 }
 
 export const HeadersSync = ({ coinCode }: TProps) => {

--- a/frontends/web/src/components/icon/icon.tsx
+++ b/frontends/web/src/components/icon/icon.tsx
@@ -120,7 +120,7 @@ export const CaretDown = ({ className, ...props }: SVGProps) => (
 );
 
 interface ExpandIconProps {
-    expand: boolean;
+  expand: boolean;
 }
 
 export const ExpandIcon = ({

--- a/frontends/web/src/components/icon/logo.tsx
+++ b/frontends/web/src/components/icon/logo.tsx
@@ -56,7 +56,7 @@ import ShiftLogo from './assets/shift-cryptosecurity-logo.svg';
 import style from './logo.module.css';
 
 interface GenericProps {
-    [property: string]: any;
+  [property: string]: any;
 }
 
 export const BitBox = (props: GenericProps) => <img {...props} draggable={false} src={BitBoxLogo} alt="BitBox" className={style.logo} />;
@@ -71,7 +71,7 @@ export const SwissMadeOpenSource = ({ large: boolean, className, ...props }: Gen
 export const SwissMadeOpenSourceDark = ({ large: boolean, className, ...props }: GenericProps) => <img {...props} draggable={false} src={SwissOpenSourceDark} alt="Swiss Made Open Source" className={`${style.swissOpenSource} ${props.large ? style.large : ''} ${className ? className : ''}`} />;
 
 type LogoMap = {
-    [property: string]: string[];
+  [property: string]: string[];
 }
 
 const logoMap: LogoMap = {
@@ -97,11 +97,11 @@ const logoMap: LogoMap = {
 };
 
 interface Props {
-    active?: boolean;
-    alt?: string;
-    className?: string;
-    coinCode: string;
-    stacked?: boolean;
+  active?: boolean;
+  alt?: string;
+  className?: string;
+  coinCode: string;
+  stacked?: boolean;
 }
 
 function Logo({ coinCode, active, stacked, ...rest }: Props) {

--- a/frontends/web/src/components/language/language.tsx
+++ b/frontends/web/src/components/language/language.tsx
@@ -23,7 +23,7 @@ import style from './language.module.css';
 import { getSelectedIndex } from '../../utils/language';
 
 type TLanguageSwitchProps = {
-    languages?: TLanguagesList;
+  languages?: TLanguagesList;
 }
 
 const LanguageSwitch = ({ languages }: TLanguageSwitchProps) => {

--- a/frontends/web/src/components/language/types.ts
+++ b/frontends/web/src/components/language/types.ts
@@ -15,8 +15,8 @@
  */
 
 export type TActiveLanguageCodes = 'ar' | 'bg' | 'cs' |'de'
-  | 'en' | 'es' | 'fa' | 'fr' | 'hi' | 'he' | 'it' | 'ja'
-  | 'ms' | 'nl' | 'pt' | 'ru' | 'sl' | 'tr' | 'zh';
+| 'en' | 'es' | 'fa' | 'fr' | 'hi' | 'he' | 'it' | 'ja'
+| 'ms' | 'nl' | 'pt' | 'ru' | 'sl' | 'tr' | 'zh';
 
 export type TLanguage = {
   code: TActiveLanguageCodes;

--- a/frontends/web/src/components/layout/header.tsx
+++ b/frontends/web/src/components/layout/header.tsx
@@ -24,10 +24,10 @@ import { toggleSidebar } from '../sidebar/sidebar';
 import AppContext from '../../contexts/AppContext';
 import style from './header.module.css';
 interface HeaderProps {
-    title?: string | JSX.Element | JSX.Element[];
-    narrow?: boolean;
-    hideSidebarToggler?: boolean;
-    children?: ReactNode;
+  title?: string | JSX.Element | JSX.Element[];
+  narrow?: boolean;
+  hideSidebarToggler?: boolean;
+  children?: ReactNode;
 }
 type Props = HeaderProps & SharedPanelProps;
 

--- a/frontends/web/src/components/message/message.tsx
+++ b/frontends/web/src/components/message/message.tsx
@@ -18,10 +18,10 @@ import { ReactNode } from 'react';
 import styles from './message.module.css';
 
 export interface Props {
-    hidden?: boolean;
-    small?: boolean;
-    type?: 'message' | 'success' | 'info' | 'warning' | 'error';
-    children: ReactNode;
+  hidden?: boolean;
+  small?: boolean;
+  type?: 'message' | 'success' | 'info' | 'warning' | 'error';
+  children: ReactNode;
 }
 
 export function Message({

--- a/frontends/web/src/components/progressRing/progressRing.tsx
+++ b/frontends/web/src/components/progressRing/progressRing.tsx
@@ -17,12 +17,12 @@
 import style from './progressRing.module.css';
 
 type TProgressRingProps = {
-    width: number;
-    value: number;
-    className?: string[] | string;
-    generic?: boolean;
-    isComplete?: boolean | undefined;
-    isError?: boolean;
+  width: number;
+  value: number;
+  className?: string[] | string;
+  generic?: boolean;
+  isComplete?: boolean | undefined;
+  isError?: boolean;
 }
 
 const ProgressRing = ({

--- a/frontends/web/src/components/qrcode/qrcode.tsx
+++ b/frontends/web/src/components/qrcode/qrcode.tsx
@@ -20,8 +20,8 @@ import { getQRCode } from '../../api/backend';
 import style from './qrcode.module.css';
 
 type TProps = {
-    data?: string;
-    size?: number;
+  data?: string;
+  size?: number;
 };
 
 export const QRCode = ({

--- a/frontends/web/src/components/rates/rates.tsx
+++ b/frontends/web/src/components/rates/rates.tsx
@@ -58,14 +58,14 @@ export function formatNumber(amount: number, maxDigits: number): string {
 }
 
 type TProvidedProps = {
-    amount?: IAmount;
-    tableRow?: boolean;
-    unstyled?: boolean;
-    skipUnit?: boolean;
-    noAction?: boolean;
-    sign?: string;
-    noBtcZeroes?: boolean;
-    alwaysShowAmounts?: boolean;
+  amount?: IAmount;
+  tableRow?: boolean;
+  unstyled?: boolean;
+  skipUnit?: boolean;
+  noAction?: boolean;
+  sign?: string;
+  noBtcZeroes?: boolean;
+  alwaysShowAmounts?: boolean;
 }
 
 

--- a/frontends/web/src/components/settingsButton/settingsButton.tsx
+++ b/frontends/web/src/components/settingsButton/settingsButton.tsx
@@ -2,13 +2,13 @@ import { ReactNode } from 'react';
 import style from './settingsButton.module.css';
 
 interface SettingsButtonProps {
-    onClick?: () => void;
-    danger?: boolean;
-    optionalText?: string;
-    secondaryText?: string | JSX.Element;
-    disabled?: boolean;
-    optionalIcon?: JSX.Element;
-    children: ReactNode;
+  onClick?: () => void;
+  danger?: boolean;
+  optionalText?: string;
+  secondaryText?: string | JSX.Element;
+  disabled?: boolean;
+  optionalIcon?: JSX.Element;
+  children: ReactNode;
 }
 
 const SettingsButton = ({

--- a/frontends/web/src/components/skeleton/skeleton.tsx
+++ b/frontends/web/src/components/skeleton/skeleton.tsx
@@ -17,8 +17,8 @@
 import style from './skeleton.module.css';
 
 type TProps = {
-    fontSize?: string;
-    minWidth?: string;
+  fontSize?: string;
+  minWidth?: string;
 };
 
 export const Skeleton = ({

--- a/frontends/web/src/components/status/status.tsx
+++ b/frontends/web/src/components/status/status.tsx
@@ -23,14 +23,14 @@ import style from './status.module.css';
 export type statusType = 'success' | 'warning' | 'info';
 
 type TPRops = {
-    hidden?: boolean;
-    type?: statusType;
-    // used as keyName in the config if dismissing the status should be persisted, so it is not
-    // shown again. Use an empty string if it should be dismissible without storing it in the
-    // config, so the status will be shown again the next time.
-    dismissible?: string;
-    className?: string;
-    children: ReactNode;
+  hidden?: boolean;
+  type?: statusType;
+  // used as keyName in the config if dismissing the status should be persisted, so it is not
+  // shown again. Use an empty string if it should be dismissible without storing it in the
+  // config, so the status will be shown again the next time.
+  dismissible?: string;
+  className?: string;
+  children: ReactNode;
 }
 
 export const Status = ({

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -32,16 +32,16 @@ import parentStyle from './transactions.module.css';
 import style from './transaction.module.css';
 
 interface State {
-    transactionDialog: boolean;
-    newNote: string;
-    editMode: boolean;
-    transactionInfo?: accountApi.ITransaction;
+  transactionDialog: boolean;
+  newNote: string;
+  editMode: boolean;
+  transactionInfo?: accountApi.ITransaction;
 }
 
 interface TransactionProps extends accountApi.ITransaction {
-    accountCode: string;
-    index: number;
-    explorerURL: string;
+  accountCode: string;
+  index: number;
+  explorerURL: string;
 }
 
 type Props = TransactionProps & TranslateProps;

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -23,10 +23,10 @@ import { Button } from '../forms';
 import style from './transactions.module.css';
 
 type TProps = {
-    accountCode: string;
-    explorerURL: string;
-    transactions?: TTransactions;
-    handleExport: () => void;
+  accountCode: string;
+  explorerURL: string;
+  transactions?: TTransactions;
+  handleExport: () => void;
 };
 
 export const Transactions = ({

--- a/frontends/web/src/components/view/view.tsx
+++ b/frontends/web/src/components/view/view.tsx
@@ -23,16 +23,16 @@ import { AnimatedChecked, Close } from '../icon/icon';
 import style from './view.module.css';
 
 type TViewProps = {
-    dialog?: boolean;
-    fitContent?: boolean;
-    fullscreen?: boolean;
-    children: ReactNode;
-    minHeight?: string;
-    onClose?: () => void;
-    textCenter?: boolean;
-    verticallyCentered?: boolean;
-    width?: string;
-    withBottomBar?: boolean;
+  dialog?: boolean;
+  fitContent?: boolean;
+  fullscreen?: boolean;
+  children: ReactNode;
+  minHeight?: string;
+  onClose?: () => void;
+  textCenter?: boolean;
+  verticallyCentered?: boolean;
+  width?: string;
+  withBottomBar?: boolean;
 };
 
 /**
@@ -106,11 +106,11 @@ export const View = ({
 };
 
 type TViewContentProps = {
-    children: ReactNode;
-    fullWidth?: boolean;
-    minHeight?: string;
-    textAlign?: 'center' | 'left';
-    withIcon?: 'success';
+  children: ReactNode;
+  fullWidth?: boolean;
+  minHeight?: string;
+  textAlign?: 'center' | 'left';
+  withIcon?: 'success';
 }
 
 /**
@@ -145,10 +145,10 @@ export const ViewContent = ({
 };
 
 type THeaderProps = {
-    small?: boolean;
-    title: ReactNode;
-    withAppLogo?: boolean;
-    children?: ReactNode;
+  small?: boolean;
+  title: ReactNode;
+  withAppLogo?: boolean;
+  children?: ReactNode;
 }
 
 /**

--- a/frontends/web/src/components/wait-dialog/wait-dialog.tsx
+++ b/frontends/web/src/components/wait-dialog/wait-dialog.tsx
@@ -23,18 +23,18 @@ import style from '../dialog/dialog.module.css';
 import React from 'react';
 
 interface WaitDialogProps {
-    includeDefault?: boolean;
-    prequel?: JSX.Element;
-    title?: string;
-    paired?: boolean;
-    touchConfirm?: boolean;
-    children?: ReactNode;
+  includeDefault?: boolean;
+  prequel?: JSX.Element;
+  title?: string;
+  paired?: boolean;
+  touchConfirm?: boolean;
+  children?: ReactNode;
 }
 
 type Props = WaitDialogProps & TranslateProps;
 
 interface State {
-    active: boolean;
+  active: boolean;
 }
 
 class WaitDialog extends Component<Props, State> {

--- a/frontends/web/src/contexts/AppContext.tsx
+++ b/frontends/web/src/contexts/AppContext.tsx
@@ -17,13 +17,13 @@
 import { Dispatch, SetStateAction, createContext } from 'react';
 
 type AppContextProps = {
-    guideShown: boolean;
-    guideExists: boolean;
-    hideAmounts: boolean;
-    setGuideExists: Dispatch<SetStateAction<boolean>>;
-    setGuideShown: Dispatch<SetStateAction<boolean>>;
-    toggleGuide: () => void;
-    toggleHideAmounts: () => void;
+  guideShown: boolean;
+  guideExists: boolean;
+  hideAmounts: boolean;
+  setGuideExists: Dispatch<SetStateAction<boolean>>;
+  setGuideShown: Dispatch<SetStateAction<boolean>>;
+  toggleGuide: () => void;
+  toggleHideAmounts: () => void;
 }
 
 const AppContext = createContext<AppContextProps>({} as AppContextProps);

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -19,8 +19,8 @@ import { getConfig, setConfig } from '../utils/config';
 import AppContext from './AppContext';
 
 type TProps = {
-    children: ReactNode;
-  }
+  children: ReactNode;
+}
 
 export const AppProvider = ({ children }: TProps) => {
   const [guideShown, setGuideShown] = useState(false);

--- a/frontends/web/src/contexts/RatesContext.tsx
+++ b/frontends/web/src/contexts/RatesContext.tsx
@@ -19,14 +19,14 @@ import { Fiat } from '../api/account';
 import { BtcUnit } from '../api/coins';
 
 type RatesContextProps = {
-    defaultCurrency: Fiat;
-    activeCurrencies: Fiat[];
-    btcUnit?: BtcUnit;
-    rotateFiat: () => void;
-    selectFiat: (fiat: Fiat) => Promise<void>;
-    updateDefaultFiat: (fiat: Fiat) => void;
-    updateRatesConfig: () => Promise<void>;
-    unselectFiat: (fiat: Fiat) => Promise<void>;
+  defaultCurrency: Fiat;
+  activeCurrencies: Fiat[];
+  btcUnit?: BtcUnit;
+  rotateFiat: () => void;
+  selectFiat: (fiat: Fiat) => Promise<void>;
+  updateDefaultFiat: (fiat: Fiat) => void;
+  updateRatesConfig: () => Promise<void>;
+  unselectFiat: (fiat: Fiat) => Promise<void>;
 }
 
 const RatesContext = createContext<RatesContextProps>({} as RatesContextProps);

--- a/frontends/web/src/contexts/RatesProvider.tsx
+++ b/frontends/web/src/contexts/RatesProvider.tsx
@@ -23,7 +23,7 @@ import { reinitializeAccounts } from '../api/backend';
 import { equal } from '../utils/equal';
 
 type TProps = {
-    children: ReactNode;
+  children: ReactNode;
 }
 
 export const RatesProvider = ({ children }: TProps) => {

--- a/frontends/web/src/contexts/WCWeb3WalletContext.tsx
+++ b/frontends/web/src/contexts/WCWeb3WalletContext.tsx
@@ -18,12 +18,12 @@ import { IWeb3Wallet } from '@walletconnect/web3wallet';
 import { createContext } from 'react';
 
 type Props = {
-    isWalletInitialized: boolean;
-    web3wallet?: IWeb3Wallet;
-    pair: (params: {
-        uri: string;
-    }) => Promise<void>;
-    initializeWeb3Wallet: () => void;
+  isWalletInitialized: boolean;
+  web3wallet?: IWeb3Wallet;
+  pair: (params: {
+    uri: string;
+  }) => Promise<void>;
+  initializeWeb3Wallet: () => void;
 }
 
 export const WCWeb3WalletContext = createContext<Props>({} as Props);

--- a/frontends/web/src/contexts/WCWeb3WalletProvider.tsx
+++ b/frontends/web/src/contexts/WCWeb3WalletProvider.tsx
@@ -23,8 +23,8 @@ import { useLoad } from '../hooks/api';
 import { getConfig, setConfig } from '../utils/config';
 
 type TProps = {
-    children: ReactNode;
-  }
+  children: ReactNode;
+}
 
 export const WCWeb3WalletProvider = ({ children }: TProps) => {
   const { t } = useTranslation();

--- a/frontends/web/src/decorators/endpoint.ts
+++ b/frontends/web/src/decorators/endpoint.ts
@@ -28,7 +28,7 @@ export type Endpoint = string;
  * Example: `{ propertyName: 'path/to/endpoint' }`
  */
 export type EndpointsObject<LoadedProps extends ObjectButNotFunction> = {
-    readonly [Key in keyof LoadedProps]: Endpoint;
+  readonly [Key in keyof LoadedProps]: Endpoint;
 };
 
 /**

--- a/frontends/web/src/globals.d.ts
+++ b/frontends/web/src/globals.d.ts
@@ -15,12 +15,12 @@
  */
 
 export declare global {
-    interface Window {
-        qt?: { webChannelTransport: unknown; };
-        android?: {
-            call: (queryID: number, query: string) => void;
-        }
-        onAndroidCallResponse?: (queryID: number, response: string) => void;
-        onAndroidPushNotification?: (msg: string) => void;
+  interface Window {
+    qt?: { webChannelTransport: unknown; };
+    android?: {
+      call: (queryID: number, query: string) => void;
     }
+    onAndroidCallResponse?: (queryID: number, response: string) => void;
+    onAndroidPushNotification?: (msg: string) => void;
+  }
 }

--- a/frontends/web/src/i18n/forTests/i18nwrapper.tsx
+++ b/frontends/web/src/i18n/forTests/i18nwrapper.tsx
@@ -18,7 +18,7 @@ import { I18nextProvider } from 'react-i18next';
 import i18n from './i18nfortests';
 
 type TProps = {
-    children: React.ReactNode
+  children: React.ReactNode
 }
 
 const I18NWrapper = ({ children }: TProps) => {

--- a/frontends/web/src/routes/account/actionButtons.tsx
+++ b/frontends/web/src/routes/account/actionButtons.tsx
@@ -23,10 +23,10 @@ import { isEthereumBased } from './utils';
 import style from './account.module.css';
 
 type TProps = {
-    canSend?: boolean;
-    code: string;
-    exchangeBuySupported?: boolean;
-    account: IAccount;
+  canSend?: boolean;
+  code: string;
+  exchangeBuySupported?: boolean;
+  account: IAccount;
 }
 
 export const ActionButtons = ({ canSend, code, exchangeBuySupported, account }: TProps) => {

--- a/frontends/web/src/routes/account/add/components/steps.tsx
+++ b/frontends/web/src/routes/account/add/components/steps.tsx
@@ -51,10 +51,10 @@ export const Steps = ({
 };
 
 type TStepProps = {
-    children: ReactNode;
-    line?: boolean;
-    status?: 'process' | 'finish' | 'wait';
-    hidden?: boolean;
+  children: ReactNode;
+  line?: boolean;
+  status?: 'process' | 'finish' | 'wait';
+  hidden?: boolean;
 }
 
 export function Step({

--- a/frontends/web/src/routes/account/info/guide.tsx
+++ b/frontends/web/src/routes/account/info/guide.tsx
@@ -19,7 +19,7 @@ import { Entry } from '../../../components/guide/entry';
 import { Guide } from '../../../components/guide/guide';
 
 interface BitcoinBasedAccountInfoGuideProps {
-    coinName: string;
+  coinName: string;
 }
 
 export function BitcoinBasedAccountInfoGuide({

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -29,8 +29,8 @@ import { BitcoinBasedAccountInfoGuide } from './guide';
 import style from './info.module.css';
 
 type TProps = {
-    accounts: IAccount[];
-    code: string;
+  accounts: IAccount[];
+  code: string;
 };
 
 export const Info = ({

--- a/frontends/web/src/routes/account/info/signingconfiguration.tsx
+++ b/frontends/web/src/routes/account/info/signingconfiguration.tsx
@@ -27,11 +27,11 @@ import { QRCode } from '../../../components/qrcode/qrcode';
 import style from './info.module.css';
 
 type TProps = {
-    account: IAccount;
-    info: TSigningConfiguration;
-    code: string;
-    signingConfigIndex: number;
-    children: ReactNode;
+  account: IAccount;
+  info: TSigningConfiguration;
+  code: string;
+  signingConfigIndex: number;
+  children: ReactNode;
 }
 
 export const SigningConfiguration = ({ account, info, code, signingConfigIndex, children }: TProps) => {

--- a/frontends/web/src/routes/account/receive/components/bb01paired.tsx
+++ b/frontends/web/src/routes/account/receive/components/bb01paired.tsx
@@ -20,7 +20,7 @@ import { hasMobileChannel } from '../../../../api/devices';
 import { Status } from '../../../../components/status/status';
 
 type TProps = {
-    deviceID: string;
+  deviceID: string;
 }
 
 export const PairedWarning = ({

--- a/frontends/web/src/routes/account/receive/components/verifybutton.tsx
+++ b/frontends/web/src/routes/account/receive/components/verifybutton.tsx
@@ -29,8 +29,8 @@ export const useVerifyLabel = (device?: TProductName): string => {
 };
 
 type TProps = JSX.IntrinsicElements['button'] & {
-    device?: TProductName;
-    forceVerification: boolean;
+  device?: TProductName;
+  forceVerification: boolean;
 };
 
 export const VerifyButton = ({

--- a/frontends/web/src/routes/account/send/components/dialogs/message-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/message-wait-dialog.tsx
@@ -3,12 +3,12 @@ import { Cancel, Checked } from '../../../../../components/icon/icon';
 import { WaitDialog } from '../../../../../components/wait-dialog/wait-dialog';
 
 type TProps = {
-    isShown: boolean;
-    messageType: 'sent' | 'abort';
+  isShown: boolean;
+  messageType: 'sent' | 'abort';
 }
 
 type TIconProps = {
-    messageType: TProps['messageType']
+  messageType: TProps['messageType']
 }
 
 export const MessageWaitDialog = ({ isShown, messageType }: TProps) => {

--- a/frontends/web/src/routes/account/send/components/dialogs/scan-qr-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/scan-qr-dialog.tsx
@@ -20,10 +20,10 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '../../../../../components/forms';
 
 type TProps = {
-    activeScanQR: boolean;
-    toggleScanQR: () => void;
-    onChangeActiveScanQR: (active: boolean) => void;
-    parseQRResult: (result: string) => void;
+  activeScanQR: boolean;
+  toggleScanQR: () => void;
+  onChangeActiveScanQR: (active: boolean) => void;
+  parseQRResult: (result: string) => void;
 }
 
 export const ScanQRDialog = ({ parseQRResult, activeScanQR, toggleScanQR, onChangeActiveScanQR }: TProps) => {

--- a/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
@@ -5,14 +5,14 @@ import { IAmount, IBalance } from '../../../../../api/account';
 import style from './coin-input.module.css';
 
 type TProps = {
-    balance?: IBalance
-    onAmountChange: (amount: string) => void;
-    onSendAllChange: (sendAll: boolean) => void;
-    sendAll: boolean;
-    amountError?: string;
-    proposedAmount?: IAmount;
-    amount: string;
-    hasSelectedUTXOs: boolean;
+  balance?: IBalance
+  onAmountChange: (amount: string) => void;
+  onSendAllChange: (sendAll: boolean) => void;
+  sendAll: boolean;
+  amountError?: string;
+  proposedAmount?: IAmount;
+  amount: string;
+  hasSelectedUTXOs: boolean;
 }
 
 export const CoinInput = ({

--- a/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
@@ -19,11 +19,11 @@ import { ConversionUnit } from '../../../../../api/account';
 import { Input } from '../../../../../components/forms';
 
 type TProps = {
-    label: ConversionUnit;
-    onFiatChange: (event: Event) => void;
-    disabled: boolean;
-    error?: string;
-    fiatAmount: string;
+  label: ConversionUnit;
+  onFiatChange: (event: Event) => void;
+  disabled: boolean;
+  error?: string;
+  fiatAmount: string;
 }
 
 export const FiatInput = ({ label, onFiatChange, disabled, error, fiatAmount }: TProps) => {

--- a/frontends/web/src/routes/account/send/components/inputs/note-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/note-input.tsx
@@ -19,8 +19,8 @@ import { Input } from '../../../../../components/forms';
 import style from './note-input.module.css';
 
 type TProps = {
-    onNoteChange: (event: Event) => void;
-    note: string;
+  onNoteChange: (event: Event) => void;
+  note: string;
 }
 
 export const NoteInput = ({ onNoteChange, note }: TProps) => {

--- a/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.tsx
@@ -25,17 +25,17 @@ import { ScanQRDialog } from '../dialogs/scan-qr-dialog';
 import style from './receiver-address-input.module.css';
 
 type TToggleScanQRButtonProps = {
-    onClick: () => void;
+  onClick: () => void;
 }
 
 type TReceiverAddressInputProps = {
-    accountCode?: string;
-    addressError?: string;
-    onInputChange: (value: string) => void;
-    recipientAddress: string;
-    activeScanQR: boolean;
-    parseQRResult: (uri: string) => void;
-    onChangeActiveScanQR: (activeScanQR: boolean) => void
+  accountCode?: string;
+  addressError?: string;
+  onInputChange: (value: string) => void;
+  recipientAddress: string;
+  activeScanQR: boolean;
+  parseQRResult: (uri: string) => void;
+  onChangeActiveScanQR: (activeScanQR: boolean) => void
 }
 
 export const ScanQRButton = ({ onClick }: TToggleScanQRButtonProps) => {

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -25,33 +25,33 @@ import { customFeeUnit, getCoinCode, isEthereumBased } from '../utils';
 import style from './feetargets.module.css';
 
 interface LoadedProps {
-    config: any;
+  config: any;
 }
 
 interface FeeTargetsProps {
-    accountCode: accountApi.AccountCode;
-    coinCode: accountApi.CoinCode;
-    disabled: boolean;
-    fiatUnit: accountApi.ConversionUnit;
-    proposedFee?: accountApi.IAmount;
-    customFee: string;
-    showCalculatingFeeLabel?: boolean;
-    onFeeTargetChange: (code: accountApi.FeeTargetCode) => void;
-    onCustomFee: (customFee: string) => void;
-    error?: string;
+  accountCode: accountApi.AccountCode;
+  coinCode: accountApi.CoinCode;
+  disabled: boolean;
+  fiatUnit: accountApi.ConversionUnit;
+  proposedFee?: accountApi.IAmount;
+  customFee: string;
+  showCalculatingFeeLabel?: boolean;
+  onFeeTargetChange: (code: accountApi.FeeTargetCode) => void;
+  onCustomFee: (customFee: string) => void;
+  error?: string;
 }
 
 export type Props = LoadedProps & FeeTargetsProps & TranslateProps;
 
 interface Options {
-    value: accountApi.FeeTargetCode;
-    text: string;
+  value: accountApi.FeeTargetCode;
+  text: string;
 }
 
 interface State {
-    feeTarget: string;
-    options: Options[] | null;
-    noFeeTargets: boolean;
+  feeTarget: string;
+  options: Options[] | null;
+  noFeeTargets: boolean;
 }
 
 class FeeTargets extends Component<Props, State> {

--- a/frontends/web/src/routes/account/send/send-guide.tsx
+++ b/frontends/web/src/routes/account/send/send-guide.tsx
@@ -5,7 +5,7 @@ import { Guide } from '../../../components/guide/guide';
 import { CoinCode } from '../../../api/account';
 
 type TProps = {
-    coinCode: CoinCode
+  coinCode: CoinCode
 }
 
 export const SendGuide = ({ coinCode }: TProps) => {

--- a/frontends/web/src/routes/account/send/send-wrapper.tsx
+++ b/frontends/web/src/routes/account/send/send-wrapper.tsx
@@ -21,10 +21,10 @@ import { RatesContext } from '../../../contexts/RatesContext';
 import { Send } from './send';
 
 type TSendProps = {
-    accounts: IAccount[];
-    code: string;
-    devices: TDevices;
-    deviceIDs: string[];
+  accounts: IAccount[];
+  code: string;
+  devices: TDevices;
+  deviceIDs: string[];
 }
 
 export const SendWrapper = ({ accounts, code, deviceIDs, devices }: TSendProps) => {

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -46,51 +46,51 @@ import { NoteInput } from './components/inputs/note-input';
 import style from './send.module.css';
 
 interface SendProps {
-    accounts: accountApi.IAccount[];
-    code: string;
-    devices: TDevices;
-    deviceIDs: string[];
-    activeCurrency: accountApi.Fiat;
+  accounts: accountApi.IAccount[];
+  code: string;
+  devices: TDevices;
+  deviceIDs: string[];
+  activeCurrency: accountApi.Fiat;
 }
 
 interface SignProgress {
-    steps: number;
-    step: number;
+  steps: number;
+  step: number;
 }
 
 type Props = SendProps & TranslateProps;
 
 interface State {
-    account?: accountApi.IAccount;
-    balance?: accountApi.IBalance;
-    proposedFee?: accountApi.IAmount;
-    proposedTotal?: accountApi.IAmount;
-    recipientAddress: string;
-    proposedAmount?: accountApi.IAmount;
-    valid: boolean;
-    amount: string;
-    fiatAmount: string;
-    fiatUnit: accountApi.Fiat;
-    sendAll: boolean;
-    feeTarget?: accountApi.FeeTargetCode;
-    customFee: string;
-    isConfirming: boolean;
-    isSent: boolean;
-    isAborted: boolean;
-    isUpdatingProposal: boolean;
-    addressError?: string;
-    amountError?: string;
-    feeError?: string;
-    paired?: boolean;
-    noMobileChannelError?: boolean;
-    signProgress?: SignProgress;
-    // show visual BitBox in dialog when instructed to sign.
-    signConfirm: boolean;
-    coinControl: boolean;
-    btcUnit: BtcUnit;
-    activeCoinControl: boolean;
-    activeScanQR: boolean;
-    note: string;
+  account?: accountApi.IAccount;
+  balance?: accountApi.IBalance;
+  proposedFee?: accountApi.IAmount;
+  proposedTotal?: accountApi.IAmount;
+  recipientAddress: string;
+  proposedAmount?: accountApi.IAmount;
+  valid: boolean;
+  amount: string;
+  fiatAmount: string;
+  fiatUnit: accountApi.Fiat;
+  sendAll: boolean;
+  feeTarget?: accountApi.FeeTargetCode;
+  customFee: string;
+  isConfirming: boolean;
+  isSent: boolean;
+  isAborted: boolean;
+  isUpdatingProposal: boolean;
+  addressError?: string;
+  amountError?: string;
+  feeError?: string;
+  paired?: boolean;
+  noMobileChannelError?: boolean;
+  signProgress?: SignProgress;
+  // show visual BitBox in dialog when instructed to sign.
+  signConfirm: boolean;
+  coinControl: boolean;
+  btcUnit: BtcUnit;
+  activeCoinControl: boolean;
+  activeScanQR: boolean;
+  note: string;
 }
 
 class Send extends Component<Props, State> {
@@ -318,12 +318,12 @@ class Send extends Component<Props, State> {
   };
 
   private txProposal = (updateFiat: boolean, result: {
-        errorCode?: string;
-        amount: accountApi.IAmount;
-        fee: accountApi.IAmount;
-        success: boolean;
-        total: accountApi.IAmount;
-    }) => {
+    errorCode?: string;
+    amount: accountApi.IAmount;
+    fee: accountApi.IAmount;
+    success: boolean;
+    total: accountApi.IAmount;
+  }) => {
     this.setState({ valid: result.success });
     if (result.success) {
       this.setState({

--- a/frontends/web/src/routes/account/send/types.ts
+++ b/frontends/web/src/routes/account/send/types.ts
@@ -1,5 +1,5 @@
 export type TSignProgress = {
-    steps: number;
-    step: number;
-  }
+  steps: number;
+  step: number;
+}
 

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -35,12 +35,12 @@ import { HideAmountsButton } from '../../../components/hideamountsbutton/hideamo
 import AppContext from '../../../contexts/AppContext';
 
 type TProps = {
-    accounts: accountApi.IAccount[];
-    devices: TDevices;
+  accounts: accountApi.IAccount[];
+  devices: TDevices;
 };
 
 export type Balances = {
-    [code: string]: accountApi.IBalance;
+  [code: string]: accountApi.IBalance;
 };
 
 export function AccountsSummary({

--- a/frontends/web/src/routes/account/summary/summarybalance.tsx
+++ b/frontends/web/src/routes/account/summary/summarybalance.tsx
@@ -31,7 +31,7 @@ type TProps = {
 }
 
 type TAccountCoinMap = {
-    [code in accountApi.CoinCode]: accountApi.IAccount[];
+  [code in accountApi.CoinCode]: accountApi.IAccount[];
 };
 
 export function SummaryBalance ({

--- a/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
@@ -25,11 +25,11 @@ import { ScanQRVideo } from '../../../send/components/inputs/scan-qr-video';
 import styles from './connect-form.module.css';
 
 type TWCConnectFormProps = {
-    code: string;
-    connectLoading: boolean;
-    uri: string;
-    onInputChange: (value: SetStateAction<string>) => void;
-    onSubmit: (uri: string) => void;
+  code: string;
+  connectLoading: boolean;
+  uri: string;
+  onInputChange: (value: SetStateAction<string>) => void;
+  onSubmit: (uri: string) => void;
 }
 
 type TMobileQRScannerProps = {

--- a/frontends/web/src/routes/account/walletconnect/components/incoming-pairing/incoming-pairing.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/incoming-pairing/incoming-pairing.tsx
@@ -25,11 +25,11 @@ import { SUPPORTED_CHAINS } from '../../../../../utils/walletconnect';
 import styles from './incoming-pairing.module.css';
 
 type TIncomingPairingProps = {
-    currentProposal: SignClientTypes.EventArguments['session_proposal'];
-    pairingMetadata: CoreTypes.Metadata;
-    receiveAddress: string;
-    onReject: () => void;
-    onApprove: () => void;
+  currentProposal: SignClientTypes.EventArguments['session_proposal'];
+  pairingMetadata: CoreTypes.Metadata;
+  receiveAddress: string;
+  onReject: () => void;
+  onApprove: () => void;
 }
 
 const PairingContainer = ({ pairingMetadata }: {pairingMetadata: TIncomingPairingProps['pairingMetadata']}) => {

--- a/frontends/web/src/routes/account/walletconnect/components/session-card/session-card.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/session-card/session-card.tsx
@@ -23,11 +23,11 @@ import { truncateAddress } from '../../../../../utils/walletconnect';
 import styles from './session-card.module.css';
 
 type TTextDataProps = {
-    accountName: string;
-    receiveAddress: string;
-    dAppName: string;
-    dAppUrl: string;
-    iconUrl?: string;
+  accountName: string;
+  receiveAddress: string;
+  dAppName: string;
+  dAppUrl: string;
+  iconUrl?: string;
 }
 
 type TWCSessionCardProps = {

--- a/frontends/web/src/routes/account/walletconnect/components/success-pairing/success-pairing.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/success-pairing/success-pairing.tsx
@@ -22,7 +22,7 @@ import { route } from '../../../../../utils/route';
 import styles from './success-pairing.module.css';
 
 type TProps = {
-    accountCode: string;
+  accountCode: string;
 }
 
 export const WCSuccessPairing = ({ accountCode }: TProps) => {

--- a/frontends/web/src/routes/accounts/select-receive.tsx
+++ b/frontends/web/src/routes/accounts/select-receive.tsx
@@ -24,7 +24,7 @@ import { isBitcoinOnly } from '../account/utils';
 import { View, ViewContent } from '../../components/view/view';
 
 type TReceiveAccountsSelector = {
-    activeAccounts: IAccount[]
+  activeAccounts: IAccount[]
 }
 export const ReceiveAccountsSelector = ({ activeAccounts }: TReceiveAccountsSelector) => {
   const [options, setOptions] = useState<TOption[]>([]);

--- a/frontends/web/src/routes/buy/components/countryselect.tsx
+++ b/frontends/web/src/routes/buy/components/countryselect.tsx
@@ -23,14 +23,14 @@ import { i18n } from '../../../i18n/i18n';
 import styles from './countryselect.module.css';
 
 export type TOption = {
-    label: string;
-    value: string;
+  label: string;
+  value: string;
 }
 
 type TProps = {
-    onChangeRegion: (newValue: SingleValue<TOption>) => void,
-    regions: TOption[]
-    selectedRegion: string;
+  onChangeRegion: (newValue: SingleValue<TOption>) => void,
+  regions: TOption[]
+  selectedRegion: string;
 }
 
 const SelectedRegionIcon = ({ regionCode }: { regionCode: string }) => {

--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -40,8 +40,8 @@ import style from './exchange.module.css';
 import { CountrySelect, TOption } from './components/countryselect';
 
 type TProps = {
-    code: string;
-    accounts: IAccount[];
+  code: string;
+  accounts: IAccount[];
 }
 
 export const Exchange = ({ code, accounts }: TProps) => {

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -29,8 +29,8 @@ import { View, ViewContent } from '../../components/view/view';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
 
 type TProps = {
-    accounts: accountApi.IAccount[];
-    code: string;
+  accounts: accountApi.IAccount[];
+  code: string;
 }
 
 export const BuyInfo = ({ code, accounts }: TProps) => {

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -30,8 +30,8 @@ import { MoonpayTerms } from './moonpay-terms';
 import style from './iframe.module.css';
 
 type TProps = {
-    accounts: IAccount[];
-    code: string;
+  accounts: IAccount[];
+  code: string;
 }
 
 export const Moonpay = ({ accounts, code }: TProps) => {

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -32,7 +32,7 @@ import Guide from './guide';
 import style from './iframe.module.css';
 
 interface TProps {
-    code: string;
+  code: string;
 }
 
 export const Pocket = ({ code }: TProps) => {

--- a/frontends/web/src/routes/buy/types.ts
+++ b/frontends/web/src/routes/buy/types.ts
@@ -17,14 +17,14 @@
 import { ExchangeDeal, ExchangeDeals } from '../../api/exchanges';
 
 export type ExchangeDealWithBestDeal = ExchangeDeal & {
-    isBestDeal?: boolean;
+  isBestDeal?: boolean;
 }
 
 export type ExchangeDealsWithSupported = ExchangeDeals & {
-    supported?: boolean;
+  supported?: boolean;
 }
 export type FrontendExchangeDealsList = {
-    exchanges: ExchangeDealsWithSupported[];
+  exchanges: ExchangeDealsWithSupported[];
 }
 
 export type Info = ExchangeDealsWithSupported['exchangeName'] | 'region';

--- a/frontends/web/src/routes/device/bitbox01/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox01/backups.tsx
@@ -30,21 +30,21 @@ import Create from './create';
 import { Restore } from './restore';
 
 interface BackupsProps {
-    deviceID: string;
-    showCreate?: boolean;
-    showRestore?: boolean;
-    requireConfirmation?: boolean;
-    onRestore?: () => void;
-    children: ReactNode;
+  deviceID: string;
+  showCreate?: boolean;
+  showRestore?: boolean;
+  requireConfirmation?: boolean;
+  onRestore?: () => void;
+  children: ReactNode;
 }
 
 type Props = BackupsProps & TranslateProps;
 
 interface State {
-    backupList: Backup[];
-    selectedBackup?: string;
-    sdCardInserted: boolean | null;
-    lock?: boolean;
+  backupList: Backup[];
+  selectedBackup?: string;
+  sdCardInserted: boolean | null;
+  lock?: boolean;
 }
 
 class Backups extends Component<Props, State> {

--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -28,20 +28,20 @@ import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
 import style from '../components/backups.module.css';
 
 interface RestoreProps {
-    selectedBackup?: string;
-    requireConfirmation: boolean;
-    deviceID: string;
-    onRestore: () => void;
+  selectedBackup?: string;
+  requireConfirmation: boolean;
+  deviceID: string;
+  onRestore: () => void;
 }
 
 type Props = RestoreProps & TranslateProps;
 
 interface State {
-    isConfirming: boolean;
-    activeDialog: boolean;
-    isLoading: boolean;
-    understand: boolean;
-    password?: string;
+  isConfirming: boolean;
+  activeDialog: boolean;
+  isLoading: boolean;
+  understand: boolean;
+  password?: string;
 }
 
 class Restore extends Component<Props, State> {

--- a/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
+++ b/frontends/web/src/routes/device/bitbox01/settings/components/mobile-pairing.tsx
@@ -29,19 +29,19 @@ import { apiPost } from '../../../../../utils/request';
 import style from '../../bitbox01.module.css';
 
 interface PairingProps {
-    deviceID: string;
-    deviceLocked: boolean;
-    paired: boolean;
-    hasMobileChannel: boolean;
-    onPairingEnabled: () => void;
+  deviceID: string;
+  deviceLocked: boolean;
+  paired: boolean;
+  hasMobileChannel: boolean;
+  onPairingEnabled: () => void;
 }
 
 type Props = PairingProps & TranslateProps;
 
 interface State {
-    channel: string | null;
-    status: string | boolean;
-    showQRCode: boolean;
+  channel: string | null;
+  status: string | boolean;
+  showQRCode: boolean;
 }
 
 class MobilePairing extends Component<Props, State> {

--- a/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/initialize.tsx
@@ -34,18 +34,18 @@ const stateEnum = Object.freeze({
 });
 
 interface InitializeProps {
-    goBack: () => void;
-    deviceID: string;
+  goBack: () => void;
+  deviceID: string;
 }
 
 type Props = InitializeProps & TranslateProps;
 
 interface State {
-    showInfo: boolean;
-    password: string | null;
-    status: string;
-    errorCode: string | null;
-    errorMessage: string;
+  showInfo: boolean;
+  password: string | null;
+  status: string;
+  errorCode: string | null;
+  errorMessage: string;
 }
 
 class Initialize extends Component<Props, State> {

--- a/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
+++ b/frontends/web/src/routes/device/bitbox01/setup/security-information.tsx
@@ -26,15 +26,15 @@ import { getDarkmode } from '../../../../components/darkmode/darkmode';
 import style from '../bitbox01.module.css';
 
 interface SecurityInformationProps {
-    goBack: () => void;
-    goal: string | null;
-    children: ReactNode;
+  goBack: () => void;
+  goal: string | null;
+  children: ReactNode;
 }
 
 type Props = SecurityInformationProps & TranslateProps;
 
 interface State {
-    showInfo: boolean;
+  showInfo: boolean;
 }
 
 class SecurityInformation extends Component<Props, State> {

--- a/frontends/web/src/routes/device/bitbox02/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox02/backups.tsx
@@ -30,13 +30,13 @@ import { HorizontallyCenteredSpinner } from '../../../components/spinner/Spinner
 import backupStyle from '../components/backups.module.css';
 
 type TProps = {
-    deviceID: string;
-    showRestore?: boolean;
-    showCreate?: boolean;
-    showRadio: boolean;
-    onSelectBackup?: (backup: Backup) => void;
-    onRestoreBackup?: (success: boolean) => void;
-    children?: ReactNode;
+  deviceID: string;
+  showRestore?: boolean;
+  showCreate?: boolean;
+  showRadio: boolean;
+  onSelectBackup?: (backup: Backup) => void;
+  onRestoreBackup?: (success: boolean) => void;
+  children?: ReactNode;
 }
 
 export const BackupsV2 = ({

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -28,7 +28,7 @@ type Props = {
 }
 
 type State = {
-    status: '' | TStatus;
+  status: '' | TStatus;
 }
 
 export class BitBox02 extends Component<Props, State> {

--- a/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
@@ -24,9 +24,9 @@ import { Button } from '../../../components/forms';
 import { useTranslation } from 'react-i18next';
 
 type TProps = {
-    deviceID: string;
-    backups: Backup[];
-    disabled: boolean;
+  deviceID: string;
+  backups: Backup[];
+  disabled: boolean;
 }
 
 export const Check = ({ deviceID, backups, disabled }: TProps) => {

--- a/frontends/web/src/routes/device/bitbox02/createbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/createbackup.tsx
@@ -24,7 +24,7 @@ import { WaitDialog } from '../../../components/wait-dialog/wait-dialog';
 import { useTranslation } from 'react-i18next';
 
 type TProps = {
-    deviceID: string;
+  deviceID: string;
 }
 
 export const Create = ({ deviceID }: TProps) => {

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -36,14 +36,14 @@ const INFO_STEPS_DISABLE = 0;
 const CONTENT_MIN_HEIGHT = '38em';
 
 interface MnemonicPassphraseButtonProps {
-    deviceID: string;
+  deviceID: string;
 }
 
 interface State {
-    infoStep: number;
-    passphraseEnabled?: boolean;
-    status: 'info' | 'progress' | 'success';
-    understood: boolean;
+  infoStep: number;
+  passphraseEnabled?: boolean;
+  status: 'info' | 'progress' | 'success';
+  understood: boolean;
 }
 
 type Props = MnemonicPassphraseButtonProps & TranslateProps;

--- a/frontends/web/src/routes/device/bitbox02/wizard.tsx
+++ b/frontends/web/src/routes/device/bitbox02/wizard.tsx
@@ -35,18 +35,18 @@ type Props = {
 }
 
 type State = {
-    versionInfo?: VersionInfo;
-    attestation: boolean | null;
-    status: '' | TStatus;
-    appStatus: '' | TWalletSetupChoices;
-    createOptions?: TWalletCreateOptions;
-    // if true, we just pair and unlock, so we can hide some steps.
-    unlockOnly: boolean;
-    showWizard: boolean;
-    waitDialog?: {
-        title: string;
-        text?: string;
-    };
+  versionInfo?: VersionInfo;
+  attestation: boolean | null;
+  status: '' | TStatus;
+  appStatus: '' | TWalletSetupChoices;
+  createOptions?: TWalletCreateOptions;
+  // if true, we just pair and unlock, so we can hide some steps.
+  unlockOnly: boolean;
+  showWizard: boolean;
+  waitDialog?: {
+    title: string;
+    text?: string;
+  };
 }
 
 export class Wizard extends Component<Props, State> {

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -26,11 +26,11 @@ import { ConnectScreenWalletConnect } from './account/walletconnect/connect';
 import { DashboardWalletConnect } from './account/walletconnect/dashboard';
 
 type TAppRouterProps = {
-    devices: TDevices;
-    deviceIDs: string[];
-    accounts: IAccount[];
-    activeAccounts: IAccount[];
-    devicesKey: ((input: string) => string)
+  devices: TDevices;
+  deviceIDs: string[];
+  accounts: IAccount[];
+  activeAccounts: IAccount[];
+  devicesKey: ((input: string) => string)
 }
 
 type TInjectParamsProps = {

--- a/frontends/web/src/routes/settings/components/device-settings/factory-reset-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/factory-reset-setting.tsx
@@ -26,20 +26,20 @@ import styles from './factory-reset-setting.module.css';
 import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
 
 type TProps = {
-    deviceID: string;
+  deviceID: string;
 }
 
 type TDialog = {
-    open: boolean;
-    handleCloseDialog: () => void;
-    isConfirming: boolean;
-    understand: boolean;
-    handleUnderstandChange: (e: ChangeEvent<HTMLInputElement>) => void;
-    handleReset: () => void;
+  open: boolean;
+  handleCloseDialog: () => void;
+  isConfirming: boolean;
+  understand: boolean;
+  handleUnderstandChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  handleReset: () => void;
 }
 
 type TWaitDialog = {
-    isConfirming: boolean;
+  isConfirming: boolean;
 }
 
 const FactoryResetSetting = ({ deviceID }: TProps) => {

--- a/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/firmware-setting.tsx
@@ -23,17 +23,17 @@ import { Checked, RedDot } from '../../../../components/icon';
 import { SettingsItem } from '../settingsItem/settingsItem';
 
 export type TProps = {
-    deviceID: string;
-    versionInfo: VersionInfo;
-    asButton?: boolean;
+  deviceID: string;
+  versionInfo: VersionInfo;
+  asButton?: boolean;
 }
 
 export type TUpgradeDialogProps = {
-    open: boolean;
-    versionInfo: VersionInfo;
-    confirming: boolean;
-    onUpgradeFirmware: () => void;
-    onClose: () => void;
+  open: boolean;
+  versionInfo: VersionInfo;
+  confirming: boolean;
+  onUpgradeFirmware: () => void;
+  onClose: () => void;
 }
 
 const FirmwareSetting = ({ deviceID, versionInfo, asButton = false }: TProps) => {

--- a/frontends/web/src/routes/settings/components/device-settings/go-to-startup-settings.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/go-to-startup-settings.tsx
@@ -22,11 +22,11 @@ import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
 import { apiPost } from '../../../../utils/request';
 
 type TGoToStartupSettingsProps = {
-    deviceID: string;
+  deviceID: string;
 }
 
 type TStartupSettingsWaitDialogProps = {
-    show: boolean;
+  show: boolean;
 }
 
 const StartupSettingsWaitDialog = ({ show }: TStartupSettingsWaitDialogProps) => {

--- a/frontends/web/src/routes/settings/components/device-settings/passphrase-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/passphrase-setting.tsx
@@ -20,8 +20,8 @@ import { ChevronRightDark } from '../../../../components/icon';
 import { route } from '../../../../utils/route';
 
 type TProps = {
-    deviceID: string;
-    passphraseEnabled: boolean;
+  deviceID: string;
+  passphraseEnabled: boolean;
 }
 
 const PassphraseSetting = ({ deviceID, passphraseEnabled }: TProps) => {

--- a/frontends/web/src/routes/settings/components/device-settings/root-fingerprint-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/root-fingerprint-setting.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { SettingsItem } from '../settingsItem/settingsItem';
 
 type TProps = {
-    rootFingerprint: string;
+  rootFingerprint: string;
 }
 
 const RootFingerprintSetting = ({ rootFingerprint }: TProps) => {

--- a/frontends/web/src/routes/settings/components/device-settings/secure-chip-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/secure-chip-setting.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { SettingsItem } from '../settingsItem/settingsItem';
 
 type TProps = {
-    secureChipModel: string;
+  secureChipModel: string;
 }
 
 const SecureChipSetting = ({ secureChipModel }: TProps) => {

--- a/frontends/web/src/routes/settings/components/dropdowns/activecurrenciesdropdown.tsx
+++ b/frontends/web/src/routes/settings/components/dropdowns/activecurrenciesdropdown.tsx
@@ -8,9 +8,9 @@ import activeCurrenciesDropdownStyle from './activecurrenciesdropdown.module.css
 import { useTranslation } from 'react-i18next';
 
 type SelectOption = {
-    label: String;
-    value: Fiat;
-  }
+  label: String;
+  value: Fiat;
+}
 
 type TSelectProps = {
   options: SelectOption[];

--- a/frontends/web/src/routes/settings/components/dropdowns/singledropdown.tsx
+++ b/frontends/web/src/routes/settings/components/dropdowns/singledropdown.tsx
@@ -18,14 +18,14 @@ import Select, { components, DropdownIndicatorProps, SingleValueProps, OptionPro
 import dropdownStyles from './dropdowns.module.css';
 
 type TOption = {
-    label: string;
-    value: string;
+  label: string;
+  value: string;
 }
 
 type TSelectProps = {
-    options: TOption[];
-    handleChange: (param?: any) => void;
-    defaultValue: TOption;
+  options: TOption[];
+  handleChange: (param?: any) => void;
+  defaultValue: TOption;
 }
 
 const DropdownIndicator = (props: DropdownIndicatorProps<TOption, false>) => {

--- a/frontends/web/src/utils/custom.d.ts
+++ b/frontends/web/src/utils/custom.d.ts
@@ -31,10 +31,10 @@ declare module '*.svg';
 
 // Extends preact's HTML attributes.
 declare namespace JSX { // tslint:disable-line:no-namespace
-    interface HTMLAttributes {
-        align?: 'left' | 'right' | 'center';
-        allow?: string;
-        autocorrect?: 'on' | 'off';
-        spellcheck?: boolean;
-    }
+  interface HTMLAttributes {
+    align?: 'left' | 'right' | 'center';
+    allow?: string;
+    autocorrect?: 'on' | 'off';
+    spellcheck?: boolean;
+  }
 }

--- a/frontends/web/src/utils/event-legacy.ts
+++ b/frontends/web/src/utils/event-legacy.ts
@@ -28,7 +28,7 @@ type Observer = (event: TEventLegacy) => void;
  * This interface describes how the subscriptions are stored.
  */
 interface ISubscriptions {
-    [subject: string]: Observer[];
+  [subject: string]: Observer[];
 }
 
 /**

--- a/frontends/web/src/utils/event.ts
+++ b/frontends/web/src/utils/event.ts
@@ -29,7 +29,7 @@ export type Observer = (event: TEvent) => void;
  * This interface describes how the subscriptions are stored.
  */
 interface Subscriptions {
-    [subject: string]: Observer[]; // TypeScript does not allow the type alias Subject there.
+  [subject: string]: Observer[]; // TypeScript does not allow the type alias Subject there.
 }
 
 /**

--- a/frontends/web/src/utils/markup.tsx
+++ b/frontends/web/src/utils/markup.tsx
@@ -18,9 +18,9 @@
 import React, { Fragment, createElement } from 'react';
 
 type TMarkupProps = {
-    tagName: keyof JSX.IntrinsicElements;
-    markup: string;
-    key?: string;
+  tagName: keyof JSX.IntrinsicElements;
+  markup: string;
+  key?: string;
 } & React.HTMLAttributes<HTMLElement>;
 
 const captureStrongElement = /^(.*)<strong>(.*)<\/strong>(.*)$/;


### PR DESCRIPTION
The existing indent rule is for JavaScript and does not consider types, props etc.

This diff is produced by adding the rule to .eslintrc.json and running `make webfix`.