### PR TITLE
frontend: revamp buysell action buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Android: handle device disconnect while the app is in the background
 - Improve send result view show relevant infos and options to make a new transaction or go back
 - Added an option in advanced settings to allow the app to start in testnet at the next restart.
+- Improve the UI of buy & sell page for mobile devices
 
 # 4.46.3
 - Fix camera access on linux

--- a/frontends/web/src/components/actionable-item/actionable-item.module.css
+++ b/frontends/web/src/components/actionable-item/actionable-item.module.css
@@ -1,0 +1,39 @@
+.container {
+  align-items: center;
+  background-color: var(--background-secondary);
+  border: none;
+  display: flex;
+  justify-content: space-between;
+  padding: 16px;
+  text-align: left;
+  width: 100%;
+}
+
+.isButton {
+  cursor: pointer;
+}
+
+.leftContent {
+  align-items: center;
+  display: flex;
+  width: 100%;
+}
+
+.rightContent {
+  align-items: center;
+  display: flex;
+}
+
+.nowrap {
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .collapse {
+    padding: 12px;
+  }
+
+  .hideDisplayedValueOnSmall {
+    display: none;
+  }
+}

--- a/frontends/web/src/components/actionable-item/actionable-item.tsx
+++ b/frontends/web/src/components/actionable-item/actionable-item.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2025 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+import { ChevronRightDark } from '@/components/icon';
+import styles from './actionable-item.module.css';
+
+type TProps = {
+  className?: string;
+  disabled?: boolean;
+  children: ReactNode;
+  onClick?: () => void;
+}
+
+export const ActionableItem = ({
+  className = '',
+  disabled,
+  children,
+  onClick,
+}: TProps) => {
+  const notButton = disabled || onClick === undefined;
+
+  const content = (
+    <div className={styles.leftContent}>
+      {children}
+      <ChevronRightDark />
+    </div>
+  );
+
+  return (
+    <>
+      {notButton ? (
+        <div className={`${styles.container} ${className}`}>
+          {content}
+        </div>
+      ) : (
+        <button
+          type="button"
+          className={`${styles.container} ${styles.isButton} ${className}`}
+          onClick={onClick}>
+          {content}
+        </button>
+      )}
+    </>
+  );
+};

--- a/frontends/web/src/routes/exchange/components/exchange-provider.module.css
+++ b/frontends/web/src/routes/exchange/components/exchange-provider.module.css
@@ -1,25 +1,21 @@
-/**
- * Copyright 2022 Shift Crypto AG
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
- 
 .container, .paymentMethodContainer {
     display: flex;
 }
 
 .exchangeName {
-    width: 30%;
+    width: 40px;
+}
+
+.exchangeContainer {
+    width: 100%;
+}
+
+.badgeContainer {
+    margin-left: auto;
+}
+
+.outerContainer {
+    position: relative;
 }
 
 .infoButton {
@@ -41,7 +37,9 @@
 .paymentMethodsContainer {
     display: flex;
     flex-direction: column;
-    width: 70%;
+    margin-left: 40px;
+    width: 100%;
+    padding-right: var(--space-quarter);
 }
 
 .paymentMethodName {
@@ -58,10 +56,6 @@
     margin-top: var(--space-eight);
 }
 
-.paymentMethodContainer > span {
-    flex-basis: 124px;
-    flex-grow: 1;
-}
 
 .radio {
     --size-default: 14px;
@@ -178,4 +172,14 @@
 
 span[role="radio"]:focus{
     outline-color: var(--color-blue);
+}
+
+@media (max-width: 400px) {
+    .exchangeName {
+        width: 50px;
+    }
+
+    .badgeContainer {
+        display: none;
+    }
 }

--- a/frontends/web/src/routes/exchange/components/exchange-providers.tsx
+++ b/frontends/web/src/routes/exchange/components/exchange-providers.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2025 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,19 @@
  * limitations under the License.
  */
 
-import { Dispatch, SetStateAction, KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDarkmode } from '@/hooks/darkmode';
 import { Bank, BankDark, CreditCard, CreditCardDark } from '@/components/icon';
-import { InfoButton } from '@/components/infobutton/infobutton';
 import { Badge } from '@/components/badge/badge';
 import { getExchangeFormattedName } from '@/routes/exchange/utils';
-import style from './exchangeselectionradio.module.css';
 import { ExchangeDeal, ExchangeDeals } from '@/api/exchanges';
-import { Info } from './infocontent';
+import style from './exchange-provider.module.css';
 
-type RadioProps = {
+type Props = {
   deals: ExchangeDeal[];
   exchangeName: ExchangeDeals['exchangeName'];
-  onChange: () => void;
-  onClickInfoButton: Dispatch<SetStateAction<Info | undefined>>;
 }
 
-type TRadioProps = RadioProps & JSX.IntrinsicElements['input'];
 type TPaymentMethodProps = { methodName: ExchangeDeal['payment'] };
 
 const PaymentMethod = ({ methodName }: TPaymentMethodProps) => {
@@ -63,7 +57,7 @@ const Deal = ({ deal }: { deal: ExchangeDeal }) => {
   return (
     <div className={style.paymentMethodContainer}>
       <PaymentMethod methodName={deal.payment} />
-      <div>
+      <div className={style.badgeContainer}>
         {deal.isBest && (
           <Badge type="success">{t('buy.exchange.bestDeal')}</Badge>
         )}
@@ -75,54 +69,21 @@ const Deal = ({ deal }: { deal: ExchangeDeal }) => {
   );
 };
 
-export const ExchangeSelectionRadio = ({
-  disabled = false,
-  id,
-  children,
-  checked,
+
+export const ExchangeProviders = ({
   deals,
-  onChange,
   exchangeName,
-  onClickInfoButton,
-  ...props
-}: TRadioProps) => {
-
-  const handleClick = () => {
-    if (!disabled) {
-      onChange();
-    }
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLSpanElement>) => {
-    if (!disabled && e.key === 'Enter') {
-      onChange();
-    }
-  };
-
+}: Props) => {
   return (
-    <div className={style.outerContainer}>
-      <span aria-checked={checked} onKeyDown={handleKeyDown} aria-disabled={disabled} role="radio" tabIndex={0} onClick={handleClick} className={style.radio}>
-        <input
-          checked={checked}
-          type="radio"
-          id={id}
-          disabled={disabled}
-          onChange={onChange}
-          {...props}
-        />
-        <label className={style.radioLabel} htmlFor={id}>
-          <div className={style.container}>
-            <p className={[style.text, style.exchangeName].join(' ')}>
-              {getExchangeFormattedName(exchangeName)}
-            </p>
-            <div className={style.paymentMethodsContainer}>
-              {deals.map(deal => <Deal key={deal.payment} deal={deal}/>)}
-            </div>
-          </div>
-        </label>
-      </span>
-      <InfoButton onClick={() => onClickInfoButton(exchangeName)} />
+    <div className={style.exchangeContainer}>
+      <div className={style.container}>
+        <p className={[style.text, style.exchangeName].join(' ')}>
+          {getExchangeFormattedName(exchangeName)}
+        </p>
+        <div className={style.paymentMethodsContainer}>
+          {deals.map(deal => <Deal key={deal.payment} deal={deal}/>)}
+        </div>
+      </div>
     </div>
-
   );
 };

--- a/frontends/web/src/routes/exchange/exchange.module.css
+++ b/frontends/web/src/routes/exchange/exchange.module.css
@@ -1,18 +1,6 @@
-/**
- * Copyright 2022 Shift Crypto AG
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+.actionableItemContainer {
+    position: relative;
+}
 
 .buttonBack {
     margin-right: auto;
@@ -26,6 +14,12 @@
 
 .container {
     margin-top: calc(var(--space-default) * 1.5);
+}
+
+.exchangeProvidersContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
 }
 
 .exchangeContainer {
@@ -109,4 +103,10 @@
     height: 1em;
     margin-right: 0.5em;
     vertical-align: text-bottom;
+}
+
+@media screen and (max-width: 400px) {
+    .buttonBack {
+        width: 100%;
+    }
 }

--- a/frontends/web/src/routes/exchange/exchange.tsx
+++ b/frontends/web/src/routes/exchange/exchange.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Shift Crypto AG
+ * Copyright 2022-2025 Shift Crypto AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ export const Exchange = ({ code, accounts, deviceIDs }: TProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [selectedRegion, setSelectedRegion] = useState('');
-  const [selectedExchange, setSelectedExchange] = useState('');
   const [regions, setRegions] = useState<TOption[]>([]);
   const [info, setInfo] = useState<TInfoContentProps>();
   const [supportedAccounts, setSupportedAccounts] = useState<IAccount[]>([]);
@@ -102,11 +101,11 @@ export const Exchange = ({ code, accounts, deviceIDs }: TProps) => {
   }, [regionList, config, nativeLocale]);
 
 
-  const goToExchange = () => {
-    if (!selectedExchange) {
+  const goToExchange = (exchange: string) => {
+    if (!exchange) {
       return;
     }
-    navigate(`/exchange/${selectedExchange}/${activeTab}/${code}`);
+    navigate(`/exchange/${exchange}/${activeTab}/${code}`);
   };
 
   const handleChangeRegion = (newValue: SingleValue<TOption>) => {
@@ -140,7 +139,6 @@ export const Exchange = ({ code, accounts, deviceIDs }: TProps) => {
                 <ExchangeTab
                   onChangeTab={(tab) => {
                     setActiveTab(tab);
-                    setSelectedExchange('');
                   }}
                   activeTab={activeTab}
                 />
@@ -149,8 +147,6 @@ export const Exchange = ({ code, accounts, deviceIDs }: TProps) => {
                     accountCode={code}
                     selectedRegion={selectedRegion}
                     deviceIDs={deviceIDs}
-                    onSelectExchange={setSelectedExchange}
-                    selectedExchange={selectedExchange}
                     goToExchange={goToExchange}
                     showBackButton={supportedAccounts.length > 1}
                     action={activeTab}


### PR DESCRIPTION
Revamp buy sell action buttons. Previously we use 2-step approach here. First user needs to select via radio button, then click on the action button (next).

In this commit, we changed the radio button to become clickable card / normal  buttons. And when clicked, this will bring the user to the next screen. This eliminates the need for the next button and shortens the steps the user need to take.

On screen width <=400px, we hide the exchange badges to save space and also set the back button to full width.

Also removed redundant page title.

<img width="1483" alt="Screenshot 2025-02-04 at 10 19 57" src="https://github.com/user-attachments/assets/0bac42c6-43cb-4538-a2c9-0679ff28dfc4" />

<img width="819" alt="Screenshot 2025-02-04 at 10 20 13" src="https://github.com/user-attachments/assets/b083301e-3a94-4c28-a06d-82c2dc51435e" />


<img width="368" alt="Screenshot 2025-02-04 at 10 20 23" src="https://github.com/user-attachments/assets/48743392-6cf8-4c26-a646-86d7b8390772" />

