### PR TITLE
frontend: add Globe icon for language settings 

### DIFF
--- a/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -41,7 +41,7 @@ export const DefaultCurrencyDropdownSetting = () => {
               await addToActiveCurrencies(fiat);
             }
           }}
-          defaultValue={{
+          value={{
             label: defaultValueLabel,
             value: defaultCurrency
           }}

--- a/frontends/web/src/routes/settings/components/appearance/languageDropDownSetting.module.css
+++ b/frontends/web/src/routes/settings/components/appearance/languageDropDownSetting.module.css
@@ -1,0 +1,7 @@
+.container {
+    display: flex;
+}
+
+.container img {
+    margin-right: var(--space-eight);
+}

--- a/frontends/web/src/routes/settings/components/appearance/languageDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/languageDropdownSetting.tsx
@@ -19,21 +19,26 @@ import { useTranslation } from 'react-i18next';
 import { defaultLanguages } from '../../../../components/language/types';
 import { getSelectedIndex } from '../../../../utils/language';
 import { SingleDropdown } from '../dropdowns/singledropdown';
+import { GlobeDark, GlobeLight } from '../../../../components/icon/icon';
+import { useDarkmode } from '../../../../hooks/darkmode';
+import styles from './languageDropDownSetting.module.css';
 
 export const LanguageDropdownSetting = () => {
   const { i18n, t } = useTranslation();
   const selectedLanguage = defaultLanguages[getSelectedIndex(defaultLanguages, i18n)];
   const formattedLanguages = defaultLanguages.map(lang => ({ label: lang.display, value: lang.code }));
+  const { isDarkMode } = useDarkmode();
+  const globe = isDarkMode ? <GlobeLight/> : <GlobeDark />;
   return (
     <SettingsItem
-      settingName={t('newSettings.appearance.language.title')}
+      settingName={<div className={styles.container}>{globe}{t('newSettings.appearance.language.title')}</div>}
       secondaryText={t('newSettings.appearance.language.description')}
       collapseOnSmall
       extraComponent={
         <SingleDropdown
           options={formattedLanguages}
           handleChange={i18n.changeLanguage}
-          defaultValue={{ label: selectedLanguage.display, value: selectedLanguage.code }}
+          value={{ label: selectedLanguage.display, value: selectedLanguage.code }}
         />
       }
     />

--- a/frontends/web/src/routes/settings/components/dropdowns/singledropdown.tsx
+++ b/frontends/web/src/routes/settings/components/dropdowns/singledropdown.tsx
@@ -25,7 +25,7 @@ type TOption = {
 type TSelectProps = {
     options: TOption[];
     handleChange: (param?: any) => void;
-    defaultValue: TOption;
+    value: TOption;
 }
 
 const DropdownIndicator = (props: DropdownIndicatorProps<TOption, false>) => {
@@ -55,13 +55,13 @@ const SingleValue = (props: SingleValueProps<TOption, false>) => {
 };
 
 
-export const SingleDropdown = ({ options, handleChange, defaultValue }: TSelectProps) => {
+export const SingleDropdown = ({ options, handleChange, value }: TSelectProps) => {
   return (
     <Select
       className={dropdownStyles.select}
       classNamePrefix="react-select"
       isSearchable={true}
-      defaultValue={defaultValue}
+      value={value}
       components={{ IndicatorSeparator: () => null, DropdownIndicator, SingleValue, Option }}
       onChange={(selected) => {
         if (selected) {

--- a/frontends/web/src/routes/settings/components/settingsItem/settingsItem.tsx
+++ b/frontends/web/src/routes/settings/components/settingsItem/settingsItem.tsx
@@ -56,7 +56,7 @@ export const SettingsItem = ({
   const content =
     (<>
       <span>
-        {typeof settingName === 'string' ? <p className={styles.primaryText}>{settingName}</p> : settingName }
+        <div className={styles.primaryText}>{settingName}</div>
         { secondaryText ? (
           <p className={styles.secondaryText}>{secondaryText}</p>
         ) : null }


### PR DESCRIPTION
To improve UX, on languages other than "en", we'd like to show a "Change back to English" button in the settings page near the language dropdown.

Also changed `defaultValue` to `value` of `SingleDropdown` component to allow for controlled input.

[Preview]:

<img width="1060" alt="wok" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/93fb7498-34c4-4b47-9b1f-56307578f3f1">
<img width="1066" alt="kow" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/253debf3-3da6-4640-bce3-af72c4ad7f5d">

