### PR TITLE
frontend/lightning: add fiat conversions to send/receive flows

### DIFF
--- a/frontends/web/src/api/coins.ts
+++ b/frontends/web/src/api/coins.ts
@@ -15,7 +15,7 @@
  */
 
 import { subscribeEndpoint, TSubscriptionCallback } from './subscribe';
-import { CoinCode } from './account';
+import { CoinCode, IAmount } from './account';
 import { ISuccess } from './backend';
 import { apiPost, apiGet } from '../utils/request';
 
@@ -45,4 +45,8 @@ export type TAmount = {
 
 export const parseExternalBtcAmount = (amount: string): Promise<TAmount> => {
   return apiGet(`coins/btc/parse-external-amount?amount=${amount}`);
+};
+
+export const getBtcSatsAmount = (sats: string): Promise<{ success: false } | { success: true, amount: IAmount }> => {
+  return apiGet(`coins/btc/sats-amount?sats=${sats}`);
 };


### PR DESCRIPTION
This also adds a getBTCSatsAmount backend endpoint that allows to convert a sat amount into an Amount object (FE: IAmount, BE: FormattedAmount) with the fiat conversions. This is not the best solution, as it would be much better to heavily refactor the invoices parsing, removing all the FE types that depends on breez and making the enpoints return a simpler struct containing only the used data (including the fiat conversions).

This is a workaround that allows to show fiat conversions in the frontend while we take our time to decide how to refactor this part.