### PR TITLE
frontend: move lightning as first keystore item in the sidebar

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -200,6 +200,10 @@ const Sidebar = ({
           </div>
         ) : null }
 
+        {lightningConfig.accounts.length !== 0 && (
+          <GetLightningLink key="lightning" handleSidebarItemClick={handleSidebarItemClick} />
+        )}
+
         { accountsByKeystore.map(keystore => (
           <div key={`keystore-${keystore.keystore.rootFingerprint}`}>
             <div className={style.sidebarHeaderContainer}>
@@ -227,7 +231,6 @@ const Sidebar = ({
             ))}
           </div>
         )) }
-        {lightningConfig.accounts.length > 0 && <GetLightningLink handleSidebarItemClick={handleSidebarItemClick} />}
 
         <div key="services" className={[style.sidebarHeaderContainer, style.end].join(' ')}></div>
         { accounts.length ? (


### PR DESCRIPTION
This commit moves Lightning item in the sidebar to be the first item of each wallet (keystore).

Alternative would be before the wallets, after the 'My portfolio' item, this would be suitable if only one lightning wallet should be supported.