### PR TITLE
frontend: remove width css property for hideamount button text

### DIFF
--- a/frontends/web/src/components/hideamountsbutton/hideamountsbutton.module.css
+++ b/frontends/web/src/components/hideamountsbutton/hideamountsbutton.module.css
@@ -2,6 +2,7 @@
     border-width: 0;
     display: flex;
     padding: 0;
+    text-align: left;
 }
 
 .button img {
@@ -10,6 +11,5 @@
 }
 
 .button span {
-    width: 96px;
     margin-left: var(--space-eight);
 }


### PR DESCRIPTION
Before:
<img width="1038" alt="x82" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/5b340995-d98c-4b63-9a48-86e970e8dbeb">

After:
<img width="1038" alt="2wd" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/a493fb9e-0479-4cbf-b4aa-649151f6fa3f">
