### PR TITLE
Frontend restore mnemonic with name

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -264,7 +264,7 @@
       "unlock": "Enter BitBox02 password to unlock."
     },
     "stepCreate": {
-      "description": "This name is used as the device name and for the backup.",
+      "description": "This name is used as the device name and for backups.",
       "error": {
         "genericMessage": "Use letters, numbers, basic symbols, spaces. Max 30 characters.",
         "invalidChars": "Name contains invalid characters: {{invalidChars}}.",


### PR DESCRIPTION
On top of https://github.com/digitalbitbox/bitbox-wallet-app/pull/2509

Restoring from mnemonic did not allow to set a device name so it
was always 'My BitBox'.

Added set device name step before continuing with restoreMnemonic.

This also fixes a bug in webdev that was caused by calling
restoreMnemonic on mount, ending up with multiple api calls and
a fail message after the workflow was done.