### PR TITLE
frontend: update chart when chart data length changed

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -118,6 +118,7 @@ class Chart extends Component<Props, State> {
     ) {
       const data = this.state.source === 'hourly' ? chartDataHourly : chartDataDaily;
       this.lineSeries.setData(data);
+      this.chart?.timeScale().fitContent();
       this.setFormattedData(data);
     }
 

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -111,10 +111,10 @@ class Chart extends Component<Props, State> {
     }
     if (
       (this.lineSeries && prev.data.chartDataDaily && prev.data.chartDataHourly && chartDataDaily && chartDataHourly)
-            && (
-              prev.data.chartDataDaily.length !== chartDataDaily.length
-                || prev.data.chartDataHourly.length !== chartDataHourly.length
-            )
+        && (
+          prev.data.chartDataDaily.length !== chartDataDaily.length
+          || prev.data.chartDataHourly.length !== chartDataHourly.length
+        )
     ) {
       const data = this.state.source === 'hourly' ? chartDataHourly : chartDataDaily;
       this.lineSeries.setData(data);


### PR DESCRIPTION
Sometimes the chart was only half filled or not everything was
displayed. This can happen if there is at least one rememebered
wallet in combination with an unlocked wallet with different age,
so that the length of the chart data changes.

calling fitContent after setting the new data fixes this
https://tradingview.github.io/lightweight-charts/docs/api/interfaces/ITimeScaleApi#fitcontent