### PR TITLE
frontend: use AccountCode everywhere

### DIFF
--- a/frontends/web/src/api/accountsync.ts
+++ b/frontends/web/src/api/accountsync.ts
@@ -15,9 +15,9 @@
  */
 
 import { TUnsubscribe } from '../utils/transport-common';
+import * as accountAPI from './account';
 import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
 import { subscribe as subscribeLegacy } from '../utils/event-legacy';
-import { IAccount } from './account';
 
 /**
  * Subscribes the given function on the "account" event and receives the
@@ -25,7 +25,7 @@ import { IAccount } from './account';
  * Returns a method to unsubscribe.
  */
 export const syncAccountsList = (
-  cb: (accounts: IAccount[],) => void
+  cb: (accounts: accountAPI.IAccount[],) => void
 ): TUnsubscribe => {
   return subscribeEndpoint('accounts', cb);
 };
@@ -35,7 +35,7 @@ export const syncAccountsList = (
  * event to receive the progress of the address sync.
  * Meant to be used with `useSubscribe`.
  */
-export const syncAddressesCount = (code: string) => {
+export const syncAddressesCount = (code: accountAPI.AccountCode) => {
   return (
     cb: TSubscriptionCallback<number>
   ) => {
@@ -49,11 +49,11 @@ export const syncAddressesCount = (code: string) => {
 
 /**
  * Fired when status of an account changed, mostly
- * used as event to call accountApi.getStatus(code).
+ * used as event to call accountAPI.getStatus(code).
  * Returns a method to unsubscribe.
  */
 export const statusChanged = (
-  cb: (code: string) => void,
+  cb: (code: accountAPI.AccountCode) => void,
 ): TUnsubscribe => {
   const unsubscribe = subscribeLegacy('statusChanged', event => {
     if (event.type === 'account' && event.code) {
@@ -68,7 +68,7 @@ export const statusChanged = (
  * Returns a method to unsubscribe.
  */
 export const syncdone = (
-  cb: (code: string) => void,
+  cb: (code: accountAPI.AccountCode) => void,
 ): TUnsubscribe => {
   return subscribeLegacy('syncdone', event => {
     if (event.type === 'account' && event.code) {

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -57,7 +57,7 @@ export type MoonpayBuyInfo = {
   address: string;
 }
 
-export const getMoonpayBuyInfo = (code: string) => {
+export const getMoonpayBuyInfo = (code: AccountCode) => {
   return (): Promise<MoonpayBuyInfo> => {
     return apiGet(`exchange/moonpay/buy-info/${code}`);
   };
@@ -96,7 +96,7 @@ export type SupportedExchanges= {
   exchanges: string[];
 };
 
-export const getExchangeBuySupported = (code: string) => {
+export const getExchangeBuySupported = (code: AccountCode) => {
   return (): Promise<SupportedExchanges> => {
     return apiGet(`exchange/buy-supported/${code}`);
   };

--- a/frontends/web/src/components/aopp/verifyaddress.tsx
+++ b/frontends/web/src/components/aopp/verifyaddress.tsx
@@ -21,7 +21,7 @@ import { Button } from '../forms';
 import { WaitDialog } from '../wait-dialog/wait-dialog';
 
 type TProps = {
-    accountCode: string;
+    accountCode: accountAPI.AccountCode;
     address: string;
     addressID: string;
 }

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -39,7 +39,7 @@ interface State {
 }
 
 interface TransactionProps extends accountApi.ITransaction {
-    accountCode: string;
+    accountCode: accountApi.AccountCode;
     index: number;
     explorerURL: string;
 }

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -16,14 +16,14 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { TTransactions } from '../../api/account';
+import { AccountCode, TTransactions } from '../../api/account';
 import { runningInAndroid } from '../../utils/env';
 import { Transaction } from './transaction';
 import { Button } from '../forms';
 import style from './transactions.module.css';
 
 type TProps = {
-    accountCode: string;
+    accountCode: AccountCode;
     explorerURL: string;
     transactions?: TTransactions;
     handleExport: () => void;

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -43,7 +43,7 @@ import style from './account.module.css';
 
 type Props = {
   accounts: accountApi.IAccount[];
-  code: string;
+  code: accountApi.AccountCode;
   devices: TDevices;
 };
 
@@ -68,7 +68,7 @@ export function Account({
 
   const hasCard = useSDCard(devices, [code]);
 
-  const onAccountChanged = useCallback((code: string, status: accountApi.IStatus | undefined) => {
+  const onAccountChanged = useCallback((code: accountApi.AccountCode, status: accountApi.IStatus | undefined) => {
     if (!code || status === undefined || status.fatalError) {
       return;
     }

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -19,7 +19,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../../hooks/api';
 import { useEsc } from '../../../hooks/keyboard';
-import { getInfo, IAccount } from '../../../api/account';
+import { getInfo, IAccount, AccountCode } from '../../../api/account';
 import { route } from '../../../utils/route';
 import { isBitcoinBased } from '../utils';
 import { ButtonLink } from '../../../components/forms';
@@ -30,7 +30,7 @@ import style from './info.module.css';
 
 type TProps = {
     accounts: IAccount[];
-    code: string;
+    code: AccountCode;
 };
 
 export const Info = ({

--- a/frontends/web/src/routes/account/info/signingconfiguration.tsx
+++ b/frontends/web/src/routes/account/info/signingconfiguration.tsx
@@ -18,7 +18,7 @@
 import { useState, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { route } from '../../../utils/route';
-import { IAccount, TBitcoinSimple, TEthereumSimple, TSigningConfiguration, verifyXPub } from '../../../api/account';
+import { AccountCode, IAccount, TBitcoinSimple, TEthereumSimple, TSigningConfiguration, verifyXPub } from '../../../api/account';
 import { getScriptName, isBitcoinBased } from '../utils';
 import { alertUser } from '../../../components/alert/Alert';
 import { CopyableInput } from '../../../components/copy/Copy';
@@ -29,7 +29,7 @@ import style from './info.module.css';
 type TProps = {
     account: IAccount;
     info: TSigningConfiguration;
-    code: string;
+    code: AccountCode;
     signingConfigIndex: number;
     children: ReactNode;
 }

--- a/frontends/web/src/routes/account/receive/index.tsx
+++ b/frontends/web/src/routes/account/receive/index.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { IAccount } from '../../../api/account';
+import { AccountCode, IAccount } from '../../../api/account';
 import { TDevices } from '../../../api/devices';
 import { Receive as ReceiveBB02 } from './receive';
 import { Receive as ReceiveBB01 } from './receive-bb01';
 
 type TProps = {
   accounts: IAccount[];
-  code: string;
+  code: AccountCode;
   deviceIDs: string[];
   devices: TDevices;
 };

--- a/frontends/web/src/routes/account/receive/receive-bb01.tsx
+++ b/frontends/web/src/routes/account/receive/receive-bb01.tsx
@@ -37,7 +37,7 @@ import style from './receive.module.css';
 
 type TProps = {
   accounts: accountApi.IAccount[];
-  code: string;
+  code: accountApi.AccountCode;
   deviceID: string;
 };
 

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -34,7 +34,7 @@ import style from './receive.module.css';
 
 type TProps = {
   accounts: accountApi.IAccount[];
-  code: string;
+  code: accountApi.AccountCode;
 };
 
 type AddressDialog = { addressType: number } | undefined;

--- a/frontends/web/src/routes/account/send/send-wrapper.tsx
+++ b/frontends/web/src/routes/account/send/send-wrapper.tsx
@@ -15,14 +15,14 @@
  */
 
 import { useContext } from 'react';
-import { IAccount } from '../../../api/account';
+import { AccountCode, IAccount } from '../../../api/account';
 import { TDevices } from '../../../api/devices';
 import { RatesContext } from '../../../contexts/RatesContext';
 import { Send } from './send';
 
 type TSendProps = {
     accounts: IAccount[];
-    code: string;
+    code: AccountCode;
     devices: TDevices;
     deviceIDs: string[];
 }

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -48,7 +48,7 @@ import style from './send.module.css';
 
 interface SendProps {
     accounts: accountApi.IAccount[];
-    code: string;
+    code: accountApi.AccountCode;
     devices: TDevices;
     deviceIDs: string[];
     activeCurrency: accountApi.Fiat;

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from 'react-i18next';
 import {
   allScriptTypes,
   getUTXOs,
+  AccountCode,
   ScriptType,
   TUTXO,
 } from '../../../api/account';
@@ -38,7 +39,7 @@ export type TSelectedUTXOs = {
 };
 
 type Props = {
-  accountCode: string;
+  accountCode: AccountCode;
   active: boolean;
   explorerURL: string;
   onChange: (selectedUTXO: TSelectedUTXOs) => void;

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -87,7 +87,7 @@ export function AccountsSummary({
   }, [mounted]);
 
   const onStatusChanged = useCallback(async (
-    code: string,
+    code: accountApi.AccountCode,
   ) => {
     if (!mounted.current) {
       return;
@@ -109,7 +109,7 @@ export function AccountsSummary({
     }));
   }, [mounted]);
 
-  const update = useCallback((code: string) => {
+  const update = useCallback((code: accountApi.AccountCode) => {
     if (mounted.current) {
       onStatusChanged(code);
       getAccountSummary();

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import { CoinCode, ScriptType, IAccount, CoinUnit, TKeystore } from '../../api/account';
+import { AccountCode, CoinCode, ScriptType, IAccount, CoinUnit, TKeystore } from '../../api/account';
 
-export function findAccount(accounts: IAccount[], accountCode: string): IAccount | undefined {
+export function findAccount(accounts: IAccount[], accountCode: AccountCode): IAccount | undefined {
   return accounts.find(({ code }) => accountCode === code);
 }
 

--- a/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/connect-form/connect-form.tsx
@@ -16,6 +16,7 @@
 
 import { SetStateAction, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import * as accountAPI from '../../../../../api/account';
 import { Button, Input } from '../../../../../components/forms';
 import { route } from '../../../../../utils/route';
 import { useMediaQuery } from '../../../../../hooks/mediaquery';
@@ -25,7 +26,7 @@ import { ScanQRVideo } from '../../../send/components/inputs/scan-qr-video';
 import styles from './connect-form.module.css';
 
 type TWCConnectFormProps = {
-    code: string;
+    code: accountAPI.AccountCode;
     connectLoading: boolean;
     uri: string;
     onInputChange: (value: SetStateAction<string>) => void;

--- a/frontends/web/src/routes/account/walletconnect/components/success-pairing/success-pairing.tsx
+++ b/frontends/web/src/routes/account/walletconnect/components/success-pairing/success-pairing.tsx
@@ -16,13 +16,14 @@
  */
 
 import { useTranslation } from 'react-i18next';
+import * as accountAPI from '../../../../../api/account';
 import { Button } from '../../../../../components/forms';
 import { AnimatedChecked } from '../../../../../components/icon';
 import { route } from '../../../../../utils/route';
 import styles from './success-pairing.module.css';
 
 type TProps = {
-    accountCode: string;
+    accountCode: accountAPI.AccountCode;
 }
 
 export const WCSuccessPairing = ({ accountCode }: TProps) => {

--- a/frontends/web/src/routes/account/walletconnect/connect.tsx
+++ b/frontends/web/src/routes/account/walletconnect/connect.tsx
@@ -32,7 +32,7 @@ import { WCSuccessPairing } from './components/success-pairing/success-pairing';
 import styles from './connect.module.css';
 
 type TProps = {
-  code: string;
+  code: accountApi.AccountCode;
   accounts: accountApi.IAccount[]
 };
 

--- a/frontends/web/src/routes/account/walletconnect/dashboard.tsx
+++ b/frontends/web/src/routes/account/walletconnect/dashboard.tsx
@@ -22,7 +22,7 @@ import { getSdkError } from '@walletconnect/utils';
 import { WCWeb3WalletContext } from '../../../contexts/WCWeb3WalletContext';
 import { route } from '../../../utils/route';
 import { getAddressFromEIPString, truncateAddress } from '../../../utils/walletconnect';
-import { IAccount, getReceiveAddressList } from '../../../api/account';
+import { AccountCode, IAccount, getReceiveAddressList } from '../../../api/account';
 import { GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
 import { View, ViewContent } from '../../../components/view/view';
 import { WCSessionCard } from './components/session-card/session-card';
@@ -33,7 +33,7 @@ import styles from './dashboard.module.css';
 
 type TProps = {
   accounts: IAccount[];
-  code: string;
+  code: AccountCode;
 }
 
 export const DashboardWalletConnect = ({ code, accounts }: TProps) => {

--- a/frontends/web/src/routes/buy/exchange.tsx
+++ b/frontends/web/src/routes/buy/exchange.tsx
@@ -19,7 +19,7 @@ import { i18n } from '../../i18n/i18n';
 import { useTranslation } from 'react-i18next';
 import { Button } from '../../components/forms';
 import * as exchangesAPI from '../../api/exchanges';
-import { IAccount } from '../../api/account';
+import { AccountCode, IAccount } from '../../api/account';
 import { Header } from '../../components/layout';
 import Guide from './guide';
 import { findAccount, getCryptoName } from '../account/utils';
@@ -40,7 +40,7 @@ import style from './exchange.module.css';
 import { CountrySelect, TOption } from './components/countryselect';
 
 type TProps = {
-    code: string;
+    code: AccountCode;
     accounts: IAccount[];
 }
 

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -30,7 +30,7 @@ import { HideAmountsButton } from '../../components/hideamountsbutton/hideamount
 
 type TProps = {
     accounts: accountApi.IAccount[];
-    code: string;
+    code: accountApi.AccountCode;
 }
 
 export const BuyInfo = ({ code, accounts }: TProps) => {

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -19,7 +19,7 @@ import { useState, useEffect, createRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../hooks/api';
 import { useDarkmode } from '../../hooks/darkmode';
-import { IAccount } from '../../api/account';
+import { AccountCode, IAccount } from '../../api/account';
 import { getConfig } from '../../utils/config';
 import { getMoonpayBuyInfo } from '../../api/exchanges';
 import Guide from './guide';
@@ -31,7 +31,7 @@ import style from './iframe.module.css';
 
 type TProps = {
     accounts: IAccount[];
-    code: string;
+    code: AccountCode;
 }
 
 export const Moonpay = ({ accounts, code }: TProps) => {

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { useState, useEffect, createRef } from 'react';
 import { RequestAddressV0Message, MessageVersion, parseMessage, serializeMessage, V0MessageType } from 'request-address';
 import { getConfig } from '../../utils/config';
-import { getTransactionList } from '../../api/account';
+import { getTransactionList, AccountCode } from '../../api/account';
 import { Dialog } from '../../components/dialog/dialog';
 import { confirmation } from '../../components/confirm/Confirm';
 import { verifyAddress, signAddress, getPocketURL } from '../../api/exchanges';
@@ -32,7 +32,7 @@ import Guide from './guide';
 import style from './iframe.module.css';
 
 interface TProps {
-    code: string;
+    code: AccountCode;
 }
 
 export const Pocket = ({ code }: TProps) => {

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -147,7 +147,7 @@ class ManageAccounts extends Component<Props, State> {
     //   </div>);
   };
 
-  private toggleAccount = (accountCode: string, active: boolean) => {
+  private toggleAccount = (accountCode: accountAPI.AccountCode, active: boolean) => {
     return backendAPI.setAccountActive(accountCode, active).then(({ success, errorMessage }) => {
       if (!success && errorMessage) {
         alertUser(errorMessage);
@@ -163,7 +163,7 @@ class ManageAccounts extends Component<Props, State> {
   //   }
   // };
 
-  private toggleShowTokens = (accountCode: string) => {
+  private toggleShowTokens = (accountCode: accountAPI.AccountCode) => {
     this.setState(({ showTokens }) => ({
       showTokens: {
         ...showTokens,
@@ -184,7 +184,7 @@ class ManageAccounts extends Component<Props, State> {
     { code: 'eth-erc20-dai0x6b17', name: 'Dai', unit: 'DAI' },
   ];
 
-  private renderTokens = (ethAccountCode: string, activeTokens?: accountAPI.IActiveToken[]) => {
+  private renderTokens = (ethAccountCode: accountAPI.AccountCode, activeTokens?: accountAPI.IActiveToken[]) => {
     return this.erc20Tokens.map(token => {
       const activeToken = (activeTokens || []).find(t => t.tokenCode === token.code);
       const active = activeToken !== undefined;
@@ -214,7 +214,7 @@ class ManageAccounts extends Component<Props, State> {
     });
   };
 
-  private toggleToken = (ethAccountCode: string, tokenCode: string, active: boolean) => {
+  private toggleToken = (ethAccountCode: accountAPI.AccountCode, tokenCode: string, active: boolean) => {
     backendAPI.setTokenActive(ethAccountCode, tokenCode, active).then(({ success, errorMessage }) => {
       if (!success && errorMessage) {
         alertUser(errorMessage);


### PR DESCRIPTION
For clarity, we should use the named type instead of `string`.