### PR TITLE
frontend/settings: add 'Export logs' feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
--
+- New feature in advanced settings: Export logs
 
 ## 4.42.0
 - Bundle BitBox02 firmware version v9.18.0 and intermediate version v9.17.1

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -128,3 +128,7 @@ export const subscribeAuth = (
 export const onAuthSettingChanged = (): Promise<void> => {
   return apiPost('on-auth-setting-changed');
 };
+
+export const exportLogs = (): Promise<ISuccess> => {
+  return apiPost('export-log');
+};

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1610,6 +1610,10 @@
         "description": "You can connect to your own Electrum full node.",
         "title": "Connect your own full node"
       },
+      "exportLogs": {
+        "description": "Export log file to help with troubleshooting and support.",
+        "title": "Export logs"
+      },
       "fee": "Enable custom fees",
       "setProxyAddress": "Set proxy address",
       "title": "Expert settings",

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -25,6 +25,7 @@ import { EnableCustomFeesToggleSetting } from './components/advanced-settings/en
 import { EnableCoinControlSetting } from './components/advanced-settings/enable-coin-control-setting';
 import { ConnectFullNodeSetting } from './components/advanced-settings/connect-full-node-setting';
 import { EnableTorProxySetting } from './components/advanced-settings/enable-tor-proxy-setting';
+import { ExportLogSetting } from './components/advanced-settings/export-log-setting';
 import { getConfig } from '../../utils/config';
 import { MobileHeader } from './components/mobile-header';
 import { Guide } from '../../components/guide/guide';
@@ -89,6 +90,7 @@ export const AdvancedSettings = ({ deviceIDs, hasAccounts }: TPagePropsWithSetti
                 <EnableAuthSetting backendConfig={backendConfig} onChangeConfig={setConfig} />
                 <EnableTorProxySetting proxyConfig={proxyConfig} onChangeConfig={setConfig} />
                 <ConnectFullNodeSetting />
+                <ExportLogSetting />
               </WithSettingsTabs>
             </ViewContent>
           </View>

--- a/frontends/web/src/routes/settings/components/advanced-settings/export-log-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/export-log-setting.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TFunction, useTranslation } from 'react-i18next';
+import { SettingsItem } from '../settingsItem/settingsItem';
+import { ChevronRightDark } from '../../../../components/icon';
+import { runningInAndroid, debug } from '../../../../utils/env';
+import { alertUser } from '../../../../components/alert/Alert';
+import { exportLogs } from '../../../../api/backend';
+
+const logs = async (t: TFunction) => {
+  try {
+    const result = await exportLogs();
+    if (result !== null && !result.success) {
+      alertUser(result.errorMessage || t('genericError'));
+    }
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+export const ExportLogSetting = () => {
+  const { t } = useTranslation();
+  return (debug === true || runningInAndroid()) ? null : (
+    <SettingsItem
+      settingName={t('settings.expert.exportLogs.title')}
+      onClick={() => logs(t)}
+      secondaryText={t('settings.expert.exportLogs.description')}
+      extraComponent={
+        <ChevronRightDark
+          width={24}
+          height={24}
+        />
+      }
+    />
+  );
+};


### PR DESCRIPTION
This commit introduces a new feature to the Settings section, enabling users to easily export log files for troubleshooting purposes. With this addition, users can access log files without the need to navigate through the application's files manually, simplifying the process of sharing logs with support team.

When 'Export Logs' is selected from the Settings menu, the save dialog opens, allowing the user to specify the destination folder. Upon confirmation, the log file, including the current date and time in the filename, is then copied to the selected folder.

This update works only on Qt and is not available in debug mode.