### PR TITLE
frontend: downgrade qrscanner from 1.4.2 to 1.3.0

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -14,7 +14,7 @@
         "flag-icons": "^6.6.6",
         "i18next": "21.6.16",
         "lightweight-charts": "4.1.1",
-        "qr-scanner": "1.4.2",
+        "qr-scanner": "1.3.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-i18next": "11.16.8",
@@ -4004,11 +4004,6 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
-    },
-    "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.3",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
-      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -8983,12 +8978,9 @@
       }
     },
     "node_modules/qr-scanner": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/qr-scanner/-/qr-scanner-1.4.2.tgz",
-      "integrity": "sha512-kV1yQUe2FENvn59tMZW6mOVfpq9mGxGf8l6+EGaXUOd4RBOLg7tRC83OrirM5AtDvZRpdjdlXURsHreAOSPOUw==",
-      "dependencies": {
-        "@types/offscreencanvas": "^2019.6.4"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/qr-scanner/-/qr-scanner-1.3.0.tgz",
+      "integrity": "sha512-xNXlZaKOW0nihHaV7KPrMYJHNp1YX9z+NTqFrbNoibGIzQpPLeIocP9187lxihU/EbgplMm7sQ4hI9jG9+zYHg=="
     },
     "node_modules/query-string": {
       "version": "7.1.3",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -26,7 +26,7 @@
     "flag-icons": "^6.6.6",
     "i18next": "21.6.16",
     "lightweight-charts": "4.1.1",
-    "qr-scanner": "1.4.2",
+    "qr-scanner": "1.3.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-i18next": "11.16.8",

--- a/frontends/web/src/hooks/qrcodescanner.ts
+++ b/frontends/web/src/hooks/qrcodescanner.ts
@@ -19,7 +19,7 @@ import QrScanner from 'qr-scanner';
 
 type TUseQRScannerOptions = {
   onStart?: () => void;
-  onResult: (result: QrScanner.ScanResult) => void;
+  onResult: (result: string) => void;
   onError: (error: any) => void;
 }
 
@@ -39,11 +39,7 @@ export const useQRScanner = (
           result => {
             scanner?.stop();
             onResult(result);
-          }, {
-            onDecodeError: onError,
-            highlightScanRegion: true,
-            highlightCodeOutline: true,
-          })
+          }, onError)
       );
 
       try {

--- a/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
@@ -29,7 +29,7 @@ export const ScanQRVideo = ({
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useQRScanner(videoRef, {
-    onResult: result => onResult(result.data),
+    onResult: result => onResult(result),
     onError: console.error
   });
 


### PR DESCRIPTION
Some Android versions seem to crash with qr-scanner@1.4.2

Older verison does not have:
- native BarcodeDetector
- highlight region