### PR TITLE
frontend/accountselector: add insured badge icon

### DIFF
--- a/frontends/web/src/components/accountselector/accountselector.module.css
+++ b/frontends/web/src/components/accountselector/accountselector.module.css
@@ -2,6 +2,7 @@
     color: var(--color-secondary);
     margin-left: auto;
     text-transform: uppercase;
+    white-space: nowrap;
 }
 
 .balanceSingleValue {

--- a/frontends/web/src/components/accountselector/accountselector.tsx
+++ b/frontends/web/src/components/accountselector/accountselector.tsx
@@ -21,6 +21,7 @@ import { Button } from '../forms';
 import Logo from '../icon/logo';
 import AppContext from '../../contexts/AppContext';
 import styles from './accountselector.module.css';
+import { InsuredShield } from '../../routes/account/components/insuredtag';
 
 export type TOption = {
   label: string;
@@ -28,6 +29,7 @@ export type TOption = {
   disabled: boolean;
   coinCode?: IAccount['coinCode'];
   balance?: string;
+  insured?: boolean;
 }
 
 type TAccountSelector = {
@@ -48,13 +50,14 @@ export const setOptionBalances = async (options: TOption[]): Promise<TOption[]> 
 
 const SelectSingleValue: FunctionComponent<SingleValueProps<TOption>> = (props) => {
   const { hideAmounts } = useContext(AppContext);
-  const { label, coinCode, balance } = props.data;
+  const { label, coinCode, balance, insured } = props.data;
   return (
     <div className={styles.singleValueContainer}>
       <components.SingleValue {...props}>
         <div className={styles.valueContainer}>
           {coinCode ? <Logo coinCode={coinCode} alt={coinCode} /> : null}
           <span className={styles.selectLabelText}>{label}</span>
+          {insured && <InsuredShield/>}
           {coinCode && balance && <span className={styles.balanceSingleValue}>{hideAmounts ? `*** ${coinCode}` : balance}</span>}
         </div>
       </components.SingleValue>
@@ -64,13 +67,14 @@ const SelectSingleValue: FunctionComponent<SingleValueProps<TOption>> = (props) 
 
 const SelectOption: FunctionComponent<OptionProps<TOption>> = (props) => {
   const { hideAmounts } = useContext(AppContext);
-  const { label, coinCode, balance } = props.data;
+  const { label, coinCode, balance, insured } = props.data;
 
   return (
     <components.Option {...props}>
       <div className={styles.valueContainer}>
         {coinCode ? <Logo coinCode={coinCode} alt={coinCode} /> : null}
         <span className={styles.selectLabelText}>{label}</span>
+        {insured && <InsuredShield/>}
         {coinCode && balance && <span className={styles.balance}>{hideAmounts ? `*** ${coinCode}` : balance}</span>}
       </div>
     </components.Option>

--- a/frontends/web/src/routes/account/components/insuredtag.module.css
+++ b/frontends/web/src/routes/account/components/insuredtag.module.css
@@ -1,5 +1,5 @@
 .insured {
-    padding: var(--space-eight) 10px;
+    padding: 4px 10px;
     border-radius: var(--space-half);
     border: 1px solid;
     font-size: var(--size-small);
@@ -9,15 +9,25 @@
     color: var(--color-darkgreen);
     margin: 0px 10px;
     text-decoration: none;
+    white-space: nowrap;
+    max-height: 24px;
+}
+
+.insured div {
+  max-height: 14px;
+  display: flex;
+  align-items: center;
 }
 
 .insured img {
   max-height: 14px;
-  margin-right: 5px;
 }
 
-@media (max-width: 382px) {
-    .insured {
-        font-size: 10px;
-    }
+.insured span {
+  margin-left: 5px;
+}
+
+.insuredShield {
+    padding: 3px;
+    max-height: 22px;
 }

--- a/frontends/web/src/routes/account/components/insuredtag.tsx
+++ b/frontends/web/src/routes/account/components/insuredtag.tsx
@@ -15,22 +15,26 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import style from './insuredtag.module.css';
 import { Link } from 'react-router-dom';
 import { Shield } from '../../../components/icon';
+import style from './insuredtag.module.css';
 
-/* TODO:
-   - go to new line on small screen size
-*/
 export const Insured = () => {
   const { t } = useTranslation();
   return (
-    <Link className={`${style.insured}`} to="/bitsurance/dashboard">
-      <div >
+    <Link className={style.insured} to="/bitsurance/dashboard">
+      <div>
         <Shield/>
-        {t('account.insured')}
+        <span>{t('account.insured')}</span>
       </div>
     </Link>
+  );
+};
 
+export const InsuredShield = () => {
+  return (
+    <div className={`${style.insured} ${style.insuredShield}`}>
+      <Shield/>
+    </div>
   );
 };

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -43,7 +43,7 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
     try {
       const supportedAccounts = await getExchangeSupportedAccounts(accounts);
       const options =
-        supportedAccounts.map(({ name, code, coinCode }) => ({ label: `${name}`, value: code, coinCode, disabled: false }));
+        supportedAccounts.map(({ name, code, coinCode, bitsuranceStatus }) => ({ label: `${name}`, value: code, coinCode, disabled: false, insured: bitsuranceStatus === 'active' }));
       setOptions(await setOptionBalances(options));
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
This is how it looks 

![immagine](https://github.com/digitalbitbox/bitbox-wallet-app/assets/11994448/331c89af-63ee-4f36-8344-7c6ccc095496)

![immagine](https://github.com/digitalbitbox/bitbox-wallet-app/assets/11994448/430b5ea2-8b47-4080-a7b6-4c76eb9cda23)

This is how it goes with very long account names

![immagine](https://github.com/digitalbitbox/bitbox-wallet-app/assets/11994448/adc9904f-98f4-40a1-9b25-d7f0b2401175)

