### PR TITLE
ios: enable bluetooth in background

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp/Info.plist
+++ b/frontends/ios/BitBoxApp/BitBoxApp/Info.plist
@@ -25,5 +25,9 @@
 			</array>
 		</dict>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>bluetooth-central</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
So e.g. displaying a receive address is not interrupted when the app is put into the background.
