### PR TITLE
frontend/account-summary: add coins total balance

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -103,6 +103,14 @@ export const getAccountsTotalBalance = (): Promise<TAccountsTotalBalanceResponse
   return apiGet('accounts/total-balance');
 };
 
+export type TCoinsTotalBalance = {
+  [key: string]: IAmount;
+};
+
+export const getCoinsTotalBalance = (): Promise<TCoinsTotalBalance> => {
+  return apiGet('accounts/coins-balance');
+};
+
 type TEthAccountCodeAndNameByAddress = SuccessResponse & {
   code: AccountCode;
   name: string;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -41,6 +41,7 @@
   "accountSummary": {
     "availableBalance": "Available balance",
     "balance": "Balance",
+    "coin": "Coin",
     "exportSummary": "Export accounts summary to downloads folder as CSV file",
     "fiatBalance": "Fiat balance",
     "name": "Account name",

--- a/frontends/web/src/routes/account/summary/coinbalance.tsx
+++ b/frontends/web/src/routes/account/summary/coinbalance.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import * as accountApi from '../../../api/account';
+import { SubTotalCoinRow } from './subtotalrow';
+import { Amount } from '../../../components/amount/amount';
+import { Skeleton } from '../../../components/skeleton/skeleton';
+import style from './accountssummary.module.css';
+
+type TProps = {
+  accounts: accountApi.IAccount[],
+  summaryData?: accountApi.ISummary,
+  coinsBalances?: accountApi.TCoinsTotalBalance,
+}
+
+type TAccountCoinMap = {
+    [code in accountApi.CoinCode]: accountApi.IAccount[];
+};
+
+export function CoinBalance ({
+  accounts,
+  summaryData,
+  coinsBalances,
+}: TProps) {
+  const { t } = useTranslation();
+
+  const getAccountsPerCoin = () => {
+    return accounts.reduce((accountPerCoin, account) => {
+      accountPerCoin[account.coinCode]
+        ? accountPerCoin[account.coinCode].push(account)
+        : accountPerCoin[account.coinCode] = [account];
+      return accountPerCoin;
+    }, {} as TAccountCoinMap);
+  };
+
+  const accountsPerCoin = getAccountsPerCoin();
+  const coins = Object.keys(accountsPerCoin) as accountApi.CoinCode[];
+
+  return (
+    <div>
+      <div className={style.accountName}>
+        <p>{t('accountSummary.total')}</p>
+      </div>
+      <div className={style.balanceTable}>
+        <table className={style.table}>
+          <colgroup>
+            <col width="33%" />
+            <col width="33%" />
+            <col width="*" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th>{t('accountSummary.coin')}</th>
+              <th>{t('accountSummary.balance')}</th>
+              <th>{t('accountSummary.fiatBalance')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            { accounts.length > 0 ? (
+              coins.map(coinCode => {
+                if (accountsPerCoin[coinCode]?.length >= 1) {
+                  const account = accountsPerCoin[coinCode][0];
+                  return (
+                    <SubTotalCoinRow
+                      key={account.coinCode}
+                      coinCode={account.coinCode}
+                      coinName={account.coinName}
+                      balance={coinsBalances && coinsBalances[coinCode]}
+                    />
+                  );
+                }
+                return null;
+              })) : null}
+          </tbody>
+          <tfoot>
+            <tr>
+              <th>
+                <strong>{t('accountSummary.total')}</strong>
+              </th>
+              <td colSpan={2}>
+                {(summaryData && summaryData.formattedChartTotal !== null) ? (
+                  <>
+                    <strong>
+                      <Amount amount={summaryData.formattedChartTotal} unit={summaryData.chartFiat}/>
+                    </strong>
+                    {' '}
+                    <span className={style.coinUnit}>
+                      {summaryData.chartFiat}
+                    </span>
+                  </>
+                ) : (<Skeleton />) }
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontends/web/src/routes/account/summary/subtotalrow.tsx
+++ b/frontends/web/src/routes/account/summary/subtotalrow.tsx
@@ -65,3 +65,36 @@ export function SubTotalRow ({ coinCode, coinName, balance }: TProps) {
     </tr>
   );
 }
+
+
+export function SubTotalCoinRow ({ coinCode, coinName, balance }: TProps) {
+  const { t } = useTranslation();
+  const nameCol = (
+    <td data-label={t('accountSummary.total')}>
+      <div className={style.coinName}>
+        <Logo className={style.coincode} coinCode={coinCode} active={true} alt={coinCode} />
+        <span className={style.showOnTableView}>
+          {coinName}
+        </span>
+      </div>
+    </td>
+  );
+  if (!balance) {
+    return null;
+  }
+  return (
+    <tr key={`${coinCode}_subtotal`} className={style.subTotal}>
+      { nameCol }
+      <td data-label={t('accountSummary.balance')}>
+        <span className={style.summaryTableBalance}>
+          <Amount amount={balance.amount} unit={balance.unit}/>
+          {' '}
+          <span className={style.coinUnit}>{balance.unit}</span>
+        </span>
+      </td>
+      <td data-label={t('accountSummary.fiatBalance')}>
+        <FiatConversion amount={balance} noAction={true} />
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
Before this update, the account summary didn't show total coin balances, especially when managing multiple wallets with the watch-only feature. This commit addresses that by adding a new coin balances table below the chart. It appears only when there are multiple wallets in the portfolio.

Restored backend code previously removed in commit https://github.com/digitalbitbox/bitbox-wallet-app/commit/d8c6ba030767703128865978ab711ddc4092d133.