### PR TITLE
backend/tests: refactor backend tests and add new tests 

### DIFF
--- a/backend/aopp_test.go
+++ b/backend/aopp_test.go
@@ -38,9 +38,6 @@ const dummySignature = "signature"
 
 const uriPrefix = "aopp:?"
 
-var rootFingerprint = []byte{0x55, 0x055, 0x55, 0x55}
-var rootFingerprint2 = []byte{0x66, 0x066, 0x66, 0x66}
-
 func defaultParams() url.Values {
 	params := url.Values{}
 	params.Set("v", "0")
@@ -63,7 +60,7 @@ func makeKeystore(
 			return "Mock keystore", nil
 		},
 		RootFingerprintFunc: func() ([]byte, error) {
-			return rootFingerprint, nil
+			return rootFingerprint1, nil
 		},
 		SupportsAccountFunc: func(coin coinpkg.Coin, meta interface{}) bool {
 			switch coin.(type) {
@@ -228,7 +225,7 @@ func TestAOPPSuccess(t *testing.T) {
 					State: aoppStateChoosingAccount,
 					Accounts: []account{
 						{Name: test.accountName, Code: test.accountCode},
-						{Name: "Second account", Code: regularAccountCode(rootFingerprint, test.coinCode, 1)},
+						{Name: "Second account", Code: regularAccountCode(rootFingerprint1, test.coinCode, 1)},
 					},
 					Callback: callback,
 					Message:  dummyMsg,
@@ -244,7 +241,7 @@ func TestAOPPSuccess(t *testing.T) {
 					State: aoppStateSuccess,
 					Accounts: []account{
 						{Name: test.accountName, Code: test.accountCode},
-						{Name: "Second account", Code: regularAccountCode(rootFingerprint, test.coinCode, 1)},
+						{Name: "Second account", Code: regularAccountCode(rootFingerprint1, test.coinCode, 1)},
 					},
 					AccountCode: test.accountCode,
 					Address:     test.address,

--- a/backend/rates/mock.go
+++ b/backend/rates/mock.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rates
+
+import (
+	"time"
+)
+
+// MockRateUpdater returns a rate updater mock. Remember to defer calling the Stop() method when using it.
+func MockRateUpdater() *RateUpdater {
+	updater := NewRateUpdater(nil, "/dev/null")
+	updater.history = map[string][]exchangeRate{
+		"btcUSD": {
+			{value: 1, timestamp: time.Unix(1598832062, 0)}, // 2020-08-31 00:01:02
+			{value: 2, timestamp: time.Unix(1598918700, 0)},
+			{value: 3, timestamp: time.Unix(1598922501, 0)},
+			{value: 4, timestamp: time.Unix(1599091262, 0)}, // 2020-09-03 00:01:02
+		},
+		"ltcUSD": {
+			{value: 4, timestamp: time.Date(2020, 8, 02, 23, 0, 0, 0, time.UTC)},
+			{value: 4, timestamp: time.Date(2020, 9, 02, 23, 0, 0, 0, time.UTC)},
+		},
+	}
+	updater.last = map[string]map[string]float64{
+		"BTC": {
+			"USD": 21.0,
+		},
+		"ETH": {
+			"USD": 1.0,
+		},
+	}
+	return updater
+}


### PR DESCRIPTION
Refactor backend tests, add some utils to make it easier to create new tests and add tests for `backend.AccountsByKeystore` and `backend.AccountsTotalBalanceByKeystore`.

In particular:
- Moved several util functions from accounts_test.go to backend_test.go (accounts_test was really long and difficult to read, and now backend_tests.go gathers all the main related utils together, while account_test.go has mainly actual tests inside)
- Added new util functions, to reduce code duplication and make it easier to create new tests
- Added tests for `backend.AccountsByKeystore` and `backend.AccountsTotalBalanceByKeystore`
- Added a RatesUpdater mock function

