### PR TITLE
frontend: ensure keystore connected in aopp workflow

### DIFF
--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -95,11 +95,14 @@ class Aopp extends Component<Props, State> {
     }
   }
 
-  private chooseAccount = (e: React.SyntheticEvent) => {
-    if (this.state.accountCode) {
-      aoppAPI.chooseAccount(this.state.accountCode);
-    }
+  private chooseAccount = async (e: React.SyntheticEvent) => {
     e.preventDefault();
+    if (this.state.accountCode) {
+      const { success } = await accountAPI.connectKeystore(this.state.accountCode);
+      if (success) {
+        aoppAPI.chooseAccount(this.state.accountCode);
+      }
+    }
   };
 
   public render() {


### PR DESCRIPTION
With remember wallet the user could choose an account that is not connected, this ensures that the correct keystore is used.