### PR TITLE
ci: replace deprecated set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,7 @@ jobs:
           #
           # Keep this in sync with default in scripts/github-ci.sh.
           CI_IMAGE_VERSION=$(cat .containerversion)
-          echo "CI_IMAGE=ghcr.io/bitboxswiss/bitbox-wallet-app-ci:$CI_IMAGE_VERSION" >> $GITHUB_ENV
-          echo "::set-output name=ci_image::ghcr.io/bitboxswiss/bitbox-wallet-app-ci:$CI_IMAGE_VERSION"
+          echo "ci_image=ghcr.io/bitboxswiss/bitbox-wallet-app-ci:$CI_IMAGE_VERSION" >> $GITHUB_OUTPUT
 
   test-lint:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
GitHub Actions is deprecating the set-output command. This updates the workflow to use the new OUTPUT environment file instead.

Removes setting an environment variable since it is unused in the job.

See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/