### PR TITLE
frontend: fix account summary spacing on small screen

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -46,6 +46,10 @@
   .chart{
     margin-bottom: var(--spacing-default);
   }
+  .chart header {
+    flex-direction: column;
+    flex-wrap: nowrap;
+  }
 
   .summary{
     align-items: center;
@@ -57,6 +61,12 @@
   }
 }
 
+@media (max-width: 768px) {
+  .chart {
+    padding-left: var(--space-half);
+    padding-right: var(--space-half);
+  }
+}
 
 .filters button {
   appearance: none;
@@ -69,6 +79,10 @@
   margin-bottom: var(--spacing-half);
   margin-left: var(--spacing-half);
   padding: 0 calc(var(--spacing-default) * .75);
+}
+
+.filters button:first-child {
+  margin-left: 0;
 }
 
 .filters button:hover:not([disabled]) {


### PR DESCRIPTION
- on some smaller breakpoints but before it centeres the total balance was touching the left screen, added some padding
- filter buttons was not centered correctly

<img width="646" alt="Screenshot 2024-05-02 at 11 57 54" src="https://github.com/digitalbitbox/bitbox-wallet-app/assets/546900/bf246881-e3e1-4fca-b6c1-f1c942d1beb6">
