### PR TITLE
frontend/account-summary: fix regression during address scanning

### DIFF
--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -189,7 +189,7 @@ export function AccountsSummary({
                   <AddBuyReceiveOnEmptyBalances accounts={accounts} balances={balances} />
                 ) : undefined
               } />
-            {accountsByKeystore && balancePerCoin &&
+            {accountsByKeystore &&
               (accountsByKeystore.map(({ keystore, accounts }) =>
                 <SummaryBalance
                   keystoreDisambiguatorName={isAmbiguiousName(keystore.name, accountsByKeystore) ? keystore.rootFingerprint : undefined}
@@ -197,7 +197,7 @@ export function AccountsSummary({
                   keystoreName={keystore.name}
                   key={keystore.rootFingerprint}
                   accounts={accounts}
-                  totalBalancePerCoin={balancePerCoin[keystore.rootFingerprint]}
+                  totalBalancePerCoin={ balancePerCoin ? balancePerCoin[keystore.rootFingerprint] : undefined}
                   totalBalance={ accountsTotalBalance ? accountsTotalBalance[keystore.rootFingerprint] : undefined}
                   balances={balances}
                 />


### PR DESCRIPTION
Recent commit d8c6ba0 refactored the account summary section to group accounts by keystore. The commit also introduced a small regression, hiding the account rendering until the balance of each account is ready, while the previous behavior was to show the accounts displaying the scanned addresses.

This fixes the regression.