### PR TITLE
frontend: better typing for Input component

### DIFF
--- a/frontends/web/src/components/forms/input.tsx
+++ b/frontends/web/src/components/forms/input.tsx
@@ -15,39 +15,21 @@
  * limitations under the License.
  */
 
-import { forwardRef } from 'react';
+import { ChangeEvent, HTMLProps, forwardRef } from 'react';
 import styles from './input.module.css';
 
-type withValue = {
-  value: string | number;
-  defaultValue?: string | number;
-} | {
-  defaultValue: string | number;
-}
 
-export type Props = withValue & {
+
+export type Props = {
     align?: 'left' | 'right';
-    autoFocus?: boolean;
     children?: React.ReactNode;
     className?: string;
-    disabled?: boolean;
     error?: string | object;
-    id?: string;
-    label?: string;
-    min?: string;
-    name?: string;
-    onInput?: (e: any) => void;
-    onPaste?: (e: any) => void;
-    pattern?: string;
-    placeholder?: string;
-    readOnly?: boolean;
-    step?: string;
-    title?: string;
+    onInput?: (e: ChangeEvent<HTMLInputElement>) => void;
     transparent?: boolean;
-    type?: 'text' | 'password' | 'number';
-    maxLength?: number;
     labelSection?: JSX.Element | undefined;
-}
+    label?: string;
+} & Omit<HTMLProps<HTMLInputElement>, 'onInput'>
 
 export default forwardRef<HTMLInputElement, Props>(function Input({
   id,

--- a/frontends/web/src/components/transactions/note.tsx
+++ b/frontends/web/src/components/transactions/note.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as accountApi from '../../api/account';
 import { Input } from '../../components/forms';
@@ -44,8 +44,8 @@ export function Note({ accountCode, note, internalID }: Props) {
     }
   }, [editMode]);
 
-  const handleNoteInput = (e: Event) => {
-    const target = e.target as HTMLInputElement;
+  const handleNoteInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const target = e.target;
     setNewNote(target.value);
   };
 

--- a/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
@@ -17,10 +17,11 @@
 import { useTranslation } from 'react-i18next';
 import { ConversionUnit } from '../../../../../api/account';
 import { Input } from '../../../../../components/forms';
+import { ChangeEvent } from 'react';
 
 type TProps = {
     label: ConversionUnit;
-    onFiatChange: (event: Event) => void;
+    onFiatChange: (event: ChangeEvent<HTMLInputElement>) => void;
     disabled: boolean;
     error?: string;
     fiatAmount: string;

--- a/frontends/web/src/routes/account/send/components/inputs/note-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/note-input.tsx
@@ -17,9 +17,10 @@
 import { useTranslation } from 'react-i18next';
 import { Input } from '../../../../../components/forms';
 import style from './note-input.module.css';
+import { ChangeEvent } from 'react';
 
 type TProps = {
-    onNoteChange: (event: Event) => void;
+    onNoteChange: (event: ChangeEvent<HTMLInputElement>) => void;
     note: string;
 }
 

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component } from 'react';
+import { ChangeEvent, Component } from 'react';
 import * as accountApi from '../../../api/account';
 import { syncdone } from '../../../api/accountsync';
 import { BtcUnit, parseExternalBtcAmount } from '../../../api/coins';
@@ -296,8 +296,8 @@ class Send extends Component<Props, State> {
     }, 400);
   };
 
-  private handleNoteInput = (event: Event) => {
-    const target = (event.target as HTMLInputElement);
+  private handleNoteInput = (event: ChangeEvent<HTMLInputElement>) => {
+    const target = event.target;
     this.setState({
       'note': target.value,
     }, () => {
@@ -332,8 +332,8 @@ class Send extends Component<Props, State> {
     }
   };
 
-  private handleFiatInput = (event: Event) => {
-    const value = (event.target as HTMLInputElement).value;
+  private handleFiatInput = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
     this.setState({ fiatAmount: value });
     this.convertFromFiat(value);
   };

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   allScriptTypes,
@@ -71,8 +71,8 @@ export const UTXOs = ({
     return () => unsubscribe();
   }, [accountCode]);
 
-  const handleUTXOChange = (event: React.SyntheticEvent) => {
-    const target = event.target as HTMLInputElement;
+  const handleUTXOChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const target = event.target;
     const outPoint = target.dataset.outpoint as string;
     const proposedUTXOs = Object.assign({}, selectedUTXOs);
     if (target.checked) {

--- a/frontends/web/src/routes/device/bitbox01/restore.tsx
+++ b/frontends/web/src/routes/device/bitbox01/restore.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { Component } from 'react';
+import React, { ChangeEvent, Component } from 'react';
 import { route } from '../../../utils/route';
 import { translate, TranslateProps } from '../../../decorators/translate';
 import { apiPost } from '../../../utils/request';
@@ -105,8 +105,8 @@ class Restore extends Component<Props, State> {
     });
   };
 
-  private handleUnderstandChange = (e: React.SyntheticEvent) => {
-    this.setState({ understand: (e.target as HTMLInputElement).checked });
+  private handleUnderstandChange = (e: ChangeEvent<HTMLInputElement>) => {
+    this.setState({ understand: e.target.checked });
   };
 
   private setValidPassword = (password: string) => {

--- a/frontends/web/src/routes/device/bitbox02/passphrase.tsx
+++ b/frontends/web/src/routes/device/bitbox02/passphrase.tsx
@@ -259,7 +259,7 @@ class Passphrase extends Component<Props, State> {
             </ul>
             <Status type={understood ? 'success' : 'warning'}>
               <Checkbox
-                onChange={e => this.setState({ understood: (e.target as HTMLInputElement)?.checked })}
+                onChange={e => this.setState({ understood: e.target.checked })}
                 id="understood"
                 checked={understood}
                 label={t('passphrase.summary.understand')}


### PR DESCRIPTION
Used `HTMLProps<HTMLInputElement>` for Input component props to remove unnecessary code & improve typing