### PR TITLE
frontend: reduce spacing on mobile for settings subtitle text

### DIFF
--- a/frontends/web/src/components/title/subtitle.tsx
+++ b/frontends/web/src/components/title/subtitle.tsx
@@ -19,11 +19,11 @@ import style from './subtitle.module.css';
 
 type Props = {
   children: ReactNode;
-  className: string;
+  className?: string;
 };
 
 export const SubTitle = ({
-  className,
+  className = '',
   children
 }: Props) => {
   const classNames = className ? `${style.subtitle} ${className}` : style.subtitle;

--- a/frontends/web/src/routes/settings/general.tsx
+++ b/frontends/web/src/routes/settings/general.tsx
@@ -54,7 +54,7 @@ export const General = ({ deviceIDs, hasAccounts }: TPagePropsWithSettingsTabs) 
           <View fullscreen={false}>
             <ViewContent>
               <WithSettingsTabs hasAccounts={hasAccounts} hideMobileMenu deviceIDs={deviceIDs}>
-                <SubTitle className="m-top-default">
+                <SubTitle>
                   {t('settings.appearance')}
                 </SubTitle>
                 <LanguageDropdownSetting />


### PR DESCRIPTION
Before:

<img width="371" alt="b_" src="https://github.com/user-attachments/assets/ab7fd0a6-7950-46d7-a07f-c5cb1e6b462e">

After:

<img width="368" alt="a_" src="https://github.com/user-attachments/assets/af495cd4-a986-4e16-98dc-b6ef72c1c4af">
