### PR TITLE
ios: fix tight margins on fullscreen View

### DIFF
--- a/frontends/web/src/components/view/view.module.css
+++ b/frontends/web/src/components/view/view.module.css
@@ -11,6 +11,7 @@
     right: 0;
     top: 0;
     padding-top: env(safe-area-inset-top, 0);
+    padding-bottom: env(safe-area-inset-top, 0);
     /* z-index between sidebar (~4000) and wait-dialog (~10000) */
     z-index: 5100;
 }
@@ -178,7 +179,7 @@
     left: 0;
     position: absolute;
     text-align: center;
-    top: 0;
+    top: env(safe-area-inset-top, 0);
     width: var(--header-height);
 }
 


### PR DESCRIPTION
We previously added space but only the top.
Added bottom spacing now as well.

Regarding the "X" button was because it's an absolute posiitoned
item, so it didn't respect the top padding.  Thus added extra
space for its `top` property here.
