### PR TITLE
frontend/lightning: fix bug in handling receive invoice error

### DIFF
--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -142,6 +142,7 @@ export function Receive() {
       setReceivePaymentResponse(receivePaymentResponse);
       setStep('invoice');
     } catch (e) {
+      setStep('select-amount');
       if (e instanceof SdkError) {
         setReceiveError(e.message);
       } else {


### PR DESCRIPTION
The LN receive workflow was failing to show errors returned by the backend because the loading screen wasn't hidden in case of errors.