### PR TITLE
frontends/android: implement transactions export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - New feature in advanced settings: Export logs
 - Add specific titles to guides replacing the generic "Guide" previously used on all pages
+- Android: enable transactions export feature
 
 ## 4.42.0
 - Bundle BitBox02 firmware version v9.18.0 and intermediate version v9.17.1

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -948,12 +948,12 @@ func (backend *Backend) SetWatchonly(rootFingerprint []byte, watchonly bool) err
 // ExportLogs function copy and save log.txt file to help users provide it to support while troubleshooting.
 func (backend *Backend) ExportLogs() error {
 	name := fmt.Sprintf("%s-log.txt", time.Now().Format("2006-01-02-at-15-04-05"))
-	downloadsDir, err := utilConfig.DownloadsDir()
+	exportsDir, err := utilConfig.ExportsDir()
 	if err != nil {
 		backend.log.WithError(err).Error("error exporting logs")
 		return err
 	}
-	suggestedPath := filepath.Join(downloadsDir, name)
+	suggestedPath := filepath.Join(exportsDir, name)
 	path := backend.Environment().GetSaveFilename(suggestedPath)
 	if path == "" {
 		return nil

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -272,12 +272,12 @@ func (handlers *Handlers) postExportTransactions(*http.Request) (interface{}, er
 		ErrorMessage string `json:"errorMessage"`
 	}
 	name := fmt.Sprintf("%s-%s-export.csv", time.Now().Format("2006-01-02-at-15-04-05"), handlers.account.Config().Config.Code)
-	downloadsDir, err := config.DownloadsDir()
+	exportsDir, err := config.ExportsDir()
 	if err != nil {
 		handlers.log.WithError(err).Error("error exporting account")
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
-	suggestedPath := filepath.Join(downloadsDir, name)
+	suggestedPath := filepath.Join(exportsDir, name)
 	path := handlers.account.Config().GetSaveFilename(suggestedPath)
 	if path == "" {
 		return nil, nil
@@ -286,26 +286,26 @@ func (handlers *Handlers) postExportTransactions(*http.Request) (interface{}, er
 
 	transactions, err := handlers.account.Transactions()
 	if err != nil {
-		handlers.log.WithError(err).Error("error exporting account")
+		handlers.log.WithError(err).Error("error getting the transactions")
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 
 	file, err := os.Create(path)
 	if err != nil {
-		handlers.log.WithError(err).Error("error exporting account")
+		handlers.log.WithError(err).Error("error creating file")
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	if err := handlers.account.ExportCSV(file, transactions); err != nil {
 		_ = file.Close()
-		handlers.log.WithError(err).Error("error exporting account")
+		handlers.log.WithError(err).Error("error writing file")
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	if err := file.Close(); err != nil {
-		handlers.log.WithError(err).Error("error exporting account")
+		handlers.log.WithError(err).Error("error closing file")
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	if err := handlers.account.Config().UnsafeSystemOpen(path); err != nil {
-		handlers.log.WithError(err).Error("error exporting account")
+		handlers.log.WithError(err).Error("error opening file")
 		return result{Success: false, ErrorMessage: err.Error()}, nil
 	}
 	return result{Success: true}, nil

--- a/backend/mobileserver/mobileserver.go
+++ b/backend/mobileserver/mobileserver.go
@@ -90,6 +90,7 @@ type GoEnvironmentInterface interface {
 	SystemOpen(string) error
 	UsingMobileData() bool
 	NativeLocale() string
+	GetSaveFilename(string) string
 	SetDarkTheme(bool)
 	DetectDarkTheme() bool
 	Auth()
@@ -194,13 +195,10 @@ func Serve(dataDir string, environment GoEnvironmentInterface, goAPI GoAPIInterf
 				}
 				return []usb.DeviceInfo{deviceInfo{i}}
 			},
-			SystemOpenFunc:      environment.SystemOpen,
-			UsingMobileDataFunc: environment.UsingMobileData,
-			NativeLocaleFunc:    environment.NativeLocale,
-			GetSaveFilenameFunc: func(suggestedFilename string) string {
-				// On mobile, we don't yet support exporting files. Implement this once needed.
-				return ""
-			},
+			SystemOpenFunc:           environment.SystemOpen,
+			UsingMobileDataFunc:      environment.UsingMobileData,
+			NativeLocaleFunc:         environment.NativeLocale,
+			GetSaveFilenameFunc:      environment.GetSaveFilename,
 			SetDarkThemeFunc:         environment.SetDarkTheme,
 			DetectDarkThemeFunc:      environment.DetectDarkTheme,
 			AuthFunc:                 environment.Auth,

--- a/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
+++ b/frontends/android/BitBoxApp/app/src/main/AndroidManifest.xml
@@ -65,5 +65,18 @@
                 android:resource="@xml/device_filter" />
         </activity>
         <service android:name=".GoService" />
+
+        <!-- to allow external apps to open local files (e.g. exported csv) -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
+
+
 </manifest>

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
@@ -18,6 +18,7 @@ import android.os.Message;
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.MutableLiveData;
 
+import java.io.File;
 import java.util.Locale;
 
 import mobileserver.GoAPIInterface;
@@ -123,6 +124,12 @@ public class GoViewModel extends AndroidViewModel {
         public void auth() {
             Util.log("Auth requested from backend");
             requestAuth();
+        }
+
+        @Override
+        public String getSaveFilename(String fileName)  {
+            File folder = getApplication().getApplicationContext().getExternalFilesDir(null);
+            return new File(folder, fileName).getAbsolutePath();
         }
 
         public void onAuthSettingChanged(boolean enabled) {

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/MainActivity.java
@@ -126,22 +126,7 @@ public class MainActivity extends AppCompatActivity {
          }
     };
 
-    private static String getMimeType(String url) {
-        String type = null;
-        String extension = MimeTypeMap.getFileExtensionFromUrl(url);
-        if (extension != null) {
-            switch (extension) {
-                case "js":
-                    type = "text/javascript";
-                    break;
-                default:
-                    type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-                    break;
-            }
-        }
 
-        return type;
-    }
 
     @Override
     public void onConfigurationChanged(Configuration newConfig){
@@ -251,7 +236,7 @@ public class MainActivity extends AppCompatActivity {
                         // Intercept local requests and serve the response from the Android assets folder.
                         try {
                             InputStream inputStream = getAssets().open(url.replace(BASE_URL, "web/"));
-                            String mimeType = getMimeType(url);
+                            String mimeType = Util.getMimeType(url);
                             if (mimeType != null) {
                                 return new WebResourceResponse(mimeType, "UTF-8", inputStream);
                             }

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/Util.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/Util.java
@@ -1,18 +1,43 @@
 package ch.shiftcrypto.bitboxapp;
 
 import android.app.Application;
+import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Process;
 import android.util.Log;
+import android.webkit.MimeTypeMap;
+
+import androidx.core.content.FileProvider;
+
+import java.io.File;
 
 public class Util {
     public static void systemOpen(Application application, String url) throws Exception {
-        // https://developer.android.com/guide/components/intents-common.html#java
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        if (intent.resolveActivity(application.getPackageManager()) != null) {
-            application.startActivity(intent);
+        Context context = application.getApplicationContext();
+        Intent intent;
+        if (url.startsWith("/")) {
+            // local file
+            intent = new Intent(Intent.ACTION_SEND);
+            Uri uri = FileProvider.getUriForFile(context,
+                    context.getPackageName() + ".provider",
+                    new File(url));
+            intent.setDataAndType(uri, getMimeType(url));
+            intent.putExtra(Intent.EXTRA_STREAM, uri);
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        } else {
+            // external link
+            intent = new Intent(Intent.ACTION_VIEW);
+            intent.setData(Uri.parse(url));
+        }
+
+        Intent chooserIntent = Intent.createChooser(intent, null);
+        chooserIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        try {
+            context.startActivity(chooserIntent);
+        } catch (ActivityNotFoundException e) {
+            throw new Exception("There are no applications available to handle " + url);
         }
     }
 
@@ -32,5 +57,21 @@ public class Util {
         // If the above killProcess didn't work and we're still here,
         // simply terminate the JVM as the last resort.
         System.exit(0);
+    }
+
+    public static String getMimeType(String url) {
+        String type = null;
+        String extension = MimeTypeMap.getFileExtensionFromUrl(url);
+        if (extension != null) {
+            switch (extension) {
+                case "js":
+                    type = "text/javascript";
+                    break;
+                default:
+                    type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+                    break;
+            }
+        }
+        return type;
     }
 }

--- a/frontends/android/BitBoxApp/app/src/main/res/xml/provider_paths.xml
+++ b/frontends/android/BitBoxApp/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="." />
+</paths>

--- a/frontends/web/src/components/transactions/transactions.tsx
+++ b/frontends/web/src/components/transactions/transactions.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 
 import { useTranslation } from 'react-i18next';
 import { AccountCode, TTransactions } from '../../api/account';
-import { runningInAndroid } from '../../utils/env';
 import { Transaction } from './transaction';
 import { Button } from '../forms';
 import style from './transactions.module.css';
@@ -37,24 +36,18 @@ export const Transactions = ({
 }: TProps) => {
   const { t } = useTranslation();
 
-  // We don't support CSV export on Android yet, as it's a tricky to deal with the Downloads
-  // folder and permissions.
-  const csvExportDisabled = runningInAndroid();
-
   return (
     <div className={style.container}>
       <div className="flex flex-row flex-between flex-items-center">
         <label className="labelXLarge">
           {t('accountSummary.transactionHistory')}
         </label>
-        { !csvExportDisabled && (
-          <Button
-            transparent
-            onClick={handleExport}
-            title={t('account.exportTransactions')}>
-            {t('account.export')}
-          </Button>
-        ) }
+        <Button
+          transparent
+          onClick={handleExport}
+          title={t('account.exportTransactions')}>
+          {t('account.export')}
+        </Button>
       </div>
       <div className={[style.columns, style.headers, style.showOnMedium].join(' ')}>
         <div className={style.type}>{t('transaction.details.type')}</div>

--- a/util/config/appdir.go
+++ b/util/config/appdir.go
@@ -81,10 +81,11 @@ func AppDir() string {
 	return appFolder
 }
 
-// DownloadsDir returns the absolute path to the Downloads folder in the home folder.
-func DownloadsDir() (string, error) {
+// ExportsDir returns the absolute path to the folder which can be used to export files.
+func ExportsDir() (string, error) {
 	if runtime.GOOS == "android" {
-		return "", errp.New("android not yet supported")
+		// Android apps are sandboxed, we don't need to specify a folder.
+		return "", nil
 	}
 	homeFolder := os.Getenv("HOME")
 	if runtime.GOOS == "windows" && homeFolder == "" {


### PR DESCRIPTION
Transactions export feature was disabled for Android environment, this implements it.

Android app storage space is sandboxed: the transactions csv is persisted inside the app dedicated storage and can be shared by any third-party app available on the system.