### PR TITLE
backend/handlers: fix bug in etherscan.ERC20GasErr handling

### DIFF
--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -405,7 +406,7 @@ func (handlers *Handlers) postAccountSendTx(r *http.Request) (interface{}, error
 	if err != nil {
 		handlers.log.WithError(err).Error("Failed to send transaction")
 		result := map[string]interface{}{"success": false, "errorMessage": err.Error()}
-		if err.Error() == etherscan.ERC20GasErr {
+		if strings.Contains(err.Error(), etherscan.ERC20GasErr) {
 			result["errorCode"] = errors.ERC20InsufficientGasFunds.Error()
 		}
 		return result, nil


### PR DESCRIPTION
The error string was not correctly checked in handlers.go, which lead the frontend to show a generic error instead of the specific one.