### PR TITLE
frontend: fix bitsurance button in german

### DIFF
--- a/frontends/web/src/routes/bitsurance/bitsurance.module.css
+++ b/frontends/web/src/routes/bitsurance/bitsurance.module.css
@@ -18,13 +18,14 @@
   margin-left: 10px;
 }
 
-.ctaButton button{
-  max-width: 240px;
-  padding: 0;
+.ctaButton button {
+  padding: 0 var(--space-half);
+  width: auto !important;
 }
 
 .ctaButton img {
   margin-right: var(--space-quarter);
+  vertical-align: text-bottom;
 }
 
 .ctaButton:focus img,


### PR DESCRIPTION
In German the button text was much longer and broke onto 2 lines.

Also the button icon was not positioned nicely anymore.

Changed to let buttons grow to 100% before they break to 2 lines, also changed the spacing a bit so that even if there are 2 lines the icon is positioned nicely.

![image](https://github.com/digitalbitbox/bitbox-wallet-app/assets/546900/14c75c37-dda5-4997-89e1-9ae7a389e921)
