### PR TITLE
backend: adjust chart display to start from zero after first tx

### DIFF
--- a/backend/chart.go
+++ b/backend/chart.go
@@ -282,11 +282,13 @@ func (backend *Backend) ChartData() (*Chart, error) {
 				FormattedValue: coin.FormatAsCurrency(currentTotal, isFiatBtc, formatBtcAsSat),
 			})
 		}
-
-		// Truncate leading zeroes.
+		// Truncate leading zeroes, if there are any keep the first one to start the chart with 0
 		for i, e := range result {
 			if e.Value > 0 {
-				return result[i:]
+				if i == 0 {
+					return result
+				}
+				return result[i-1:]
 			}
 		}
 		// Everything was zeroes.


### PR DESCRIPTION
This commit modifies the chart display after the initial transaction. Previously, the chart would begin at the first fiat value of the transaction,  resulting in only one data point visible in the middle of the chart. With this update, the chart now starts at zero, providing a better view of the data.