### PR TITLE
frontend: split lightning send workflow into smaller components

### DIFF
--- a/frontends/web/src/routes/lightning/send/send.tsx
+++ b/frontends/web/src/routes/lightning/send/send.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2023 Shift Crypto AG
+ * Copyright 2023-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import * as accountApi from '../../../api/account';
 import { Column, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
 import { View, ViewButtons, ViewContent } from '../../../components/view/view';
 import { Button } from '../../../components/forms';
-import { InputType, InputTypeVariant, SdkError, getParseInput, postSendPayment } from '../../../api/lightning';
+import { InputType, InputTypeVariant, LnInvoice, SdkError, getParseInput, postSendPayment } from '../../../api/lightning';
 import { SimpleMarkup } from '../../../utils/markup';
 import { route } from '../../../utils/route';
 import { toSat } from '../../../utils/conversion';
@@ -46,7 +46,135 @@ const SendingSpinner = () => {
   return <Spinner text={message} guideExists={false} />;
 };
 
-export function Send() {
+type InvoiceInputProps = {
+  invoice: LnInvoice;
+};
+
+const InvoiceInput = ({ invoice }: InvoiceInputProps) => {
+  const { t } = useTranslation();
+  const balance: accountApi.IBalance = {
+    hasAvailable: true,
+    available: {
+      amount: `${toSat(invoice.amountMsat || 0)}`,
+      // TODO: conversions missing
+      unit: 'sat'
+    },
+    hasIncoming: false,
+    incoming: {
+      amount: '0',
+      unit: 'sat'
+    }
+  };
+  return (
+    <>
+      <h1 className={styles.title}>{t('lightning.send.confirm.title')}</h1>
+      <div className={styles.info}>
+        <h2 className={styles.label}>{t('lightning.send.confirm.amount')}</h2>
+        <Amount amount={balance.available.amount} unit={balance.available.unit} removeBtcTrailingZeroes />/{' '}
+        <FiatConversion amount={balance.available} noBtcZeroes />
+      </div>
+      {invoice.description && (
+        <div className={styles.info}>
+          <h2 className={styles.label}>{t('lightning.send.confirm.memo')}</h2>
+          {invoice.description}
+        </div>
+      )}
+    </>
+  );
+};
+
+type PaymentInputProps = {
+  input: InputType;
+};
+
+const PaymentInput = ({ input }: PaymentInputProps) => {
+  switch (input.type) {
+  case InputTypeVariant.BOLT11:
+    return (
+      <InvoiceInput invoice={input.invoice} />
+    );
+  }
+};
+
+type SendWorkflowProps = {
+  onBack: () => void;
+  onInput: (input: string) => void;
+  onSend: () => void;
+  parsedInput?: InputType;
+  rawInputError?: string;
+  step: TStep;
+};
+
+const SendWorkflow = ({
+  onBack,
+  onInput,
+  onSend,
+  parsedInput,
+  rawInputError,
+  step,
+}: SendWorkflowProps) => {
+  const { t } = useTranslation();
+  switch (step) {
+  case 'select-invoice':
+    return (
+      <View fitContent>
+        <ViewContent textAlign="center">
+          <Grid col="1">
+            <Column>
+              {/* this flickers quickly, as there is 'SdkError: Generic: Breez SDK error: Unrecognized input type' when logging rawInputError */}
+              {rawInputError && <Status type="warning">{rawInputError}</Status>}
+              <ScanQRVideo onResult={onInput} />
+              {/* Note: unfortunatelly we probably can't read from HTML5 clipboard api directly in Qt/Android WebView */}
+              <Button transparent onClick={() => console.log('TODO: implement paste')}>
+                {t('lightning.send.rawInput.label')}
+              </Button>
+            </Column>
+          </Grid>
+        </ViewContent>
+        <ViewButtons reverseRow>
+          <Button secondary onClick={onBack}>
+            {t('button.back')}
+          </Button>
+        </ViewButtons>
+      </View>
+    );
+  case 'confirm':
+    if (!parsedInput) {
+      return 'no invoice found';
+    }
+    return (
+      <View fitContent minHeight="100%">
+        <ViewContent>
+          <Grid col="1">
+            <Column>
+              <PaymentInput input={parsedInput} />
+            </Column>
+          </Grid>
+        </ViewContent>
+        <ViewButtons>
+          <Button primary onClick={onSend}>
+            {t('button.send')}
+          </Button>
+          <Button secondary onClick={onBack}>
+            {t('button.back')}
+          </Button>
+        </ViewButtons>
+      </View>
+    );
+  case 'sending':
+    return <SendingSpinner />;
+  case 'success':
+    return (
+      <View fitContent textCenter verticallyCentered>
+        <ViewContent withIcon="success">
+          <SimpleMarkup className={styles.successMessage} markup={t('lightning.send.success.message')} tagName="p" />
+        </ViewContent>
+      </View>
+    );
+  }
+};
+
+export const Send = () => {
   const { t } = useTranslation();
   const [parsedInput, setParsedInput] = useState<InputType>();
   const [rawInputError, setRawInputError] = useState<string>();
@@ -109,97 +237,6 @@ export function Send() {
     }
   };
 
-  const renderInputTypes = () => {
-    switch (parsedInput!.type) {
-    case InputTypeVariant.BOLT11:
-      const balance: accountApi.IBalance = {
-        hasAvailable: true,
-        available: {
-          amount: `${toSat(parsedInput?.invoice.amountMsat || 0)}`,
-          unit: 'sat'
-        },
-        hasIncoming: false,
-        incoming: {
-          amount: '0',
-          unit: 'sat'
-        }
-      };
-      return (
-        <Column>
-          <h1 className={styles.title}>{t('lightning.send.confirm.title')}</h1>
-          <div className={styles.info}>
-            <h2 className={styles.label}>{t('lightning.send.confirm.amount')}</h2>
-            <Amount amount={balance.available.amount} unit={balance.available.unit} removeBtcTrailingZeroes />/{' '}
-            <FiatConversion amount={balance.available} noBtcZeroes />
-          </div>
-          {parsedInput?.invoice.description && (
-            <div className={styles.info}>
-              <h2 className={styles.label}>{t('lightning.send.confirm.memo')}</h2>
-              {parsedInput?.invoice.description}
-            </div>
-          )}
-        </Column>
-      );
-    }
-  };
-
-  const renderSteps = () => {
-    switch (step) {
-    case 'select-invoice':
-      return (
-        <View fitContent>
-          <ViewContent textAlign="center">
-            <Grid col="1">
-              <Column>
-                {/* this flickers quickly, as there is 'SdkError: Generic: Breez SDK error: Unrecognized input type' when logging rawInputError */}
-                {rawInputError && <Status type="warning">{rawInputError}</Status>}
-                <ScanQRVideo onResult={parseInput} />
-                {/* Note: unfortunatelly we probably can't read from HTML5 clipboard api directly in Qt/Andoird WebView */}
-                <Button transparent onClick={() => console.log('TODO: implement paste')}>
-                  {t('lightning.send.rawInput.label')}
-                </Button>
-              </Column>
-            </Grid>
-          </ViewContent>
-          <ViewButtons reverseRow>
-            {/* <Button primary onClick={parseInput} disabled={busy}>
-            {t('button.send')}
-          </Button> */}
-            <Button secondary onClick={back}>
-              {t('button.back')}
-            </Button>
-          </ViewButtons>
-        </View>
-      );
-    case 'confirm':
-      return (
-        <View fitContent minHeight="100%">
-          <ViewContent>
-            <Grid col="1">{renderInputTypes()}</Grid>
-          </ViewContent>
-          <ViewButtons>
-            <Button primary onClick={sendPayment}>
-              {t('button.send')}
-            </Button>
-            <Button secondary onClick={back}>
-              {t('button.back')}
-            </Button>
-          </ViewButtons>
-        </View>
-      );
-    case 'sending':
-      return <SendingSpinner />;
-    case 'success':
-      return (
-        <View fitContent textCenter verticallyCentered>
-          <ViewContent withIcon="success">
-            <SimpleMarkup className={styles.successMessage} markup={t('lightning.send.success.message')} tagName="p" />
-          </ViewContent>
-        </View>
-      );
-    }
-  };
-
   return (
     <GuideWrapper>
       <GuidedContent>
@@ -208,9 +245,16 @@ export function Send() {
             {sendError}
           </Status>
           <Header title={<h2>{t('lightning.send.title')}</h2>} />
-          {renderSteps()}
+          <SendWorkflow
+            onBack={back}
+            onInput={parseInput}
+            onSend={sendPayment}
+            parsedInput={parsedInput}
+            rawInputError={rawInputError}
+            step={step}
+          />
         </Main>
       </GuidedContent>
     </GuideWrapper>
   );
-}
+};


### PR DESCRIPTION
Having one big component with multiple conditional variable child components is convenient but can also lead to more spaghetti code.

Split Send into separate components, similar as we did in setup.