### PR TITLE
ios: set minimum-scale, and maximum-scale to disable zoom

### DIFF
--- a/frontends/web/index.html
+++ b/frontends/web/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta 
+    name="viewport"
+    content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#000000" />
     <title>BitBoxApp</title>
   </head>


### PR DESCRIPTION
setting intial-scale=1 is not enough to disable zooming on iOS app.
