### PR TITLE
frontend: type 2 subscription fns signProgresss and signConfirm 

### DIFF
--- a/frontends/web/src/api/devicessync.ts
+++ b/frontends/web/src/api/devicessync.ts
@@ -77,3 +77,30 @@ export const attestationCheckDone = (
   });
   return unsubscribe;
 };
+
+export type TSignProgress = {
+  steps: number;
+  step: number;
+}
+
+export const signProgress = (
+  cb: (progress: TSignProgress) => void
+): TUnsubscribe => {
+  const unsubscribe = subscribeLegacy('signProgress', event => {
+    if ('type' in event && event.type === 'device' && event.data === 'signProgress') {
+      cb(event.meta);
+    }
+  });
+  return unsubscribe;
+};
+
+export const signConfirm = (
+  cb: () => void
+): TUnsubscribe => {
+  const unsubscribe = subscribeLegacy('signConfirm', event => {
+    if ('type' in event && event.type === 'device' && event.data === 'signConfirm') {
+      cb();
+    }
+  });
+  return unsubscribe;
+};

--- a/frontends/web/src/routes/account/send/components/dialogs/confirm-wait-dialog.tsx
+++ b/frontends/web/src/routes/account/send/components/dialogs/confirm-wait-dialog.tsx
@@ -1,10 +1,11 @@
 import { useTranslation } from 'react-i18next';
 import { WaitDialog } from '../../../../../components/wait-dialog/wait-dialog';
-import { TSignProgress } from '../../types';
+
 import { CoinCode, ConversionUnit, FeeTargetCode, Fiat, IAmount } from '../../../../../api/account';
 import { Amount } from '../../../../../components/amount/amount';
 import { customFeeUnit } from '../../../utils';
 import style from './confirm-wait-dialog.module.css';
+import { TSignProgress } from '../../../../../api/devicessync';
 
 type TransactionStatus = {
   isConfirming: boolean;

--- a/frontends/web/src/routes/account/send/types.ts
+++ b/frontends/web/src/routes/account/send/types.ts
@@ -1,5 +1,0 @@
-export type TSignProgress = {
-    steps: number;
-    step: number;
-  }
-


### PR DESCRIPTION
type 2 subscription fns `signProgresss` and `signConfirm`

On top of that did a small refactor creating a reusable `updateBalance` fn.