### PR TITLE
frontend: add and use 3rd party guide links and text

### DIFF
--- a/frontends/web/src/components/guide/entry.tsx
+++ b/frontends/web/src/components/guide/entry.tsx
@@ -23,7 +23,7 @@ export type TEntryProp = {
     title: string;
     text: string;
     link?: {
-        url: string;
+        url?: string;
         text: string;
     };
 }
@@ -58,12 +58,18 @@ export const Entry = (props: TProps) => {
             {entry.text.trim().split('\n').map((p, idx) => <p key={idx}>{p}</p>)}
             {entry.link && (
               <p>
-                <A
-                  className={style.link}
-                  data-testid="link"
-                  href={entry.link.url}>
-                  {entry.link.text}
-                </A>
+                {entry.link.url ? (
+                  <A
+                    className={style.link}
+                    data-testid="link"
+                    href={entry.link.url}>
+                    {entry.link.text}
+                  </A>
+                ) : (
+                  <span className={style.link}>
+                    {entry.link.text}
+                  </span>
+                )}
               </p>
             )}
             {props.children}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -958,7 +958,9 @@
     },
     "appendix": {
       "link": "Contact us!",
-      "text": "Another question?"
+      "questionService": "Having issues with {{serviceName}}?",
+      "text": "Another question?",
+      "textService": "If you are having issues with {{serviceName}}, please contact them directly:"
     },
     "backups": {
       "check": {

--- a/frontends/web/src/routes/bitsurance/guide.tsx
+++ b/frontends/web/src/routes/bitsurance/guide.tsx
@@ -47,6 +47,7 @@ export const BitsuranceGuide = () => {
       <Entry key="guide.bitsurance.what" entry={t('guide.bitsurance.what', { returnObjects: true })} />
       <Entry key="guide.bitsurance.status" entry={t('guide.bitsurance.status', { returnObjects: true })} />
       <Entry key="guide.bitsurance.renew" entry={t('guide.bitsurance.renew', { returnObjects: true })} />
+
       <Entry key="guide.bitsurance.privacy" entry={{
         link: {
           text: t('guide.bitsurance.privacy.link.text'),
@@ -63,6 +64,16 @@ export const BitsuranceGuide = () => {
         text: t('guide.bitsurance.faq.text'),
         title: t('guide.bitsurance.faq.title'),
       }} />
+      <Entry
+        key="guide.appendix.questionService"
+        entry={{
+          title: t('guide.appendix.questionService', { serviceName: 'Bitsurance' }),
+          text: t('guide.appendix.textService', { serviceName: 'Bitsurance' }),
+          link: {
+            text: 'service@bitsurance.eu',
+          },
+        }}
+      />
     </Guide>
   );
 };

--- a/frontends/web/src/routes/exchange/guide.tsx
+++ b/frontends/web/src/routes/exchange/guide.tsx
@@ -46,9 +46,33 @@ const usePrivacyLink = (exchange?: TExchangeName) => {
   }
 };
 
+const useServiceLink = (exchange?: TExchangeName) => {
+  switch (exchange) {
+  case 'btcdirect':
+    return ({
+      name: 'BTC Direct',
+      text: 'btcdirect.eu/contact',
+      url: 'https://btcdirect.eu/contact',
+    });
+  case 'moonpay':
+    return ({
+      name: 'MoonPay',
+      text: 'support.moonpay.com',
+      url: 'https://support.moonpay.com/',
+    });
+  case 'pocket':
+    return ({
+      name: 'Pocket Bitcoin',
+      text: 'pocketbitcoin.com/contact',
+      url: 'https://pocketbitcoin.com/contact',
+    });
+  }
+};
+
 export const ExchangeGuide = ({ exchange, translationContext }: BuyGuideProps) => {
   const { t } = useTranslation();
   const link = usePrivacyLink(exchange);
+  const serviceLink = useServiceLink(exchange);
 
   return (
     <Guide title={t('guide.guideTitle.buySell')}>
@@ -56,7 +80,19 @@ export const ExchangeGuide = ({ exchange, translationContext }: BuyGuideProps) =
         link,
         text: t('buy.info.disclaimer.protection.descriptionGeneric', { context: translationContext }),
         title: t('buy.info.disclaimer.protection.title'),
-      }} />
+      }}
+      />
+      <Entry
+        key="guide.appendix.questionService"
+        entry={{
+          title: t('guide.appendix.questionService', { serviceName: serviceLink?.name }),
+          text: t('guide.appendix.textService', { serviceName: serviceLink?.name }),
+          link: {
+            text: serviceLink?.text || '',
+            url: serviceLink?.url,
+          },
+        }}
+      />
     </Guide>
   );
 };


### PR DESCRIPTION
For third party services, we'd like to use their own links to be put in the Guide.

