### PR TITLE
backend/coins: refactor formatted amounts and add unit tests

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -875,7 +875,6 @@ func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *
 		},
 		GetSaveFilename:  backend.environment.GetSaveFilename,
 		UnsafeSystemOpen: backend.environment.SystemOpen,
-		BtcCurrencyUnit:  backend.config.AppConfig().Backend.BtcUnit,
 	}
 
 	// This function is passed as a callback to the BTC account constructor. It is called when the

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -56,8 +56,6 @@ type AccountConfig struct {
 	GetSaveFilename func(suggestedFilename string) string
 	// Opens a file in a default application. The filename is not checked.
 	UnsafeSystemOpen func(filename string) error
-	// BtcCurrencyUnit is the unit which should be used to format fiat amounts values expressed in BTC..
-	BtcCurrencyUnit coin.BtcUnit
 }
 
 // BaseAccount is an account struct with common functionality to all coin accounts.

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -94,90 +94,27 @@ func (handlers *Handlers) Uninit() {
 	handlers.account = nil
 }
 
-// FormattedAmount with unit and conversions.
-type FormattedAmount struct {
-	Amount      string            `json:"amount"`
-	Unit        string            `json:"unit"`
-	Conversions map[string]string `json:"conversions"`
-	// Estimated flag is enabled if the Conversions map was expected to
-	// be calculated using historical rates, but latest rates have been used instead.
-	Estimated bool `json:"estimated"`
-}
-
-func (handlers *Handlers) formatAmountAsJSON(amount coin.Amount, isFee bool) FormattedAmount {
-	accountCoin := handlers.account.Coin()
-	return FormattedAmount{
-		Amount: accountCoin.FormatAmount(amount, isFee),
-		Unit:   accountCoin.GetFormatUnit(isFee),
-		Conversions: coin.Conversions(
-			amount,
-			accountCoin,
-			isFee,
-			handlers.account.Config().RateUpdater,
-			util.FormatBtcAsSat(handlers.account.Config().BtcCurrencyUnit),
-		),
-	}
-}
-
-func (handlers *Handlers) formatAmountAtTimeAsJSON(amount coin.Amount, timeStamp *time.Time) FormattedAmount {
-	accountCoin := handlers.account.Coin()
-	rateUpdater := handlers.account.Config().RateUpdater
-	formatBtcAsSat := util.FormatBtcAsSat(handlers.account.Config().BtcCurrencyUnit)
-	var conversions map[string]string
-	var estimated bool
-
-	if timeStamp == nil {
-		conversions = coin.Conversions(
-			amount,
-			accountCoin,
-			false,
-			rateUpdater,
-			formatBtcAsSat,
-		)
-		estimated = true
-	} else {
-		conversions, estimated = coin.ConversionsAtTime(
-			amount,
-			accountCoin,
-			false,
-			rateUpdater,
-			formatBtcAsSat,
-			timeStamp,
-		)
-	}
-	return FormattedAmount{
-		Amount:      accountCoin.FormatAmount(amount, false),
-		Unit:        accountCoin.GetFormatUnit(false),
-		Conversions: conversions,
-		Estimated:   estimated,
-	}
-}
-
-func (handlers *Handlers) formatBTCAmountAsJSON(amount btcutil.Amount, isFee bool) FormattedAmount {
-	return handlers.formatAmountAsJSON(coin.NewAmountFromInt64(int64(amount)), isFee)
-}
-
 // Transaction is the info returned per transaction by the /transactions and /transaction endpoint.
 type Transaction struct {
-	TxID                     string            `json:"txID"`
-	InternalID               string            `json:"internalID"`
-	NumConfirmations         int               `json:"numConfirmations"`
-	NumConfirmationsComplete int               `json:"numConfirmationsComplete"`
-	Type                     string            `json:"type"`
-	Status                   accounts.TxStatus `json:"status"`
-	Amount                   FormattedAmount   `json:"amount"`
-	AmountAtTime             FormattedAmount   `json:"amountAtTime"`
-	DeductedAmountAtTime     FormattedAmount   `json:"deductedAmountAtTime"`
-	Fee                      FormattedAmount   `json:"fee"`
-	Time                     *string           `json:"time"`
-	Addresses                []string          `json:"addresses"`
-	Note                     string            `json:"note"`
+	TxID                     string                              `json:"txID"`
+	InternalID               string                              `json:"internalID"`
+	NumConfirmations         int                                 `json:"numConfirmations"`
+	NumConfirmationsComplete int                                 `json:"numConfirmationsComplete"`
+	Type                     string                              `json:"type"`
+	Status                   accounts.TxStatus                   `json:"status"`
+	Amount                   coin.FormattedAmountWithConversions `json:"amount"`
+	AmountAtTime             coin.FormattedAmountWithConversions `json:"amountAtTime"`
+	DeductedAmountAtTime     coin.FormattedAmountWithConversions `json:"deductedAmountAtTime"`
+	Fee                      coin.FormattedAmountWithConversions `json:"fee"`
+	Time                     *string                             `json:"time"`
+	Addresses                []string                            `json:"addresses"`
+	Note                     string                              `json:"note"`
 
 	// BTC specific fields.
-	VSize        int64           `json:"vsize"`
-	Size         int64           `json:"size"`
-	Weight       int64           `json:"weight"`
-	FeeRatePerKb FormattedAmount `json:"feeRatePerKb"`
+	VSize        int64                               `json:"vsize"`
+	Size         int64                               `json:"size"`
+	Weight       int64                               `json:"weight"`
+	FeeRatePerKb coin.FormattedAmountWithConversions `json:"feeRatePerKb"`
 
 	// ETH specific fields
 	Gas   uint64  `json:"gas"`
@@ -196,19 +133,20 @@ func (handlers *Handlers) ensureAccountInitialized(h func(*http.Request) (interf
 // getTxInfoJSON encodes a given transaction in JSON.
 // If `detail` is false, Coin related details, fees and historical fiat amount won't be included.
 func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail bool) Transaction {
-	var feeString FormattedAmount
+	accountConfig := handlers.account.Config()
+	var feeString coin.FormattedAmountWithConversions
 	if txInfo.Fee != nil {
-		feeString = handlers.formatAmountAsJSON(*txInfo.Fee, true)
+		feeString = txInfo.Fee.FormatWithConversions(handlers.account.Coin(), true, accountConfig.RateUpdater)
 	}
-	amount := handlers.formatAmountAsJSON(txInfo.Amount, false)
+	amount := txInfo.Amount.FormatWithConversions(handlers.account.Coin(), false, accountConfig.RateUpdater)
 	var formattedTime *string
 	timestamp := txInfo.Timestamp
 	if timestamp == nil {
 		timestamp = txInfo.CreatedTimestamp
 	}
 
-	deductedAmountAtTime := handlers.formatAmountAtTimeAsJSON(txInfo.DeductedAmount, timestamp)
-	amountAtTime := handlers.formatAmountAtTimeAsJSON(txInfo.Amount, timestamp)
+	deductedAmountAtTime := txInfo.DeductedAmount.FormatWithConversionsAtTime(handlers.account.Coin(), timestamp, accountConfig.RateUpdater)
+	amountAtTime := txInfo.Amount.FormatWithConversionsAtTime(handlers.account.Coin(), timestamp, accountConfig.RateUpdater)
 
 	if timestamp != nil {
 		t := timestamp.Format(time.RFC3339)
@@ -247,7 +185,7 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 			txInfoJSON.Weight = txInfo.Weight
 			feeRatePerKb := txInfo.FeeRatePerKb
 			if feeRatePerKb != nil {
-				txInfoJSON.FeeRatePerKb = handlers.formatBTCAmountAsJSON(*feeRatePerKb, true)
+				txInfoJSON.FeeRatePerKb = coin.ConvertBTCAmount(handlers.account.Coin(), *feeRatePerKb, true, accountConfig.RateUpdater)
 			}
 		case *eth.Coin:
 			txInfoJSON.Gas = txInfo.Gas
@@ -344,6 +282,7 @@ func (handlers *Handlers) getAccountInfo(*http.Request) (interface{}, error) {
 }
 
 func (handlers *Handlers) getUTXOs(*http.Request) (interface{}, error) {
+	accountConfig := handlers.account.Config()
 	result := []map[string]interface{}{}
 
 	t, ok := handlers.account.(*btc.Account)
@@ -378,7 +317,7 @@ func (handlers *Handlers) getUTXOs(*http.Request) (interface{}, error) {
 				"outPoint":      output.OutPoint.String(),
 				"txId":          output.OutPoint.Hash.String(),
 				"txOutput":      output.OutPoint.Index,
-				"amount":        handlers.formatBTCAmountAsJSON(btcutil.Amount(output.TxOut.Value), false),
+				"amount":        coin.ConvertBTCAmount(handlers.account.Coin(), btcutil.Amount(output.TxOut.Value), false, accountConfig.RateUpdater),
 				"address":       address,
 				"scriptType":    output.Address.AccountConfiguration.ScriptType(),
 				"note":          handlers.account.TxNote(output.OutPoint.Hash.String()),
@@ -391,11 +330,12 @@ func (handlers *Handlers) getUTXOs(*http.Request) (interface{}, error) {
 }
 
 func (handlers *Handlers) getAccountBalance(*http.Request) (interface{}, error) {
+	accountConfig := handlers.account.Config()
 	type balance struct {
-		HasAvailable bool            `json:"hasAvailable"`
-		Available    FormattedAmount `json:"available"`
-		HasIncoming  bool            `json:"hasIncoming"`
-		Incoming     FormattedAmount `json:"incoming"`
+		HasAvailable bool                                `json:"hasAvailable"`
+		Available    coin.FormattedAmountWithConversions `json:"available"`
+		HasIncoming  bool                                `json:"hasIncoming"`
+		Incoming     coin.FormattedAmountWithConversions `json:"incoming"`
 	}
 
 	type result struct {
@@ -410,9 +350,9 @@ func (handlers *Handlers) getAccountBalance(*http.Request) (interface{}, error) 
 		Success: true,
 		Balance: balance{
 			HasAvailable: accountBalance.Available().BigInt().Sign() > 0,
-			Available:    handlers.formatAmountAsJSON(accountBalance.Available(), false),
+			Available:    accountBalance.Available().FormatWithConversions(handlers.account.Coin(), false, accountConfig.RateUpdater),
 			HasIncoming:  accountBalance.Incoming().BigInt().Sign() > 0,
-			Incoming:     handlers.formatAmountAsJSON(accountBalance.Incoming(), false),
+			Incoming:     accountBalance.Incoming().FormatWithConversions(handlers.account.Coin(), false, accountConfig.RateUpdater),
 		},
 	}, nil
 }
@@ -551,6 +491,7 @@ func txProposalError(err error) (interface{}, error) {
 }
 
 func (handlers *Handlers) postAccountTxProposal(r *http.Request) (interface{}, error) {
+	accountConfig := handlers.account.Config()
 	var input sendTxInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		return txProposalError(errp.WithStack(err))
@@ -561,9 +502,9 @@ func (handlers *Handlers) postAccountTxProposal(r *http.Request) (interface{}, e
 	}
 	return map[string]interface{}{
 		"success": true,
-		"amount":  handlers.formatAmountAsJSON(outputAmount, false),
-		"fee":     handlers.formatAmountAsJSON(fee, true),
-		"total":   handlers.formatAmountAsJSON(total, false),
+		"amount":  outputAmount.FormatWithConversions(handlers.account.Coin(), false, accountConfig.RateUpdater),
+		"fee":     fee.FormatWithConversions(handlers.account.Coin(), true, accountConfig.RateUpdater),
+		"total":   total.FormatWithConversions(handlers.account.Coin(), false, accountConfig.RateUpdater),
 	}, nil
 }
 

--- a/backend/coins/btc/util/util.go
+++ b/backend/coins/btc/util/util.go
@@ -18,7 +18,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/ltc"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/btcsuite/btcd/btcutil"
@@ -68,9 +67,4 @@ func AddressFromPkScript(pkScript []byte, net *chaincfg.Params) (btcutil.Address
 		return nil, errp.New("Taproot not supported on Litecoin")
 	}
 	return addresses[0], nil
-}
-
-// FormatBtcAsSat returns true if the btcUnit param is `[t]sat`.
-func FormatBtcAsSat(btcUnit coin.BtcUnit) bool {
-	return btcUnit == coin.BtcUnitSats
 }

--- a/backend/coins/coin/amount.go
+++ b/backend/coins/coin/amount.go
@@ -17,9 +17,12 @@ package coin
 import (
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/btcsuite/btcd/btcutil"
 )
 
 // Amount represents an amount in the smallest coin unit (e.g. satoshi).
@@ -74,6 +77,64 @@ func (amount Amount) Int64() (int64, error) {
 // BigInt returns a copy of the underlying big integer.
 func (amount Amount) BigInt() *big.Int {
 	return new(big.Int).Set(amount.n)
+}
+
+// FormattedAmountWithConversions and json tags.
+type FormattedAmountWithConversions struct {
+	Amount      string            `json:"amount"`
+	Unit        string            `json:"unit"`
+	Conversions map[string]string `json:"conversions"`
+	// Estimated flag is enabled if the Conversions map was expected to
+	// be calculated using historical rates, but latest rates have been used instead.
+	Estimated bool `json:"estimated"`
+}
+
+// FormatWithConversions formats the Amount and adds fiat conversions.
+func (amount Amount) FormatWithConversions(accountCoin Coin, isFee bool, rateUpdater *rates.RateUpdater) FormattedAmountWithConversions {
+	return FormattedAmountWithConversions{
+		Amount: accountCoin.FormatAmount(amount, isFee),
+		Unit:   accountCoin.GetFormatUnit(isFee),
+		Conversions: Conversions(
+			amount,
+			accountCoin,
+			isFee,
+			rateUpdater),
+	}
+}
+
+// FormatWithConversionsAtTime formats the Amount and adds fiat conversions at a given timestamp.
+func (amount Amount) FormatWithConversionsAtTime(accountCoin Coin, timeStamp *time.Time, rateUpdater *rates.RateUpdater) FormattedAmountWithConversions {
+	var conversions map[string]string
+	var estimated bool
+
+	if timeStamp == nil {
+		conversions = Conversions(
+			amount,
+			accountCoin,
+			false,
+			rateUpdater,
+		)
+		estimated = true
+	} else {
+		conversions, estimated = ConversionsAtTime(
+			amount,
+			accountCoin,
+			false,
+			rateUpdater,
+			timeStamp,
+		)
+	}
+	return FormattedAmountWithConversions{
+		Amount:      accountCoin.FormatAmount(amount, false),
+		Unit:        accountCoin.GetFormatUnit(false),
+		Conversions: conversions,
+		Estimated:   estimated,
+	}
+}
+
+// ConvertBTCAmount formats a btcUtil.Amount and its fiat conversions into a FiatConvertedAmount.
+func ConvertBTCAmount(accountCoin Coin, amount btcutil.Amount, isFee bool, rateUpdater *rates.RateUpdater) FormattedAmountWithConversions {
+	return NewAmountFromInt64(int64(amount)).FormatWithConversions(accountCoin, isFee, rateUpdater)
 }
 
 // SendAmount is either a concrete amount, or "all"/"max". The concrete amount is user input and is

--- a/backend/coins/coin/amount_test.go
+++ b/backend/coins/coin/amount_test.go
@@ -22,6 +22,7 @@ import (
 	"testing/quick"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,4 +101,14 @@ func TestSendAmount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(0), amount.BigInt().Int64())
 
+}
+
+func TestFormatWithConversionsAtTime(t *testing.T) {
+	testCoin := mockCoin(t)
+	rateUpdater := rates.MockRateUpdater()
+
+	amount := coin.NewAmountFromInt64(12345678)
+	formattedAmount := amount.FormatWithConversionsAtTime(&testCoin, nil, rateUpdater)
+	// conversions are tested separately, we just check for the estimated flag when timestamp is nil.
+	require.True(t, formattedAmount.Estimated)
 }

--- a/backend/coins/coin/conversions.go
+++ b/backend/coins/coin/conversions.go
@@ -48,7 +48,7 @@ func FormatAsCurrency(amount *big.Rat, currency string) string {
 }
 
 // Conversions handles fiat conversions.
-func Conversions(amount Amount, coin Coin, isFee bool, ratesUpdater *ratesPkg.RateUpdater, formatBtcAsSats bool) map[string]string {
+func Conversions(amount Amount, coin Coin, isFee bool, ratesUpdater *ratesPkg.RateUpdater) map[string]string {
 	conversions := map[string]string{}
 	rates := ratesUpdater.LatestPrice()
 	if rates != nil {
@@ -66,11 +66,11 @@ func Conversions(amount Amount, coin Coin, isFee bool, ratesUpdater *ratesPkg.Ra
 // ConversionsAtTime handles fiat conversions at a specific time.
 // It returns the map of conversions and a bool indicating if the rates have been estimated
 // using the latest instead of the historical rates for recent transactions.
-func ConversionsAtTime(amount Amount, coin Coin, isFee bool, ratesUpdater *ratesPkg.RateUpdater, formatBtcAsSats bool, timeStamp *time.Time) (map[string]string, bool) {
+func ConversionsAtTime(amount Amount, coin Coin, isFee bool, ratesUpdater *ratesPkg.RateUpdater, timeStamp *time.Time) (map[string]string, bool) {
 	latestRatesTime := ratesUpdater.HistoryLatestTimestampCoin(string(coin.Code()))
 	historicalRatesNotAvailable := latestRatesTime.IsZero() || latestRatesTime.Before(*timeStamp)
 	if historicalRatesNotAvailable && time.Since(*timeStamp) < 2*time.Hour {
-		return Conversions(amount, coin, isFee, ratesUpdater, formatBtcAsSats), true
+		return Conversions(amount, coin, isFee, ratesUpdater), true
 	}
 
 	conversions := map[string]string{}

--- a/backend/coins/coin/conversions_test.go
+++ b/backend/coins/coin/conversions_test.go
@@ -17,8 +17,11 @@ package coin_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	coinMock "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin/mocks"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,4 +33,57 @@ func TestSat2Btc(t *testing.T) {
 func TestBtc2Sat(t *testing.T) {
 	require.Equal(t, "123456789", coin.Btc2Sat(new(big.Rat).SetFloat64(1.23456789)).FloatString(0))
 	require.Equal(t, "12345", coin.Btc2Sat(new(big.Rat).SetFloat64(0.00012345)).FloatString(0))
+}
+
+func mockCoin(t *testing.T) coinMock.CoinMock {
+	t.Helper()
+	return coinMock.CoinMock{
+		UnitFunc: func(isFee bool) string {
+			return "BTC"
+		},
+
+		ToUnitFunc: func(amount coin.Amount, isFee bool) float64 {
+			result, _ := new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(1e8)).Float64()
+			return result
+		},
+		CodeFunc: func() coin.Code {
+			return coin.CodeBTC
+		},
+		FormatAmountFunc: func(amount coin.Amount, isFee bool) string {
+			return new(big.Rat).SetFrac(amount.BigInt(), big.NewInt(1e8)).FloatString(8)
+		},
+		GetFormatUnitFunc: func(isFee bool) string {
+			return "BTC"
+		},
+	}
+}
+
+func TestConversions(t *testing.T) {
+	updater := rates.MockRateUpdater()
+	defer updater.Stop()
+	testCoin := mockCoin(t)
+
+	conversions := coin.Conversions(coin.NewAmountFromInt64(12345678), &testCoin, false, updater)
+	require.Equal(t, "2.59", conversions["USD"])
+}
+
+func TestConversionsAtTime(t *testing.T) {
+	updater := rates.MockRateUpdater()
+	defer updater.Stop()
+	testCoin := mockCoin(t)
+
+	timestamp := time.Unix(1598832062, 0)
+	conversions, estimated := coin.ConversionsAtTime(coin.NewAmountFromInt64(12345678), &testCoin, false, updater, &timestamp)
+	require.Equal(t, "0.12", conversions["USD"])
+	require.False(t, estimated)
+
+	timestamp = time.Unix(1598922501, 0)
+	conversions, estimated = coin.ConversionsAtTime(coin.NewAmountFromInt64(12345678), &testCoin, false, updater, &timestamp)
+	require.Equal(t, "0.37", conversions["USD"])
+	require.False(t, estimated)
+
+	timestamp = time.Now()
+	conversions, estimated = coin.ConversionsAtTime(coin.NewAmountFromInt64(12345678), &testCoin, false, updater, &timestamp)
+	require.Equal(t, "2.59", conversions["USD"])
+	require.True(t, estimated)
 }

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -80,7 +80,7 @@ export const getAccounts = (): Promise<IAccount[]> => {
 };
 
 export type TAccountsBalanceByCoin = {
-  [key in CoinCode]?: IAmount;
+  [key in CoinCode]?: TAmountWithConversions;
 };
 
 export type TAccountsBalanceResponse = {
@@ -122,7 +122,7 @@ export const getAccountsTotalBalance = (): Promise<TAccountsTotalBalanceResponse
 type CoinFormattedAmount = {
   coinCode: CoinCode;
   coinName: string;
-  formattedAmount: IAmount;
+  formattedAmount: TAmountWithConversions;
 };
 
 export type TCoinsTotalBalanceResponse = {
@@ -231,18 +231,18 @@ export type Conversions = {
     [key in Fiat]?: string;
 };
 
-export interface IAmount {
+export type TAmountWithConversions = {
     amount: string;
     conversions?: Conversions;
     unit: CoinUnit;
     estimated: boolean;
-}
+};
 
 export interface IBalance {
     hasAvailable: boolean;
-    available: IAmount;
+    available: TAmountWithConversions;
     hasIncoming: boolean;
-    incoming: IAmount;
+    incoming: TAmountWithConversions;
 }
 
 export type TBalanceResponse = {
@@ -261,11 +261,11 @@ export type TTransactionType = 'send' | 'receive' | 'send_to_self';
 
 export interface ITransaction {
     addresses: string[];
-    amount: IAmount;
-    amountAtTime: IAmount;
-    fee: IAmount;
-    feeRatePerKb: IAmount;
-    deductedAmountAtTime: IAmount;
+    amount: TAmountWithConversions;
+    amountAtTime: TAmountWithConversions;
+    fee: TAmountWithConversions;
+    feeRatePerKb: TAmountWithConversions;
+    deductedAmountAtTime: TAmountWithConversions;
     gas: number;
     nonce: number | null;
     internalID: string;
@@ -353,10 +353,10 @@ export type TTxInput = {
 );
 
 export type TTxProposalResult = {
-  amount: IAmount;
-  fee: IAmount;
+  amount: TAmountWithConversions;
+  fee: TAmountWithConversions;
   success: true;
-  total: IAmount;
+  total: TAmountWithConversions;
 } | {
   errorCode: string;
   success: false;
@@ -428,7 +428,7 @@ export type TUTXO = {
   txId: string;
   txOutput: number;
   address: string;
-  amount: IAmount;
+  amount: TAmountWithConversions;
   note: string;
   scriptType: ScriptType;
   addressReused: boolean;

--- a/frontends/web/src/components/amount/amount-with-unit.tsx
+++ b/frontends/web/src/components/amount/amount-with-unit.tsx
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 import { useContext } from 'react';
-import { CoinUnit, ConversionUnit, IAmount } from '@/api/account';
+import { CoinUnit, ConversionUnit, TAmountWithConversions } from '@/api/account';
 import { RatesContext } from '@/contexts/RatesContext';
 import { Amount } from '@/components/amount/amount';
 import { isBitcoinCoin } from '@/routes/account/utils';
 import style from './amount-with-unit.module.css';
 
 type TAmountWithUnitProps = {
-    amount: IAmount;
+    amount: TAmountWithConversions;
     tableRow?: boolean;
     enableRotateUnit?: boolean;
     sign?: string;

--- a/frontends/web/src/components/amount/conversion-amount.tsx
+++ b/frontends/web/src/components/amount/conversion-amount.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useContext } from 'react';
-import type { IAmount, TTransactionType } from '@/api/account';
+import type { TAmountWithConversions, TTransactionType } from '@/api/account';
 import { RatesContext } from '@/contexts/RatesContext';
 import { Arrow } from '@/components/transactions/components/arrows';
 import { Amount } from '@/components/amount/amount';
@@ -23,8 +23,8 @@ import { getTxSign } from '@/utils/transaction';
 import styles from './conversion-amount.module.css';
 
 type TConversionAmountProps = {
-  amount: IAmount;
-  deductedAmount: IAmount;
+  amount: TAmountWithConversions;
+  deductedAmount: TAmountWithConversions;
   type: TTransactionType;
 };
 

--- a/frontends/web/src/components/transactions/components/details-dialog.tsx
+++ b/frontends/web/src/components/transactions/components/details-dialog.tsx
@@ -16,7 +16,7 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ITransaction, IAmount, getTransaction, TTransactionStatus, TTransactionType } from '@/api/account';
+import { ITransaction, TAmountWithConversions, getTransaction, TTransactionStatus, TTransactionType } from '@/api/account';
 import { A } from '@/components/anchor/anchor';
 import { Dialog } from '@/components/dialog/dialog';
 import { Amount } from '@/components/amount/amount';
@@ -40,7 +40,7 @@ type TProps = {
   numConfirmations: number;
   numConfirmationsComplete: number;
   time: string | null;
-  amount: IAmount;
+  amount: TAmountWithConversions;
   sign: string;
   explorerURL: string;
 }

--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import type { IAmount, TTransactionStatus, TTransactionType, ITransaction } from '@/api/account';
+import type { TAmountWithConversions, TTransactionStatus, TTransactionType, ITransaction } from '@/api/account';
 import { useMediaQuery } from '@/hooks/mediaquery';
 import { Loupe } from '@/components/icon/icon';
 import { parseTimeLong, parseTimeShort } from '@/utils/date';
@@ -149,8 +149,8 @@ const Status = ({
 };
 
 type TAmountsProps = {
-  amount: IAmount;
-  deductedAmount: IAmount,
+  amount: TAmountWithConversions;
+  deductedAmount: TAmountWithConversions,
   type: TTransactionType;
 }
 

--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { CoinCode, ConversionUnit, FeeTargetCode, Fiat, IAmount } from '@/api/account';
+import { CoinCode, ConversionUnit, FeeTargetCode, Fiat, TAmountWithConversions } from '@/api/account';
 import { UseDisableBackButton } from '@/hooks/backbutton';
 import { Amount } from '@/components/amount/amount';
 import { customFeeUnit } from '@/routes/account/utils';
@@ -26,9 +26,9 @@ import { FiatValue } from '../fiat-value';
 import style from './confirm.module.css';
 
 type TransactionDetails = {
-  proposedAmount?: IAmount;
-  proposedFee?: IAmount;
-  proposedTotal?: IAmount;
+  proposedAmount?: TAmountWithConversions;
+  proposedFee?: TAmountWithConversions;
+  proposedTotal?: TAmountWithConversions;
   feeTarget?: FeeTargetCode;
   customFee: string;
   recipientAddress: string;

--- a/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Checkbox, Input } from '@/components/forms';
-import { IAmount, IBalance } from '@/api/account';
+import { TAmountWithConversions, IBalance } from '@/api/account';
 import style from './coin-input.module.css';
 
 type TProps = {
@@ -10,7 +10,7 @@ type TProps = {
     onSendAllChange: (sendAll: boolean) => void;
     sendAll: boolean;
     amountError?: string;
-    proposedAmount?: IAmount;
+    proposedAmount?: TAmountWithConversions;
     amount: string;
     hasSelectedUTXOs: boolean;
 }

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -30,7 +30,7 @@ type Props = {
   coinCode: accountApi.CoinCode;
   disabled: boolean;
   fiatUnit: accountApi.ConversionUnit;
-  proposedFee?: accountApi.IAmount;
+  proposedFee?: accountApi.TAmountWithConversions;
   customFee: string;
   showCalculatingFeeLabel?: boolean;
   onFeeTargetChange: (code: accountApi.FeeTargetCode) => void;

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -52,10 +52,10 @@ type Props = SendProps & TranslateProps;
 
 export type State = {
     balance?: accountApi.IBalance;
-    proposedFee?: accountApi.IAmount;
-    proposedTotal?: accountApi.IAmount;
+    proposedFee?: accountApi.TAmountWithConversions;
+    proposedTotal?: accountApi.TAmountWithConversions;
     recipientAddress: string;
-    proposedAmount?: accountApi.IAmount;
+    proposedAmount?: accountApi.TAmountWithConversions;
     valid: boolean;
     amount: string;
     fiatAmount: string;

--- a/frontends/web/src/routes/account/summary/subtotalrow.tsx
+++ b/frontends/web/src/routes/account/summary/subtotalrow.tsx
@@ -22,7 +22,7 @@ import style from './accountssummary.module.css';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 
 type TProps = {
-  balance?: accountApi.IAmount;
+  balance?: accountApi.TAmountWithConversions;
   coinCode: accountApi.CoinCode;
   coinName: string;
 };


### PR DESCRIPTION
This refactors the code to format amounts with fiat conversions, removing it from handlers into the coin package, and adds some tests.
