### PR TITLE
frontend: show if account is disabled on manage accounts

### DIFF
--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -3,6 +3,15 @@
     margin-bottom: var(--spacing-default);
 }
 
+.accountNameInactive {
+    color: var(--color-secondary);
+}
+
+.disabledText {
+    color: var(--color-secondary);
+    margin: 0;
+}
+
 .walletHeader {
     align-items: end;
     display: flex;

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -72,22 +72,25 @@ class ManageAccounts extends Component<Props, State> {
           <div
             className={`${style.acccountLink} ${active ? style.accountActive : ''}`}
             onClick={() => active && route(`/account/${account.code}`)}>
-            <Logo className={`${style.coinLogo} m-right-half`} coinCode={account.coinCode} alt={account.coinUnit} />
-            <span>
+            <Logo stacked active={account.active} className={`${style.coinLogo} m-right-half`} coinCode={account.coinCode} alt={account.coinUnit} />
+            <span className={!account.active ? style.accountNameInactive : ''}>
               {account.name}
               {' '}
               <span className="unit">({account.coinUnit})</span>
             </span>
           </div>
-          <Button
-            className={style.editBtn}
-            onClick={() => this.setState({ currentlyEditedAccount: account })}
-            transparent>
-            <EditActive />
-            <span className="hide-on-small">
-              {t('manageAccounts.editAccount')}
-            </span>
-          </Button>
+          <div className="flex flex-items-center">
+            {!account.active ? <p className={`text-small ${style.disabledText}`}>{t('generic.enabled_false')}</p> : null}
+            <Button
+              className={style.editBtn}
+              onClick={() => this.setState({ currentlyEditedAccount: account })}
+              transparent>
+              <EditActive />
+              <span className="hide-on-small">
+                {t('manageAccounts.editAccount')}
+              </span>
+            </Button>
+          </div>
           {active && account.coinCode === 'eth' ? (
             <div className={style.tokenSection}>
               <div className={`${style.tokenContainer} ${tokensVisible ? style.tokenContainerOpen : ''}`}>


### PR DESCRIPTION
Now that the "disable account" toggle is in the "edit" dialog, it is hard to see which accounts are disabled.

We'll grey out disabled accounts and add "disabled" text next to the edit button to make it clearer that the account is disabled

Previews:

![dasxaewd](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/dcb43542-3a48-4316-8ff4-844754f83c75)
![asdx](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/144c8274-3536-42b8-ba80-732b6bb3d12f)
![ewd](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/a5d42fb0-3115-4328-9e97-62d20f3052d2)
