### PR TITLE
frontend: use blue colour for link in `Status` component

### DIFF
--- a/frontends/web/src/components/banner/banner.module.css
+++ b/frontends/web/src/components/banner/banner.module.css
@@ -1,5 +1,5 @@
 .link {
-  color: var(--color-alt);
+  color: var(--color-blue);
 }
 
 .link:focus {


### PR DESCRIPTION
Before:
<img width="230" alt="B_____" src="https://github.com/user-attachments/assets/c2b5d9fb-9fd7-4233-aeb5-0aa304f62c2d">

After:
<img width="268" alt="A_____" src="https://github.com/user-attachments/assets/36cd5a4a-8976-414a-beab-974d8bdbcb3d">
