### PR TITLE
frontend: update redirects when lightning wallet active

### DIFF
--- a/frontends/web/src/contexts/LightningProvider.tsx
+++ b/frontends/web/src/contexts/LightningProvider.tsx
@@ -16,7 +16,7 @@
 
 import { ReactNode } from 'react';
 import { LightningContext } from './LightningContext';
-import { TLightningAccountConfig, getLightningConfig, subscribeLightningConfig } from '../api/lightning';
+import { getLightningConfig, subscribeLightningConfig } from '../api/lightning';
 import { useSync } from '../hooks/api';
 import { useDefault } from '../hooks/default';
 
@@ -27,7 +27,7 @@ type TProps = {
 export const LightningProvider = ({ children }: TProps) => {
   const lightningConfig = useDefault(
     useSync(getLightningConfig, subscribeLightningConfig),
-    { accounts: {} as TLightningAccountConfig[] },
+    { accounts: [] },
   );
 
   return (


### PR DESCRIPTION
When the lightning wallet is enabled and the device disconnects (with no watch-only accounts present), the application should redirect to My Portfolio and not to "Please connect your device" as the lightning wallet is active.

This PR also updates the initial state of lightningConfig within the LightningProvider component to use an empty array for the `accounts` property.