### PR TITLE
frontend: fix available balancewelcome

### DIFF
--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -303,7 +303,6 @@ export function Account({
             <div className="flex flex-column flex-reverse-mobile">
               <label className="labelXLarge flex-self-start-mobile hide-on-small">
                 {t('accountSummary.availableBalance')}
-                {t('welcome.title')}
               </label>
               <div className="flex flex-row flex-between flex-item-center flex-column-mobile flex-reverse-mobile">
                 <Balance balance={balance} />


### PR DESCRIPTION
Somehow the text Welcome is shown directly after 'available balance'

regression introduced in ee2d529a1a26187e9cf2cfafd4c0fa284939d687