### PR TITLE
frontend: full width for Dropdowns in General settings on mobile

### DIFF
--- a/frontends/web/src/routes/settings/components/appearance/settingsdropdown.module.css
+++ b/frontends/web/src/routes/settings/components/appearance/settingsdropdown.module.css
@@ -5,3 +5,11 @@
 .select :global(.react-select__option) {
     padding: var(--space-half) var(--space-quarter);
 }
+
+
+@media (max-width: 768px) { 
+    .select {
+        margin-top: var(--space-quarter);
+        width: 100%;
+    }
+}


### PR DESCRIPTION
Before:
<img width="397" alt="___1" src="https://github.com/user-attachments/assets/a60d83a7-5484-4b2c-ac3d-1ff5b4bf9112">

After:
<img width="387" alt="altpu" src="https://github.com/user-attachments/assets/94cf4b6e-f36b-4127-816b-e2343f55ae53">
