### PR TITLE
backend/usb: update hid identifier

### DIFF
--- a/backend/devices/usb/hid.go
+++ b/backend/devices/usb/hid.go
@@ -90,7 +90,7 @@ func (info hidDeviceInfo) Product() string {
 
 // Identifier implements DeviceInfo.
 func (info hidDeviceInfo) Identifier() string {
-	return hex.EncodeToString([]byte(info.DeviceInfo.Path))
+	return hex.EncodeToString([]byte(info.DeviceInfo.Path + info.DeviceInfo.Product))
 }
 
 // singleThreadedDevice runs all hidapi functions in the same OS thread. See the docs of the


### PR DESCRIPTION
Whith this update the device identifier changes when the bitbox reboots into bootloader and forces the app to detect the reboot, that was sometime missed.