### PR TITLE
frontend: fix actions btns spacing when collapsed

### DIFF
--- a/frontends/web/src/components/transactions/transactions.module.css
+++ b/frontends/web/src/components/transactions/transactions.module.css
@@ -1,5 +1,6 @@
 .container {
   margin: calc(var(--space-default) * 1.5) 0;
+  margin-top: 18px; /*calc(var(--space-default) * 1.5 - var(--space-quarter) * 2 - 14px);*/
 }
 
 .header {

--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -23,7 +23,8 @@
 .actionsContainer {
     display: flex;
     transform: translateY(-36%);
-    margin-top: var(--space-quarter);
+    margin-top: calc(var(--space-quarter) * 2);
+    padding-bottom: 14px;
 }
 
 .buy,
@@ -37,6 +38,7 @@
     font-size: var(--size-default);
     height: calc(var(--item-height) / 1.5);
     line-height: calc(var(--item-height) / 1.5);
+    margin-bottom: var(--space-quarter);
     margin-left: var(--space-quarter);
     min-width: calc(var(--item-height) * 2);
     padding: 0 var(--space-half);
@@ -45,6 +47,10 @@
     transition: background-color ease-out 0.2s;
     width: auto;
     will-change: background-color;
+}
+
+.walletConnect {
+    justify-content: center;
 }
 
 .withWalletConnect.actionsContainer {
@@ -76,15 +82,14 @@
 
 @media (max-width: 768px) {
     .actionsContainer {
-        flex: 0 0 91%;
+        flex-wrap: wrap;
         justify-content: space-between;
         margin-bottom: var(--space-default);
-        max-width: 91%;
-        transform: none;
-        width: 91%;
         margin-left: auto;
         margin-right: auto;
-        flex-wrap: wrap;
+        padding-bottom: 0;
+        transform: none;
+        width: 100%;
     }
 
 
@@ -115,8 +120,11 @@
 
     .send,
     .receive,
-    .buy {
+    .buy,
+    .walletConnect
+    {
         font-size: var(--size-small);
+        margin-bottom: 0;
         width: auto;
     }
 }


### PR DESCRIPTION
Before:
<img width="1483" alt="2e" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/41bf1bcc-a3e7-430c-8756-927e74ce323e">

After:
<img width="1483" alt="ewda" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/d78634f2-9194-4854-9182-0c84fdfd1047">

<img width="948" alt="asdsa" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/ada56f30-31eb-46f1-9d80-25f3c9bd1b21">
