### PR TITLE
frontend: do not sort accounts

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -46,7 +46,6 @@ import { AuthRequired } from './components/auth/authrequired';
 import { WCWeb3WalletProvider } from './contexts/WCWeb3WalletProvider';
 import { RatesProvider } from './contexts/RatesProvider';
 import { WCSigningRequest } from './components/wallet-connect/incoming-signing-request';
-import { sortAccounts } from './routes/account/utils';
 
 export const App = () => {
   const { t } = useTranslation();
@@ -146,8 +145,7 @@ export const App = () => {
   };
 
   const deviceIDs: string[] = Object.keys(devices);
-  const sortedAccounts = sortAccounts(accounts);
-  const activeAccounts = sortedAccounts.filter(acct => acct.active);
+  const activeAccounts = accounts.filter(acct => acct.active);
   return (
     <ConnectedApp>
       <AppProvider>
@@ -184,7 +182,7 @@ export const App = () => {
                     })
                   }
                   <AppRouter
-                    accounts={sortedAccounts}
+                    accounts={accounts}
                     activeAccounts={activeAccounts}
                     deviceIDs={deviceIDs}
                     devices={devices}

--- a/frontends/web/src/routes/account/utils.test.ts
+++ b/frontends/web/src/routes/account/utils.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { CoinCode, IAccount } from '../../api/account';
-import { getAccountsByKeystore, sortAccounts } from './utils';
+import { getAccountsByKeystore } from './utils';
 
 
 const createAccount = ({
@@ -127,54 +127,6 @@ describe('utils/getAccountsByKeystore', () => {
     expect(result[1].accounts.every(({ keystore }) => keystore.rootFingerprint === 'w2')).toBe(true);
     expect(result[0].accounts[2].code).toBe(accounts[6].code);
     expect(result[1].accounts[3].code).toBe(accounts[5].code);
-  });
-
-});
-
-describe('utils/sortAccounts', () => {
-
-  it('should return a new sorted array', () => {
-    const accounts = [
-      createAccount({ code: 'a2', name: 'A2', keystore: { name: 'W1', rootFingerprint: 'w1' } }),
-      createAccount({ code: 'b2', name: 'B2', keystore: { name: 'W2', rootFingerprint: 'w2' } }),
-      createAccount({ code: 'a3', name: 'A3', keystore: { name: 'W1', rootFingerprint: 'w1' } }),
-      createAccount({ code: 'a1', name: 'A1', keystore: { name: 'W1', rootFingerprint: 'w1' } }),
-      createAccount({ code: 'b3', name: 'B3', keystore: { name: 'W2', rootFingerprint: 'w2' } }),
-      createAccount({ code: 'b1', name: 'B1', keystore: { name: 'W2', rootFingerprint: 'w2' } }),
-      createAccount({ code: 'b4', name: 'B4', keystore: { name: 'W2', rootFingerprint: 'w2' } }),
-    ];
-    const result = sortAccounts(accounts);
-    expect(accounts).not.toBe(result);
-    expect(result.length).toBe(accounts.length);
-    expect(result[0].keystore.rootFingerprint).toBe('w1');
-    expect(result[1].keystore.rootFingerprint).toBe('w1');
-    expect(result[2].keystore.rootFingerprint).toBe('w1');
-    expect(result[3].keystore.rootFingerprint).toBe('w2');
-    expect(result[4].keystore.rootFingerprint).toBe('w2');
-    expect(result[5].keystore.rootFingerprint).toBe('w2');
-    expect(result[6].keystore.rootFingerprint).toBe('w2');
-  });
-
-  it('should return a new sorted array, but this time all keystores have the same name', () => {
-    const accounts = [
-      createAccount({ code: 'a2', name: 'A2', keystore: { name: 'W1', rootFingerprint: 'w1' } }),
-      createAccount({ code: 'b2', name: 'B2', keystore: { name: 'W1', rootFingerprint: 'w2' } }),
-      createAccount({ code: 'a3', name: 'A3', keystore: { name: 'W1', rootFingerprint: 'w1' } }),
-      createAccount({ code: 'a1', name: 'A1', keystore: { name: 'W1', rootFingerprint: 'w1' } }),
-      createAccount({ code: 'b3', name: 'B3', keystore: { name: 'W1', rootFingerprint: 'w2' } }),
-      createAccount({ code: 'b1', name: 'B1', keystore: { name: 'W1', rootFingerprint: 'w2' } }),
-      createAccount({ code: 'b4', name: 'B4', keystore: { name: 'W1', rootFingerprint: 'w2' } }),
-    ];
-    const result = sortAccounts(accounts);
-    expect(accounts).not.toBe(result);
-    expect(result.length).toBe(accounts.length);
-    expect(result[0].keystore.rootFingerprint).toBe('w1');
-    expect(result[1].keystore.rootFingerprint).toBe('w1');
-    expect(result[2].keystore.rootFingerprint).toBe('w1');
-    expect(result[3].keystore.rootFingerprint).toBe('w2');
-    expect(result[4].keystore.rootFingerprint).toBe('w2');
-    expect(result[5].keystore.rootFingerprint).toBe('w2');
-    expect(result[6].keystore.rootFingerprint).toBe('w2');
   });
 
 });

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -100,12 +100,6 @@ export type TAccountsByKeystore = {
   accounts: IAccount[];
 };
 
-export const sortAccounts = (accounts: IAccount[]): IAccount[] => {
-  return Array.from(accounts).sort((ac1, ac2) => {
-    return `${ac1.keystore.rootFingerprint}${ac1.code}`.localeCompare(`${ac2.keystore.rootFingerprint}${ac2.code}`);
-  });
-};
-
 // Returns the accounts grouped by the keystore fingerprint.
 export function getAccountsByKeystore(accounts: IAccount[]): TAccountsByKeystore[] {
   return Object.values(accounts.reduce((acc, account) => {


### PR DESCRIPTION
The backend has a fairly involved accounts sorting function already in `backend/accounts.go:sortAccounts`. The current frontend sorting function sorts lexicographically by fingerprint and account code, which is a different ordering than before, but has two more problems:

- account number 10 comes before account number 2, which is wrong
- account codes cannot be relied upon to have the current structure, they could be random IDs, in which case the accounts would be ordered randomly

The original sorting in the frontend was added in
937a023bfa16e9de69ce52da4b1b7df5c10333a1 to work around a React bug where accounts were ordered differently in the sidebar vs manage accounts, but since moving to React functional components in both places, this is not needed anymore.