### PR TITLE
backend/btc: update SignBTCAddress and add tests

### DIFF
--- a/backend/coins/btc/account_test.go
+++ b/backend/coins/btc/account_test.go
@@ -189,9 +189,9 @@ func TestSignAddress(t *testing.T) {
 	account := mockAccount(t, nil)
 	require.NoError(t, account.Initialize())
 	// pt2r is not an available script type in the mocked account.
-	_, _, err := btc.SignBTCAddress(account, "Hello there", "p2tr")
+	_, _, err := btc.SignBTCAddress(account, "Hello there", signing.ScriptTypeP2TR)
 	require.Error(t, err)
-	address, signature, err := btc.SignBTCAddress(account, "Hello there", "p2wpkh")
+	address, signature, err := btc.SignBTCAddress(account, "Hello there", signing.ScriptTypeP2WPKH)
 	require.NoError(t, err)
 	require.NotEmpty(t, address)
 	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("signature")), signature)

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -712,9 +712,9 @@ func (handlers *Handlers) postSignBTCAddress(r *http.Request) (interface{}, erro
 	}
 
 	var request struct {
-		AccountCode types.Code `json:"accountCode"`
-		Msg         string     `json:"msg"`
-		Format      string     `json:"format"`
+		AccountCode types.Code         `json:"accountCode"`
+		Msg         string             `json:"msg"`
+		Format      signing.ScriptType `json:"format"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return response{Success: false, ErrorMessage: err.Error()}, nil

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -409,7 +409,7 @@ export type AddressSignResponse = {
   errorCode?: 'userAbort' | 'wrongKeystore';
 }
 
-export const signAddress = (format: string, msg: string, code: AccountCode): Promise<AddressSignResponse> => {
+export const signAddress = (format: ScriptType | '', msg: string, code: AccountCode): Promise<AddressSignResponse> => {
   return apiPost(`account/${code}/sign-address`, { format, msg, code });
 };
 

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -29,6 +29,7 @@ import { BitsuranceGuide } from './guide';
 import { getBitsuranceURL } from '../../api/bitsurance';
 import { route } from '../../utils/route';
 import style from './widget.module.css';
+import { convertScriptType } from '../../utils/request-addess';
 
 type TProps = {
     code: string;
@@ -106,7 +107,7 @@ export const BitsuranceWidget = ({ code }: TProps) => {
 
   const handleRequestAddress = (message: RequestAddressV0Message) => {
     signing = true;
-    const addressType = message.withScriptType ? String(message.withScriptType) : 'p2wpkh';
+    const addressType = message.withScriptType ? convertScriptType(message.withScriptType) : '';
     const withMessageSignature = message.withMessageSignature ? message.withMessageSignature : '';
     const withExtendedPublicKey = !!message.withExtendedPublicKey;
     signAddress(

--- a/frontends/web/src/routes/buy/pocket.tsx
+++ b/frontends/web/src/routes/buy/pocket.tsx
@@ -29,6 +29,7 @@ import { useLoad } from '../../hooks/api';
 import { alertUser } from '../../components/alert/Alert';
 import Guide from './guide';
 import style from './iframe.module.css';
+import { convertScriptType } from '../../utils/request-addess';
 
 interface TProps {
     code: AccountCode;
@@ -101,7 +102,7 @@ export const Pocket = ({ code }: TProps) => {
 
   const handleRequestAddress = (message: RequestAddressV0Message) => {
     signing = true;
-    const addressType = message.withScriptType ? String(message.withScriptType) : '';
+    const addressType = message.withScriptType ? convertScriptType(message.withScriptType) : '';
     const withMessageSignature = message.withMessageSignature ? message.withMessageSignature : '';
     signAddress(
       addressType,

--- a/frontends/web/src/utils/request-addess.ts
+++ b/frontends/web/src/utils/request-addess.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { V0MessageScriptType } from 'request-address';
+import { ScriptType } from '../api/account';
+
+
+// convertScriptType converts a V0MessageScriptType script type (https://www.npmjs.com/package/request-address#v0messagescripttype)
+// into a ScriptType, as defined in api/account.ts.
+export const convertScriptType = (scriptType: V0MessageScriptType): ScriptType => {
+  if (scriptType === V0MessageScriptType.P2SH) {
+    return 'p2wpkh-p2sh';
+  }
+
+  return scriptType as ScriptType;
+};


### PR DESCRIPTION
Removes an unnecessary check in the function and adds a unit test function.

This was suggested in the review of #2485 