### PR TITLE
backend/aopp: fix bug in aopp signing flow

### DIFF
--- a/backend/aopp.go
+++ b/backend/aopp.go
@@ -179,6 +179,16 @@ func (backend *Backend) aoppKeystoreRegistered() {
 	var accounts []account
 	var filteredDueToScriptType bool
 	for _, acct := range backend.accounts {
+		accountFingerprint, err := acct.Config().Config.SigningConfigurations.RootFingerprint()
+		if err != nil {
+			backend.log.WithError(err).Error("Account rootfingerprint not available")
+			backend.aoppSetError(errAOPPUnknown)
+			return
+		}
+
+		if err := compareRootFingerprint(backend.keystore, accountFingerprint); err != nil {
+			continue
+		}
 		if acct.Config().Config.Inactive || acct.Config().Config.HiddenBecauseUnused {
 			continue
 		}


### PR DESCRIPTION
Since watch-only feature introduction, AOPP doesn't correctly handle the available accounts list, making it possible to request signing a message for an account, while having a different wallet connected. In that case there is a mismatch between the addresses displayed by the bbapp and the wallet. This also causes the signing flow to fail because of the mismatch between the address and the signature.

This commit gives a poor man's fix to the issue, filtering the available accounts and including only those belonging to the currently connected keystore.