### PR TITLE
android: add com.google.android.gms.version to AndroidManifest.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add specific titles to guides replacing the generic "Guide" previously used on all pages
 - Android: enable transactions export feature
 - Format amounts using localized decimal and group separator
+- Fix BitBoxApp crash on GrapheneOS and other phones without Google Play Services when scanning QR codes.
 
 ## 4.42.0
 - Preselect backup when there's only one backup available

--- a/frontends/android/BitBoxApp/app/build.gradle
+++ b/frontends/android/BitBoxApp/app/build.gradle
@@ -37,6 +37,11 @@ dependencies {
     implementation "android.arch.lifecycle:extensions:1.1.1"
     implementation "android.arch.lifecycle:viewmodel:1.1.1"
     implementation project(path: ':mobileserver')
+    // The frontend depends on qr-scanner (https://github.com/nimiq/qr-scanner)
+    // which uses the Shape Detection API BarcodeDetector.  We use Google Play Services
+    // to interact with the native barcode scanner. See (2):
+    // https://developers.google.com/ml-kit/vision/barcode-scanning/android
+    implementation 'com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.0'
 
 
     // Fix Duplicate class

--- a/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
+++ b/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
@@ -34,6 +34,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <!-- This tag might be required when interacting with Google Play Services, see https://developers.google.com/android/guides/setup. -->
+        <!-- We interact with Google Play services through the JS QR code scanning library, which invokes the GPS Barcode scanner if available. -->
+        <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
         <!-- launchMode: Makes sure that onIntent/onResume is reliably called on usb attached/detached events -->
         <!-- configChanges: Makes sure onCreate is not called on those changes, which prevents an ugly reload -->
         <activity


### PR DESCRIPTION
Edited PR #2646 

A user reported a crash when accessing the camera for QR code scanning. The crash report said that this tag was required.

I could not find much info about why accessing the camera would require Google Play Services. It seems however that simply adding the tag should not prevent the app to be installed on devices without Google Play Services.

Edit: the app did not build because the resource `@integer/google_play_services_version` was not defined/did not exist which indicates that google play services was not properly integrated/recognized by the build system.

Adding google play services to the dependencies in `build.gradle` fixes the problem and the app builds. Two GrapheneOS users confirmed that this build fixes the issue for them.

