### PR TITLE
frontend: fix account selector title on buy / sell page

### DIFF
--- a/frontends/web/src/routes/exchange/info.tsx
+++ b/frontends/web/src/routes/exchange/info.tsx
@@ -108,7 +108,7 @@ export const ExchangeInfo = ({ code, accounts }: TProps) => {
                 supportedAccounts && (
                   <GroupedAccountSelector
                     accounts={supportedAccounts}
-                    title={ t('generic.buySell')}
+                    title={ t('receive.selectAccount')}
                     disabled={disabled}
                     selected={selected}
                     onChange={setSelected}


### PR DESCRIPTION
Rename 'Buy & Sell' title to 'Select account'
for clarity in the account selector of Buy & Sell page.

The same behaviour can be seen for the Receive account selector.