### PR TITLE
frontend: handle error when initialising/starting QR scanner

### DIFF
--- a/frontends/web/src/hooks/qrcodescanner.ts
+++ b/frontends/web/src/hooks/qrcodescanner.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { RefObject, useEffect } from 'react';
+import { RefObject, useEffect, useState } from 'react';
 import QrScanner from 'qr-scanner';
+import { useTranslation } from 'react-i18next';
 
 type TUseQRScannerOptions = {
   onStart?: () => void;
@@ -30,6 +31,8 @@ export const useQRScanner = (
     onError,
   }: TUseQRScannerOptions
 ) => {
+  const { t } = useTranslation();
+  const [initErrorMessage, setInitErrorMessage] = useState();
 
   useEffect(() => {
     const startScanner = async () => {
@@ -51,8 +54,11 @@ export const useQRScanner = (
         if (onStart) {
           onStart();
         }
-      } catch (error) {
+      } catch (error: any) {
         console.error(error);
+        const stringifiedError = error.toString();
+        const cameraNotFound = stringifiedError === 'Camera not found.';
+        setInitErrorMessage(cameraNotFound ? t('send.scanQRNoCameraMessage') : stringifiedError);
       }
 
       return () => {
@@ -68,6 +74,7 @@ export const useQRScanner = (
       // Clean up scanner
       scannerPromise.then(cleanupFunc => cleanupFunc());
     };
-  }, [videoRef, onStart, onResult, onError]);
+  }, [videoRef, onStart, onResult, onError, t]);
 
+  return { initErrorMessage };
 };

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1626,6 +1626,7 @@
     "noFeeTargets": "Fee rate estimations are currently unavailable. Please try again later or enter a custom fee.",
     "priority": "Priority",
     "scanQR": "Scan QR code",
+    "scanQRNoCameraMessage": "Camera not found. Please ensure that your device supports a camera and permissions are correctly set.",
     "signprogress": {
       "description": "This is a transaction containing a lot of data. To fully sign the transaction, you will be asked to confirm {{steps}} times.",
       "label": "Progress"

--- a/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/scan-qr-video.tsx
@@ -28,7 +28,7 @@ export const ScanQRVideo = ({
 }: TProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
 
-  useQRScanner(videoRef, {
+  const { initErrorMessage } = useQRScanner(videoRef, {
     onResult: result => onResult(result.data),
     onError: console.error
   });
@@ -39,7 +39,7 @@ export const ScanQRVideo = ({
       be hidden once the camera / video component
        gets loaded.*/}
       <div className={style.spinnerAnimationContainer}>
-        <SpinnerAnimation />
+        {initErrorMessage ? <p>{initErrorMessage}</p> : <SpinnerAnimation />}
       </div>
       <video
         className={style.qrVideo}

--- a/frontends/web/src/routes/lightning/components/payments.module.css
+++ b/frontends/web/src/routes/lightning/components/payments.module.css
@@ -19,7 +19,6 @@
 
 .columns >  *,
 .columnGroup > * {
-  align-items: flex-start;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -82,6 +81,11 @@
   .columns {
     flex-direction: column;
     justify-content: center;
+  }
+
+  .columns >  *,
+  .columnGroup > * { 
+    align-items: flex-start;
   }
 
   .columnGroup:last-child {


### PR DESCRIPTION
previously, when there's an error during QR scanner init, such as camera not being found, it didn't get handled. This is causing the UI to be "stuck" showing the loading spinner until the error gets resolved.

For better UX, we'd like to show the error message.

[Preview]:

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/648f1da1-8e6f-4f07-8bde-2fa3df294c3d

