### PR TITLE
backend/backend: refactor backend accounts keystores

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -16,9 +16,7 @@
 package backend
 
 import (
-	"encoding/hex"
 	"fmt"
-	"math/big"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,8 +32,6 @@ import (
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/electrum"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/types"
-	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/btc/util"
-	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	coinpkg "github.com/digitalbitbox/bitbox-wallet-app/backend/coins/coin"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth"
 	"github.com/digitalbitbox/bitbox-wallet-app/backend/coins/eth/etherscan"
@@ -544,95 +540,12 @@ func (backend *Backend) Accounts() AccountsList {
 	return backend.accounts
 }
 
-// AccountsByKeystore returns a map of the current accounts of the backend, grouped
-// by keystore.
-func (backend *Backend) AccountsByKeystore() (KeystoresAccountsListMap, error) {
-	accountsByKeystore := KeystoresAccountsListMap{}
-	defer backend.accountsAndKeystoreLock.RLock()()
-	for _, account := range backend.accounts {
-		persistedAccount := account.Config().Config
-		rootFingerprint, err := persistedAccount.SigningConfigurations.RootFingerprint()
-		if err != nil {
-			return nil, err
-		}
-		keystore, err := backend.Config().AccountsConfig().LookupKeystore(rootFingerprint)
-		if err != nil {
-			return nil, err
-		}
-		accountsByKeystore[keystore] = append(accountsByKeystore[keystore], account)
-	}
-	return accountsByKeystore, nil
-}
-
-// KeystoreTotalAmount represents the total balance amount of the accounts belongings to a keystore.
+// KeystoreTotalAmount represents the total balance amount of the accounts belonging to a keystore.
 type KeystoreTotalAmount = struct {
 	// FiatUnit is the fiat unit of the total amount
 	FiatUnit string `json:"fiatUnit"`
 	// Total formatted for frontend visualization
 	Total string `json:"total"`
-}
-
-// AccountsTotalBalanceByKeystore returns a map of accounts' total balances across coins, grouped by keystore.
-func (backend *Backend) AccountsTotalBalanceByKeystore() (map[string]KeystoreTotalAmount, error) {
-	totalAmounts := make(map[string]KeystoreTotalAmount)
-	fiat := backend.Config().AppConfig().Backend.MainFiat
-	isFiatBtc := fiat == rates.BTC.String()
-	fiatUnit := fiat
-	if isFiatBtc && backend.Config().AppConfig().Backend.BtcUnit == coin.BtcUnitSats {
-		fiatUnit = "sat"
-	}
-
-	formatBtcAsSat := util.FormatBtcAsSat(backend.Config().AppConfig().Backend.BtcUnit)
-
-	accountsByKeystore, err := backend.AccountsByKeystore()
-	if err != nil {
-		return nil, err
-	}
-	for keystore, accountList := range accountsByKeystore {
-		rootFingerprint := hex.EncodeToString(keystore.RootFingerprint)
-		currentTotal := new(big.Rat)
-		for _, account := range accountList {
-			if account.Config().Config.Inactive {
-				continue
-			}
-			if account.FatalError() {
-				continue
-			}
-			err := account.Initialize()
-			if err != nil {
-				return nil, err
-			}
-			balance, err := account.Balance()
-			if err != nil {
-				return nil, err
-			}
-			// e.g. 1e8 for Bitcoin/Litecoin, 1e18 for Ethereum, etc. Used to convert from the smallest
-			// unit to the standard unit (BTC, LTC; ETH, etc.).
-			coinDecimals := new(big.Int).Exp(
-				big.NewInt(10),
-				big.NewInt(int64(account.Coin().Decimals(false))),
-				nil,
-			)
-
-			price, err := backend.RatesUpdater().LatestPriceForPair(account.Coin().Unit(false), fiat)
-			if err != nil {
-				return nil, err
-			}
-			fiatValue := new(big.Rat).Mul(
-				new(big.Rat).SetFrac(
-					balance.Available().BigInt(),
-					coinDecimals,
-				),
-				new(big.Rat).SetFloat64(price),
-			)
-			currentTotal.Add(currentTotal, fiatValue)
-		}
-		totalAmounts[rootFingerprint] = KeystoreTotalAmount{
-			FiatUnit: fiatUnit,
-			Total:    coin.FormatAsCurrency(currentTotal, isFiatBtc, formatBtcAsSat),
-		}
-	}
-	return totalAmounts, nil
 }
 
 // OnAccountInit installs a callback to be called when an account is initialized.

--- a/backend/coins/coin/coin.go
+++ b/backend/coins/coin/coin.go
@@ -82,3 +82,13 @@ type Coin interface {
 	// Close shuts down all resources obtained by the coin (network connections, databases, etc.).
 	Close() error
 }
+
+// DecimalsExp returns the conversion exponential from the smallest unit to the standard unit
+// (BTC, LTC; ETH, etc.). e.g. 1e8 for Bitcoin/Litecoin, 1e18 for Ethereum, etc.
+func DecimalsExp(coin Coin) *big.Int {
+	return new(big.Int).Exp(
+		big.NewInt(10),
+		big.NewInt(int64(coin.Decimals(false))),
+		nil,
+	)
+}

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -18,7 +18,6 @@ package handlers
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -696,8 +695,7 @@ func (handlers *Handlers) getAccountsBalance(*http.Request) (interface{}, error)
 	if err != nil {
 		return nil, err
 	}
-	for keystore, accountList := range accountsByKeystore {
-		rootFingerprint := hex.EncodeToString(keystore.RootFingerprint)
+	for rootFingerprint, accountList := range accountsByKeystore {
 		totalPerCoin := make(map[coin.Code]*big.Int)
 		conversionsPerCoin := make(map[coin.Code]map[string]string)
 		for _, account := range accountList {


### PR DESCRIPTION
Addressing most of the observations done in #2513, in particular:
- Use hex keystore fingerprint as key for KeystoresAccountsListMap 
- Move some functions from backend.go to accounts.go
- Create backend.accountFiatBalance to reduce code duplication between `AccountsTotalBalanceByKeystore` and `ChartData`

Unit tests will come in a separate PR, together with a small refactoring of backend tests.