### PR TITLE
android: add com.google.android.gms.version to AndroidManifest.xml

### DIFF
--- a/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
+++ b/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
@@ -34,6 +34,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <!-- Fixes crash when accessing the camera on some devices -->
+        <!-- ```A required meta-data tag in your app's AndroidManifest.xml does not exist.  You must have the following declaration within the <application> element:     <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" /> ``` -->
+        <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
         <!-- launchMode: Makes sure that onIntent/onResume is reliably called on usb attached/detached events -->
         <!-- configChanges: Makes sure onCreate is not called on those changes, which prevents an ugly reload -->
         <activity


### PR DESCRIPTION
A user reported a crash when accessing the camera for QR code scanning. The crash report said that this tag was required.

I could not find much info about why accessing the camera would require Google Play Services. It seems however that simply adding the tag should not prevent the app to be installed on devices without Google Play Services.