### PR TITLE
Fix FeeParam naming issue

### DIFF
--- a/backend/lightning/dto.go
+++ b/backend/lightning/dto.go
@@ -123,8 +123,8 @@ type openChannelFeeRequestDto struct {
 }
 
 type openChannelFeeResponseDto struct {
-	FeeMsat       *uint64             `json:"feeMsat"`
-	UsedFeeParams openingFeeParamsDto `json:"usedFeeParams"`
+	FeeMsat   *uint64             `json:"feeMsat"`
+	FeeParams openingFeeParamsDto `json:"feeParams"`
 }
 
 type openingFeeParamsDto struct {

--- a/backend/lightning/response.go
+++ b/backend/lightning/response.go
@@ -223,8 +223,8 @@ func toNodeStateDto(nodeState breez_sdk.NodeState) nodeStateDto {
 
 func toOpenChannelFeeResponseDto(openChannelFeeResponse breez_sdk.OpenChannelFeeResponse) openChannelFeeResponseDto {
 	return openChannelFeeResponseDto{
-		FeeMsat:       openChannelFeeResponse.FeeMsat,
-		UsedFeeParams: toOpeningFeeParamsDto(openChannelFeeResponse.FeeParams),
+		FeeMsat:   openChannelFeeResponse.FeeMsat,
+		FeeParams: toOpeningFeeParamsDto(openChannelFeeResponse.FeeParams),
 	}
 }
 


### PR DESCRIPTION
Fixes an issue raised by @thisconnect about the naming of the `FeeParams` in the type OpenChannelFeeResponse. It was renamed in the Breez SDK from `UsedFeeParams` to `FeeParams`. PR #2636 updated it's use to `FeeParams` in the frontend but not in the backend.
