### PR TITLE
backend/bitbox02: require fw v9.18.0 for BIP-85

### DIFF
--- a/backend/devices/bitbox02/handlers/handlers.go
+++ b/backend/devices/bitbox02/handlers/handlers.go
@@ -325,7 +325,7 @@ func (handlers *Handlers) getVersionHandler(_ *http.Request) interface{} {
 		CanGotoStartupSettings:     currentVersion.AtLeast(semver.NewSemVer(9, 6, 0)),
 		CanBackupWithRecoveryWords: currentVersion.AtLeast(semver.NewSemVer(9, 13, 0)),
 		CanCreate12Words:           currentVersion.AtLeast(semver.NewSemVer(9, 6, 0)),
-		CanBIP85:                   currentVersion.AtLeast(semver.NewSemVer(9, 16, 0)),
+		CanBIP85:                   currentVersion.AtLeast(semver.NewSemVer(9, 18, 0)),
 	}
 }
 


### PR DESCRIPTION
Expected to be released in that version.