### PR TITLE
frontend: render "Connected Wallet" text on the badge correctly

### DIFF
--- a/frontends/web/src/routes/accounts/all-accounts.tsx
+++ b/frontends/web/src/routes/accounts/all-accounts.tsx
@@ -120,8 +120,9 @@ export const AllAccounts = ({ accounts = [] }: AllAccountsProps) => {
                   {keystore.keystore.connected && (
                     <Badge
                       icon={props => <USBSuccess {...props} />}
-                      type="success"
-                      title={t('device.keystoreConnected')} />
+                      type="success">
+                      {t('device.keystoreConnected')}
+                    </Badge>
                   )}
 
                 </div>


### PR DESCRIPTION
Before:
<img width="362" alt="Screenshot 2025-06-11 at 08 48 23" src="https://github.com/user-attachments/assets/2ddf6fdf-4b5a-474b-ac23-8e7f3313a24e" />

After:
<img width="362" alt="Screenshot 2025-06-11 at 08 49 48" src="https://github.com/user-attachments/assets/f78ae83e-0949-44a2-94b4-10673906efe4" />
