### PR TITLE
backend/lightning: make ligthning SDK connection synchronous

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -687,7 +687,7 @@ func (backend *Backend) Start() <-chan interface{} {
 	backend.configureHistoryExchangeRates()
 
 	backend.environment.OnAuthSettingChanged(backend.config.AppConfig().Backend.Authentication)
-	backend.lightning.Connect()
+	go backend.lightning.Connect()
 	return backend.events
 }
 


### PR DESCRIPTION
The previous asynchronous connection made difficult to properly handle errors during the activation and also caused the redirect to the lightning account to happen before the sdk completed connecting. This was causing an error being shown for a few seconds right after the activation.

The activation flow may now take a few seconds to complete, but the frontend shows a nice loader so that should not be a big issue.