### PR TITLE
frontend: use Buy & sell instead of Exchange

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -33,7 +33,7 @@ import deviceSettings from '@/assets/icons/wallet-light.svg';
 import { debug } from '@/utils/env';
 import { AppLogoInverted, Logo } from '@/components/icon/logo';
 import { CloseXWhite, RedDot, USBSuccess } from '@/components/icon';
-import { getAccountsByKeystore, isAmbiguiousName, isBitcoinOnly } from '@/routes/account/utils';
+import { getAccountsByKeystore, isAmbiguiousName } from '@/routes/account/utils';
 import { SkipForTesting } from '@/routes/device/components/skipfortesting';
 import { Badge } from '@/components/badge/badge';
 import { AppContext } from '@/contexts/AppContext';
@@ -164,7 +164,6 @@ const Sidebar = ({
   };
 
   const hidden = sidebarStatus === 'forceHidden';
-  const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
   const accountsByKeystore = getAccountsByKeystore(accounts);
   const userInSpecificAccountExchangePage = (pathname.startsWith('/exchange'));
 
@@ -237,9 +236,7 @@ const Sidebar = ({
                   <img draggable={false} src={coins} />
                 </div>
                 <span className={style.sidebarLabel}>
-                  { t('generic.exchange', {
-                    context: hasOnlyBTCAccounts ? 'bitcoin' : 'crypto'
-                  })}
+                  {t('generic.buySell')}
                 </span>
               </NavLink>
             </div>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -743,13 +743,11 @@
   },
   "generic": {
     "buy": "Buy {{coinCode}}",
+    "buySell": "Buy & sell",
     "buy_bitcoin": "Buy Bitcoin",
     "buy_crypto": "Buy crypto",
     "enabled_false": "Disabled",
     "enabled_true": "Enabled",
-    "exchange": "Exchange {{coinCode}}",
-    "exchange_bitcoin": "Exchange Bitcoin",
-    "exchange_crypto": "Exchange crypto",
     "receive": "Receive {{coinCode}}",
     "receive_bitcoin": "Receive Bitcoin",
     "receive_crypto": "Receive crypto"
@@ -1025,7 +1023,7 @@
       "accountSummary": "Account summary guide",
       "advancedSettings": "Advanced settings guide",
       "appearance": "Appearance guide",
-      "exchange": "Exchange guide",
+      "buySell": "Buy & sell guide",
       "insurance": "Insurance guide",
       "manageAccount": "Manage accounts guide",
       "manageDevice": "Manage device guide",

--- a/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
+++ b/frontends/web/src/routes/account/info/buyReceiveCTA.tsx
@@ -85,10 +85,7 @@ export const BuyReceiveCTA = ({
         {exchangeSupported && (
           <Button primary onClick={onExchangeCTA}>
             {/* "Exchange Bitcoin", "Exchange crypto" or "Exchange LTC" (via placeholder "Exchange {{coinCode}}") */}
-            {t('generic.exchange', {
-              context: isBitcoin ? 'bitcoin' : (unit ? '' : 'crypto'),
-              coinCode: unit
-            })}
+            {t('generic.buySell')}
           </Button>
         )}
         {account && isEthereumBased(account.coinCode) && !account.isToken && (

--- a/frontends/web/src/routes/exchange/exchange.tsx
+++ b/frontends/web/src/routes/exchange/exchange.tsx
@@ -24,7 +24,7 @@ import * as exchangesAPI from '@/api/exchanges';
 import { AccountCode, IAccount } from '@/api/account';
 import { Header } from '@/components/layout';
 import { ExchangeGuide } from './guide';
-import { findAccount, isBitcoinOnly } from '@/routes/account/utils';
+import { isBitcoinOnly } from '@/routes/account/utils';
 import { useLoad } from '@/hooks/api';
 import { getRegionNameFromLocale } from '@/i18n/utils';
 import { getExchangeFormattedName, getExchangeSupportedAccounts } from './utils';
@@ -59,13 +59,9 @@ export const Exchange = ({ code, accounts, deviceIDs }: TProps) => {
   const nativeLocale = useLoad(getNativeLocale);
   const config = useLoad(getConfig);
 
-  const account = findAccount(accounts, code);
   const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
-  const isBitcoin = hasOnlyBTCAccounts || (account && isBitcoinOnly(account?.coinCode));
 
-  const title = t('generic.exchange', {
-    context: isBitcoin ? 'bitcoin' : 'crypto',
-  });
+  const title = t('generic.buySell');
 
   // get the list of accounts supported by exchanges, needed to correctly handle back button.
   useEffect(() => {

--- a/frontends/web/src/routes/exchange/guide.tsx
+++ b/frontends/web/src/routes/exchange/guide.tsx
@@ -39,7 +39,7 @@ export const ExchangeGuide = ({ exchange, translationContext }: BuyGuideProps) =
   const privacyLink = exchange === 'pocket' ? pocketLink : moonpayLink;
 
   return (
-    <Guide title={t('guide.guideTitle.exchange')}>
+    <Guide title={t('guide.guideTitle.buySell')}>
       <Entry key="guide.buy.protection" entry={{
         link: exchange ? privacyLink : undefined,
         text: t('buy.info.disclaimer.protection.descriptionGeneric', { context: translationContext }),

--- a/frontends/web/src/routes/exchange/info.tsx
+++ b/frontends/web/src/routes/exchange/info.tsx
@@ -95,7 +95,7 @@ export const ExchangeInfo = ({ code, accounts }: TProps) => {
         <GuidedContent>
           <Header title={
             <h2>
-              {t('generic.exchange', { context: translationContext })}
+              {t('generic.buySell')}
             </h2>
           }>
             <HideAmountsButton />
@@ -108,7 +108,7 @@ export const ExchangeInfo = ({ code, accounts }: TProps) => {
                 supportedAccounts && (
                   <GroupedAccountSelector
                     accounts={supportedAccounts}
-                    title={t('generic.exchange', { context: translationContext })}
+                    title={ t('generic.buySell')}
                     disabled={disabled}
                     selected={selected}
                     onChange={setSelected}

--- a/frontends/web/src/routes/exchange/pocket.tsx
+++ b/frontends/web/src/routes/exchange/pocket.tsx
@@ -273,7 +273,7 @@ export const Pocket = ({ code, action }: TProps) => {
         <div className={style.header}>
           <Header title={
             <h2>
-              {t('generic.exchange', { context: 'bitcoin' })}
+              {t('generic.buySell')}
             </h2>
           } />
         </div>


### PR DESCRIPTION
Also removed unused `generic.exchange` translation key from codebase.
<img width="1483" alt="bs1" src="https://github.com/user-attachments/assets/b850346e-ccfd-48cf-ada3-89b8b08c222a">
<img width="1483" alt="bs2" src="https://github.com/user-attachments/assets/ac906ad7-7423-49c6-9953-bb57a6464aa5">
<img width="979" alt="bs3" src="https://github.com/user-attachments/assets/8f44f9cf-72fe-4b72-a3d5-51d61d38d767">
