### PR TITLE
frontend: fix mobile remember wallet settings layout

### DIFF
--- a/frontends/web/src/routes/settings/components/manage-accounts/watchonlySettings.module.css
+++ b/frontends/web/src/routes/settings/components/manage-accounts/watchonlySettings.module.css
@@ -1,11 +1,17 @@
 .label {
-  white-space: nowrap;
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.label * {
+  margin-left: auto;
 }
 
 .labelText {
   display: inline-block;
   font-size: 14px;
   line-height: 1;
-  margin-right: 8px;
-  vertical-align: sub;
+  margin-top: 2px;
 }

--- a/frontends/web/src/routes/settings/manage-accounts.module.css
+++ b/frontends/web/src/routes/settings/manage-accounts.module.css
@@ -13,17 +13,25 @@
 }
 
 .walletHeader {
-    align-items: end;
+    align-items: flex-start;
     display: flex;
-    flex-wrap: wrap;
     justify-content: space-between;
     margin-bottom: var(--space-eight);
 }
 
 .walletTitle {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
     font-size: 20px;
     font-weight: 400;
     margin: 0 0 var(--space-quarter) 0;
+    width: 50%;
+}
+
+.keystoreName {
+    margin-bottom: var(--space-eight);
+    margin-right: var(--space-quarter);
 }
 
 .walletTitle small {

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -249,7 +249,7 @@ class ManageAccounts extends Component<Props, State> {
                         asCard>
                         <div className={style.walletHeader}>
                           <h2 className={style.walletTitle}>
-                            <span className="p-right-quarter">
+                            <span className={style.keystoreName}>
                               {keystore.keystore.name}
                               { isAmbiguousName(keystore.keystore.name, accountsByKeystore) ? (
                                 // Disambiguate accounts group by adding the fingerprint.


### PR DESCRIPTION
Previously, the switch collapses if it has no enough space causing inconsistent layout between accounts. Now, that switch always stays on right edge top of the container. If there's no enough space, the name of the account and the switch label will collapse.


Before: 
<img width="373" alt="Sasd9" src="https://github.com/user-attachments/assets/960784b6-d7ea-4f33-8097-d6509135109a">
<img width="350" alt="Sasd" src="https://github.com/user-attachments/assets/5ce91ed3-6713-4c3b-a96f-8b5a634afa50">


After:
<img width="354" alt="Scx7" src="https://github.com/user-attachments/assets/2d44488f-08a0-49f1-b1f0-86ce1fdc3c46">


After, on super small screen:

<img width="401" alt="Sasd4" src="https://github.com/user-attachments/assets/2d581c39-e2d0-463b-83f8-24bc873a56be">
(the fingerprint is hidden when this screenshot was taken).
