### PR TITLE
frontend: move lightning config to context

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -42,7 +42,6 @@ import { RouterWatcher } from './utils/route';
 import { Darkmode } from './components/darkmode/darkmode';
 import { AuthRequired } from './components/auth/authrequired';
 import { WCSigningRequest } from './components/wallet-connect/incoming-signing-request';
-import { getLightningConfig, subscribeLightningConfig } from './api/lightning';
 import { Providers } from './contexts/providers';
 
 export const App = () => {
@@ -51,7 +50,6 @@ export const App = () => {
 
   const accounts = useDefault(useSync(getAccounts, syncAccountsList), []);
   const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});
-  const lightningConfig = useDefault(useSync(getLightningConfig, subscribeLightningConfig), { inactive: true });
 
   const prevDevices = usePrevious(devices);
 
@@ -154,7 +152,6 @@ export const App = () => {
           <Sidebar
             accounts={activeAccounts}
             deviceIDs={deviceIDs}
-            lightningInactive={lightningConfig.inactive}
           />
           <div className="appContent flex flex-column flex-1" style={{ minWidth: 0 }}>
             <Update />
@@ -184,7 +181,6 @@ export const App = () => {
               deviceIDs={deviceIDs}
               devices={devices}
               devicesKey={devicesKey}
-              lightningInactive={lightningConfig.inactive}
             />
             <RouterWatcher />
           </div>

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -16,10 +16,12 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
 import { Link, NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { TKeystores, subscribeKeystores, getKeystores } from '../../api/keystores';
 import { IAccount } from '../../api/account';
+import { useLightning } from '../../hooks/lightning';
 import coins from '../../assets/icons/coins.svg';
 import ejectIcon from '../../assets/icons/eject.svg';
 import shieldIcon from '../../assets/icons/shield_grey.svg';
@@ -29,7 +31,6 @@ import settingsGrey from '../../assets/icons/settings-alt_disabled.svg';
 import { debug } from '../../utils/env';
 import { apiPost } from '../../utils/request';
 import Logo, { AppLogoInverted } from '../icon/logo';
-import { useLocation } from 'react-router';
 import { CloseXWhite, USBSuccess } from '../icon';
 import { getAccountsByKeystore, isAmbiguiousName, isBitcoinOnly } from '../../routes/account/utils';
 import { SkipForTesting } from '../../routes/device/components/skipfortesting';
@@ -40,7 +41,6 @@ import style from './sidebar.module.css';
 type SidebarProps = {
   deviceIDs: string[];
   accounts: IAccount[];
-  lightningInactive: boolean;
 };
 
 type ItemClickProps = { handleSidebarItemClick: (e: React.SyntheticEvent) => void };
@@ -91,11 +91,11 @@ const eject = (e: React.SyntheticEvent): void => {
 const Sidebar = ({
   deviceIDs,
   accounts,
-  lightningInactive,
 }: SidebarProps) => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
   const { activeSidebar, sidebarStatus, toggleSidebar } = useContext(AppContext);
+  const { lightningConfig } = useLightning();
 
   useEffect(() => {
     const swipe = {
@@ -227,7 +227,7 @@ const Sidebar = ({
             ))}
           </div>
         )) }
-        {!lightningInactive && <GetLightningLink handleSidebarItemClick={handleSidebarItemClick} />}
+        {!lightningConfig.inactive && <GetLightningLink handleSidebarItemClick={handleSidebarItemClick} />}
 
         <div key="services" className={[style.sidebarHeaderContainer, style.end].join(' ')}></div>
         { accounts.length ? (

--- a/frontends/web/src/contexts/LightningContext.tsx
+++ b/frontends/web/src/contexts/LightningContext.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext } from 'react';
+import { LightningConfig } from '../api/lightning';
+
+type Props = {
+    lightningConfig: LightningConfig;
+}
+
+export const LightningContext = createContext<Props>({} as Props);

--- a/frontends/web/src/contexts/LightningProvider.tsx
+++ b/frontends/web/src/contexts/LightningProvider.tsx
@@ -15,28 +15,28 @@
  */
 
 import { ReactNode } from 'react';
-import { DarkModeProvider } from './DarkmodeProvider';
-import { AppProvider } from './AppProvider';
-import { WCWeb3WalletProvider } from './WCWeb3WalletProvider';
-import { RatesProvider } from './RatesProvider';
-import { LightningProvider } from './LightningProvider';
+import { LightningContext } from './LightningContext';
+import { getLightningConfig, subscribeLightningConfig } from '../api/lightning';
+import { useSync } from '../hooks/api';
+import { useDefault } from '../hooks/default';
 
-type Props = {
+type TProps = {
   children: ReactNode;
-};
+}
 
-export const Providers = ({ children }: Props) => {
+export const LightningProvider = ({ children }: TProps) => {
+  const lightningConfig = useDefault(
+    useSync(getLightningConfig, subscribeLightningConfig),
+    { inactive: true },
+  );
+
   return (
-    <AppProvider>
-      <DarkModeProvider>
-        <RatesProvider>
-          <WCWeb3WalletProvider>
-            <LightningProvider>
-              {children}
-            </LightningProvider>
-          </WCWeb3WalletProvider>
-        </RatesProvider>
-      </DarkModeProvider>
-    </AppProvider>
+    <LightningContext.Provider
+      value={{
+        lightningConfig
+      }}>
+      {children}
+    </LightningContext.Provider>
   );
 };
+

--- a/frontends/web/src/hooks/lightning.ts
+++ b/frontends/web/src/hooks/lightning.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext } from 'react';
+import { LightningContext } from '../contexts/LightningContext';
+
+export const useLightning = () => {
+  const { lightningConfig } = useContext(LightningContext);
+  return { lightningConfig };
+};

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -35,13 +35,12 @@ import { ConnectScreenWalletConnect } from './account/walletconnect/connect';
 import { DashboardWalletConnect } from './account/walletconnect/dashboard';
 
 type TAppRouterProps = {
-    devices: TDevices;
-    deviceIDs: string[];
-    accounts: IAccount[];
-    activeAccounts: IAccount[];
-    devicesKey: ((input: string) => string)
-    lightningInactive: boolean;
-  }
+  devices: TDevices;
+  deviceIDs: string[];
+  accounts: IAccount[];
+  activeAccounts: IAccount[];
+  devicesKey: ((input: string) => string)
+}
 
 type TInjectParamsProps = {
   children: ReactChild;
@@ -52,7 +51,13 @@ const InjectParams = ({ children }: TInjectParamsProps) => {
   return React.cloneElement(children as React.ReactElement, params);
 };
 
-export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAccounts, lightningInactive }: TAppRouterProps) => {
+export const AppRouter = ({
+  devices,
+  deviceIDs,
+  devicesKey,
+  accounts,
+  activeAccounts,
+}: TAppRouterProps) => {
   const hasAccounts = accounts.length > 0;
   const Homepage = <DeviceSwitch
     key={devicesKey('device-switch-default')}
@@ -206,7 +211,6 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
     <AdvancedSettings
       deviceIDs={deviceIDs}
       hasAccounts={hasAccounts}
-      lightningInactive={lightningInactive}
     />
   </InjectParams>;
 

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoad } from '../../hooks/api';
+import { useLightning } from '../../hooks/lightning';
 import { Main, Header, GuideWrapper, GuidedContent } from '../../components/layout';
 import { View, ViewContent } from '../../components/view/view';
 import { WithSettingsTabs } from './components/tabs';
@@ -53,10 +54,11 @@ export type TConfig = {
   frontend?: TFrontendConfig;
 };
 
-export const AdvancedSettings = ({ deviceIDs, hasAccounts, lightningInactive }: TPagePropsWithSettingsTabs & { lightningInactive: boolean }) => {
+export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
   const fetchedConfig = useLoad(getConfig) as TConfig;
   const [config, setConfig] = useState<TConfig>();
+  const { lightningConfig } = useLightning();
 
   const frontendConfig = config?.frontend;
   const backendConfig = config?.backend;
@@ -82,7 +84,7 @@ export const AdvancedSettings = ({ deviceIDs, hasAccounts, lightningInactive }: 
           <View fullscreen={false}>
             <ViewContent>
               <WithSettingsTabs deviceIDs={deviceIDs} hideMobileMenu hasAccounts={hasAccounts}>
-                {lightningInactive ? <EnableLightning /> : <DisableLightning />}
+                {lightningConfig.inactive ? <EnableLightning /> : <DisableLightning />}
                 <EnableCustomFeesToggleSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
                 <EnableCoinControlSetting frontendConfig={frontendConfig} onChangeConfig={setConfig} />
                 <EnableAuthSetting backendConfig={backendConfig} onChangeConfig={setConfig} />


### PR DESCRIPTION
Moved Lightning config loader and subscription to a new lightning context/provider and hook, with this every component can now use the useLightning hook to get the current config.

This context could also be used to subscribe to NodeState changes.