### PR TITLE
frontend: fix unsupported css property

### DIFF
--- a/frontends/web/src/components/amount/conversion-amount.module.css
+++ b/frontends/web/src/components/amount/conversion-amount.module.css
@@ -7,7 +7,7 @@
   align-items: baseline;
   display: flex;
   font-variant: tabular-nums;
-  justify-content: end;
+  margin-left: auto;
   gap: var(--space-eight);
 }
 

--- a/frontends/web/src/components/transactions/transaction.module.css
+++ b/frontends/web/src/components/transactions/transaction.module.css
@@ -55,6 +55,8 @@
 }
 
 .txAmountsColumn {
+  display: flex;
+  flex-direction: column;
   flex-grow: 1;
   flex-shrink: 0;
   font-size: 14px;


### PR DESCRIPTION
Bug exists across platforms due to an unsupported CSS property in the browser engine: `justify-content: end;`.

Our QT is running version 90.x, which doesn’t support this property. Support for justify-content: end; begins in Chrome 93.x.

<hr />

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [x] checking if your changes affect other coins or tokens in unintended ways
- [x] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
