### PR TITLE
frontend: deactivate hide amounts if disabled from settings page

### DIFF
--- a/frontends/web/src/contexts/AppContext.tsx
+++ b/frontends/web/src/contexts/AppContext.tsx
@@ -28,6 +28,7 @@ type AppContextProps = {
     setGuideExists: Dispatch<SetStateAction<boolean>>;
     setGuideShown: Dispatch<SetStateAction<boolean>>;
     setSidebarStatus: Dispatch<SetStateAction<TSidebarStatus>>;
+    setHideAmounts: Dispatch<SetStateAction<boolean>>;
     toggleGuide: () => void;
     toggleHideAmounts: () => void;
     toggleSidebar: () => void;

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -71,6 +71,7 @@ export const AppProvider = ({ children }: TProps) => {
         setGuideShown,
         setGuideExists,
         setSidebarStatus,
+        setHideAmounts,
         toggleHideAmounts,
         toggleSidebar
       }}>

--- a/frontends/web/src/routes/settings/components/appearance/hideAmountsSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/hideAmountsSetting.tsx
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Toggle } from '../../../../components/toggle/toggle';
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { useLoad } from '../../../../hooks/api';
 import { getConfig, setConfig } from '../../../../utils/config';
+import { AppContext } from '../../../../contexts/AppContext';
 
 export const HideAmountsSetting = () => {
   const { t } = useTranslation();
+  const { setHideAmounts } = useContext(AppContext);
   const [allowHideAmounts, setAllowHideAmounts] = useState<boolean>();
   const config = useLoad(getConfig);
 
@@ -37,6 +39,12 @@ export const HideAmountsSetting = () => {
   }, [config]);
 
   const toggleAllowHideAmounts = async () => {
+    if (allowHideAmounts) {
+      setHideAmounts(false);
+      await setConfig({
+        frontend: { hideAmounts: false }
+      });
+    }
     setAllowHideAmounts(!allowHideAmounts);
     await setConfig({
       frontend: { allowHideAmounts: !allowHideAmounts }


### PR DESCRIPTION
previously, we deactivate hide amounts only via the "hide/show amounts" button (shown on the top of some pages).

Due to this, amounts will still be hidden even if we disable the settings as a whole - given we didn't disable the feature via the "hide/show amounts" btn.

This commit fixes it by always setting `setHideAmounts(false)`
as well as the config value `hideAmounts: false` if we disable
the feature via settings.