### PR TITLE
frontend: adjust 'Back' & title font size on MobileHeader

### DIFF
--- a/frontends/web/src/components/layout/header.module.css
+++ b/frontends/web/src/components/layout/header.module.css
@@ -117,6 +117,11 @@
     .header {
         padding: var(--space-half);
     }
+
+    .title {
+        padding-right: 0;
+    }
+
     .sidebarToggler.hideSidebarToggler {
         display: none;
     }

--- a/frontends/web/src/routes/settings/components/mobile-header.module.css
+++ b/frontends/web/src/routes/settings/components/mobile-header.module.css
@@ -10,7 +10,7 @@
     color: var(--color-default);
     display: flex;
     align-items: center;
-    font-size: var(--size-title);
+    font-size: var(--size-default);
     padding: var(--space-quarter);
     padding-left: 0;
     text-decoration: none;
@@ -24,25 +24,28 @@
     cursor: pointer;
 }
 
-.backButton img {
-    margin-right: var(--space-eight);
-}
-
 .headerText {
-    font-size: var(--size-title);
+    font-size: var(--size-default);
     font-weight: 400;
     margin: 0 auto;
     position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-}
-
-.withGuide .headerText {
-    left: calc(50% + 37px);
+    left: calc(50% + 16px);
+    transform: translateX(calc(-50% + 16px));
 }
 
 @media (max-width: 768px) {
     .container {
         display: flex;
+    }
+}
+
+@media (max-width: 329px) {
+    .backButton span {
+        display: none;
+    }
+    
+    .headerText {
+        left: calc(50% + 8px);
+        transform: translateX(calc(-50% + 8px));
     }
 }

--- a/frontends/web/src/routes/settings/components/mobile-header.tsx
+++ b/frontends/web/src/routes/settings/components/mobile-header.tsx
@@ -32,7 +32,7 @@ export const MobileHeader = ({ title, withGuide = false }: TProps) => {
   };
   return (
     <div className={`${styles.container} ${withGuide ? `${styles.withGuide}` : ''}`}>
-      <button onClick={handleClick} className={styles.backButton}><ChevronLeftDark /> {t('button.back')}</button>
+      <button onClick={handleClick} className={styles.backButton}><ChevronLeftDark /> <span>{t('button.back')}</span></button>
       <h1 className={styles.headerText}>{title}</h1>
     </div>
   );


### PR DESCRIPTION
and adjusted the position of the title to centre better on the screen as well as hiding the "Back" button text on exceptionally small screen devices (width <330px).

Preview on super small screen (280px width):
![eswd](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/59e3cde9-1388-47b8-9ce8-ae602e750e84)

Preview on small screen (360px width):

![491](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/9fa2db32-7b1c-4262-baa9-7e1fafa0b8c2)


![2edw](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/5999d345-93ff-46a4-b8dd-c17141e5071e)
