### PR TITLE
ios: add safe-area-inset- for sidebar to prevent tight margins

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.module.css
+++ b/frontends/web/src/components/sidebar/sidebar.module.css
@@ -42,7 +42,7 @@
     /* mobile viewport bug fix */
     min-height: -webkit-fill-available;
     overflow-y: auto;
-    padding: 0 0 var(--spacing-default) 0;
+    padding: 0 0 calc(var(--spacing-default) + env(safe-area-inset-bottom)) 0;
     position: fixed;
     top: 0;
     width: var(--sidebar-width-large);
@@ -65,6 +65,7 @@
     height: 70px;
     justify-content: space-between;
     padding: calc(var(--spacing-default) + var(--spacing-half)) var(--spacing-large);
+    padding-top: calc(var(--spacing-default) + var(--spacing-half) + env(safe-area-inset-top, 0));
     background-size: cover;
     background-color: rgba(0, 0, 0, 0.1);
     opacity: 1;


### PR DESCRIPTION
expanding tight margins that exist on the sidebar on ipad devices.