### PR TITLE
frontend: fix restore-mnemonic error in webdev

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/wizard.tsx
+++ b/frontends/web/src/routes/device/bitbox02/wizard.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { useLoad, useSync } from '../../../hooks/api';
 import { getStatus, getVersion, verifyAttestation } from '../../../api/bitbox02';
@@ -54,10 +54,10 @@ export const Wizard = ({ deviceID }: TProps) => {
     })
   );
 
-  const handleGetStarted = () => {
+  const handleGetStarted = useCallback(() => {
     setShowWizard(false);
     navigate('/account-summary');
-  };
+  }, [navigate]);
 
   useEffect(() => {
     if (status === undefined) {
@@ -71,10 +71,11 @@ export const Wizard = ({ deviceID }: TProps) => {
     }
   }, [status, showWizard, unlockOnly]);
 
-  const handleAbort = () => {
+  const handleAbort = useCallback(() => {
     setAppStatus('');
     setCreateOptions(undefined);
-  };
+  }, []);
+
   if (status === undefined) {
     return null;
   }


### PR DESCRIPTION
This fixes a failed-error at the end of restore-from-mnemonic workflow. Although there was a fail meassage everything worked normally after (new keystore showed up in sidebar etc). Could only reproduce in webdev. but not in 4.40.0 release or qt-osx build form master.

It seems to happen when restoreFromMnemonic is called multiple times. This can happend due to state changes in parent wizard component.

restoreFromMnemonic is a long-poll request that starts the workflow and stays open until the whole process on the device is completed. Maybe the backend could be improved as well and keep track if the workflow was already initiated.
Also this might timeout, we should test.

The frontend fix is to keep a reference if the api was called. This could probably be written as hook.

Also used useCallback hooks in parent component, so optimize the effects so that onAbort does cause the effect to exectute.