### PR TITLE
frontend: start script fix

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -1132,9 +1132,9 @@ func (handlers *Handlers) apiMiddleware(devMode bool, h func(*http.Request) (int
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if devMode {
-			// This enables us to run a server on a different port serving just the UI, while still
-			// allowing it to access the API.
-			w.Header().Set("Access-Control-Allow-Origin", "http://localhost:8080")
+			// This enables us to run a server on a different port/address serving just the UI,
+			// while still allowing it to access the API.
+			w.Header().Set("Access-Control-Allow-Origin", "*")
 		}
 		value, err := h(r)
 		if err != nil {

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "dev": "npm run start",
-    "start": "vite --port 8080 --cors",
+    "start": "vite --host --port 8080 --cors",
     "build": "npm run typescript && vite build",
     "lint": "npm run typescript && eslint --ext .jsx,.js,.ts,.tsx ./src",
     "typescript": "tsc -p tsconfig.json",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "dev": "npm run start",
-    "start": "vite --host --port 8080 --cors",
+    "start": "vite --host --port 8080",
     "build": "npm run typescript && vite build",
     "lint": "npm run typescript && eslint --ext .jsx,.js,.ts,.tsx ./src",
     "typescript": "tsc -p tsconfig.json",


### PR DESCRIPTION
It's not possible to interact with the frontend/vite server from the host machine when it is running in the container (`make dockerdev`, `make webdev`) we need to add the `--host` flag to tell vite to [listen to all addresses](https://vitejs.dev/config/server-options#server-host).

I do not quite understand why this is necessary since we start the container with `-p 8080:8080` which maps the host port to the container port / publishes the container port. The backend can be reached from the host too on `localhost:8082` so I really don't understand why the vite server has problems.

Also remove the `--cors` flag as [it is enabled by default ](https://vitejs.dev/config/server-options#server-cors)and we do not use the flag to configure CORS.