### PR TITLE
frontend: created and used GroupedAccountSelector

### DIFF
--- a/frontends/web/src/components/groupedaccountselector/groupedaccountselector.module.css
+++ b/frontends/web/src/components/groupedaccountselector/groupedaccountselector.module.css
@@ -18,8 +18,23 @@
     padding: 0 calc(var(--space-quarter) + var(--space-eight));
 }
 
+.groupHeader {
+    align-items: center;
+    display: flex;
+    padding: var(--space-eight) 0;
+    padding-bottom: 8px;
+}
+
 .select {
     margin-bottom: var(--space-half);
+}
+
+.select :global(.react-select__group-heading) {
+    color: var(--color-default);
+    font-size: var(--size-default);
+    margin: 0;
+    padding-right: var(--space-quarter);
+    text-transform: unset;
 }
 
 .select :global(.react-select__menu) {
@@ -90,3 +105,4 @@
     width: 20px;
     height: 20px;
 }
+

--- a/frontends/web/src/components/groupedaccountselector/services.ts
+++ b/frontends/web/src/components/groupedaccountselector/services.ts
@@ -1,0 +1,30 @@
+import { getBalance } from '../../api/account';
+import { TAccountsByKeystore, isAmbiguiousName } from '../../routes/account/utils';
+import { TGroupedOption, TOption } from './groupedaccountselector';
+
+export const createGroupedOptions = (accountsByKeystore: TAccountsByKeystore[]) => {
+  return accountsByKeystore.map(({ keystore, accounts }) => ({
+    label: `${keystore.name} ${isAmbiguiousName(keystore.name, accountsByKeystore) ? `(${keystore.rootFingerprint})` : ''}`,
+    connected: keystore.connected,
+    options: accounts.map((account) => ({ label: account.name, value: account.code, coinCode: account.coinCode, disabled: false })) as TOption[]
+  }));
+};
+
+const appendBalance = async (option: TOption) => {
+  const balance = await getBalance(option.value);
+  return { ...option, balance: `${balance.available.amount} ${balance.available.unit}` };
+};
+
+export const getBalancesForGroupedAccountSelector = async (originalGroupedOptions: TGroupedOption[]) => {
+
+  const groupedOptions = originalGroupedOptions.map(group => ({
+    ...group,
+    options: [...group.options]
+  }));
+  for (const group of groupedOptions) {
+    const promises = group.options.map(appendBalance);
+    group.options = await Promise.all(promises);
+  }
+
+  return groupedOptions;
+};

--- a/frontends/web/src/routes/accounts/select-receive.tsx
+++ b/frontends/web/src/routes/accounts/select-receive.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Shift Crypto AG
+ * Copyright 2023-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,30 +14,21 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getBalance, IAccount } from '../../api/account';
-import { AccountSelector, TOption } from '../../components/accountselector/accountselector';
+import { IAccount } from '../../api/account';
 import { Header } from '../../components/layout';
 import { route } from '../../utils/route';
 import { isBitcoinOnly } from '../account/utils';
 import { View, ViewContent } from '../../components/view/view';
+import { GroupedAccountSelector } from '../../components/groupedaccountselector/groupedaccountselector';
 
 type TReceiveAccountsSelector = {
     activeAccounts: IAccount[]
 }
 export const ReceiveAccountsSelector = ({ activeAccounts }: TReceiveAccountsSelector) => {
-  const [options, setOptions] = useState<TOption[]>([]);
   const [code, setCode] = useState('');
   const { t } = useTranslation();
-
-  useEffect(() => {
-    const options = activeAccounts.map(account => ({ label: account.name, value: account.code, disabled: false, coinCode: account.coinCode } as TOption));
-    //setting options without balance
-    setOptions(options);
-    //asynchronously fetching each account's balance
-    getBalances(options).then(options => setOptions(options));
-  }, [activeAccounts]);
 
   const handleProceed = () => {
     route(`/account/${code}/receive`);
@@ -47,20 +38,20 @@ export const ReceiveAccountsSelector = ({ activeAccounts }: TReceiveAccountsSele
 
   const title = t('receive.title', { accountName: hasOnlyBTCAccounts ? 'Bitcoin' : t('buy.info.crypto') });
 
-  const getBalances = async (options: TOption[]) => {
-    return Promise.all(options.map((option) => (
-      getBalance(option.value).then(balance => {
-        return { ...option, balance: `${balance.available.amount} ${balance.available.unit}` };
-      })
-    )));
-  };
-
   return (
     <>
       <Header title={<h2>{title}</h2>} />
       <View width="550px" verticallyCentered fullscreen={false}>
         <ViewContent>
-          <AccountSelector onChange={setCode} onProceed={handleProceed} options={options} title={t('receive.selectAccount')} selected={code} />
+          {activeAccounts && activeAccounts.length > 0 &&
+            <GroupedAccountSelector
+              title={t('receive.selectAccount')}
+              accounts={activeAccounts}
+              selected={code}
+              onChange={setCode}
+              onProceed={handleProceed}
+            />
+          }
         </ViewContent>
       </View>
     </>

--- a/frontends/web/src/routes/buy/info.tsx
+++ b/frontends/web/src/routes/buy/info.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { route } from '../../utils/route';
 import * as accountApi from '../../api/account';
 import { getExchangeSupportedAccounts } from './utils';
-import Guide from './guide';
-import { AccountSelector, TOption, setOptionBalances } from '../../components/accountselector/accountselector';
 import { GuidedContent, GuideWrapper, Header, Main } from '../../components/layout';
 import { Spinner } from '../../components/spinner/Spinner';
 import { isBitcoinOnly } from '../account/utils';
 import { View, ViewContent } from '../../components/view/view';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
+import { GroupedAccountSelector } from '../../components/groupedaccountselector/groupedaccountselector';
+import Guide from './guide';
 
 type TProps = {
     accounts: accountApi.IAccount[];
@@ -34,60 +34,53 @@ type TProps = {
 
 export const BuyInfo = ({ code, accounts }: TProps) => {
   const [selected, setSelected] = useState<string>(code);
-  const [options, setOptions] = useState<TOption[]>();
   const [disabled, setDisabled] = useState<boolean>(false);
+  const [supportedAccounts, setSupportedAccounts] = useState<accountApi.IAccount[]>();
 
   const { t } = useTranslation();
 
-  const checkSupportedCoins = useCallback(async () => {
+  useEffect(() => {
     try {
-      const supportedAccounts = await getExchangeSupportedAccounts(accounts);
-      const options =
-        supportedAccounts.map(({ name, code, coinCode, bitsuranceStatus }) => ({ label: `${name}`, value: code, coinCode, disabled: false, insured: bitsuranceStatus === 'active' }));
-      setOptions(await setOptionBalances(options));
+      getExchangeSupportedAccounts(accounts).then(exchangeSupportedAccounts => {
+        setSupportedAccounts(exchangeSupportedAccounts);
+      });
     } catch (e) {
       console.error(e);
     }
-
   }, [accounts]);
 
-  const maybeProceed = useCallback(async () => {
-    if (options !== undefined && options.length === 1) {
-      const accountCode = options[0].value;
-      const connectResult = await accountApi.connectKeystore(accountCode);
-      if (!connectResult.success) {
-        return;
-      }
-      route(`/buy/exchange/${accountCode}`);
+  useEffect(() => {
+    if (supportedAccounts !== undefined && supportedAccounts.length === 1) {
+      // If user only has one supported account for exchange
+      // and they don't have the correct device connected
+      // they'll be prompted to do so.
+      const accountCode = supportedAccounts[0].code;
+      connectKeystore(accountCode).then(connected => {
+        if (connected) {
+          route(`/buy/exchange/${accountCode}`);
+        }
+      });
     }
-  }, [options]);
-
-  const handleChangeAccount = (selected: string) => {
-    setSelected(selected);
-  };
-
-  useEffect(() => {
-    checkSupportedCoins();
-  }, [checkSupportedCoins]);
-
-  useEffect(() => {
-    maybeProceed();
-  }, [maybeProceed, options]);
+  }, [supportedAccounts]);
 
   const handleProceed = async () => {
     setDisabled(true);
     try {
-      const connectResult = await accountApi.connectKeystore(selected);
-      if (!connectResult.success) {
-        return;
+      const connected = await connectKeystore(selected);
+      if (connected) {
+        route(`/buy/exchange/${selected}`);
       }
     } finally {
       setDisabled(false);
     }
-    route(`/buy/exchange/${selected}`);
   };
 
-  if (options === undefined) {
+  const connectKeystore = async (keystore: string) => {
+    const connectResult = await accountApi.connectKeystore(keystore);
+    return connectResult.success;
+  };
+
+  if (supportedAccounts === undefined) {
     return <Spinner guideExists={false} text={t('loading')} />;
   }
 
@@ -103,17 +96,18 @@ export const BuyInfo = ({ code, accounts }: TProps) => {
           </Header>
           <View width="550px" verticallyCentered fullscreen={false}>
             <ViewContent>
-              { options.length === 0 ? (
+              { !supportedAccounts || supportedAccounts.length === 0 ? (
                 <div className="content narrow isVerticallyCentered">{t('accountSummary.noAccount')}</div>
               ) : (
-                <AccountSelector
-                  title={t('buy.title', { name })}
-                  disabled={disabled}
-                  options={options}
-                  selected={selected}
-                  onChange={handleChangeAccount}
-                  onProceed={handleProceed}
-                />
+                supportedAccounts &&
+                      <GroupedAccountSelector
+                        accounts={supportedAccounts}
+                        title={t('buy.title', { name })}
+                        disabled={disabled}
+                        selected={selected}
+                        onChange={setSelected}
+                        onProceed={handleProceed}
+                      />
               )}
             </ViewContent>
           </View>


### PR DESCRIPTION
to improve our UX when multiple keystore is connected, we'd like to add a grouping on the account selector.

This account selector is used on the info buy page (`/buy/info`) as well as the receive page (`/accounts/select-receive`) and bitsurance.

<img width="776" alt="Screenshot 2024-01-22 at 11 40 10" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/3975e48a-000a-4456-853b-eabba868a561">

<img width="776" alt=";l" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/148aca74-a4d7-4fd0-b84d-49b5002be8e8">

<img width="776" alt="d2" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/811a1677-6869-4b15-abd7-8490b5bd3bc9">

<img width="776" alt="d3" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/61a619b4-409b-41af-bbd9-cb60fcf24770">

