### PR TITLE
frontend/settings: remove dead code form manage account

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -97,8 +97,6 @@ type Backend interface {
 	SetAccountActive(accountCode accountsTypes.Code, active bool) error
 	SetTokenActive(accountCode accountsTypes.Code, tokenCode string, active bool) error
 	RenameAccount(accountCode accountsTypes.Code, name string) error
-	// disabling for now, we'll either bring this back (if user request it) or remove for good
-	// AccountSetWatch(filter func(*config.Account) bool, watch *bool) error
 	AOPP() backend.AOPP
 	AOPPCancel()
 	AOPPApprove()
@@ -215,8 +213,6 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/set-account-active", handlers.postSetAccountActiveHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/set-token-active", handlers.postSetTokenActiveHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/rename-account", handlers.postRenameAccountHandler).Methods("POST")
-	// disabling for now, we'll either bring this back (if user request it) or remove for good
-	// getAPIRouterNoError(apiRouter)("/account-set-watch", handlers.postAccountSetWatchHandler).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/accounts/reinitialize", handlers.postAccountsReinitializeHandler).Methods("POST")
 	getAPIRouter(apiRouter)("/account-summary", handlers.getAccountSummary).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/supported-coins", handlers.getSupportedCoinsHandler).Methods("GET")
@@ -805,33 +801,6 @@ func (handlers *Handlers) postRenameAccountHandler(r *http.Request) interface{} 
 	}
 	return response{Success: true}
 }
-
-// disabling for now, we'll either bring this back (if user request it) or remove for good
-/*
-func (handlers *Handlers) postAccountSetWatchHandler(r *http.Request) interface{} {
-	var jsonBody struct {
-		AccountCode accountsTypes.Code `json:"accountCode"`
-		Watch       bool               `json:"watch"`
-	}
-
-	type response struct {
-		Success      bool   `json:"success"`
-		ErrorMessage string `json:"errorMessage,omitempty"`
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&jsonBody); err != nil {
-		return response{Success: false, ErrorMessage: err.Error()}
-	}
-
-	filter := func(account *config.Account) bool {
-		return account.Code == jsonBody.AccountCode
-	}
-	if err := handlers.backend.AccountSetWatch(filter, &jsonBody.Watch); err != nil {
-		return response{Success: false, ErrorMessage: err.Error()}
-	}
-	return response{Success: true}
-}
-*/
 
 func (handlers *Handlers) postAccountsReinitializeHandler(_ *http.Request) interface{} {
 	handlers.backend.ReinitializeAccounts()

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -48,10 +48,6 @@ export const renameAccount = (accountCode: AccountCode, name: string): Promise<I
   return apiPost('rename-account', { accountCode, name });
 };
 
-export const accountSetWatch = (accountCode: AccountCode, watch: boolean): Promise<ISuccess> => {
-  return apiPost('account-set-watch', { accountCode, watch });
-};
-
 export const reinitializeAccounts = (): Promise<null> => {
   return apiPost('accounts/reinitialize');
 };

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -108,45 +108,6 @@ class ManageAccounts extends Component<Props, State> {
     });
   };
 
-  private renderWatchOnlyToggle = () => {
-    // const { t } = this.props;
-    const { currentlyEditedAccount } = this.state;
-    if (!currentlyEditedAccount) {
-      return;
-    }
-    if (!currentlyEditedAccount.keystore.watchonly) {
-      return;
-    }
-    return null;
-    // disabling for now, we'll either bring this back (if user request it) or remove for good
-    // return (
-    //   <div className="flex flex-column">
-    //     <div className={style.watchOnlyContainer}>
-    //       <div className="flex">
-    //         <EyeOpenedDark width={18} height={18} />
-    //         <p className={style.watchOnlyTitle}>{t('manageAccounts.watchAccount')}</p>
-    //       </div>
-    //       <Toggle
-    //         checked={currentlyEditedAccount.watch}
-    //         className={style.toggle}
-    //         id={currentlyEditedAccount.code}
-    //         onChange={async (event) => {
-    //           event.target.disabled = true;
-    //           await this.setWatch(currentlyEditedAccount.code, !currentlyEditedAccount.watch);
-    //           this.setState({ currentlyEditedAccount: { ...currentlyEditedAccount, watch: !currentlyEditedAccount.watch } });
-    //           event.target.disabled = false;
-    //         }}
-    //       />
-    //     </div>
-    //     <p className={style.watchOnlyNote}>{t('manageAccounts.watchAccountDescription')}</p>
-    //     {
-    //       !currentlyEditedAccount.watch && <div className={style.watchOnlyAccountHidden}>
-    //         <p>{t('manageAccounts.accountHidden')}</p>
-    //       </div>
-    //     }
-    //   </div>);
-  };
-
   private toggleAccount = (accountCode: accountAPI.AccountCode, active: boolean) => {
     return backendAPI.setAccountActive(accountCode, active).then(({ success, errorMessage }) => {
       if (!success && errorMessage) {
@@ -154,14 +115,6 @@ class ManageAccounts extends Component<Props, State> {
       }
     });
   };
-
-  // disabling for now, we'll either bring this back (if user request it) or remove for good
-  // private setWatch = async (accountCode: string, watch: boolean) => {
-  //   const result = await backendAPI.accountSetWatch(accountCode, watch);
-  //   if (!result.success && result.errorMessage) {
-  //     alertUser(result.errorMessage);
-  //   }
-  // };
 
   private toggleShowTokens = (accountCode: accountAPI.AccountCode) => {
     this.setState(({ showTokens }) => ({
@@ -343,7 +296,6 @@ class ManageAccounts extends Component<Props, State> {
                             }} />
                         </Label>
                         <p>{t('newSettings.appearance.enableAccount.description')}</p>
-                        {this.renderWatchOnlyToggle()}
                         <DialogButtons>
                           <Button
                             disabled={!currentlyEditedAccount.name}


### PR DESCRIPTION
In previous commit 4fb2f72 we commented out the code to enable/disable watch-only at an account level. Since we didn't receive any request about that now we are completely removing it from the code base.