### PR TITLE
frontend: remove old scanner zxing/library

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -11,7 +11,6 @@
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/types": "^2.10.4",
         "@walletconnect/web3wallet": "^1.9.3",
-        "@zxing/library": "0.18.3",
         "flag-icons": "^6.6.6",
         "i18next": "21.6.16",
         "lightweight-charts": "3.8.0",
@@ -4830,26 +4829,6 @@
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
       }
-    },
-    "node_modules/@zxing/library": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.18.3.tgz",
-      "integrity": "sha512-7ny4JjUu2UfIiuyjewxeRZViXJ8GsSOoNZ+o6o0AdPvUQlaISdsGnIUVGDviJerEYeT1MKhaL7jUtjdYs3KO/Q==",
-      "dependencies": {
-        "ts-custom-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.4.0"
-      },
-      "optionalDependencies": {
-        "@zxing/text-encoding": "~0.9.0"
-      }
-    },
-    "node_modules/@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -9988,14 +9967,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/ts-custom-error": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
-      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -23,7 +23,6 @@
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/types": "^2.10.4",
     "@walletconnect/web3wallet": "^1.9.3",
-    "@zxing/library": "0.18.3",
     "flag-icons": "^6.6.6",
     "i18next": "21.6.16",
     "lightweight-charts": "3.8.0",


### PR DESCRIPTION
In the following commit qr-scanner was added, but @zxing/library was not removed: 35cf802331e6e285361cb3fa06c3d85cfe1e3977