### PR TITLE
bitbox02/bootloader: log monotonic version

### DIFF
--- a/backend/devices/bitbox02bootloader/device.go
+++ b/backend/devices/bitbox02bootloader/device.go
@@ -164,6 +164,11 @@ func (device *Device) VersionInfo() (*VersionInfo, error) {
 		return nil, err
 	}
 	canUpgrade := erased || bundledFirmwareVersion > currentFirmwareVersion
+	device.log.
+		WithField("bundledFirmwareVersion", bundledFirmwareVersion).
+		WithField("currentFirmwareVersion", currentFirmwareVersion).
+		WithField("erased", erased).
+		WithField("canUpgrade", canUpgrade).Info("VersionInfo")
 	return &VersionInfo{
 		Erased:     erased,
 		CanUpgrade: canUpgrade,


### PR DESCRIPTION
Sometimes users get 'invalid firmware' and go into the bootloader screen without the button to install/upgrade `CanUpgrade=false`. This should never happen if the user is using the latest app release. This may help debug the problem should it appear again.