### PR TITLE
android: add lnalpha build target

### DIFF
--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -21,6 +21,10 @@ android {
             applicationIdSuffix ".debug"
             resValue "string", "app_name", "BitBoxApp DEBUG"
         }
+        lnalpha {
+            applicationIdSuffix ".lnalpha"
+            resValue "string", "app_name", "BitBoxApp LN Alpha"
+        }
     }
     namespace 'ch.shiftcrypto.bitboxapp'
 }


### PR DESCRIPTION
So an alpha release of the BitBoxApp for Android does not interfere with existing installations of the BitBoxApp.