### PR TITLE
frontend: fix bip-85 graphic too small

### DIFF
--- a/frontends/web/src/routes/settings/components/device-settings/bip85-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/bip85-setting.tsx
@@ -76,7 +76,9 @@ export const Bip85Setting = ({ deviceID, canBIP85 }: TProps) => {
             <Column textCenter>
               <img
                 src={isDarkMode ? bip85GraphicLight : bip85Graphic}
-                style={{ maxWidth: '100%' }}
+                style={{ height: 'auto', width: '100%' }}
+                width="320"
+                height="147"
               />
             </Column>
           </Grid>


### PR DESCRIPTION
This change fixes the graphic about BIP-85 child keys that did not use the whole available width in the Qt app.