### PR TITLE
Rotated Bitsurance API key

### DIFF
--- a/backend/bitsurance/bitsurance.go
+++ b/backend/bitsurance/bitsurance.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	apiKey        = "265bfd773038c9ad9da7047e107babba0269bc3d31952172d9b10335e8a9d8e9"
+	apiKey        = "cv9K9SXaMGMy26ThA3sqVetROkhRSPLU"
 	apiURL        = "https://api.bitsurance.eu/api/"
 	testApiURL    = "https://testapi.bitsurance.eu/api/"
 	widgetVersion = "1"


### PR DESCRIPTION
In preperation for the GoLive I did a last API key rotation. The new key also works with test & production server and should now stay constant after release. Its a public published key anyway, but now its prepared for GoLive. 

Not part of this PR but as a reminder ... the `backend.DevServers()` can now give back `false` to signal to work against the production API for next release.
