### PR TITLE
experiment] frontend: show spinner after unlock, before accounts are loaded

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { TKeystores, subscribeKeystores, getKeystores } from '../../api/keystores';
+import { useKeystores } from '../../hooks/backend';
 import { IAccount } from '../../api/account';
 import coins from '../../assets/icons/coins.svg';
 import ejectIcon from '../../assets/icons/eject.svg';
@@ -130,15 +130,7 @@ const Sidebar = ({
     };
   }, [activeSidebar, sidebarStatus, toggleSidebar]);
 
-  const [keystores, setKeystores] = useState<TKeystores>();
-
-  useEffect(() => {
-    getKeystores().then(keystores => {
-      setKeystores(keystores);
-    });
-    // this passes the unsubscribe function directly the return function of useEffect, used when the component unmounts.
-    return subscribeKeystores(setKeystores);
-  }, []);
+  const keystores = useKeystores();
 
   const handleSidebarItemClick = (event: React.SyntheticEvent) => {
     const el = (event.target as Element).closest('a');

--- a/frontends/web/src/hooks/backend.ts
+++ b/frontends/web/src/hooks/backend.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { TKeystores, subscribeKeystores, getKeystores } from '../api/keystores';
+
+export function useKeystores(): TKeystores | undefined {
+  const [keystores, setKeystores] = useState<TKeystores>();
+  useEffect(() => {
+    getKeystores().then(keystores => {
+      setKeystores(keystores);
+    });
+    // this passes the unsubscribe function directly the return function of useEffect, used when the component unmounts.
+    return subscribeKeystores(setKeystores);
+  }, []);
+  return keystores;
+}

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -16,9 +16,14 @@
 
 import { useTranslation } from 'react-i18next';
 import { i18n } from '../../i18n/i18n';
+import { getDeviceList } from '../../api/devices';
+import { syncDeviceList } from '../../api/devicessync';
+import { useSync } from '../..//hooks/api';
+import { useKeystores } from '../../hooks/backend';
 import { useDarkmode } from '../../hooks/darkmode';
 import { Entry } from '../../components/guide/entry';
 import { Guide } from '../../components/guide/guide';
+import { Spinner } from '../../components/spinner/Spinner';
 import { AppLogo, AppLogoInverted, SwissMadeOpenSource, SwissMadeOpenSourceDark } from '../../components/icon/logo';
 import { Footer, Header } from '../../components/layout';
 import style from './bitbox01/bitbox01.module.css';
@@ -27,6 +32,13 @@ export const Waiting = () => {
   const { t } = useTranslation();
   const { isDarkMode } = useDarkmode();
 
+  const keystores = useKeystores();
+  const devices = useSync(getDeviceList, syncDeviceList);
+  if ((keystores !== undefined && keystores.length) || (devices !== undefined && Object.keys(devices).length)) {
+    return (
+      <Spinner guideExists text={'Loading accounts'} />
+    );
+  }
   return (
     <div className="contentWithGuide">
       <div className="container">


### PR DESCRIPTION
After unlock, especially the first time, it can take many seconds for the initial set of accounts to be loaded. Until then, the app shows nothing in the sidebar and 'Please connect your device to get started'.

The user is easily confused, it seems as something went wrong.

We can probably speed up this loading with firmware and app changes, but this is a quick improvement that shows a spinner until the accounts become available.