### PR TITLE
backend: handle connection error during lightning activation

### DIFF
--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -121,6 +121,9 @@ func (lightning *Lightning) Activate() error {
 	}
 
 	if err = lightning.connect(true); err != nil {
+		if deactivateErr := lightning.Deactivate(); deactivateErr != nil {
+			lightning.log.Error(deactivateErr)
+		}
 		return err
 	}
 


### PR DESCRIPTION
If an error occurs during the lightning connection process, it is returned, but the lightning configuration is not cleared. This leads to the appearance of a lightning wallet in the app when, in reality, it doesn't exist. This commit addresses this issue by deactivating the lightning configuration if any error occurs during this step.