### PR TITLE
qt: fix unknown escape sequence warning

### DIFF
--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -136,14 +136,14 @@ public:
 
         // All the requests originated in the wallet-connect section are allowed, as they are needed to
         // load the Dapp logos and it is not easy to filter out non-images requests.
-        bool onWCPage = currentUrl.contains(QRegularExpression("^qrc:/account/[^\/]+/wallet-connect/.*$"));
+        bool onWCPage = currentUrl.contains(QRegularExpression(R"(^qrc:/account/[^\/]+/wallet-connect/.*$)"));
         if (onWCPage) {
           return;
         }
 
         // Needed for the wallet connect workflow.
-        bool VerifyWCRequest = requestedUrl.contains(QRegularExpression("^https://verify\.walletconnect\.com/.*$"));
-        if (VerifyWCRequest) {
+        bool verifyWCRequest = requestedUrl.contains(QRegularExpression(R"(^https://verify\.walletconnect\.com/.*$)"));
+        if (verifyWCRequest) {
           return;
         }
 


### PR DESCRIPTION
`\/` in the regular expressions is not a valid escape sequence in C++ strings. It still somehow worked, but it's good to fix the warning just in case.

We use raw string literals to avoid any escaping:
https://en.wikipedia.org/wiki/C%2B%2B11#New_string_literals