### PR TITLE
frontend: align center "no backups" text and padding on container

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox02/backups.tsx
@@ -128,7 +128,7 @@ export const BackupsV2 = ({
                 }
               </div>
             ) : (
-              <p>{t('backup.noBackups')}</p>
+              <p className="text-center">{t('backup.noBackups')}</p>
             )
           }
         </div>

--- a/frontends/web/src/routes/device/components/backups.module.css
+++ b/frontends/web/src/routes/device/components/backups.module.css
@@ -9,6 +9,7 @@
     flex-direction: column;
     text-align: left;
     flex: 1;
+    padding: var(--space-eight);
 }
 
 .listContainer {


### PR DESCRIPTION
Preview before:

<img width="871" alt="bfr" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/594bd2fe-742d-404f-96d3-ef30993614b7">


<img width="1483" alt="Screenshot 2024-04-29 at 09 05 28" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/01518ae7-8f4c-4052-9b1c-a420b9e50be8">

Preview after:

<img width="736" alt="afr" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/9fe437d0-fbb4-4de9-8a27-9d250b7877c1">


<img width="1483" alt="axs" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/5d044f1f-29ae-42c8-bea4-9af4cef800dd">

Preview after (with backups):
<img width="1483" alt="qewd" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/28676406/446bbe54-a542-469b-a5b5-57664e57019a">
