### PR TITLE
backend: fix balance time series computation with failed txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix build on M-processor Apple machines
 - Add support for Ethereum EIP-1559 transactions: https://eips.ethereum.org/EIPS/eip-1559
 - Replace deprecated Ethgasstation with Etherscan for fee estimation (including base + priority fee for EIP-1559)
+- Fixed a bug where the portfolio chart could show wrong values in an Ethereum account containing failed transactions
 
 ## 4.40.0
 - Add support for watch-only - see your accounts and portfolio without connecting your BitBox02

--- a/backend/accounts/transaction.go
+++ b/backend/accounts/transaction.go
@@ -163,15 +163,21 @@ func NewOrderedTransactions(txs []*TransactionData) OrderedTransactions {
 		tx := txs[i]
 		switch tx.Type {
 		case TxTypeReceive:
-			balance.Add(balance, tx.Amount.BigInt())
+			if tx.Status != TxStatusFailed {
+				balance.Add(balance, tx.Amount.BigInt())
+			}
 		case TxTypeSend:
-			balance.Sub(balance, tx.Amount.BigInt())
-			// Subtract fee as well.
+			if tx.Status != TxStatusFailed {
+				balance.Sub(balance, tx.Amount.BigInt())
+			}
+			// Subtract fee as well. Ethereum: it is deducted even if the tx failed, as the tx was
+			// mined.
 			if tx.Fee != nil && !tx.FeeIsDifferentUnit {
 				balance.Sub(balance, tx.Fee.BigInt())
 			}
 		case TxTypeSendSelf:
-			// Subtract only fee.
+			// Subtract only fee. Ethereum: it is deducted even if the tx failed, as the tx was
+			// mined.
 			if tx.Fee != nil && !tx.FeeIsDifferentUnit {
 				balance.Sub(balance, tx.Fee.BigInt())
 			}


### PR DESCRIPTION
In ETH, there can be failed transactions that are mined (gas limit too low). The fee is deducted, but the amount is not transfered.

We need to take this into account, otherwise the chart can go out of whack.