### PR TITLE
frontend: convert BB02 wizard.tsx to a functional component

### DIFF
--- a/frontends/web/src/api/devicessync.ts
+++ b/frontends/web/src/api/devicessync.ts
@@ -68,11 +68,11 @@ export const channelHashChanged = (
  */
 export const attestationCheckDone = (
   deviceID: string,
-  cb: (deviceID: string) => void,
+  cb: () => void,
 ): TUnsubscribe => {
   const unsubscribe = subscribeLegacy('attestationCheckDone', event => {
     if (event.type === 'device' && event.deviceID === deviceID) {
-      cb(deviceID);
+      cb();
     }
   });
   return unsubscribe;

--- a/frontends/web/src/routes/device/bitbox02/setup/pairing.tsx
+++ b/frontends/web/src/routes/device/bitbox02/setup/pairing.tsx
@@ -24,7 +24,7 @@ import { PointToBitBox02 } from '../../../../components/icon';
 import { Button } from '../../../../components/forms';
 
 type Props = {
-  attestation: boolean | null;
+  attestation: boolean | null | undefined;
   deviceID: string;
   pairingFailed: boolean;
 }

--- a/frontends/web/src/routes/device/bitbox02/unlock.tsx
+++ b/frontends/web/src/routes/device/bitbox02/unlock.tsx
@@ -20,7 +20,7 @@ import { Status } from '../../../components/status/status';
 import { PasswordEntry } from './components/password-entry/password-entry';
 
 type Props = {
-  attestation: boolean | null;
+  attestation: boolean | null | undefined;
 }
 
 export const Unlock = ({ attestation }: Props) => {


### PR DESCRIPTION
The waitDialog state was unused so I removed it.

Instead of resetting `status` to `''`, instead I reset `showWizard`, which should work the same way to hide the dialog. The reason is that there is no easy way to set the `status` state manually, and it also seems cleaner.