### PR TITLE
frontend: improve mobile settings UI

### DIFF
--- a/frontends/web/src/components/layout/header.module.css
+++ b/frontends/web/src/components/layout/header.module.css
@@ -89,6 +89,7 @@
 @media (max-width: 768px) {
     .header {
         padding: var(--space-half);
+        padding-bottom: 0;
     }
 
     .title {

--- a/frontends/web/src/components/layout/header.tsx
+++ b/frontends/web/src/components/layout/header.tsx
@@ -31,7 +31,7 @@ type Props = {
 export const Header = ({
   title,
   hideSidebarToggler,
-  children
+  children,
 }: Props) => {
   const { t } = useTranslation();
 

--- a/frontends/web/src/routes/settings/about.tsx
+++ b/frontends/web/src/routes/settings/about.tsx
@@ -44,7 +44,7 @@ export const About = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
               </>
             } />
           <View fullscreen={false}>
-            <ViewContent>
+            <ViewContent fullWidth>
               <WithSettingsTabs devices={devices} hideMobileMenu hasAccounts={hasAccounts}>
                 <AppVersion />
               </WithSettingsTabs>

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -88,7 +88,7 @@ export const AdvancedSettings = ({ devices, hasAccounts }: TPagePropsWithSetting
               </>
             } />
           <View fullscreen={false}>
-            <ViewContent>
+            <ViewContent fullWidth>
               <WithSettingsTabs
                 devices={devices}
                 hideMobileMenu

--- a/frontends/web/src/routes/settings/bb02-settings.module.css
+++ b/frontends/web/src/routes/settings/bb02-settings.module.css
@@ -15,4 +15,8 @@
     .skeletonWrapper {
          margin-bottom: 2px;
     }
+
+    .withMobilePadding {
+        padding: 0 var(--space-half);
+    }
 }

--- a/frontends/web/src/routes/settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/settings/bb02-settings.tsx
@@ -39,6 +39,7 @@ import { ManageDeviceGuide } from '@/routes/device/bitbox02/settings-guide';
 import { MobileHeader } from './components/mobile-header';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
+import { SubTitle } from '@/components/title';
 import styles from './bb02-settings.module.css';
 
 type TProps = {
@@ -73,7 +74,7 @@ const BB02Settings = ({ deviceID, devices, hasAccounts }: TWrapperProps) => {
               </>
             }/>
           <View fullscreen={false}>
-            <ViewContent>
+            <ViewContent fullWidth>
               <WithSettingsTabs
                 devices={devices}
                 hideMobileMenu
@@ -113,14 +114,14 @@ const Content = ({ deviceID }: TProps) => {
     <>
       {/*"Backups" section*/}
       <div className={styles.section}>
-        <h3 className="subTitle">{t('deviceSettings.backups.title')}</h3>
+        <SubTitle className={styles.withMobilePadding}>{t('deviceSettings.backups.title')}</SubTitle>
         <ManageBackupSetting deviceID={deviceID} />
         <ShowRecoveryWordsSetting deviceID={deviceID} />
       </div>
 
       {/*"Device information" section*/}
       <div className={styles.section}>
-        <h3 className="subTitle">{t('deviceSettings.deviceInformation.title')}</h3>
+        <SubTitle className={styles.withMobilePadding}>{t('deviceSettings.deviceInformation.title')}</SubTitle>
         {deviceInfo ? (
           <DeviceNameSetting
             deviceName={deviceInfo.name}
@@ -155,7 +156,7 @@ const Content = ({ deviceID }: TProps) => {
 
       {/*"Expert settings" section*/}
       <div className={styles.section}>
-        <h3 className="subTitle">{t('settings.expert.title')}</h3>
+        <SubTitle className={styles.withMobilePadding}>{t('settings.expert.title')}</SubTitle>
         {
           deviceInfo ? (
             <PassphraseSetting

--- a/frontends/web/src/routes/settings/general.module.css
+++ b/frontends/web/src/routes/settings/general.module.css
@@ -1,0 +1,5 @@
+@media (max-width: 768px) {
+    .subtitleWithMobilePadding {
+        padding: 0 var(--space-half);
+    }
+}

--- a/frontends/web/src/routes/settings/general.tsx
+++ b/frontends/web/src/routes/settings/general.tsx
@@ -31,7 +31,7 @@ import { SubTitle } from '@/components/title';
 import { TPagePropsWithSettingsTabs } from './types';
 import { GlobalBanners } from '@/components/banners';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-
+import style from './general.module.css';
 export const General = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
   return (
@@ -50,9 +50,9 @@ export const General = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) =>
               </>
             } />
           <View fullscreen={false}>
-            <ViewContent>
+            <ViewContent fullWidth>
               <WithSettingsTabs hasAccounts={hasAccounts} hideMobileMenu devices={devices}>
-                <SubTitle>
+                <SubTitle className={style.subtitleWithMobilePadding}>
                   {t('settings.appearance')}
                 </SubTitle>
                 <LanguageDropdownSetting />
@@ -61,7 +61,7 @@ export const General = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) =>
                 <DarkmodeToggleSetting />
                 { hasAccounts ? (
                   <>
-                    <SubTitle className="m-top-default">
+                    <SubTitle className={`m-top-default ${style.subtitleWithMobilePadding}`}>
                       {t('settings.notes.title')}
                     </SubTitle>
                     <NotesExport />

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -217,7 +217,7 @@ export const ManageAccounts = ({ accounts, devices, hasAccounts }: Props) => {
               </>
             } />
           <View fullscreen={false}>
-            <ViewContent>
+            <ViewContent fullWidth>
               <WithSettingsTabs devices={devices} hideMobileMenu hasAccounts={hasAccounts}>
                 <Button
                   className={style.addAccountBtn}

--- a/frontends/web/src/routes/settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/settings/mobile-settings.tsx
@@ -49,11 +49,12 @@ export const MobileSettings = ({ devices, hasAccounts }: TPagePropsWithSettingsT
       <ContentWrapper>
         <GlobalBanners />
       </ContentWrapper>
-      <Header title={
-        <MobileHeader onClick={handleClick} title={t('settings.title')} />
-      } />
+      <Header
+        title={
+          <MobileHeader onClick={handleClick} title={t('settings.title')} />
+        } />
       <View fullscreen={false}>
-        <ViewContent>
+        <ViewContent fullWidth>
           <Tabs devices={devices} hasAccounts={hasAccounts} />
         </ViewContent>
       </View>

--- a/frontends/web/src/routes/settings/more.tsx
+++ b/frontends/web/src/routes/settings/more.tsx
@@ -40,9 +40,10 @@ export const More = () => {
           <ContentWrapper>
             <GlobalBanners />
           </ContentWrapper>
-          <Header title={<h2>{t('settings.more')}</h2>} />
+          <Header
+            title={<h2>{t('settings.more')}</h2>} />
           <View fullscreen={false}>
-            <ViewContent>
+            <ViewContent fullWidth>
               <div className={styles.container}>
                 <ActionableItem
                   onClick={() => navigate('/settings')}


### PR DESCRIPTION
- Lesser whitespace between header and content
- Settings items to be full width

<img width="319" alt="Screenshot 2025-05-19 at 09 56 36" src="https://github.com/user-attachments/assets/8e505356-379c-48d0-8a38-13e5ebb84109" />

<img width="339" alt="Screenshot 2025-05-19 at 09 56 48" src="https://github.com/user-attachments/assets/84bb7a21-0a57-4437-a542-0bb793352ced" />

<img width="349" alt="Screenshot 2025-05-19 at 09 56 54" src="https://github.com/user-attachments/assets/3f8ef772-6614-41d9-9231-398e76ef048f" />

<img width="329" alt="Screenshot 2025-05-19 at 09 57 01" src="https://github.com/user-attachments/assets/d80ded1d-9de2-4319-b73a-e60a904892dc" />

