### PR TITLE
frontend: skeleton when txhistory conversion amount isnt available

### DIFF
--- a/frontends/web/src/components/amount/amount.tsx
+++ b/frontends/web/src/components/amount/amount.tsx
@@ -126,7 +126,7 @@ export const FormattedAmount = ({
   unit,
   removeBtcTrailingZeroes,
   alwaysShowAmounts = false,
-}: TProps) => {
+}: Omit<TProps, 'allowRotateCurrencyOnMobile'>) => {
   const { hideAmounts } = useContext(AppContext);
   const { decimal, group } = useContext(LocalizationContext);
 

--- a/frontends/web/src/components/amount/conversion-amount.module.css
+++ b/frontends/web/src/components/amount/conversion-amount.module.css
@@ -1,5 +1,14 @@
+.skeletonContainer {
+  max-width: 64px;
+  width: 100%;
+}
+
 .txConversionAmount {
+  align-items: baseline;
+  display: flex;
   font-variant: tabular-nums;
+  justify-content: end;
+  gap: var(--space-eight);
 }
 
 .txPrefix,

--- a/frontends/web/src/components/amount/conversion-amount.tsx
+++ b/frontends/web/src/components/amount/conversion-amount.tsx
@@ -21,12 +21,13 @@ import { Arrow } from '@/components/transactions/components/arrows';
 import { Amount } from '@/components/amount/amount';
 import { getTxSign } from '@/utils/transaction';
 import styles from './conversion-amount.module.css';
+import { Skeleton } from '@/components/skeleton/skeleton';
 
 type TConversionAmountProps = {
   amount: IAmount;
   deductedAmount: IAmount;
   type: TTransactionType;
-}
+};
 
 const btcUnits: Readonly<string[]> = ['BTC', 'TBTC', 'sat', 'tsat'];
 
@@ -40,6 +41,7 @@ export const ConversionAmount = ({
 }: TConversionAmountProps) => {
   const { defaultCurrency } = useContext(RatesContext);
   const conversion = amount?.conversions && amount?.conversions[defaultCurrency];
+
   const sign = getTxSign(type);
   const estimatedPrefix = '\u2248'; // ≈
   const sendToSelf = type === 'send_to_self';
@@ -52,26 +54,28 @@ export const ConversionAmount = ({
 
   return (
     <span className={styles.txConversionAmount}>
-      {sendToSelf && (
-        <span className={styles.txSmallInlineIcon}>
-          <Arrow type="send_to_self" />
-        </span>
+      {conversion && amountToShow ? (
+        <>
+          {sendToSelf && (
+            <span className={styles.txSmallInlineIcon}>
+              <Arrow type="send_to_self" />
+            </span>
+          )}
+          {amountToShow.estimated && !skipEstimatedPrefix && (
+            <span className={styles.txPrefix}>{estimatedPrefix}{' '}</span>
+          )}
+          {conversion && !sendToSelf ? sign : null}
+          <Amount
+            amount={sendToSelf ? amountToShow.amount : conversion || ''}
+            unit={conversionUnit}
+          />
+        </>
+      ) : (
+        <div className={styles.skeletonContainer}>
+          <Skeleton />
+        </div>
       )}
-      {amountToShow.estimated && !skipEstimatedPrefix && (
-        <span className={styles.txPrefix}>
-          {estimatedPrefix}
-          {' '}
-        </span>
-      )}
-      {conversion && !sendToSelf ? sign : null}
-      <Amount
-        amount={sendToSelf ? amountToShow.amount : conversion || ''}
-        unit={conversionUnit}
-      />
-      <span className={styles.txUnit}>
-        {' '}
-        {conversionUnit}
-      </span>
+      <span className={styles.txUnit}>{' '}{conversionUnit}</span>
     </span>
   );
 };


### PR DESCRIPTION
Sometimes, when the connection is slow, the conversion amount on the tx history list will render "---".

This is actually down in the `amount` component. However, we'd like to use skeleton here on the txlist to better indicate loading for this particular view.

Showing the skeleton:

<img width="1043" alt="rup" src="https://github.com/user-attachments/assets/38dd8bac-d01f-45fd-94e3-1940b5670f6f" />


