### PR TITLE
fix: buy page title shows "Buy Bitcoin" if only has btc account

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -75,6 +75,7 @@ const Sidebar = ({
   accounts,
 }: SidebarProps) => {
   const { t } = useTranslation();
+  const { pathname } = useLocation();
   const { activeSidebar, sidebarStatus, toggleSidebar } = useContext(AppContext);
 
   useEffect(() => {
@@ -148,6 +149,7 @@ const Sidebar = ({
   const hidden = sidebarStatus === 'forceHidden';
   const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
   const accountsByKeystore = getAccountsByKeystore(accounts);
+  const userInSpecificAccountBuyPage = (pathname.startsWith('/buy'));
 
   return (
     <div className={[style.sidebarContainer, hidden ? style.forceHide : ''].join(' ')}>
@@ -209,7 +211,7 @@ const Sidebar = ({
         { accounts.length ? (
           <div key="buy" className={style.sidebarItem}>
             <NavLink
-              className={({ isActive }) => isActive ? style.sidebarActive : ''}
+              className={({ isActive }) => isActive || userInSpecificAccountBuyPage ? style.sidebarActive : ''}
               to="/buy/info">
               <div className={style.single}>
                 <img draggable={false} src={coins} />

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -24,7 +24,7 @@ import Guide from './guide';
 import { AccountSelector, TOption } from '../../components/accountselector/accountselector';
 import { GuidedContent, GuideWrapper, Header, Main } from '../../components/layout';
 import { Spinner } from '../../components/spinner/Spinner';
-import { findAccount, getCryptoName } from '../account/utils';
+import { isBitcoinOnly } from '../account/utils';
 import { View, ViewContent } from '../../components/view/view';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
 
@@ -104,8 +104,8 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
     return <Spinner guideExists={false} text={t('loading')} />;
   }
 
-  const account = findAccount(accounts, code);
-  const name = getCryptoName(t('buy.info.crypto'), account);
+  const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
+  const name = hasOnlyBTCAccounts ? 'Bitcoin' : t('buy.info.crypto');
 
   return (
     <Main>


### PR DESCRIPTION
also fixed the active state / class  of the sidebar when user is in specific account's buy page (`/buy/exchange/accountCode`).

Preview:

Shows "Buy Bitcoin" as title when only BTC accounts are loaded:

<img width="1437" alt="btcttl" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/efc1ae36-b35f-4402-a5cb-bd0e991948c4">

:Shows Sidebar active when on specific account's buy page:

<img width="1437" alt="sdb" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/ebcbc8d3-4916-41bc-8944-010b739c6ee1">
