### PR TITLE
frontend: Maintain chart timeframe when rotating currencies

### DIFF
--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -230,6 +230,17 @@ class Chart extends Component<Props, State> {
         lineColor: 'rgba(94, 148, 192, 1)',
         crosshairMarkerRadius: 6,
       });
+      switch (this.state.display) {
+      case 'week':
+        this.displayWeek();
+        break;
+      case 'month':
+        this.displayMonth();
+        break;
+      case 'year':
+        this.displayYear();
+        break;
+      }
       this.lineSeries.setData(this.props.data.chartDataDaily as ChartData);
       this.setFormattedData(this.props.data.chartDataDaily as ChartData);
       this.chart.timeScale().subscribeVisibleLogicalRangeChange(this.calculateChange);


### PR DESCRIPTION
Previously, the chart would reset to 'All' whenever the currency was changed. This commit ensures that the selected timeframe remains consistent when rotating currencies.