### PR TITLE
frontend: handle zero amount invoices when sending with lightning

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1190,7 +1190,7 @@
     },
     "receive": {
       "amountSats": {
-        "label": "Sats",
+        "label": "Sat",
         "placeholder": "Enter amount"
       },
       "description": {


### PR DESCRIPTION
Added a new step edit-invoice to allow specifying a custom amount if no amount was given or amount is 0.

Other change:
- back button on confirm screen goes now back to the lighting view was going back to the QR scanner