### PR TITLE
backend/lightning: refactor lightning configuration

### DIFF
--- a/backend/config/config_test.go
+++ b/backend/config/config_test.go
@@ -110,14 +110,19 @@ func TestSetLightningConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	lightningCfg := cfg.LightningConfig()
-	require.Equal(t, true, lightningCfg.Inactive)
-	lightningCfg.Inactive = false
+	require.Equal(t, 0, len(lightningCfg.Accounts))
+	lightningCfg.Accounts = append(lightningCfg.Accounts, &LightningAccountConfig{
+		Mnemonic:        "test",
+		Code:            "v0-test-ln-0",
+		Number:          0,
+		RootFingerprint: []byte("fingerprint"),
+	})
 	require.NoError(t, cfg.SetLightningConfig(lightningCfg))
 
 	cfg2, err := NewConfig(appConfigFilename, accountsConfigFilename, lightningConfigFilename)
 	require.NoError(t, err)
 	require.Equal(t, cfg, cfg2)
-	require.Equal(t, false, cfg2.LightningConfig().Inactive)
+	require.Equal(t, 1, len(lightningCfg.Accounts))
 }
 
 // TestMigrationSaved tests that migrations are applied when a config is loaded, and that the

--- a/backend/config/lightning.go
+++ b/backend/config/lightning.go
@@ -15,17 +15,35 @@
 
 package config
 
+import (
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
+	"github.com/digitalbitbox/bitbox-wallet-app/util/jsonp"
+)
+
+// LightningAccountConfig is the configuration of a single Lightning account.
+type LightningAccountConfig struct {
+	// Mnemonic is the wallet node generated from the device entropy.
+	Mnemonic string `json:"mnemonic"`
+	// RootFingerprint is fingerprint of the keystore that generated the entropy.
+	RootFingerprint jsonp.HexBytes `json:"rootFingerprint"`
+	// Code is the code of the lightning account.
+	Code types.Code `json:"code"`
+	// Number is the lightning account incremental number.
+	Number uint16 `json:"number"`
+}
+
 // LightningConfig holds information related to the lightning config.
 type LightningConfig struct {
 	// Inactive is true if lightning has not yet been setup.
 	Inactive bool `json:"inactive"`
-	// Mnemonic is the wallet node generated from the device entropy.
-	Mnemonic string `json:"mnemonic"`
+	// Accounts is an array of existing lightning accounts configurations.
+	Accounts []*LightningAccountConfig `json:"accounts"`
 }
 
 // newDefaultAccountsConfig returns the default accounts config.
 func newDefaultLightningConfig() LightningConfig {
 	return LightningConfig{
 		Inactive: true,
+		Accounts: []*LightningAccountConfig{},
 	}
 }

--- a/backend/config/lightning.go
+++ b/backend/config/lightning.go
@@ -29,13 +29,11 @@ type LightningAccountConfig struct {
 	// Code is the code of the lightning account.
 	Code types.Code `json:"code"`
 	// Number is the lightning account incremental number.
-	Number uint16 `json:"number"`
+	Number uint16 `json:"num"`
 }
 
 // LightningConfig holds information related to the lightning config.
 type LightningConfig struct {
-	// Inactive is true if lightning has not yet been setup.
-	Inactive bool `json:"inactive"`
 	// Accounts is an array of existing lightning accounts configurations.
 	Accounts []*LightningAccountConfig `json:"accounts"`
 }
@@ -43,7 +41,6 @@ type LightningConfig struct {
 // newDefaultAccountsConfig returns the default accounts config.
 func newDefaultLightningConfig() LightningConfig {
 	return LightningConfig{
-		Inactive: true,
 		Accounts: []*LightningAccountConfig{},
 	}
 }

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -16,10 +16,13 @@
 package lightning
 
 import (
+	"encoding/hex"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/breez/breez-sdk-go/breez_sdk"
+	"github.com/digitalbitbox/bitbox-wallet-app/backend/accounts/types"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/config"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/keystore"
 	"github.com/digitalbitbox/bitbox-wallet-app/util/errp"
@@ -62,6 +65,10 @@ func (lightning *Lightning) Activate() error {
 		return errp.New("Lightning node already active")
 	}
 
+	if len(lightningConfig.Accounts) > 0 {
+		return errp.New("Lightning accounts already configured")
+	}
+
 	keystore := lightning.getKeystore()
 	if keystore == nil || !keystore.SupportsDeterministicEntropy() {
 		return errp.New("No keystore available")
@@ -72,14 +79,25 @@ func (lightning *Lightning) Activate() error {
 		return err
 	}
 
+	fingerprint, err := keystore.RootFingerprint()
+	if err != nil {
+		return err
+	}
+
 	entropyMnemonic, err := bip39.NewMnemonic(entropy)
 	if err != nil {
 		lightning.log.WithError(err).Warn("Error generating mnemonic")
 		return errp.New("Error generating mnemonic")
 	}
 
+	lightningAccount := config.LightningAccountConfig{
+		Mnemonic:        entropyMnemonic,
+		RootFingerprint: fingerprint,
+		Code:            types.Code(strings.Join([]string{"v0-", hex.EncodeToString(fingerprint), "-ln-0"}, "")),
+		Number:          0,
+	}
 	lightningConfig.Inactive = false
-	lightningConfig.Mnemonic = entropyMnemonic
+	lightningConfig.Accounts = append(lightningConfig.Accounts, &lightningAccount)
 
 	if err = lightning.setLightningConfig(lightningConfig); err != nil {
 		return err
@@ -119,7 +137,7 @@ func (lightning *Lightning) Deactivate() error {
 	lightning.Disconnect()
 
 	lightningConfig.Inactive = true
-	lightningConfig.Mnemonic = ""
+	lightningConfig.Accounts = []*config.LightningAccountConfig{}
 
 	if err := lightning.setLightningConfig(lightningConfig); err != nil {
 		return err
@@ -128,15 +146,23 @@ func (lightning *Lightning) Deactivate() error {
 	return nil
 }
 
+func accountBreezFolder(accountCode types.Code) string {
+	return strings.Join([]string{"breez-", string(accountCode)}, "")
+}
+
 // connect initializes the connection configuration and calls connect to create a Breez SDK instance.
 func (lightning *Lightning) connect() {
 	lightningConfig := lightning.config.LightningConfig()
 
-	if !lightningConfig.Inactive && len(lightningConfig.Mnemonic) > 0 && lightning.sdkService == nil {
+	if !lightningConfig.Inactive && len(lightningConfig.Accounts) > 0 && lightning.sdkService == nil {
 		initializeLogging(lightning.log)
 
+		// At the moment we only support one LN account, but the config files could possibly
+		// support multiple accounts, for future extensions.
+		account := lightningConfig.Accounts[0]
+
 		// TODO: this seed should be determined from the account/device.
-		seed, err := breez_sdk.MnemonicToSeed(lightningConfig.Mnemonic)
+		seed, err := breez_sdk.MnemonicToSeed(account.Mnemonic)
 
 		if err != nil {
 			lightning.log.WithError(err).Warn("BreezSDK: MnemonicToSeed failed")
@@ -150,7 +176,7 @@ func (lightning *Lightning) connect() {
 			},
 		}
 
-		workingDir := path.Join(lightning.cacheDirectoryPath, "breez-sdk")
+		workingDir := path.Join(lightning.cacheDirectoryPath, accountBreezFolder(account.Code))
 
 		if err := os.MkdirAll(workingDir, 0700); err != nil {
 			lightning.log.WithError(err).Warn("Error creating working directory")

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -15,6 +15,7 @@
  */
 
 import { apiGet, apiPost } from '../utils/request';
+import { AccountCode } from './account';
 import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
 import qs from 'query-string';
 
@@ -25,8 +26,15 @@ export interface ILightningResponse<T> {
   errorCode?: string;
 }
 
-export type LightningConfig = {
-  inactive: boolean;
+export type TLightningAccountConfig = {
+  mnemonic: string;
+  rootFingerprint: string;
+  code: AccountCode;
+  num: number;
+};
+
+export type TLightningConfig = {
+  accounts: TLightningAccountConfig[];
 };
 
 export type NodeSetup = {
@@ -878,11 +886,11 @@ const postApiResponse = async <T, C extends object | undefined>(url: string, dat
  * Lightning interface
  */
 
-export const getLightningConfig = async (): Promise<LightningConfig> => {
+export const getLightningConfig = async (): Promise<TLightningConfig> => {
   return await apiGet('lightning/config');
 };
 
-export const postLightningConfig = async (data: LightningConfig): Promise<void> => {
+export const postLightningConfig = async (data: TLightningConfig): Promise<void> => {
   return await apiPost('lightning/config', data);
 };
 
@@ -938,7 +946,7 @@ export const postReceivePayment = async (data: ReceivePaymentRequest): Promise<R
  * event to notify when a change to the lightning config has occurred.
  * Meant to be used with `useSubscribe`.
  */
-export const subscribeLightningConfig = (cb: TSubscriptionCallback<LightningConfig>) => {
+export const subscribeLightningConfig = (cb: TSubscriptionCallback<TLightningConfig>) => {
   return subscribeEndpoint('lightning/config', cb);
 };
 

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -227,7 +227,7 @@ const Sidebar = ({
             ))}
           </div>
         )) }
-        {!lightningConfig.inactive && <GetLightningLink handleSidebarItemClick={handleSidebarItemClick} />}
+        {lightningConfig.accounts.length > 0 && <GetLightningLink handleSidebarItemClick={handleSidebarItemClick} />}
 
         <div key="services" className={[style.sidebarHeaderContainer, style.end].join(' ')}></div>
         { accounts.length ? (

--- a/frontends/web/src/contexts/LightningContext.tsx
+++ b/frontends/web/src/contexts/LightningContext.tsx
@@ -15,10 +15,10 @@
  */
 
 import { createContext } from 'react';
-import { LightningConfig } from '../api/lightning';
+import { TLightningConfig } from '../api/lightning';
 
 type Props = {
-    lightningConfig: LightningConfig;
+    lightningConfig: TLightningConfig;
 }
 
 export const LightningContext = createContext<Props>({} as Props);

--- a/frontends/web/src/contexts/LightningProvider.tsx
+++ b/frontends/web/src/contexts/LightningProvider.tsx
@@ -16,7 +16,7 @@
 
 import { ReactNode } from 'react';
 import { LightningContext } from './LightningContext';
-import { getLightningConfig, subscribeLightningConfig } from '../api/lightning';
+import { TLightningAccountConfig, getLightningConfig, subscribeLightningConfig } from '../api/lightning';
 import { useSync } from '../hooks/api';
 import { useDefault } from '../hooks/default';
 
@@ -27,7 +27,7 @@ type TProps = {
 export const LightningProvider = ({ children }: TProps) => {
   const lightningConfig = useDefault(
     useSync(getLightningConfig, subscribeLightningConfig),
-    { inactive: true },
+    { accounts: {} as TLightningAccountConfig[] },
   );
 
   return (

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -84,7 +84,7 @@ export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetti
           <View fullscreen={false}>
             <ViewContent>
               <WithSettingsTabs deviceIDs={deviceIDs} hideMobileMenu hasAccounts={hasAccounts}>
-                {lightningConfig.inactive ? <EnableLightning /> : <DisableLightning />}
+                {lightningConfig.accounts.length === 0 ? <EnableLightning /> : <DisableLightning />}
                 <EnableCustomFeesToggleSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
                 <EnableCoinControlSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
                 <EnableAuthSetting backendConfig={backendConfig} onChangeConfig={setConfig} />


### PR DESCRIPTION
To ensure future compatibility in case we'll support multiple lightning accounts, we need to refactor the breez cache folder name and the lightning config struct, which is persisted as a json config file.