### PR TITLE
frontend: better font size & spacing during firwmware install

### DIFF
--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.module.css
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.module.css
@@ -1,0 +1,23 @@
+.content {
+    font-size: 16px;
+    margin: 0;
+}
+
+.progressBar {
+    margin: var(--space-quarter) 0;
+}
+
+.additionalUpgrade {
+    font-size: 16px;
+    margin: 0;
+    margin-top: var(--space-eight);
+}
+
+@media (max-width: 768px) {
+    .content,
+    .additionalUpgrade
+    {
+        font-size: 14px;
+    }
+}
+

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -17,13 +17,15 @@
 
 import { useTranslation } from 'react-i18next';
 import * as bitbox02BootloaderAPI from '@/api/bitbox02bootloader';
-import { useLoad, useSync } from '@/hooks/api';
 import { useDarkmode } from '@/hooks/darkmode';
+import { useSync, useLoad } from '@/hooks/api';
 import { Button } from '@/components/forms';
 import { View, ViewContent } from '@/components/view/view';
 import { BitBox02, BitBox02Inverted } from '@/components/icon/logo';
 import { Status } from '@/components/status/status';
+import { SubTitle } from '@/components/title';
 import { ToggleShowFirmwareHash } from './toggleshowfirmwarehash';
+import style from './bitbox02bootloader.module.css';
 
 type TProps = {
   deviceID: string;
@@ -58,17 +60,17 @@ export const BitBox02Bootloader = ({ deviceID }: TProps) => {
       const value = Math.round(status.progress * 100);
       contents = (
         <div className="box large">
-          <h2 className="subTitle">
+          <SubTitle>
             {t('bb02Bootloader.upgradeTitle', { context: (versionInfo.erased ? 'install' : '') })}
-          </h2>
+          </SubTitle>
           { versionInfo.additionalUpgradeFollows ? (
             <>
-              <p>{t('bb02Bootloader.additionalUpgradeFollows1')}</p>
-              <p>{t('bb02Bootloader.additionalUpgradeFollows2')}</p>
+              <p className={style.additionalUpgrade}>{t('bb02Bootloader.additionalUpgradeFollows1')}</p>
+              <p className={style.additionalUpgrade}>{t('bb02Bootloader.additionalUpgradeFollows2')}</p>
             </>
           ) : null }
-          <progress value={value} max="100">{value}%</progress>
-          <p style={{ marginBottom: 0 }}>
+          <progress className={style.progressBar} value={value} max="100">{value}%</progress>
+          <p className={style.content}>
             {t('bootloader.progress', {
               progress: value.toString(),
               context: (versionInfo.erased ? 'install' : ''),
@@ -124,6 +126,7 @@ export const BitBox02Bootloader = ({ deviceID }: TProps) => {
       </div>
     );
   }
+
   return (
     <View fitContent verticallyCentered width="600px">
       <ViewContent>


### PR DESCRIPTION
Same as #3028  (closed due to wrong head branch).

<img width="754" alt="fw_update" src="https://github.com/user-attachments/assets/57ed2d89-ab1f-4603-a786-5f91b82b8cea">


<img width="781" alt="fw_install" src="https://github.com/user-attachments/assets/d86136a8-2349-4ce7-aa6b-94824c078927">

<img width="842" alt="fw_additional" src="https://github.com/user-attachments/assets/f3b766ac-ee33-4ec6-b072-7ba196ec38c4">