### PR TITLE
frontend: center appupgraderequired view

### DIFF
--- a/frontends/web/src/components/appupgraderequired.tsx
+++ b/frontends/web/src/components/appupgraderequired.tsx
@@ -27,6 +27,7 @@ export const AppUpgradeRequired = () => {
       <Header />
       <View
         fullscreen
+        textCenter
         verticallyCentered
         width="840px"
         withBottomBar>


### PR DESCRIPTION
App-upgrade-required component looks better if fully centered, as it is just a message and a download button.