### PR TITLE
frontend: change support links to redirects

### DIFF
--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -72,8 +72,8 @@ export const Waiting = () => {
           link: {
             text: t('guide.waiting.lostDevice.link.text'),
             url: (i18n.resolvedLanguage === 'de')
-              ? 'https://shiftcrypto.support/help/de-de/5-backup/8-wie-kann-ich-ein-bitbox02-wallet-in-ein-drittanbieter-wallet-importieren'
-              : 'https://shiftcrypto.support/help/en-us/5-backup/8-how-do-i-restore-my-wallet-if-my-bitbox02-is-lost',
+              ? 'https://bitbox.swiss/redirects/restore-wallet-without-bitbox-de/'
+              : 'https://bitbox.swiss/redirects/restore-wallet-without-bitbox-en/',
           },
           text: t('guide.waiting.lostDevice.text'),
           title: t('guide.waiting.lostDevice.title'),

--- a/frontends/web/src/routes/settings/electrum.tsx
+++ b/frontends/web/src/routes/settings/electrum.tsx
@@ -90,8 +90,8 @@ export const ElectrumSettings = () => {
           link: {
             text: t('guide.settings-electrum.instructions.link.text'),
             url: (i18n.resolvedLanguage === 'de')
-              ? 'https://shiftcrypto.support/help/de-de/14-privatsphare/29-verbindung-der-bitboxapp-zu-meinem-bitcoin-full-node'
-              : 'https://shiftcrypto.support/help/en-us/14-privacy/29-how-to-connect-the-bitboxapp-to-my-own-full-node'
+              ? 'https://bitbox.swiss/redirects/connect-your-own-full-node-de/'
+              : 'https://bitbox.swiss/redirects/connect-your-own-full-node-en/'
           },
           text: t('guide.settings-electrum.instructions.text'),
           title: t('guide.settings-electrum.instructions.title')


### PR DESCRIPTION
Replacing external links to our knowledge base with redirects on the website enables easy and swift maintenance if the knowledge base URL ever changes in the future, e.g. because of a domain change or entirely new knowledge base system.

This will avoid broken links in old BitBoxApp versions in the future. The new redirect links are already implemented on the website.

* https://bitbox.swiss/redirects/restore-wallet-without-bitbox-en
* https://bitbox.swiss/redirects/restore-wallet-without-bitbox-de
* https://bitbox.swiss/redirects/connect-your-own-full-node-en
* https://bitbox.swiss/redirects/connect-your-own-full-node-de