### PR TITLE
frontend: default `show` as `false` for status component

### DIFF
--- a/frontends/web/src/components/status/status.tsx
+++ b/frontends/web/src/components/status/status.tsx
@@ -40,7 +40,7 @@ export const Status = ({
   className,
   children,
 }: TPRops) => {
-  const [show, setShow] = useState(true);
+  const [show, setShow] = useState(dismissible ? false : true);
 
   const checkConfig = useCallback(async () => {
     if (dismissible) {
@@ -68,6 +68,7 @@ export const Status = ({
   if (hidden || !show) {
     return null;
   }
+
   return (
     <div className={[style.container, style[type], className ? className : '', dismissible ? style.withCloseBtn : ''].join(' ')}>
       <div className={style.status}>


### PR DESCRIPTION
defaulting `show` to `true` may cause flickering if the status
is `dismissible` and has previously been dismissed.

This is due to the status getting rendered (since `show` is true) by
default, several seconds/ms before `checkConfig` finishes.

In other words, the status gets rendered for a very short time
before it disappears after `checkConfig` finishes, giving the
appearance of a flicker.

Before:


https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/62f0cb88-d211-422d-84e3-36d454fb1021



After:



https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/6553aabb-dbb2-4588-a010-9b0d098a7d48


