### PR TITLE
backend/bitbox02bootloader: allow re-installing firmware

### DIFF
--- a/backend/devices/bitbox02bootloader/device.go
+++ b/backend/devices/bitbox02bootloader/device.go
@@ -223,8 +223,9 @@ func (device *Device) UpgradeFirmware() error {
 
 // VersionInfo contains version information about the upgrade.
 type VersionInfo struct {
-	Erased     bool `json:"erased"`
-	CanUpgrade bool `json:"canUpgrade"`
+	Erased       bool `json:"erased"`
+	CanUpgrade   bool `json:"canUpgrade"`
+	CanReinstall bool `json:"canReinstall"`
 	// AdditionalUpgradeFollows is true if there is more than one upgrade to be performed
 	// (intermediate and final).
 	AdditionalUpgradeFollows bool `json:"additionalUpgradeFollows"`
@@ -250,17 +251,20 @@ func (device *Device) VersionInfo() (*VersionInfo, error) {
 		return nil, err
 	}
 	canUpgrade := erased || latestFirmwareVersion > currentFirmwareVersion
+	canReinstall := !erased && latestFirmwareVersion == currentFirmwareVersion
 	additionalUpgradeFollows := nextFw.monotonicVersion < latestFirmwareVersion
 	device.log.
 		WithField("latestFirmwareVersion", latestFirmwareVersion).
 		WithField("currentFirmwareVersion", currentFirmwareVersion).
 		WithField("erased", erased).
 		WithField("canUpgrade", canUpgrade).
+		WithField("canReinstall", canReinstall).
 		WithField("additionalUpgradeFollows", additionalUpgradeFollows).
 		Info("VersionInfo")
 	return &VersionInfo{
 		Erased:                   erased,
 		CanUpgrade:               canUpgrade,
+		CanReinstall:             canReinstall,
 		AdditionalUpgradeFollows: additionalUpgradeFollows,
 	}, nil
 }

--- a/frontends/web/src/api/bitbox02bootloader.ts
+++ b/frontends/web/src/api/bitbox02bootloader.ts
@@ -45,6 +45,9 @@ export type TVersionInfo = {
   erased: boolean;
   // Indicates whether the user can install/upgrade firmware.
   canUpgrade: boolean;
+  // Indicates whether the user can re-install the same version of the firwmare.
+  // This is useful if an install/upgrade process was interrupted and the user has to try again.
+  canReinstall: boolean;
   // This is true if there is more than one upgrade to be performed (intermediate and final).
   additionalUpgradeFollows: boolean;
 };

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -87,11 +87,11 @@ export const BitBox02Bootloader = ({ deviceID }: TProps) => {
           </div>
         )}
         <div className="buttons">
-          { versionInfo.canUpgrade ? (
+          { versionInfo.canUpgrade || versionInfo.canReinstall ? (
             <Button
               primary
               onClick={() => bitbox02BootloaderAPI.upgradeFirmware(deviceID)}>
-              {t('bootloader.button', { context: (versionInfo.erased ? 'install' : '') })}
+              {t('bootloader.button', { context: (versionInfo.erased ? 'install' : versionInfo.canReinstall ? 'reinstall' : '') })}
             </Button>
           ) : null }
           { !versionInfo.erased && (

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -365,6 +365,7 @@
   "bootloader": {
     "button": "Upgrade firmware now",
     "button_install": "Install firmware now",
+    "button_reinstall": "Reinstall firmware now",
     "progress": "Upgrading: {{progress}}%",
     "progress_install": "Installing: {{progress}}%",
     "success": "Upgrade successful! Please replug the device. This time, do not touch the button."


### PR DESCRIPTION
Problem: a new device ships with the latest firmware monotonic version. User sees 'Install' because the device is erased (no firmware on it), but during first install of firmware, unplugs. Upon replug, the device will show 'Invalid firmware' and boot into bootloader again. Since the monotonic version of the firmware to be installed is the same as the version stored on the device, and the device is not erased (half of the firmware is on it), the user sees no button to upgrade/instll anymore.

This commit fixes this by still showing the upgrade button if the versions are the same. The downside is that users see this even if the firmware is fully installed. To fix this, we'd need a new bootloader API call to check if the firmware is bootable/valid, so this is a workaround.