### PR TITLE
frontend: add missing key prop

### DIFF
--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -189,6 +189,7 @@ export function AccountsSummary({ accounts, devices }: TProps) {
             {accountsByKeystore &&
               (accountsByKeystore.map(({ keystore, accounts }) =>
                 <SummaryBalance
+                  key={keystore.rootFingerprint}
                   keystoreDisambiguatorName={isAmbiguiousName(keystore.name, accountsByKeystore) ? keystore.rootFingerprint : undefined}
                   accountsKeystore={keystore}
                   accounts={accounts}


### PR DESCRIPTION
Small regression introduced in 40976c936c7e388bd4a361a04b674d94ae1b3c83

Fixes the error:

accountssummary.tsx:180 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `AccountsSummary`.