### PR TITLE
ci: install nsis without pre

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ before_build:
 build_script:
   - echo on
   - choco install make
-  - choco install nsis -pre
+  - choco install nsis
   - mkdir %GOPATH%\src\github.com\digitalbitbox
   - cd ..
   - mv bitbox-wallet-app %GOPATH%\src\github.com\digitalbitbox\


### PR DESCRIPTION
The -pre flag is used with Chocolatey, a package manager for Windows.
This flag specifies that Chocolatey should install a pre-release
version of the software package, if available.

This commit removes -pre flag to test if appveyor ci still fails
at installing nsis.