### PR TITLE
backend: use new URLs for update/banners

### DIFF
--- a/backend/banners/banners.go
+++ b/backend/banners/banners.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const bannersURL = "https://bitbox.swiss/updates/banners.json"
+const bannersURL = "https://bitboxapp.shiftcrypto.io/banners.json"
 
 // MessageKey enumerates the possible keys in the banners json.
 type MessageKey string

--- a/backend/update.go
+++ b/backend/update.go
@@ -23,7 +23,7 @@ import (
 	"github.com/digitalbitbox/bitbox02-api-go/util/semver"
 )
 
-const updateFileURL = "https://bitbox.swiss/updates/desktop.json"
+const updateFileURL = "https://bitboxapp.shiftcrypto.io/desktop.json"
 
 var (
 	// Version of the backend as displayed to the user.


### PR DESCRIPTION
The desktop.json/banners.json files are moved from the bitbox.swiss website to a dedicated domain to serve files to the BitBoxApp.

The old URLs will do a 301 redirect to the new ones - old BitBoxApp versions will automatically follow the redirects.