### PR TITLE
frontend: fix transaction list for lightning

### DIFF
--- a/frontends/web/src/routes/lightning/components/payment.module.css
+++ b/frontends/web/src/routes/lightning/components/payment.module.css
@@ -12,18 +12,9 @@
     font-weight: 400;
 }
 
-.date {
-
-}
-
 .description {
     text-overflow: ellipsis;
     overflow: hidden;
-}
-
-.description .badge {
-    margin-left: 5px;
-    color: var(--color-secondary);
 }
 
 .amount {
@@ -82,10 +73,6 @@
 @media (max-width: 1080px), (min-width: 1200px) and (max-width: 1322px) {
     .container {
         margin: 0 0 var(--space-quarter) 0;
-    }
-
-    .container.first {
-
     }
 
     .row {

--- a/frontends/web/src/routes/lightning/components/payment.tsx
+++ b/frontends/web/src/routes/lightning/components/payment.tsx
@@ -1,6 +1,5 @@
 /**
- * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2024 Shift Devices AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +52,8 @@ export const Payment = ({ index, payment }: TProps) => {
           <div className={parentStyle.activity}>
             <span className={style.address}>{payment.description || ''}</span>
           </div>
+        </div>
+        <div className={parentStyle.columnGroup}>
           <div className={`${parentStyle.currency} ${payment.paymentType === PaymentType.RECEIVED ? style.receive : style.send}`}>
             <span className={`${style.amount} ${style.amountOverflow}`} data-unit=" sat">
               {sign}

--- a/frontends/web/src/routes/lightning/components/payments.module.css
+++ b/frontends/web/src/routes/lightning/components/payments.module.css
@@ -1,140 +1,134 @@
 .container {
-    margin: calc(var(--space-default) * 1.5) 0;
+  margin: calc(var(--space-default) * 1.5) 0;
+}
+
+.columns {
+  align-items: center;
+  background-color: var(--background-secondary);
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  margin-bottom: 1px;
+  width: 100%;
+}
+
+.headers {
+  font-weight: bold;
+  height: 48px;
+}
+
+.columns >  *,
+.columnGroup > * {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-size: var(--size-default);
+  padding: 0 var(--space-quarter);
+}
+
+.columnGroup {
+  width: 100%;
+  padding: 0;
+}
+
+.type {
+  min-width: 54px;
+  width: 54px;
+  justify-content: center;
+}
+
+.date {
+  min-width: 98px;
+  width: 98px;
+}
+
+.activity {
+  min-width: 334px;
+  width: 334px;
+  text-align: left;
+}
+
+.currency {
+  justify-content: flex-end;
+}
+
+.empty {
+  background-color: var(--background-secondary);
+  height: 52px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}
+
+.empty p {
+  font-size: var(--size-default);
+  font-weight: 400;
+  color: var(--color-secondary);
+}
+
+@media (min-width: 1081px) and (max-width: 1199px), (min-width: 1323px) {
+  .activity {
+    padding: var(--space-quarter) 0;
   }
-  
+}
+
+@media (max-width: 1080px), (min-width: 1200px) and (max-width: 1322px) {
+  .showOnMedium {
+    display: none;
+  }
+
   .columns {
-    align-items: center;
-    background-color: var(--background-secondary);
-    display: flex;
-    flex-direction: row;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .columnGroup:last-child {
+    margin-top: var(--space-quarter);
+  }
+
+  .type {
+    min-width: 36px;
+    width: 36px;
     justify-content: flex-start;
-    margin-bottom: 1px;
-    width: 100%;
   }
-  
-  .headers {
-    font-weight: bold;
-    height: 48px;
+
+  .date {
+    min-width: 126px;
+    width: 126px;
   }
-  
+}
+
+@media (max-width: 768px) {
+  .container {
+    margin: var(--space-default) 0;
+  }
+
+  .currency {
+    min-width: 0;
+    width: auto;
+  }
+}
+
+@media (max-width: 666px) {
   .columns >  *,
   .columnGroup > * {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    font-size: var(--size-default);
-    padding: 0 var(--space-quarter);
+    padding: 0 var(--space-eight);
   }
-  
-  .columnGroup {
-    width: 100%;
-    padding: 0;
-  }
-  
+
   .type {
-    min-width: 54px;
-    width: 54px;
-    justify-content: center;
+    min-width: 26px;
+    width: 26px;
   }
-  
-  .date {
-    min-width: 98px;
-    width: 98px;
-  }
-  
+
   .activity {
-    min-width: 334px;
-    width: 334px;
-    text-align: left;
+    min-width: 0;
+    width: auto;
   }
-  
-  .currency {
-    min-width: 230px;
-    width: 230px;
-    justify-content: flex-end;
+
+  .date {
+    min-width: 80px;
+    width: 80px;
   }
-  
-  .empty {
-    background-color: var(--background-secondary);
-    height: 52px;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-  }
-  
-  .empty p {
-    font-size: var(--size-default);
-    font-weight: 400;
-    color: var(--color-secondary);
-  }
-  
-  @media (min-width: 1081px) and (max-width: 1199px), (min-width: 1323px) {
-    .hideOnMedium {
-      display: none;
-    }
-  
-    .activity {
-      padding: var(--space-quarter) 0;
-    }
-  }
-  
-  @media (max-width: 1080px), (min-width: 1200px) and (max-width: 1322px) {
-    .showOnMedium {
-      display: none;
-    }
-  
-    .columns {
-      flex-direction: column;
-      justify-content: center;
-    }
-  
-    .columnGroup:last-child {
-      margin-top: var(--space-quarter);
-    }
-  
-    .type {
-      min-width: 36px;
-      width: 36px;
-      justify-content: flex-start;
-    }
-  
-    .date {
-      min-width: 126px;
-      width: 126px;
-    }
-  }
-  
-  @media (max-width: 768px) {
-    .container {
-      margin: var(--space-default) 0;
-    }
-  
-    .currency {
-      min-width: 0;
-      width: auto;
-    }
-  }
-  
-  @media (max-width: 666px) {
-    .columns >  *,
-    .columnGroup > * {
-      padding: 0 var(--space-eight);
-    }
-  
-    .type {
-      min-width: 26px;
-      width: 26px;
-    }
-  
-    .activity {
-      min-width: 0;
-      width: auto;
-    }
-  
-    .date {
-      min-width: 80px;
-      width: 80px;
-    }
-  }
-  
+}


### PR DESCRIPTION
following our already existing transaction list layout, on mobile, the amount collapses (flex column) to the second row. This keeps the amount visible if it's long or when the description / note is long.

Also removes unused CSS classes.

_screen size: 350px_
[Preview], before:
_(long note)_
![992S](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/35c6e7d6-2c65-41f5-90e8-06c31d145d23)

![ODAS](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/6d238081-44e7-4236-9d53-f2e72f762d9a)

[Preview], after: 
![ asx](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/dbeffed1-1325-4faf-9076-17fd8ab16a8c)

![dxa](https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/478f314a-6e54-4ed8-bd2f-e4dd96fe261d)

