### PR TITLE
frontend: add alpha release warning banner on lightning account

### DIFF
--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -28,6 +28,7 @@ import { LightningGuide } from './guide';
 import { toSat } from '../../utils/conversion';
 import { Payments } from './components/payments';
 import { unsubscribe } from '../../utils/subscriptions';
+import { Status } from '../../components/status/status';
 
 export function Lightning() {
   const { t } = useTranslation();
@@ -107,6 +108,11 @@ export function Lightning() {
     <GuideWrapper>
       <GuidedContent>
         <Main>
+          <Status
+            dismissible="lightning-alpha-warning"
+            type="warning">
+            This is an alpha release intended for preview and testing. Only use lightning with a small amount of funds!
+          </Status>
           <Header
             title={
               <h2>


### PR DESCRIPTION
As this is an alpha release intended for preview and testing, this commit adds a warning to only use lightning with a small amount of funds.