### PR TITLE
frontend/bitsurance: check keystore when skipping account selection

### DIFF
--- a/frontends/web/src/routes/bitsurance/account.tsx
+++ b/frontends/web/src/routes/bitsurance/account.tsx
@@ -65,7 +65,12 @@ export const BitsuranceAccount = ({ code, accounts }: TProps) => {
   // if there is only one account available let's automatically redirect to the widget
   useEffect(() => {
     if (btcAccounts !== undefined && btcAccounts.length === 1) {
-      route(`/bitsurance/widget/${btcAccounts[0].code}`);
+      connectKeystore(btcAccounts[0].code).then(connectResult => {
+        if (!connectResult.success) {
+          return;
+        }
+        route(`/bitsurance/widget/${btcAccounts[0].code}`);
+      });
     }
   }, [btcAccounts]);
 


### PR DESCRIPTION
When there is only one insurable account, the Bitsurance workflow skips the account selection step. Doing it, it was missing to request the keystore connection in case it was disconnected. This fixes the issue.