### PR TITLE
qt: log rendering mode

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -226,14 +226,18 @@ int main(int argc, char *argv[])
         // issues were observed on Windows and the app crashes on some Linux systems.
         qputenv("QMLSCENE_DEVICE", "softwarecontext");
         qputenv("QT_QUICK_BACKEND", "software");
+        goLog("BITBOXAPP_RENDER=software");
     } else if (renderMode == "auto") {
         // Do nothing: leave it to Qt to decide the rendering backend, which is usually hardware
         // accelerated if available.
         //
         // In rare cases, this can lead to rendering artefacts and crashes, which is why it is not
         // enabled by default.
+        std::cerr << "Rendering mode: automatic (usually hardware accelerated)" << std::endl;
+        goLog("BITBOXAPP_RENDER=auto");
     } else {
         std::cerr << "Invalid value for BITBOXAPP_RENDER" << std::endl;
+        goLog("Invalid value for BITBOXAPP_RENDER");
         return 1;
     }
 


### PR DESCRIPTION
If a user manually has to set this, it would be helpul to see this msg
to know that the right var was set.
