### PR TITLE
frontend: context-sensitive guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Android: fix file upload forms in MoonPay
 - Replace the existing BIP69 lexicographical sorting of tx inputs/outputs with a randomized sorting approach
 - Android: fix app crash after close and re-open
+- Add specific titles to guides replacing the generic "Guide" previously used on all pages
 
 ## 4.41.0
 - New feature: insure your bitcoins through Bitsurance

--- a/frontends/web/src/components/guide/guide.module.css
+++ b/frontends/web/src/components/guide/guide.module.css
@@ -11,18 +11,15 @@
 }
 
 .close {
-    color: var(--color-alt);
-    font-size: var(--size-default) !important;
-    text-decoration: none;
+    height: 24px;
+    width: 24px;
     display: flex;
-    flex-direction: row;
-    align-items: center;
-    line-height: 1;
+    padding: 4px;
 }
 
 .close img {
-    width: 18px;
-    height: 18px;
+    width: 20px;
+    height: 20px;
     margin-left: calc(var(--space-quarter) / 2);
 }
 

--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -15,17 +15,21 @@
  */
 
 import { ReactNode, useContext, useEffect } from 'react';
+import { t } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { A } from '../anchor/anchor';
 import { CloseXWhite } from '../icon';
 import { AppContext } from '../../contexts/AppContext';
+import { Button } from '../forms';
 import style from './guide.module.css';
+
 
 export type TProps = {
     children?: ReactNode;
+    title?: string
 }
 
-const Guide = ({ children }: TProps) => {
+const Guide = ({ children, title = t('guide.title') }: TProps) => {
   const { guideShown, toggleGuide, setGuideExists } = useContext(AppContext);
 
   useEffect(() => {
@@ -41,11 +45,11 @@ const Guide = ({ children }: TProps) => {
       <div className={[style.overlay, guideShown && style.show].join(' ')} onClick={toggleGuide}></div>
       <div className={[style.guide, guideShown && style.show].join(' ')}>
         <div className={[style.header, 'flex flex-row flex-between flex-items-center'].join(' ')}>
-          <h2>{t('guide.title')}</h2>
-          <a href="#" className={style.close} onClick={toggleGuide}>
-            {t('guide.toggle.close')}
+          <h2>{title}</h2>
+
+          <Button transparent className={style.close} onClick={toggleGuide}>
             <CloseXWhite />
-          </a>
+          </Button>
         </div>
         <div className={style.content}>
           {children}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -985,6 +985,20 @@
         "title": "Why show the secure chip model?"
       }
     },
+    "guideTitle": {
+      "account": "Account guide",
+      "accountInformation": "Account information guide",
+      "accountSummary": "Account summary guide",
+      "advancedSettings": "Advanced settings guide",
+      "appearance": "Appearance guide",
+      "buy": "Buy guide",
+      "insurance": "Insurance guide",
+      "manageAccount": "Manage accounts guide",
+      "manageDevice": "Manage device guide",
+      "receive": "Receive guide",
+      "send": "Send guide",
+      "walletConnect": "WalletConnect guide"
+    },
     "receive": {
       "address": {
         "text": "You can give the address to others to send you some coins. Just make sure they are sending to the correct address.",

--- a/frontends/web/src/routes/account/guide.tsx
+++ b/frontends/web/src/routes/account/guide.tsx
@@ -38,7 +38,7 @@ export function AccountGuide({
 }: Props) {
   const { t } = useTranslation();
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.account')}>
       <Entry key="accountDescription" entry={t('guide.accountDescription')} />
       {hasNoBalance && (
         <Entry key="accountSendDisabled" entry={t('guide.accountSendDisabled', {

--- a/frontends/web/src/routes/account/info/guide.tsx
+++ b/frontends/web/src/routes/account/info/guide.tsx
@@ -27,7 +27,7 @@ export function BitcoinBasedAccountInfoGuide({
 }: BitcoinBasedAccountInfoGuideProps) {
   const { t } = useTranslation();
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.accountInformation')}>
       <Entry key="guide.accountInfo.xpub" entry={t('guide.accountInfo.xpub')} shown={true} />
       <Entry key="guide.accountInfo.multipleXPubs" entry={{
         text: t('guide.accountInfo.multipleXPubs.text', { coinName }),

--- a/frontends/web/src/routes/account/receive/components/guide.tsx
+++ b/frontends/web/src/routes/account/receive/components/guide.tsx
@@ -29,7 +29,7 @@ export function ReceiveGuide({
 }: Props) {
   const { t } = useTranslation();
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.receive')}>
       <Entry key="guide.receive.address" entry={t('guide.receive.address')} />
       <Entry key="guide.receive.whyVerify" entry={t('guide.receive.whyVerify')} />
       <Entry key="guide.receive.howVerify" entry={t('guide.receive.howVerify')} />

--- a/frontends/web/src/routes/account/send/send-guide.tsx
+++ b/frontends/web/src/routes/account/send/send-guide.tsx
@@ -11,7 +11,7 @@ type TProps = {
 export const SendGuide = ({ coinCode }: TProps) => {
   const { t } = useTranslation();
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.send')}>
       <Entry key="guide.send.whyFee" entry={t('guide.send.whyFee')} />
       { isBitcoinBased(coinCode) && (
         <Entry key="guide.send.priority" entry={t('guide.send.priority')} />

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -235,7 +235,7 @@ export function AccountsSummary({
           </View>
         </Main>
       </GuidedContent>
-      <Guide>
+      <Guide title={t('guide.guideTitle.accountSummary')}>
         <Entry key="accountSummaryDescription" entry={t('guide.accountSummaryDescription')} />
         <Entry key="accountSummaryAmount" entry={{
           link: {

--- a/frontends/web/src/routes/account/walletconnect/guide.tsx
+++ b/frontends/web/src/routes/account/walletconnect/guide.tsx
@@ -5,7 +5,7 @@ import { Entry } from '../../../components/guide/entry';
 export const WCGuide = () => {
   const { t } = useTranslation();
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.walletConnect')}>
       <Entry
         key="guide.walletConnect.whatIsWalletConnect"
         entry={t('guide.walletConnect.whatIsWalletConnect')}

--- a/frontends/web/src/routes/bitsurance/guide.tsx
+++ b/frontends/web/src/routes/bitsurance/guide.tsx
@@ -41,7 +41,7 @@ export const BitsuranceGuide = () => {
   const { t } = useTranslation();
 
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.insurance')}>
       <Entry key="guide.bitsurance.why" entry={t('guide.bitsurance.why')} shown={true} />
       <Entry key="guide.bitsurance.who" entry={t('guide.bitsurance.who')} />
       <Entry key="guide.bitsurance.what" entry={t('guide.bitsurance.what')} />

--- a/frontends/web/src/routes/buy/guide.tsx
+++ b/frontends/web/src/routes/buy/guide.tsx
@@ -39,7 +39,7 @@ export default function BuyGuide({ name, exchange }: BuyGuideProps) {
   const privacyLink = exchange === 'pocket' ? pocketLink : moonpayLink;
 
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.buy')}>
       <Entry key="guide.buy.security" entry={{
         link: {
           text: t('buy.info.disclaimer.security.link'),

--- a/frontends/web/src/routes/device/bitbox02/settings-guide.tsx
+++ b/frontends/web/src/routes/device/bitbox02/settings-guide.tsx
@@ -33,7 +33,7 @@ const getLink = () => {
 export const ManageDeviceGuide = () => {
   const { t } = useTranslation();
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.manageDevice')}>
       <Entry key="whatAreAccounts" entry={t('guide.device.name')} />
       <Entry key="guide.device.secure-chip" entry={{
         link: {

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -105,7 +105,7 @@ const AdvancedSettingsGuide = () => {
   const { t } = useTranslation();
 
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.advancedSettings')}>
       <Entry key="guide.settings-electrum.why" entry={t('guide.settings-electrum.why')} />
       <Entry key="guide.settings-electrum.tor" entry={t('guide.settings-electrum.tor')} />
     </Guide>

--- a/frontends/web/src/routes/settings/appearance.tsx
+++ b/frontends/web/src/routes/settings/appearance.tsx
@@ -67,7 +67,7 @@ const AppearanceGuide = () => {
   const { t } = useTranslation();
 
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.appearance')}>
       <Entry key="guide.settings.sats" entry={t('guide.settings.sats')} />
       <Entry key="guide.accountRates" entry={{
         link: {

--- a/frontends/web/src/routes/settings/manage-account-guide.tsx
+++ b/frontends/web/src/routes/settings/manage-account-guide.tsx
@@ -40,7 +40,7 @@ export const AccountGuide = ({ accounts }: TAccountGuide) => {
   const { t } = useTranslation();
   const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
   return (
-    <Guide>
+    <Guide title={t('guide.guideTitle.manageAccount')}>
       <Entry key="whatAreAccounts" entry={t('guide.accounts.whatAreAccounts')} />
       <Entry key="whyIsThisUseful" entry={t('guide.accounts.whyIsThisUseful')} />
       <Entry key="whatIsRememberWallet" entry={t('guide.accounts.whatIsRememberWallet')} />


### PR DESCRIPTION
to improve the  UX, we'd like to have individualised guide title for each page and removed the "Close guide" text near the "X" icon.

<img width="1483" alt="pwt" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/cdc1c72d-a033-40de-abc2-2c41c897e21c">
