### PR TITLE
frontend: add guide entry for supported coins

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -802,6 +802,13 @@
         "text": "Bitcoin and Litecoin can have an arbitrary amount of accounts. After five accounts, you can only add another account if the previous account has been used. \nOther coins can have a maximum of five accounts.",
         "title": "How many accounts can I create?"
       },
+      "supportedCoins": {
+        "link": {
+          "text": "View supported coins"
+        },
+        "text": "The BitBoxApp supports Bitcoin, Litecoin, Ethereum as well as a selection of ERC20 token. For Cardano and other tokens, use your BitBox02 with alternative software such as AdaLite or Rabby. You can find an exhaustive list of all supported coins on our website:",
+        "title": "Which coins are supported?"
+      },
       "howtoAddTokens": {
         "text": "Tokens using the ERC20 standard are tied to a specific Ethereum account. To enable or disable a particular token, open the \"Manage accounts\" screen, expand your Ethereum account and switch the desired token on or off.",
         "title": "How can I add additional tokens?"

--- a/frontends/web/src/routes/account/add/add-account-guide.tsx
+++ b/frontends/web/src/routes/account/add/add-account-guide.tsx
@@ -17,24 +17,35 @@
 import { useTranslation } from 'react-i18next';
 import { Entry } from '../../../components/guide/entry';
 import { Guide } from '../../../components/guide/guide';
+import { IAccount } from '../../../api/account';
+import { isBitcoinOnly } from '../../account/utils';
 
-export const AddAccountGuide = () => {
+type TAddAccountGuide = {
+  accounts: IAccount[]
+}
+
+export const AddAccountGuide = ({ accounts }: TAddAccountGuide) => {
   const { t } = useTranslation();
+  const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
   return (
     <Guide>
       <Entry key="whatAreAccounts" entry={t('guide.accounts.whatAreAccounts')} />
       <Entry key="whyIsThisUseful" entry={t('guide.accounts.whyIsThisUseful')} />
       <Entry key="recoverAccounts" entry={t('guide.accounts.recoverAccounts')} />
       <Entry key="moveFunds" entry={t('guide.accounts.moveFunds')} />
-      <Entry key="supportedCoins" entry={{
-        link: {
-          text: t('guide.accounts.supportedCoins.link.text'),
-          url: 'https://bitbox.swiss/coins/',
-        },
-        text: t('guide.accounts.supportedCoins.text'),
-        title: t('guide.accounts.supportedCoins.title'),
-      }} />
-      <Entry key="howtoAddTokens" entry={t('guide.accounts.howtoAddTokens')} />
+      { !hasOnlyBTCAccounts && (
+        <>
+          <Entry key="supportedCoins" entry={{
+            link: {
+              text: t('guide.accounts.supportedCoins.link.text'),
+              url: 'https://bitbox.swiss/coins/',
+            },
+            text: t('guide.accounts.supportedCoins.text'),
+            title: t('guide.accounts.supportedCoins.title'),
+          }} />
+          <Entry key="howtoAddTokens" entry={t('guide.accounts.howtoAddTokens')} />
+        </>
+      )}
       <Entry key="howManyAccounts" entry={t('guide.accounts.howManyAccounts')} />
     </Guide>
   );

--- a/frontends/web/src/routes/account/add/add-account-guide.tsx
+++ b/frontends/web/src/routes/account/add/add-account-guide.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
+import { i18n } from '../../../i18n/i18n';
 import { Entry } from '../../../components/guide/entry';
 import { Guide } from '../../../components/guide/guide';
 import { IAccount } from '../../../api/account';
@@ -23,6 +24,17 @@ import { isBitcoinOnly } from '../../account/utils';
 type TAddAccountGuide = {
   accounts: IAccount[]
 }
+
+const getCoinsLink = () => {
+  switch (i18n.resolvedLanguage) {
+  case 'de':
+    return 'https://bitbox.swiss/de/coins/';
+  case 'es':
+    return 'https://bitbox.swiss/es/monedas/';
+  default:
+    return 'https://bitbox.swiss/coins/';
+  }
+};
 
 export const AddAccountGuide = ({ accounts }: TAddAccountGuide) => {
   const { t } = useTranslation();
@@ -38,7 +50,7 @@ export const AddAccountGuide = ({ accounts }: TAddAccountGuide) => {
           <Entry key="supportedCoins" entry={{
             link: {
               text: t('guide.accounts.supportedCoins.link.text'),
-              url: 'https://bitbox.swiss/coins/',
+              url: getCoinsLink(),
             },
             text: t('guide.accounts.supportedCoins.text'),
             title: t('guide.accounts.supportedCoins.title'),

--- a/frontends/web/src/routes/account/add/add-account-guide.tsx
+++ b/frontends/web/src/routes/account/add/add-account-guide.tsx
@@ -26,6 +26,14 @@ export const AddAccountGuide = () => {
       <Entry key="whyIsThisUseful" entry={t('guide.accounts.whyIsThisUseful')} />
       <Entry key="recoverAccounts" entry={t('guide.accounts.recoverAccounts')} />
       <Entry key="moveFunds" entry={t('guide.accounts.moveFunds')} />
+      <Entry key="supportedCoins" entry={{
+        link: {
+          text: t('guide.accounts.supportedCoins.link.text'),
+          url: 'https://bitbox.swiss/coins/',
+        },
+        text: t('guide.accounts.supportedCoins.text'),
+        title: t('guide.accounts.supportedCoins.title'),
+      }} />
       <Entry key="howtoAddTokens" entry={t('guide.accounts.howtoAddTokens')} />
       <Entry key="howManyAccounts" entry={t('guide.accounts.howManyAccounts')} />
     </Guide>

--- a/frontends/web/src/routes/account/add/add.tsx
+++ b/frontends/web/src/routes/account/add/add.tsx
@@ -27,13 +27,16 @@ import { CoinDropDown } from './components/coin-dropdown';
 import { Check } from '../../../components/icon/icon';
 import { AddAccountGuide } from './add-account-guide';
 import { route } from '../../../utils/route';
-import { addAccount, CoinCode, TAddAccount } from '../../../api/account';
+import { addAccount, CoinCode, TAddAccount, IAccount } from '../../../api/account';
 import styles from './add.module.css';
 
+type TAddAccountGuide = {
+  accounts: IAccount[]
+}
 
 type TStep = 'select-coin' | 'choose-name' | 'success';
 
-export const AddAccount = () => {
+export const AddAccount = ({ accounts }: TAddAccountGuide) => {
   const [accountCode, setAccountCode] = useState<string>();
   const [accountName, setAccountName] = useState('');
   const [coinCode, setCoinCode] = useState<'choose' | CoinCode>('choose');
@@ -260,7 +263,7 @@ export const AddAccount = () => {
           </div>
         </div>
       </div>
-      <AddAccountGuide />
+      <AddAccountGuide accounts={accounts} />
     </div>
   );
 };

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -196,7 +196,7 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
         <Route path="wallet-connect/connect" element={AccConnectScreenWC} />
         <Route path="wallet-connect/dashboard" element={AccDashboardWC} />
       </Route>
-      <Route path="add-account" element={<AddAccount />} />
+      <Route path="add-account" element={<AddAccount accounts={accounts}/>} />
       <Route path="account-summary" element={AccountsSummaryEl} />
       <Route path="buy">
         <Route path="info" element={BuyInfoEl} >

--- a/frontends/web/src/routes/settings/manage-account-guide.tsx
+++ b/frontends/web/src/routes/settings/manage-account-guide.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
+import { i18n } from '../../i18n/i18n';
 import { Entry } from '../../components/guide/entry';
 import { Guide } from '../../components/guide/guide';
 import { IAccount } from '../../api/account';
@@ -23,6 +24,17 @@ import { isBitcoinOnly } from '../account/utils';
 type TAccountGuide = {
   accounts: IAccount[]
 }
+
+const getCoinsLink = () => {
+  switch (i18n.resolvedLanguage) {
+  case 'de':
+    return 'https://bitbox.swiss/de/coins/';
+  case 'es':
+    return 'https://bitbox.swiss/es/monedas/';
+  default:
+    return 'https://bitbox.swiss/coins/';
+  }
+};
 
 export const AccountGuide = ({ accounts }: TAccountGuide) => {
   const { t } = useTranslation();
@@ -39,7 +51,7 @@ export const AccountGuide = ({ accounts }: TAccountGuide) => {
           <Entry key="supportedCoins" entry={{
             link: {
               text: t('guide.accounts.supportedCoins.link.text'),
-              url: 'https://bitbox.swiss/coins/',
+              url: getCoinsLink(),
             },
             text: t('guide.accounts.supportedCoins.text'),
             title: t('guide.accounts.supportedCoins.title'),

--- a/frontends/web/src/routes/settings/manage-account-guide.tsx
+++ b/frontends/web/src/routes/settings/manage-account-guide.tsx
@@ -17,9 +17,16 @@
 import { useTranslation } from 'react-i18next';
 import { Entry } from '../../components/guide/entry';
 import { Guide } from '../../components/guide/guide';
+import { IAccount } from '../../api/account';
+import { isBitcoinOnly } from '../account/utils';
 
-export const AccountGuide = () => {
+type TAccountGuide = {
+  accounts: IAccount[]
+}
+
+export const AccountGuide = ({ accounts }: TAccountGuide) => {
   const { t } = useTranslation();
+  const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
   return (
     <Guide>
       <Entry key="whatAreAccounts" entry={t('guide.accounts.whatAreAccounts')} />
@@ -27,15 +34,19 @@ export const AccountGuide = () => {
       <Entry key="whatIsRememberWallet" entry={t('guide.accounts.whatIsRememberWallet')} />
       <Entry key="recoverAccounts" entry={t('guide.accounts.recoverAccounts')} />
       <Entry key="moveFunds" entry={t('guide.accounts.moveFunds')} />
-      <Entry key="supportedCoins" entry={{
-        link: {
-          text: t('guide.accounts.supportedCoins.link.text'),
-          url: 'https://bitbox.swiss/coins/',
-        },
-        text: t('guide.accounts.supportedCoins.text'),
-        title: t('guide.accounts.supportedCoins.title'),
-      }} />
-      <Entry key="howtoAddTokens" entry={t('guide.accounts.howtoAddTokens')} />
+      { !hasOnlyBTCAccounts && (
+        <>
+          <Entry key="supportedCoins" entry={{
+            link: {
+              text: t('guide.accounts.supportedCoins.link.text'),
+              url: 'https://bitbox.swiss/coins/',
+            },
+            text: t('guide.accounts.supportedCoins.text'),
+            title: t('guide.accounts.supportedCoins.title'),
+          }} />
+          <Entry key="howtoAddTokens" entry={t('guide.accounts.howtoAddTokens')} />
+        </>
+      )}
       <Entry key="howManyAccounts" entry={t('guide.accounts.howManyAccounts')} />
     </Guide>
   );

--- a/frontends/web/src/routes/settings/manage-account-guide.tsx
+++ b/frontends/web/src/routes/settings/manage-account-guide.tsx
@@ -27,6 +27,14 @@ export const AccountGuide = () => {
       <Entry key="whatIsRememberWallet" entry={t('guide.accounts.whatIsRememberWallet')} />
       <Entry key="recoverAccounts" entry={t('guide.accounts.recoverAccounts')} />
       <Entry key="moveFunds" entry={t('guide.accounts.moveFunds')} />
+      <Entry key="supportedCoins" entry={{
+        link: {
+          text: t('guide.accounts.supportedCoins.link.text'),
+          url: 'https://bitbox.swiss/coins/',
+        },
+        text: t('guide.accounts.supportedCoins.text'),
+        title: t('guide.accounts.supportedCoins.title'),
+      }} />
       <Entry key="howtoAddTokens" entry={t('guide.accounts.howtoAddTokens')} />
       <Entry key="howManyAccounts" entry={t('guide.accounts.howManyAccounts')} />
     </Guide>

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -315,7 +315,7 @@ class ManageAccounts extends Component<Props, State> {
             </View>
           </Main>
         </GuidedContent>
-        <AccountGuide />
+        <AccountGuide accounts={accounts}/>
       </GuideWrapper>
     );
   }


### PR DESCRIPTION
Added a "Which coins are supported?" guide entry in settings/manage-accounts and add-account, which links back to the [coins overview](https://bitbox.swiss/coins/) on the BitBox homepage. If users struggle to add a Cardano or ERC20 token account, they can now find information on this directly in the BitBoxApp.

It also makes sense to hide this new and the existing "How can I add additional tokens" entry for Bitcoin-only edition users, since they are irrelevant.

**Preview in add-acount:**
<img width="1326" alt="Screenshot_2024-03-11_at_07 47 29" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/79049748/eea1ec55-d455-4265-a697-0d20c1763ac4">
