### PR TITLE
backend/account: fix bug in account discovery

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -590,7 +591,7 @@ func (backend *Backend) Testing() bool {
 // Accounts returns the current accounts of the backend.
 func (backend *Backend) Accounts() AccountsList {
 	defer backend.accountsAndKeystoreLock.RLock()()
-	return backend.accounts
+	return slices.Clone(backend.accounts)
 }
 
 // KeystoreTotalAmount represents the total balance amount of the accounts belonging to a keystore.


### PR DESCRIPTION
Recent commit 726289c7eedbd5157cf5f514cca4e4ce2cc4e9b3 made the account Initialization asynchronous, moving the `account.ensureAddresses()` call on a separate thread. This caused a regression inside `backend.checkAccountUsed()`, where the method wasn't waiting for the complete account synchronization before marking it as used.

This commit fixes the issue waiting for account sync before checking if it used.

Note: The tests didn't catch the regression: I couldn't find an easy way to add some latency in the mocked addresses verification, but it would be nice to introduce it in a test to make it more reliable. Any suggestions? 
