### PR TITLE
frontend: convert bitbox02.tsx to a functional component

### DIFF
--- a/frontends/web/src/api/devicessync.ts
+++ b/frontends/web/src/api/devicessync.ts
@@ -36,11 +36,11 @@ export const syncDeviceList = (
  */
 export const statusChanged = (
   deviceID: string,
-  cb: (deviceID: string) => void,
+  cb: () => void,
 ): TUnsubscribe => {
   const unsubscribe = subscribeLegacy('statusChanged', event => {
     if (event.type === 'device' && event.deviceID === deviceID) {
-      cb(deviceID);
+      cb();
     }
   });
   return unsubscribe;


### PR DESCRIPTION
The status does not need to be synced, as the status does not change from or to `initialized` while the user is in the Manage Device screen.