### PR TITLE
backend/keystore: detect new keystores after a wrong one

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -697,8 +697,8 @@ func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *
 						Action:  action.Replace,
 						Object: data{
 							Type:         "error",
-							ErrorCode:    "wrongKeystore",
-							ErrorMessage: err.Error(),
+							ErrorCode:    err.Error(),
+							ErrorMessage: "",
 						},
 					})
 					c := make(chan bool)
@@ -712,7 +712,7 @@ func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *
 					select {
 					case retry := <-c:
 						if !retry {
-							err = ErrUserAbort
+							err = errp.ErrUserAbort
 							break outerLoop
 						}
 					case <-time.After(timeout):
@@ -727,7 +727,7 @@ func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *
 				// If a previous connect-keystore request is in progress, the previous request is
 				// failed, but we don't dismiss the prompt, as the new prompt has already been shown
 				// by the above "connect" notification.
-			case err == nil || errp.Cause(err) == ErrUserAbort:
+			case err == nil || errp.Cause(err) == errp.ErrUserAbort:
 				// Dismiss prompt after success or upon user abort.
 				backend.Notify(observable.Event{
 					Subject: "connect-keystore",
@@ -737,7 +737,7 @@ func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *
 			default:
 				var errorCode = ""
 				if errp.Cause(err) == errTimeout {
-					errorCode = "timeout"
+					errorCode = err.Error()
 				}
 				// Display error to user.
 				backend.Notify(observable.Event{

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -891,7 +891,7 @@ func (backend *Backend) GetAccountFromCode(acctCode accountsTypes.Code) (account
 
 // CancelConnectKeystore cancels a pending keystore connection request if one exists.
 func (backend *Backend) CancelConnectKeystore() {
-	backend.connectKeystore.cancel(ErrUserAbort)
+	backend.connectKeystore.cancel(errp.ErrUserAbort)
 }
 
 // SetWatchonly sets the keystore's watchonly flag to `watchonly`.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -687,6 +687,7 @@ func (backend *Backend) DeregisterKeystore() {
 	// keystore. For now we just remove all, then re-add the rest.
 	backend.initPersistedAccounts()
 	backend.emitAccountsStatusChanged()
+	backend.connectKeystore.onDisconnect()
 }
 
 // Register registers the given device at this backend.
@@ -890,7 +891,7 @@ func (backend *Backend) GetAccountFromCode(acctCode accountsTypes.Code) (account
 
 // CancelConnectKeystore cancels a pending keystore connection request if one exists.
 func (backend *Backend) CancelConnectKeystore() {
-	backend.connectKeystore.cancel(errUserAbort)
+	backend.connectKeystore.cancel(ErrUserAbort)
 }
 
 // SetWatchonly sets the keystore's watchonly flag to `watchonly`.

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -51,11 +51,6 @@ type Handlers struct {
 	log     *logrus.Entry
 }
 
-const (
-	// ErrUserAbort is returned if the user aborted the current operation.
-	errUserAbort errp.ErrorCode = "userAbort"
-)
-
 // NewHandlers creates a new Handlers instance.
 func NewHandlers(
 	handleFunc func(string, func(*http.Request) (interface{}, error)) *mux.Route, log *logrus.Entry) *Handlers {
@@ -739,10 +734,10 @@ func (handlers *Handlers) postSignBTCAddress(r *http.Request) (interface{}, erro
 		request.Format)
 	if err != nil {
 		if firmware.IsErrorAbort(err) {
-			return response{Success: false, ErrorCode: string(errUserAbort)}, nil
+			return response{Success: false, ErrorCode: errp.ErrUserAbort.Error()}, nil
 		}
 		if errp.Cause(err) == backend.ErrWrongKeystore {
-			return response{Success: false, ErrorCode: string("wrongKeystore")}, nil
+			return response{Success: false, ErrorCode: backend.ErrWrongKeystore.Error()}, nil
 		}
 
 		handlers.log.WithField("code", account.Config().Config.Code).Error(err)

--- a/backend/connectkeystore.go
+++ b/backend/connectkeystore.go
@@ -17,21 +17,20 @@ package backend
 import (
 	"bytes"
 	"context"
-	"errors"
 	"time"
 
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/locker"
 )
 
-// ErrWrongKeystore is returned if the connected keystore is not the expected one.
-var ErrWrongKeystore = errors.New("Wrong device/keystore connected.")
+const (
+	// ErrWrongKeystore is returned if the connected keystore is not the expected one.
+	ErrWrongKeystore errp.ErrorCode = "wrongKeystore"
 
-// ErrUserAbort is raised when a keystore connection is aborted calling CancelConnectKeystore().
-var ErrUserAbort = errors.New("aborted by user")
-var errReplaced = errors.New("replaced by new prompt")
-
-var errTimeout = errors.New("timeout")
+	errTimeout  errp.ErrorCode = "timeout"
+	errReplaced errp.ErrorCode = "connectReplaced"
+)
 
 // connectKeystore is a helper struct to enable connecting to a keystore with a specific root
 // fingerprint.

--- a/backend/connectkeystore_test.go
+++ b/backend/connectkeystore_test.go
@@ -15,7 +15,6 @@
 package backend
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -38,7 +37,7 @@ func TestConnectKeystore(t *testing.T) {
 
 	t.Run("timeout", func(t *testing.T) {
 		_, err := ck.connect(nil, fingerprint, time.Millisecond)
-		require.Equal(t, context.DeadlineExceeded, err)
+		require.Equal(t, errTimeout, err)
 	})
 
 	t.Run("already connected", func(t *testing.T) {
@@ -53,10 +52,10 @@ func TestConnectKeystore(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			time.Sleep(50 * time.Millisecond)
-			ck.cancel(errUserAbort)
+			ck.cancel(ErrUserAbort)
 		}()
 		_, err := ck.connect(nil, fingerprint, time.Second)
-		require.Equal(t, errUserAbort, err)
+		require.Equal(t, ErrUserAbort, err)
 		wg.Wait()
 	})
 

--- a/backend/connectkeystore_test.go
+++ b/backend/connectkeystore_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	keystoremock "github.com/digitalbitbox/bitbox-wallet-app/backend/keystore/mocks"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
 
 	"github.com/stretchr/testify/require"
 )
@@ -52,10 +53,10 @@ func TestConnectKeystore(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			time.Sleep(50 * time.Millisecond)
-			ck.cancel(ErrUserAbort)
+			ck.cancel(errp.ErrUserAbort)
 		}()
 		_, err := ck.connect(nil, fingerprint, time.Second)
-		require.Equal(t, ErrUserAbort, err)
+		require.Equal(t, errp.ErrUserAbort, err)
 		wg.Wait()
 	})
 

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -76,13 +76,15 @@ export const socksProxyCheck = (proxyAddress: string): Promise<ISuccess> => {
   return apiPost('socksproxy/check', proxyAddress);
 };
 
+export type TConnectKeystoreErrorCode = 'wrongKeystore' | 'timeout';
+
 export type TSyncConnectKeystore = null | {
   typ: 'connect';
   keystoreName: string;
 } | {
   typ: 'error';
-  errorCode: 'wrongKeystore';
-  errorMessage: '';
+  errorCode?: TConnectKeystoreErrorCode;
+  errorMessage: string;
 };
 
 /**

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -673,6 +673,7 @@
     "aoppUnsupportedFormat": "There are no available accounts that support the requested address format.",
     "aoppUnsupportedKeystore": "The connected device cannot sign messages for this asset.",
     "aoppVersion": "Unknown version.",
+    "keystoreTimeout": "Wallet request expired. Please try again.",
     "wrongKeystore": "Wrong wallet connected. Please make sure to insert the correct device matching this account.",
     "wrongKeystore2": " If you are using the optional passphrase, make sure you have entered the correct passphrase for the account."
   },

--- a/util/errp/errp.go
+++ b/util/errp/errp.go
@@ -65,6 +65,6 @@ func (e ErrorCode) Error() string {
 // The follwing error codes are defined here because they are shared between packages.
 // Package specific error codes should be defined inside the package itself.
 const (
-// ErrUserAbort is returned if the user aborted the current operation.
-// This is just an example: ErrUserAbort ErrorCode = "userAbort"
+	// ErrUserAbort is returned if the user aborted the current operation.
+	ErrUserAbort ErrorCode = "userAbort"
 )


### PR DESCRIPTION
With the current implementation, when the wrong keystore is connected after a keystore request, the app is not able to automatically detect the connection of the correct keystore. The only option for the user is to cancel the 'connect keystore' popup and repeat the action to create a new keystore connection request. This is counterintuitive and inefficient.

This adds a `connectkeystore.retryCallback` that allows waiting for a new keystore to be connected and checking if that is the expected one.

This PR is a better solution than #2487, as it solves the same issue while being easier and completely transparent to the frontend. It also makes #2489 unnecessary. 