### PR TITLE
frontend: fix overlapping loading animations of Moonpay

### DIFF
--- a/frontends/web/src/routes/buy/iframe.module.css
+++ b/frontends/web/src/routes/buy/iframe.module.css
@@ -15,6 +15,10 @@
     z-index: 3000;
 }
 
+.hide {
+    opacity: 0;
+}
+
 .header {
     position: relative;
     z-index: 2200;

--- a/frontends/web/src/routes/buy/moonpay.tsx
+++ b/frontends/web/src/routes/buy/moonpay.tsx
@@ -104,7 +104,7 @@ export const Moonpay = ({ accounts, code }: TProps) => {
                     width="100%"
                     height={height}
                     frameBorder="0"
-                    className={style.iframe}
+                    className={`${style.iframe} ${!iframeLoaded ? style.hide : ''}`}
                     allow="camera; payment"
                     src={`${moonpay.url}&colorCode=%235E94BF&theme=${isDarkMode ? 'dark' : 'light'}`}>
                   </iframe>


### PR DESCRIPTION
The onLoad event handler of the Moonpay iframe gets called slightly late, causing the overlapping of loading animations of BBapp's and Moonpay's.

To fix this, we made the iframe to be initialy transparent and only show it when onLoad gets fired.

[Preview before]:

https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/7a4632ee-6d2c-4b4c-820e-10ab0bee8477


[Preview after]:


https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/3d3e6b96-2fc8-4120-8cf9-e06d0c206187

