### PR TITLE
frontend/android: update make logcat command

### DIFF
--- a/frontends/android/Makefile
+++ b/frontends/android/Makefile
@@ -16,7 +16,7 @@ prepare-android:
 logcat:
 	adb logcat -s \
 		GoLog \
-		ch.shiftcrypto.bitboxapp \
+		bitboxapp \
 		ActivityManager \
 		InputDispatcher \
 		libprocessgroup \


### PR DESCRIPTION
In commit 225705be7 we changed the app log identifier to fix an Android warning. This commit updates the `make logcat` command consequently.