### PR TITLE
frontend: type convert coin from and to currency

### DIFF
--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -288,6 +288,32 @@ export const getReceiveAddressList = (code: AccountCode) => {
   };
 };
 
+export type TTxInput = {
+  address: string;
+  amount: string;
+  feeTarget: FeeTargetCode;
+  customFee: string;
+  sendAll: 'yes' | 'no';
+  selectedUTXOs: string[],
+};
+
+export type TTxProposalResult = {
+  amount: IAmount;
+  fee: IAmount;
+  success: true;
+  total: IAmount;
+} | {
+  errorCode: string;
+  success: false;
+};
+
+export const proposeTx = (
+  accountCode: AccountCode,
+  txInput: TTxInput,
+): Promise<TTxProposalResult> => {
+  return apiPost(`account/${accountCode}/tx-proposal`, txInput);
+};
+
 export interface ISendTx {
     aborted?: boolean;
     success?: boolean;

--- a/frontends/web/src/api/coins.ts
+++ b/frontends/web/src/api/coins.ts
@@ -15,8 +15,8 @@
  */
 
 import { subscribeEndpoint, TSubscriptionCallback } from './subscribe';
-import { CoinCode } from './account';
-import { ISuccess } from './backend';
+import type { CoinCode, Fiat } from './account';
+import type { ISuccess } from './backend';
 import { apiPost, apiGet } from '../utils/request';
 
 export type BtcUnit = 'default' | 'sat';
@@ -45,4 +45,42 @@ export type TAmount = {
 
 export const parseExternalBtcAmount = (amount: string): Promise<TAmount> => {
   return apiGet(`coins/btc/parse-external-amount?amount=${amount}`);
+};
+
+type TConvertCurrency = {
+  amount: string;
+  coinCode: CoinCode;
+  fiatUnit: Fiat;
+};
+
+type TConvertFromCurrencyResponse = {
+  success: true;
+  amount: string;
+} | {
+  success: false;
+  errMsg: string; // TODO: backend should return useful errorMessage
+};
+
+export const convertFromCurrency = ({
+  amount,
+  coinCode,
+  fiatUnit,
+}: TConvertCurrency): Promise<TConvertFromCurrencyResponse> => {
+  return apiGet(`coins/convert-from-fiat?from=${fiatUnit}&to=${coinCode}&amount=${amount}`);
+};
+
+type TConvertToCurrencyResponse = {
+  success: true;
+  fiatAmount: string;
+} | {
+  success: false;
+  // errMsg: string; // TODO: backend should return useful errorMessage
+};
+
+export const convertToCurrency = ({
+  amount,
+  coinCode,
+  fiatUnit,
+}: TConvertCurrency): Promise<TConvertToCurrencyResponse> => {
+  return apiGet(`coins/convert-to-plain-fiat?from=${coinCode}&to=${fiatUnit}&amount=${amount}`);
 };

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -96,8 +96,8 @@ class Send extends Component<Props, State> {
   // pendingProposals keeps all requests that have been made
   // to /tx-proposal in case there are multiple parallel requests
   // we can ignore all other but the last one
-  private pendingProposals: any = [];
-  private proposeTimeout: any = null;
+  private pendingProposals: Array<Promise<accountApi.TTxProposalResult>> = [];
+  private proposeTimeout: ReturnType<typeof setTimeout> | null = null;
 
   public readonly state: State = {
     recipientAddress: '',
@@ -283,14 +283,14 @@ class Send extends Component<Props, State> {
     }
     this.setState({ isUpdatingProposal: true });
     this.proposeTimeout = setTimeout(() => {
-      const propose = accountApi.proposeTx(this.getAccount()!.code, txInput)
-        .then(result => {
-          const pos = this.pendingProposals.indexOf(propose);
-          if (this.pendingProposals.length - 1 === pos) {
-            this.txProposal(updateFiat, result);
-          }
-          this.pendingProposals.splice(pos, 1);
-        })
+      const propose = accountApi.proposeTx(this.getAccount()!.code, txInput);
+      propose.then(result => {
+        const pos = this.pendingProposals.indexOf(propose);
+        if (this.pendingProposals.length - 1 === pos) {
+          this.txProposal(updateFiat, result);
+        }
+        this.pendingProposals.splice(pos, 1);
+      })
         .catch(() => {
           this.setState({ valid: false });
           this.pendingProposals.splice(this.pendingProposals.indexOf(propose), 1);

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -1,6 +1,6 @@
 /**
  * Copyright 2018 Shift Devices AG
- * Copyright 2023 Shift Crypto AG
+ * Copyright 2023-2024 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import { Button, ButtonLink } from '../../../components/forms';
 import { Column, ColumnButtons, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
 import { Status } from '../../../components/status/status';
 import { translate, TranslateProps } from '../../../decorators/translate';
-import { apiPost } from '../../../utils/request';
 import { getConfig } from '../../../utils/config';
 import { FeeTargets } from './feetargets';
 import { route } from '../../../utils/route';
@@ -248,10 +247,10 @@ class Send extends Component<Props, State> {
     }
   };
 
-  private txInput = () => ({
+  private txInput = (): accountApi.TTxInput => ({
     address: this.state.recipientAddress,
     amount: this.state.amount,
-    feeTarget: this.state.feeTarget || '',
+    feeTarget: this.state.feeTarget || 'economy',
     customFee: this.state.customFee,
     sendAll: this.state.sendAll ? 'yes' : 'no',
     selectedUTXOs: Object.keys(this.selectedUTXOs),
@@ -279,7 +278,7 @@ class Send extends Component<Props, State> {
     }
     this.setState({ isUpdatingProposal: true });
     this.proposeTimeout = setTimeout(() => {
-      const propose = apiPost('account/' + this.getAccount()!.code + '/tx-proposal', txInput)
+      const propose = accountApi.proposeTx(this.getAccount()!.code, txInput)
         .then(result => {
           const pos = this.pendingProposals.indexOf(propose);
           if (this.pendingProposals.length - 1 === pos) {
@@ -304,13 +303,10 @@ class Send extends Component<Props, State> {
     });
   };
 
-  private txProposal = (updateFiat: boolean, result: {
-        errorCode?: string;
-        amount: accountApi.IAmount;
-        fee: accountApi.IAmount;
-        success: boolean;
-        total: accountApi.IAmount;
-    }) => {
+  private txProposal = (
+    updateFiat: boolean,
+    result: accountApi.TTxProposalResult,
+  ) => {
     this.setState({ valid: result.success });
     if (result.success) {
       this.setState({


### PR DESCRIPTION
Part of typing all api calls.

Note: in the future we should call Fiat just currencies as it can contain Fiat as well as Bitcoin.