### PR TITLE
frontend: adjust padding & wordbreak for cta & action buttons

### DIFF
--- a/frontends/web/src/routes/account/account.module.css
+++ b/frontends/web/src/routes/account/account.module.css
@@ -34,6 +34,10 @@
     padding-bottom: 0;
 }
 
+.actionsContainer span {
+    word-break: normal;
+}
+
 .exchange,
 .receive,
 .walletConnect,

--- a/frontends/web/src/routes/account/info/buy-receive-cta.module.css
+++ b/frontends/web/src/routes/account/info/buy-receive-cta.module.css
@@ -12,3 +12,10 @@
 .walletConnect span {
     margin-left: var(--space-eight);
 }
+
+@media (max-width: 425px) {
+    .buttons button {
+        padding: var(--space-quarter);
+        font-size: 14px;
+    }
+}


### PR DESCRIPTION
With the current setup, on smaller screens, buy & receive buttons have no proper padding:
Before:
<img width="378" alt="Screenshot 2025-02-03 at 09 25 24" src="https://github.com/user-attachments/assets/12bd4df7-6b99-4c33-b66f-dab982a02267" />

After:
<img width="452" alt="Screenshot 2025-02-03 at 09 44 24" src="https://github.com/user-attachments/assets/bf923d82-4f51-4e29-bc2c-35338798f180" />


For action buttons, on smaller screens, the buttons have improper wordbreak causing them to look odd:

Before:
<img width="360" alt="Screenshot 2025-02-04 at 09 19 59" src="https://github.com/user-attachments/assets/c7c133d7-7d98-4fc3-9564-f8b3efd55773" />


After:
<img width="385" alt="Screenshot 2025-02-04 at 09 19 51" src="https://github.com/user-attachments/assets/e28886fe-7bff-4b8b-84c9-16d68f25e39f" />
