### PR TITLE
frontend: validate devicename input field in setup

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -265,6 +265,11 @@
     },
     "stepCreate": {
       "description": "This name is used as the device name and for the backup.",
+      "error": {
+        "genericMessage": "Use letters, numbers, basic symbols, spaces. Max 30 characters.",
+        "invalidChars": "Name contains invalid characters: {{invalidChars}}.",
+        "tooLong": "Name is too long."
+      },
       "nameLabel": "BitBox02 name",
       "namePlaceholder": "My BitBox02",
       "title": "Choose BitBox02 name",

--- a/frontends/web/src/routes/device/bitbox02/setup/name.module.css
+++ b/frontends/web/src/routes/device/bitbox02/setup/name.module.css
@@ -2,3 +2,19 @@
 .wizardLabel label {
   font-size: var(--size-wizard-text) !important;
 }
+
+.inputError input,
+.inputError input:focus {
+  border-color: var(--color-danger);
+}
+
+.errorMessage {
+  color: var(--color-danger);
+  display: block;
+  font-size: var(--size-medium);
+  padding-top: var(--space-quarter);
+}
+
+.errorMessage[hidden] {
+  display: none;
+}


### PR DESCRIPTION
We already have a backend validation, but that only shows an invalid input message after the user clicked continue.

Better experience is to give live feedback and information about what is wrong.

It should only allow: printable ascii chars, with max length of 30 including spaces, but not starting or ending with (that is just trimmed, without showing an error to the user).