### PR TITLE
frontend/rates: fix bug in rotate fiat

### DIFF
--- a/frontends/web/src/contexts/RatesProvider.tsx
+++ b/frontends/web/src/contexts/RatesProvider.tsx
@@ -51,7 +51,7 @@ export const RatesProvider = ({ children }: TProps) => {
   const rotateFiat = () => {
     const index = activeCurrencies.indexOf(defaultCurrency);
     const fiat = activeCurrencies[(index + 1) % activeCurrencies.length];
-    setDefaultCurrency(fiat);
+    updateDefaultFiat(fiat);
   };
 
   const updateDefaultFiat = (fiat: Fiat) => {


### PR DESCRIPTION
`rotateFiat` function of the RatesProvider was missing to update the app config with the new default fiat selected. This fixes the issue.