### PR TITLE
frontend: set width for dropdowns in settings page

### DIFF
--- a/frontends/web/src/routes/settings/components/appearance/settingsdropdown.module.css
+++ b/frontends/web/src/routes/settings/components/appearance/settingsdropdown.module.css
@@ -1,7 +1,6 @@
 .select {
     width: 280px;
 }
-
 .select :global(.react-select__option) {
     padding: var(--space-half) var(--space-quarter);
 }
@@ -9,7 +8,12 @@
 
 @media (max-width: 768px) { 
     .select {
-        margin-top: var(--space-quarter);
         width: 100%;
+    }
+}
+
+@media (max-width: 560px) {
+    .select {
+        margin-top: 12px;
     }
 }

--- a/frontends/web/src/routes/settings/components/settingsItem/settingsItem.module.css
+++ b/frontends/web/src/routes/settings/components/settingsItem/settingsItem.module.css
@@ -32,6 +32,8 @@
 .rightContentContainer {
     align-items: center;
     display: flex;
+    justify-content: flex-end;
+    width: 50%;
 }
 
 .displayedValue {


### PR DESCRIPTION
Currently, the width of these dropdowns in the settings page
follow the content inside it, causing it to look inconsistent.

We unify their width to improve the UI.

Before:

<img width="738" alt="pjxro" src="https://github.com/user-attachments/assets/381745ef-a89a-4a59-b7d4-636dd9f2c230" />



After:
<img width="741" alt="razu4" src="https://github.com/user-attachments/assets/8f46948c-03d5-4ee7-8e33-17268a66eeb0" />
