### PR TITLE
frontend: temp hide paste-invoice button

### DIFF
--- a/frontends/web/src/routes/lightning/send/send.tsx
+++ b/frontends/web/src/routes/lightning/send/send.tsx
@@ -124,13 +124,12 @@ const SendWorkflow = ({
         <ViewContent textAlign="center">
           <Grid col="1">
             <Column>
-              {/* this flickers quickly, as there is 'SdkError: Generic: Breez SDK error: Unrecognized input type' when logging rawInputError */}
               {rawInputError && <Status type="warning">{rawInputError}</Status>}
               <ScanQRVideo onResult={onCameraInput} />
-              {/* Note: unfortunatelly we probably can't read from HTML5 clipboard api directly in Qt/Android WebView */}
-              <Button transparent onClick={() => console.log('TODO: implement paste')}>
+              {/* temporary disabled paste button, reason: reading from HTML5 clipboard api is surpressed in Qt/Android WebView */}
+              {/* <Button transparent onClick={() => console.log('TODO: implement paste')}>
                 {t('lightning.send.rawInput.label')}
-              </Button>
+              </Button> */}
             </Column>
           </Grid>
         </ViewContent>


### PR DESCRIPTION
We can't use modern HMTL5 paste from clipboard api as this is suppressed in the webviews.

Also:
- removed comment about flickering error, seems to be fine