### PR TITLE
frontend: vite build target to chrome83

### DIFF
--- a/frontends/web/vite.config.mjs
+++ b/frontends/web/vite.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig(() => {
     build: {
       modulePreload: false,
       outDir: 'build',
+      target: ['chrome83'],
     },
     plugins: [
       react(),


### PR DESCRIPTION
By default vitejs uses the following build targets: es2020, edge88, firefox78, chrome87, safari14. But this is not very useful as it contains targets the BitBoxApp never runs on (edge, firefox) and does not target the chrome version that is currently used in Qt webview, which is chrome83.

https://vitejs.dev/config/build-options#build-target

Explicitly setting the build target to chrome83 has the following effect:

- un-minified bundle is smaller 3,271.26 kB -> 3,266.49 kB
- changes traditional class constructor pattern to modern class field declarations https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields