### PR TITLE
frontend/bootloader: use replace instead of reload in getStatus

### DIFF
--- a/backend/devices/bitbox02bootloader/device.go
+++ b/backend/devices/bitbox02bootloader/device.go
@@ -122,7 +122,8 @@ func (device *Device) fireEvent() {
 		// New-school
 		device.Notify(observable.Event{
 			Subject: fmt.Sprintf("devices/bitbox02-bootloader/%s/status", device.deviceID),
-			Action:  action.Reload,
+			Action:  action.Replace,
+			Object:  device.Status(),
 		})
 	}
 }

--- a/frontends/web/src/api/bitbox02bootloader.ts
+++ b/frontends/web/src/api/bitbox02bootloader.ts
@@ -31,6 +31,14 @@ export const getStatus = (
   return apiGet(`devices/bitbox02-bootloader/${deviceID}/status`);
 };
 
+export const syncStatus = (deviceID: string) => {
+  return (
+    cb: TSubscriptionCallback<TStatus>
+  ) => {
+    return subscribeEndpoint(`devices/bitbox02-bootloader/${deviceID}/status`, cb);
+  };
+};
+
 export type TVersionInfo = {
   // Indicates whether the device has any firmware already installed on it.
   // It is considered "erased" if there's no firmware, and it also happens
@@ -78,12 +86,4 @@ export const setShowFirmwareHash = (
     `devices/bitbox02-bootloader/${deviceID}/set-firmware-hash-enabled`,
     enabled,
   );
-};
-
-export const syncStatus = (deviceID: string) => {
-  return (
-    cb: TSubscriptionCallback<TStatus>
-  ) => {
-    return subscribeEndpoint(`devices/bitbox02-bootloader/${deviceID}/status`, cb);
-  };
 };

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -17,7 +17,7 @@
 
 import { useTranslation } from 'react-i18next';
 import * as bitbox02BootloaderAPI from '../../../api/bitbox02bootloader';
-import { useLoad, useSubscribe } from '../../../hooks/api';
+import { useLoad, useSync } from '../../../hooks/api';
 import { useDarkmode } from '../../../hooks/darkmode';
 import { CenteredContent } from '../../centeredcontent/centeredcontent';
 import { Button } from '../../forms';
@@ -32,7 +32,10 @@ type TProps = {
 export const BitBox02Bootloader = ({ deviceID }: TProps) => {
   const { t } = useTranslation();
   const { isDarkMode } = useDarkmode();
-  const status = useSubscribe(bitbox02BootloaderAPI.syncStatus(deviceID));
+  const status = useSync(
+    () => bitbox02BootloaderAPI.getStatus(deviceID),
+    bitbox02BootloaderAPI.syncStatus(deviceID),
+  );
   const versionInfo = useLoad(() => bitbox02BootloaderAPI.getVersionInfo(deviceID));
 
   if (versionInfo === undefined) {


### PR DESCRIPTION
And also load the status when the component loads, otherwise the view is wrong if the user exists and re-enters the view (until a new push notification arrives).