### PR TITLE
frontend: increase mobile settings back button's height

### DIFF
--- a/frontends/web/src/routes/settings/components/mobile-header.module.css
+++ b/frontends/web/src/routes/settings/components/mobile-header.module.css
@@ -18,6 +18,10 @@
     text-decoration: none;
 }
 
+.backButton img {
+    height: 24px;
+}
+
 .backButton:focus {
     outline: none;
 }


### PR DESCRIPTION
to align better with the page's title and guide (and to increase touch space) the height of the back button is increased to 24px.

Preview:
![fhuda](https://github.com/user-attachments/assets/cb4c6637-9869-4533-ad4c-9da664c30fe9)

