### PR TITLE
frontend: reduce container spacing on mobile

### DIFF
--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -77,7 +77,7 @@
         min-height: auto !important;
     }
     .inner.fit {
-        padding-bottom: var(--space-half);
+        padding-bottom: 0;
         padding-top: 0;
     }
 
@@ -122,7 +122,7 @@
 }
 @media (max-width: 768px) {
     .fill {
-        padding: 0 0 var(--space-default) 0;
+        padding: 0;
     }
     .header {
         padding-left: var(--space-half);
@@ -250,18 +250,22 @@
 .buttons.reverseRow {
     flex-direction: row;
 }
-.dialog .buttons {
-    padding-left: var(--space-default);
-    padding-right: var(--space-default);
-}
 .fit .buttons {
     margin-top: var(--space-half);
+    padding-left: 0;
+    padding-right: 0;
+}
+.dialog .buttons {
     padding-left: var(--space-half);
     padding-right: var(--space-half);
 }
 @media (max-width: 768px) {
     .buttons {
         padding: 0 var(--space-half);
+    }
+    .fit .buttons {
+        margin-top: 0;
+        padding: var(--space-half);
     }
 }
 @media (max-width: 768px) and (orientation: portrait) {


### PR DESCRIPTION
With this ViewBottons are nicely positioned on mobile.

One change affects large screen that fixes a small misalingment of
aopp success buttons.

Buttons container on large screen should have no padding if inside
a View component with fitContent prop, else they are misaligned
with the content.

Button padding is only needed for small screen and defined later
in this change.

I tested the following views:
- send scan qr code dialog
- AOPP
- AppUpgradeRequired
- AuthRequired
- walletconnect (tested only without active pairing)
- ReceiveAccountsSelector accounts/select-receive
- party tested bitsurance
- pairing
- passphrase
