### PR TITLE
frontend: properly paste localized amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add specific titles to guides replacing the generic "Guide" previously used on all pages
 - Android: enable transactions export feature
 - Format amounts using localized decimal and group separator
+- Support pasting different localized number formats, i.e. dot and comma separated amounts
 - Fix BitBoxApp crash on GrapheneOS and other phones without Google Play Services when scanning QR codes.
 
 ## 4.42.0

--- a/frontends/web/src/components/forms/index.tsx
+++ b/frontends/web/src/components/forms/index.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2021-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ export { Button, ButtonLink } from './button';
 export { default as Checkbox } from './checkbox';
 export { Radio } from './radio';
 export { Field } from './field';
-export { default as Input } from './input';
+export { Input } from './input';
+export { NumberInput } from './input-number';
 export { Label } from './label';
 export { Select } from './select';

--- a/frontends/web/src/components/forms/input-number.test.tsx
+++ b/frontends/web/src/components/forms/input-number.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { NumberInput } from './input-number';
+
+describe('components/forms/input-number', () => {
+  it('should preserve type attribute', () => {
+    const { container } = render(<NumberInput defaultValue="" />);
+    expect(container.querySelector('[type="number"')).toBeTruthy();
+  });
+
+  it('should have children', () => {
+    render(<NumberInput defaultValue=""><span>label</span></NumberInput>);
+    expect(screen.getByText('label')).toBeTruthy();
+  });
+
+  it('should have a label', () => {
+    render(<NumberInput id="myInput" label="Label" defaultValue="" />);
+    expect(screen.getByLabelText('Label')).toBeTruthy();
+  });
+
+  it('should preserve text', () => {
+    render(<NumberInput label="Label" error="text too short" defaultValue="" />);
+    expect(screen.getByText('text too short')).toBeTruthy();
+  });
+
+  it('should paste supported number formats', async () => {
+    const mockCallback = vi.fn();
+    render(
+      <NumberInput placeholder="Number input" onChange={mockCallback} />
+    );
+    const input = screen.queryByPlaceholderText('Number input');
+    if (!input) {
+      throw new Error('Input not found');
+    }
+    fireEvent.paste(input, {
+      clipboardData: {
+        getData: () => '1,000,000.50'
+      }
+    });
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockCallback).toHaveBeenCalledWith(expect.objectContaining({
+      target: expect.objectContaining({ value: '1000000.50' })
+    }));
+
+    fireEvent.paste(input, { clipboardData: { getData: () => '100.50' } });
+    expect(mockCallback).toHaveBeenCalledTimes(2);
+    expect(mockCallback.mock.calls[1][0].target.value).toBe('100.50');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,0' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.0');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,0' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.0');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,00' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.00');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1.00' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.00');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,000' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.000');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,000.00' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.00');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1.000,00' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.00');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '100,50' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('100.50');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '100.00' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('100.00');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '100,000' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('100.000');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '100.000' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('100.000');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '.99' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('.99');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => ',99' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('.99');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '0.0000000000000000001' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('0.0000000000000000001');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '0,0000000000000000001' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('0.0000000000000000001');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1\'000\'000.50' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1\'000\'000,50' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1 000 000.50' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1.000.000,50' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1 000.50' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.50');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1.000,50' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.50');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,000.50' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.50');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,000,000.50' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+  });
+
+  it('has some unsupported number formats', async () => {
+    const mockCallback = vi.fn();
+    render(
+      <NumberInput placeholder="Weird formats" onChange={mockCallback} />
+    );
+    const input = screen.queryByPlaceholderText('Weird formats');
+    if (!input) {
+      throw new Error('Input not found');
+    }
+
+    fireEvent.paste(input, { clipboardData: { getData: () => '100,' } });
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('');
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,000.000,50' } });
+    expect(mockCallback).toHaveBeenCalledTimes(0);
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,,000' } });
+    expect(mockCallback).toHaveBeenCalledTimes(0);
+
+    mockCallback.mockClear();
+    fireEvent.paste(input, { clipboardData: { getData: () => '1,000' } });
+    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.000');
+
+  });
+
+});

--- a/frontends/web/src/components/forms/input-number.tsx
+++ b/frontends/web/src/components/forms/input-number.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2024 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback } from 'react';
+import { Input, TInputProps } from './input';
+
+type Props = Omit<TInputProps, 'ref' | 'onInput'>;
+
+export const NumberInput = (({
+  onChange,
+  ...props
+}: Props) => {
+
+  // support pasting of various different formats
+  // the function tries to do some light string replacement and see if it becomes a number
+  // if NaN it tries to detect and change a few commonly localized formats
+  // 100,50 should become 100.50, and not 10050
+  // more examples in the condition
+  const handlePaste = useCallback((event: React.ClipboardEvent<HTMLInputElement>) => {
+    if (!event.currentTarget || !event.clipboardData) {
+      return;
+    }
+    const text = (
+      event.clipboardData
+        .getData('text')
+        .trim()
+        // remove thousand separator characters space (fr, ru, sw) and apostrophe (ch, li)
+        .replace(/[ ']/g, '')
+    );
+
+    const target = event.currentTarget;
+    const dividedByComma = text.split(',');
+    const dividedByDot = text.split('.');
+    // see if this would turn to a valid number
+    const value = Number(text);
+    if (value && !Number.isNaN(value)) {
+      // valid number, stop here and let paste event continue
+      target.value = text;
+    } else if (
+      // comma decimal separator 100,50 or ,99
+      dividedByComma.length === 2
+      && dividedByDot.length === 1
+    ) {
+      target.value = dividedByComma.join('.');
+    } else if (
+      // comma decimal with dot thousand separator i.e. 1.000.000,50 (de, es, it)
+      dividedByComma.length === 2
+      && dividedByDot.length > 1
+      && dividedByDot[dividedByDot.length - 1]?.includes(',')
+    ) {
+      target.value = [
+        dividedByComma[0].replace(/[.]/g, ''), // replace dot in whole coins 1.000.000
+        dividedByComma[1], // rest i.e. 50
+      ].join('.');
+    } else if (
+      // dot decimal with comma thousand separator i.e. 1,000,000.50 (cn, jp, us)
+      dividedByDot.length === 2
+      && dividedByComma.length > 1
+      && dividedByComma[dividedByComma.length - 1]?.includes('.')
+    ) {
+      target.value = [
+        dividedByDot[0].replace(/[,]/g, ''), // replace comma in 1,000,000
+        dividedByDot[1], // rest i.e. 50
+      ].join('.');
+    } else {
+      console.warn(`unexpected format ${text.replace(/[\d]/g, '9')}`);
+      return;
+    }
+    if (onChange) {
+      onChange({ ...event, target });
+    }
+    event.preventDefault();
+  }, [onChange]);
+
+  return (
+    <Input
+      {...props}
+      type="number"
+      onInput={onChange}
+      onPaste={handlePaste}
+    />
+  );
+});

--- a/frontends/web/src/components/forms/input.test.tsx
+++ b/frontends/web/src/components/forms/input.test.tsx
@@ -17,7 +17,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import Input from './input';
+import { Input } from './input';
 
 describe('components/forms/input', () => {
   it('should preserve type attribute', () => {

--- a/frontends/web/src/components/forms/input.tsx
+++ b/frontends/web/src/components/forms/input.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2021 Shift Crypto AG
+ * Copyright 2021-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@
 import { ChangeEvent, HTMLProps, forwardRef } from 'react';
 import styles from './input.module.css';
 
-
-
-export type Props = {
+export type TInputProps = {
     align?: 'left' | 'right';
     children?: React.ReactNode;
     className?: string;
@@ -31,7 +29,7 @@ export type Props = {
     label?: string;
 } & Omit<HTMLProps<HTMLInputElement>, 'onInput'>
 
-export default forwardRef<HTMLInputElement, Props>(function Input({
+export const Input = forwardRef<HTMLInputElement, TInputProps>(({
   id,
   label = '',
   error,
@@ -42,7 +40,7 @@ export default forwardRef<HTMLInputElement, Props>(function Input({
   type = 'text',
   labelSection,
   ...props
-}, ref) {
+}: TInputProps, ref) => {
   return (
     <div className={[
       styles.input,

--- a/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Shift Crypto AG
+ * Copyright 2023-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,29 +14,34 @@
  * limitations under the License.
  */
 
+import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConversionUnit } from '../../../../../api/account';
-import { Input } from '../../../../../components/forms';
-import { ChangeEvent } from 'react';
+import { NumberInput } from '../../../../../components/forms';
 
 type TProps = {
-    label: ConversionUnit;
-    onFiatChange: (event: ChangeEvent<HTMLInputElement>) => void;
-    disabled: boolean;
-    error?: string;
-    fiatAmount: string;
+  label: ConversionUnit;
+  onFiatChange: (amount: string) => void;
+  disabled: boolean;
+  error?: string;
+  fiatAmount: string;
 }
 
-export const FiatInput = ({ label, onFiatChange, disabled, error, fiatAmount }: TProps) => {
+export const FiatInput = ({
+  label,
+  onFiatChange,
+  disabled,
+  error,
+  fiatAmount,
+}: TProps) => {
   const { t } = useTranslation();
   return (
-    <Input
-      type="number"
+    <NumberInput
       step="any"
       min="0"
       label={label}
       id="fiatAmount"
-      onInput={onFiatChange}
+      onChange={(event: ChangeEvent<HTMLInputElement>) => onFiatChange(event.target.value)}
       disabled={disabled}
       error={error}
       value={fiatAmount}

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -332,10 +332,9 @@ class Send extends Component<Props, State> {
     }
   };
 
-  private handleFiatInput = (event: ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    this.setState({ fiatAmount: value });
-    this.convertFromFiat(value);
+  private handleFiatInput = (fiatAmount: string) => {
+    this.setState({ fiatAmount });
+    this.convertFromFiat(fiatAmount);
   };
 
   private convertToFiat = (value?: string | boolean) => {


### PR DESCRIPTION
Amounts on invoices can use localized formatting for thousand and
decimal separators.

The BitBoxApp uses an input[type="number"] element as input field
which converts strings to numbers. Pasting amounts with localized
formatting can mess up the actual amount.
i.e. 100,50 becomes 10050, which is 100x off.

This change supports some additional formats by listening on the
onPaste event and conditionally patching some formats.

With this change, formats such as the following are now properly
converted.

- 100,50
- ,99
- 0,0000000000000000001
- 1'000'000,50
- 1'000'000.50
- 1 000 000.50
- 1.000.000,50
- 1.000,50
- 1,000.50
- 1,000,000.50

This change introduces a new NumberInput component that allows
pasting more formats. It is still just an input field for numbers
and not specifically aware or currencies.

Not detected are numbers without decimals, i.e 1,000 will become 1
instead of 1000 (localized), accidentally pasting 1 is preferable
than accidentally pasting 1000x too much.