### PR TITLE
frontend: revamp sdcardcheck (bb02) UI

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -288,6 +288,7 @@
     },
     "stepInsertSD": {
       "insertSDCard": "Please insert a microSD card into your BitBox02 to continue.",
+      "insertSDCardToSeeBackups": "Please insert the microSD card into your BitBox02 to see your backups.",
       "insertSDcardTitle": "Insert microSD card"
     },
     "stepPassword": {

--- a/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
+++ b/frontends/web/src/routes/device/bitbox02/sdcardcheck.tsx
@@ -17,8 +17,9 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { checkSDCard } from '@/api/bitbox02';
-import { Dialog, DialogButtons } from '@/components/dialog/dialog';
 import { Button } from '@/components/forms';
+import { PointToBitBox02 } from '@/components/icon';
+import { View, ViewButtons, ViewContent, ViewHeader } from '@/components/view/view';
 import { BackButton } from '@/components/backbutton/backbutton';
 import { HorizontallyCenteredSpinner } from '@/components/spinner/SpinnerAnimation';
 
@@ -44,25 +45,24 @@ const SDCardCheck = ({ deviceID, children }: TProps) => {
   return (
     <div>
       {!sdCardInserted ? (
-        <Dialog open={!sdCardInserted} title="Check your device" small>
-          <div className="columnsContainer half">
-            <div className="columns">
-              <div className="column">
-                <p>{t('backup.insert')}</p>
-              </div>
-            </div>
-          </div>
-          <DialogButtons>
+        <View textCenter>
+          <ViewHeader title={t('bitbox02Wizard.stepInsertSD.insertSDcardTitle')}>
+            {t('bitbox02Wizard.stepInsertSD.insertSDCardToSeeBackups')}
+          </ViewHeader>
+          <ViewContent minHeight="280px">
+            <PointToBitBox02 />
+          </ViewContent>
+          <ViewButtons>
             <Button
               primary
               onClick={check}>
               {t('button.ok')}
             </Button>
-            <BackButton>
+            <BackButton enableEsc>
               {t('button.back')}
             </BackButton>
-          </DialogButtons>
-        </Dialog>
+          </ViewButtons>
+        </View>
       ) : children}
     </div>
   );

--- a/frontends/web/src/routes/device/manage-backups/manage-backups.tsx
+++ b/frontends/web/src/routes/device/manage-backups/manage-backups.tsx
@@ -17,6 +17,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { TDevices } from '@/api/devices';
+import { SubTitle } from '@/components/title';
 import { BackButton } from '@/components/backbutton/backbutton';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
@@ -48,7 +49,6 @@ export const ManageBackups = ({
             title={<h2>{t('backup.title')}</h2>}
           />
           <div className="content padded">
-            <h3 className="subTitle">{t('backup.list')}</h3>
             <BackupsList
               deviceID={deviceID}
               devices={devices}
@@ -74,15 +74,19 @@ const BackupsList = ({
   }
   switch (devices[deviceID]) {
   case 'bitbox':
+
     return (
-      <Backups
-        deviceID={deviceID}
-        showCreate={true}
-        showRestore={false}>
-        <BackButton>
-          {t('button.back')}
-        </BackButton>
-      </Backups>
+      <>
+        <SubTitle>{t('backup.list')}</SubTitle>
+        <Backups
+          deviceID={deviceID}
+          showCreate={true}
+          showRestore={false}>
+          <BackButton>
+            {t('button.back')}
+          </BackButton>
+        </Backups>
+      </>
     );
   case 'bitbox02':
     return (


### PR DESCRIPTION
Use view component and new design in the sdcardcheck component (manage backups) for the bb02, instead of the Dialog.

This is done to improve UX.

Before:

<img width="1366" alt="sadx" src="https://github.com/user-attachments/assets/8bcdf451-4b72-402f-9e73-f43645c866ce">

After:

<img width="1483" alt="Ssadasdasd" src="https://github.com/user-attachments/assets/5a9781cd-6dce-4f47-a192-ed4d19cf9cfb">

<img width="338" alt="Screenshot 1999-01-01 at 12 34 56" src="https://github.com/user-attachments/assets/29fc28d3-cf70-4b7e-aee8-1ad03cec4021">
