### PR TITLE
frontend: increase confirm send width

### DIFF
--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -76,7 +76,7 @@ export const BB02ConfirmSend = ({
 
 
   return (
-    <View fullscreen width="740px">
+    <View fullscreen width="840px">
       <ViewHeader title={<div className={style.title}>{t('send.confirm.title')}</div>} />
       <ViewContent>
         <Message type="info">


### PR DESCRIPTION
Previous size was a bit too small causing selected coins (if coin control is enabled) to be broken into two lines. We increase the size so it stays in one line.