### PR TITLE
frontend/qt: remove rebase errors related to linking Breez SDK

### DIFF
--- a/frontends/qt/BitBox.pro
+++ b/frontends/qt/BitBox.pro
@@ -25,12 +25,6 @@ DEFINES += QT_DEPRECATED_WARNINGS
 include(external/singleapplication/singleapplication.pri)
 DEFINES += QAPPLICATION_CLASS=QApplication
 
-win64 {
-    LIBS += -L$$PWD/../../vendor/github.com/breez/breez-sdk-go/breez_sdk/lib/windows-amd64/ -lbreez_sdk_bindings
-    INCLUDEPATH += $$PWD/../../vendor/github.com/breez/breez-sdk-go/breez_sdk/lib/windows-amd64
-    DEPENDPATH += $$PWD/../../vendor/github.com/breez/breez-sdk-go/breez_sdk/lib/windows-amd64
-}
-
 win32 {
     # -llibssp would be nice to have on Windows
     LIBS += -L$$PWD/server/ -llibserver
@@ -44,7 +38,7 @@ win32 {
     #QMAKE_LFLAGS += -Wl,--dynamicbase
 } else {
     QMAKE_CXXFLAGS += -std=c++11
-    LIBS += -L$$PWD/server -lbreez_sdk_bindings -lserver
+    LIBS += -L$$PWD/server -lserver
     QMAKE_CXXFLAGS += $$CFORTIFY
     QMAKE_CXXFLAGS += $$CSTACK
     QMAKE_CXXFLAGS += $$CMISC

--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -25,9 +25,6 @@ clean:
 	cd server && $(MAKE) clean
 linux:
 	$(MAKE) clean
-	cp ../../vendor/github.com/breez/breez-sdk-go/breez_sdk/lib/linux-amd64/libbreez_sdk_bindings.so server/
-	apt-get install -y chrpath
-	chrpath -r $$ORIGIN/lib server/libbreez_sdk_bindings.so
 	cd server && $(MAKE) linux
 	$(MAKE) base
 	mkdir -p build/linux-tmp/lib build/linux
@@ -49,7 +46,6 @@ linux:
 	mv build/linux-tmp/BitBoxApp-*-x86_64.AppImage build/linux/
 osx:
 	$(MAKE) clean
-	cp ../../vendor/github.com/breez/breez-sdk-go/breez_sdk/lib/darwin-amd64/libbreez_sdk_bindings.dylib server/
 	cd server && $(MAKE) macosx
 	$(MAKE) base
 	mkdir build/osx


### PR DESCRIPTION
7d3ab0abab500a319f138991012edb19b19ac2dd rebased incorrectly on top of

https://github.com/digitalbitbox/bitbox-wallet-app/pull/2378 https://github.com/digitalbitbox/bitbox-wallet-app/pull/2377 https://github.com/digitalbitbox/bitbox-wallet-app/pull/2373

These PRs fixed linking on Win/macOS/Linux, and the changes in the above commit are therefore not needed.