### PR TITLE
frontend: fix disabled chart filters after user empty wallet

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -135,6 +135,10 @@ class Chart extends Component<Props, State> {
     return this.props.data.chartDataDaily && this.props.data.chartDataDaily.length > 0;
   };
 
+  private hasHourlyData = (): boolean => {
+    return this.props.data.chartDataHourly && this.props.data.chartDataHourly.length > 0;
+  };
+
   private setFormattedData(data: ChartData) {
     this.formattedData = {} as FormattedData;
 
@@ -482,11 +486,14 @@ class Chart extends Component<Props, State> {
     } = this.state;
     const hasDifferenece = difference && Number.isFinite(difference);
     const hasData = this.hasData();
+    const hasHourlyData = this.hasHourlyData();
     const disableFilters = !hasData || chartDataMissing;
+    const disableWeeklyFilters = !hasHourlyData || chartDataMissing;
     const showMobileTotalValue = toolTipVisible && !!toolTipValue && isMobile;
     const chartFiltersProps = {
       display,
       disableFilters,
+      disableWeeklyFilters,
       onDisplayWeek: this.displayWeek,
       onDisplayMonth: this.displayMonth,
       onDisplayYear: this.displayYear,

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -482,7 +482,7 @@ class Chart extends Component<Props, State> {
     } = this.state;
     const hasDifferenece = difference && Number.isFinite(difference);
     const hasData = this.hasData();
-    const disableFilters = !hasData || chartTotal === 0 || chartDataMissing;
+    const disableFilters = !hasData || chartDataMissing;
     const showMobileTotalValue = toolTipVisible && !!toolTipValue && isMobile;
     const chartFiltersProps = {
       display,

--- a/frontends/web/src/routes/account/summary/filters.tsx
+++ b/frontends/web/src/routes/account/summary/filters.tsx
@@ -21,6 +21,7 @@ import styles from './chart.module.css';
 const Filters = ({
   display,
   disableFilters,
+  disableWeeklyFilters,
   onDisplayWeek,
   onDisplayMonth,
   onDisplayYear,
@@ -31,7 +32,7 @@ const Filters = ({
     <div className={styles.filters}>
       <button
         className={display === 'week' ? styles.filterActive : undefined}
-        disabled={disableFilters}
+        disabled={disableFilters || disableWeeklyFilters}
         onClick={onDisplayWeek}>
         {t('chart.filter.week')}
       </button>

--- a/frontends/web/src/routes/account/summary/types.ts
+++ b/frontends/web/src/routes/account/summary/types.ts
@@ -19,6 +19,7 @@ export type TChartDisplay = 'week' | 'month' | 'year' | 'all';
 export type TChartFiltersProps = {
   display: TChartDisplay
   disableFilters: boolean;
+  disableWeeklyFilters: boolean;
   onDisplayWeek: () => void;
   onDisplayMonth: () => void;
   onDisplayYear: () => void;


### PR DESCRIPTION
This commit addresses the problem of disabled chart filters in the portfolio view when users empty their wallet. They were unable to change the chart view once they emptied their wallet.