### PR TITLE
frontend: fix buttons touching on account info (mobile)

### DIFF
--- a/frontends/web/src/routes/account/info/info.module.css
+++ b/frontends/web/src/routes/account/info/info.module.css
@@ -29,9 +29,6 @@
     max-width: 100%;
 }
 
-.address {
-}
-
 .buttons {
     clear: both;
     display: flex;
@@ -81,6 +78,11 @@
 
     .infoContent {
         width: 100%;
+    }
+
+    .buttons {
+        flex-direction: column-reverse;
+        gap: var(--space-half)
     }
 
     .largeEntry {


### PR DESCRIPTION
Changed the flex direction on smaller screens and added gap between these buttons.

<img width="419" alt="Account" src="https://github.com/user-attachments/assets/6302deb6-2961-48be-a09a-22a688a75e28" />
