### PR TITLE
frontend/android: fix app close and re-open crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Show QR scanner video in fullscreen on mobile for onchain transactions
 - Android: fix file upload forms in MoonPay
 - Replace the existing BIP69 lexicographical sorting of tx inputs/outputs with a randomized sorting approach
+- Android: fix app crash after close and re-open
 
 ## 4.41.0
 - New feature: insure your bitcoins through Bitsurance

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoService.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoService.java
@@ -75,6 +75,8 @@ public class GoService extends Service {
     @Override
     public void onDestroy() {
         Util.log("GoService onDestroy()");
+        // It would be nice to call MobileServer.shutdown() here, but that function
+        // is currently incomplete and can lead to unpredictable results.
     }
 
     public void startServer(String filePath, GoEnvironmentInterface goEnvironment, GoAPIInterface goAPI) {

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -607,7 +607,11 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         Util.log("lifecycle: onDestroy");
+        if (goService != null) {
+            unbindService(connection);
+        }
         super.onDestroy();
+        Util.quit(MainActivity.this);
     }
 
     @Override
@@ -650,17 +654,7 @@ public class MainActivity extends AppCompatActivity {
             .setMessage("Do you really want to exit?")
             .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int which) {
-                    // Move to background to avoid possible auto-restart after app exit.
-                    // When in foreground, the system may assume the process quit
-                    // unexpectedly and can try restarting it: Android can't tell
-                    // whether the app exited on purpose, suddenly crashed or terminated
-                    // by the system to reclaim resources.
-                    moveTaskToBack(true);
-                    // Send SIGKILL signal to the app's process and let the system shut it down.
-                    Process.killProcess(Process.myPid());
-                    // If the above killProcess didn't work and we're still here,
-                    // simply terminate the JVM as the last resort.
-                    System.exit(0);
+                    Util.quit(MainActivity.this);
                 }
             })
             .setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/Util.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/Util.java
@@ -3,6 +3,7 @@ package ch.shiftcrypto.bitboxapp;
 import android.app.Application;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Process;
 import android.util.Log;
 
 public class Util {
@@ -17,5 +18,19 @@ public class Util {
 
     public static void log(String msg) {
         Log.d("bitboxapp", msg);
+    }
+
+    public static void quit(MainActivity activity) {
+        // Move to background to avoid possible auto-restart after app exit.
+        // When in foreground, the system may assume the process quit
+        // unexpectedly and can try restarting it: Android can't tell
+        // whether the app exited on purpose, suddenly crashed or terminated
+        // by the system to reclaim resources.
+        activity.moveTaskToBack(true);
+        // Send SIGKILL signal to the app's process and let the system shut it down.
+        Process.killProcess(Process.myPid());
+        // If the above killProcess didn't work and we're still here,
+        // simply terminate the JVM as the last resort.
+        System.exit(0);
     }
 }


### PR DESCRIPTION
On various Android versions, when closing the app through the app manager (i.e. swiping out the app from the list you get by pressing the squared button on the device) the backend service was still running. This was causing a crash the next time the app was opened, as an already running backend was detected.

The nice fix for this would be to call Mobileserver.shutdown() when destroying the GoService, but this is not easy, as the server shutdown is only drafted, at the moment.

This commit explicitly kills the app (the same way as it happens when clicking the back button) to fix the issue.