### PR TITLE
frontend: refactor fns & component for device name validation

### DIFF
--- a/frontends/web/src/routes/settings/components/device-settings/device-name-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/device-name-setting.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useRef, useState, ChangeEvent } from 'react';
+import { useState, ChangeEvent, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SettingsItem } from '../settingsItem/settingsItem';
 import { ChevronRightDark } from '../../../../components/icon';
@@ -23,6 +23,9 @@ import { Dialog, DialogButtons } from '../../../../components/dialog/dialog';
 import { getDeviceInfo, setDeviceName } from '../../../../api/bitbox02';
 import { alertUser } from '../../../../components/alert/Alert';
 import { WaitDialog } from '../../../../components/wait-dialog/wait-dialog';
+import { TDeviceNameError, getInvalidCharsInDeviceName, getDeviceNameValidationError } from '../../../../utils/device';
+import { DeviceNameErrorMessage } from '../../../device/bitbox02/setup/name';
+import nameStyle from '../../../device/bitbox02/setup/name.module.css';
 
 type TDeviceNameSettingProps = {
   deviceName: string;
@@ -33,7 +36,7 @@ type TDialogProps = {
   open: boolean;
   onClose: () => void;
   currentName: string;
-  onInputChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onInputChange: (value: string) => void;
   name: string;
   handleUpdateName: () => void;
 }
@@ -85,11 +88,12 @@ const DeviceNameSetting = ({ deviceName, deviceID }: TDeviceNameSettingProps) =>
         extraComponent={<ChevronRightDark />}
         onClick={() => setActive(true)}
       />
+
       <SetDeviceNameDialog
         open={active}
         onClose={handleCloseDialog}
         currentName={currentName}
-        onInputChange={(e) => setName(e.target.value)}
+        onInputChange={setName}
         name={name}
         handleUpdateName={updateName}
       />
@@ -100,7 +104,16 @@ const DeviceNameSetting = ({ deviceName, deviceID }: TDeviceNameSettingProps) =>
 
 const SetDeviceNameDialog = ({ open, onClose, currentName, onInputChange, name, handleUpdateName }: TDialogProps) => {
   const { t } = useTranslation();
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [validationNameError, setValidationNameError] = useState<TDeviceNameError>();
+  const invalidChars = useMemo(() => getInvalidCharsInDeviceName(name), [name]);
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    const error = getDeviceNameValidationError(value);
+    setValidationNameError(error);
+    onInputChange(value);
+  };
+
 
   return (
     <Dialog
@@ -120,20 +133,21 @@ const SetDeviceNameDialog = ({ open, onClose, currentName, onInputChange, name, 
           </div>
           <div className="column">
             <Input
-              pattern="^.{0,63}$"
+              className={`m-none ${validationNameError ? nameStyle.inputError : ''}`}
               label={t('bitbox02Settings.deviceName.input')}
-              onInput={onInputChange}
-              ref={inputRef}
+              onInput={handleInputChange}
               placeholder={t('bitbox02Settings.deviceName.placeholder')}
               value={name}
-              id="deviceName" />
+              id="deviceName"
+            />
+            <DeviceNameErrorMessage error={validationNameError} invalidChars={invalidChars} />
           </div>
         </div>
       </div>
       <DialogButtons>
         <Button
           primary
-          disabled={!(name && inputRef?.current?.validity.valid)}
+          disabled={!(name && !validationNameError)}
           onClick={handleUpdateName}
         >
           {t('button.ok')}

--- a/frontends/web/src/utils/device.test.ts
+++ b/frontends/web/src/utils/device.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getDeviceNameValidationError } from './device';
+
+describe('getDeviceNameValidationError', () => {
+  it('returns undefined (no error) for an empty name', () => {
+    expect(getDeviceNameValidationError('')).toBeUndefined();
+    expect(getDeviceNameValidationError('   ')).toBeUndefined();
+  });
+
+  it('returns undefined (no error) for a valid name', () => {
+    expect(getDeviceNameValidationError('My BitBox')).toBeUndefined();
+    expect(getDeviceNameValidationError('BitBox123')).toBeUndefined();
+  });
+
+  it('returns "tooLong" for names longer than 30 characters', () => {
+    const longName = 'ThisDeviceNameIsWayTooLongAndInvalid';
+    expect(getDeviceNameValidationError(longName)).toEqual('tooLong');
+  });
+
+  it('returns "invalidChars" for names with invalid characters', () => {
+    expect(getDeviceNameValidationError('MyDevicä')).toEqual('invalidChars');
+    expect(getDeviceNameValidationError('MyDeviíïäá')).toEqual('invalidChars');
+  });
+
+  it('handles boundary conditions properly', () => {
+    const validShortName = 'A';
+    const validLongName = '123456789012345678901234567890';
+    expect(getDeviceNameValidationError(validShortName)).toBeUndefined();
+    expect(getDeviceNameValidationError(validLongName)).toBeUndefined();
+  });
+});

--- a/frontends/web/src/utils/device.ts
+++ b/frontends/web/src/utils/device.ts
@@ -1,0 +1,28 @@
+export type TDeviceNameError = undefined | 'tooLong' | 'invalidChars'
+
+// matches any character that is not a printable ASCII character or space
+export const regexInvalid = /[^ -~]/g;
+
+export const getDeviceNameValidationError = (name: string): TDeviceNameError => {
+  const trimmed = name.trim();
+  regexInvalid.lastIndex = 0; // resets lastIndex before each test
+
+  if (trimmed.length < 1) {
+    return undefined;
+  }
+
+  if (trimmed.length > 30) {
+    return 'tooLong';
+  }
+
+  if (regexInvalid.test(trimmed)) {
+    return 'invalidChars';
+  }
+
+};
+
+export const getInvalidCharsInDeviceName = (deviceName: string) => deviceName.match(regexInvalid)?.filter(filterUnique).join(', ');
+
+const filterUnique = (value: string, index: number, array: string[]) => {
+  return array.indexOf(value) === index;
+};


### PR DESCRIPTION
Frontend device name validation was previously added from #2509 . 

This PR refactors the methods in that PR and a component `DeviceNameErrorMessage` to be reused in  `device-name-setting.tsx`.

[Preview]:

<img width="426" alt="ld" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/114e711b-66d7-4695-b9e5-d5c02771ea36">

<img width="406" alt="dsx" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/a247cfb8-0725-40df-a66b-14f1f5c519c5">
