### PR TITLE
frontend: fix spacing between receiver address and tx detail label

### DIFF
--- a/frontends/web/src/routes/account/send/send.module.css
+++ b/frontends/web/src/routes/account/send/send.module.css
@@ -4,6 +4,6 @@
 
 
 .coinControlButtonContainer {
-    height: 50px;
+    height: 58px;
     margin-bottom: var(--space-quarter);
 }

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -441,10 +441,13 @@ class Send extends Component<Props, State> {
                 <Balance balance={balance} noRotateFiat/>
                 <div className={`flex flex-row flex-between ${style.container}`}>
                   <label className="labelXLarge">{t('send.transactionDetails')}</label>
-                  <CoinControl
-                    account={account}
-                    onSelectedUTXOsChange={this.onSelectedUTXOsChange}
-                  />
+                  <div className={style.coinControlButtonContainer}>
+                    <CoinControl
+                      account={account}
+                      onSelectedUTXOsChange={this.onSelectedUTXOsChange}
+                    />
+                  </div>
+
                 </div>
                 <Grid col="1">
                   <Column>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/3f3eb179-5c40-43bb-b833-b748190d04f0)

After (without coin control):

<img width="1483" alt="egrfde" src="https://github.com/user-attachments/assets/eac61f64-9f15-486c-92be-df311e3b813b">

After (with coin control):

<img width="1483" alt="fdas" src="https://github.com/user-attachments/assets/38873486-be9c-4e10-a3cb-a96529177028">
