### PR TITLE
logging: remove unused logging.json config file

### DIFF
--- a/util/logging/configuration.go
+++ b/util/logging/configuration.go
@@ -15,9 +15,6 @@
 package logging
 
 import (
-	"encoding/json"
-
-	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/sirupsen/logrus"
 )
 
@@ -25,41 +22,8 @@ import (
 type Configuration struct {
 	// Output location of the logger.
 	// Can be either a path relative to the configuration directory, STDOUT or STDERR.
-	Output string `json:"output"`
+	Output string
 
 	// Level from which on the entries are logged.
-	Level logrus.Level `json:"level"`
-}
-
-// MarshalJSON implements json.Marshaler.
-func (configuration Configuration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&map[string]string{
-		"output": configuration.Output,
-		"level":  configuration.Level.String(),
-	})
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (configuration *Configuration) UnmarshalJSON(bytes []byte) error {
-	var encoding map[string]string
-	if err := json.Unmarshal(bytes, &encoding); err != nil {
-		return errp.Wrap(err, "Could not unmarshal the logging configuration.")
-	}
-
-	output, found := encoding["output"]
-	if !found {
-		return errp.New("The output was not found in the logging configuration.")
-	}
-	configuration.Output = output
-
-	level, found := encoding["level"]
-	if !found {
-		return errp.New("The level was not found in the logging configuration.")
-	}
-	var err error
-	configuration.Level, err = logrus.ParseLevel(level)
-	if err != nil {
-		return errp.Wrap(err, "Could not parse the level of the logging configuration.")
-	}
-	return nil
+	Level logrus.Level
 }

--- a/util/logging/instance.go
+++ b/util/logging/instance.go
@@ -15,18 +15,11 @@
 package logging
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/config"
 	"github.com/sirupsen/logrus"
-)
-
-const (
-	// configFileName stores the name of the file that contains the logging configuration.
-	configFileName = "logging.json"
 )
 
 var instance *Logger
@@ -35,23 +28,9 @@ var once sync.Once
 // Get returns the configured logger or a new one based on the configuration file.
 func Get() *Logger {
 	once.Do(func() {
-		var configuration Configuration
-		configFile := config.NewFile(config.AppDir(), configFileName)
-		if configFile.Exists() {
-			fmt.Printf("Loading log config from '%s'.\n", configFile.Path())
-			if err := configFile.ReadJSON(&configuration); err != nil {
-				fmt.Fprintf(os.Stderr, "Can't read log config: %v; logging to stderr.\n", err)
-				configuration.Output = "STDERR"
-			}
-		} else {
-			fmt.Printf("Writing new log config to '%s'.\n", configFile.Path())
-			configuration = Configuration{
-				Output: filepath.Join(config.AppDir(), "log.txt"),
-				Level:  logrus.DebugLevel, // Change to InfoLevel before a release.
-			}
-			if err := configFile.WriteJSON(configuration); err != nil {
-				fmt.Fprintf(os.Stderr, "Can't write log config: %v.\n", err)
-			}
+		configuration := Configuration{
+			Output: filepath.Join(config.AppDir(), "log.txt"),
+			Level:  logrus.DebugLevel,
 		}
 		instance = NewLogger(&configuration)
 	})


### PR DESCRIPTION
It stored the path to log.txt and output level. Not sure why, it is not used for anything really, it was always log.txt in the app folder (which the log export etc assume).

That this file was stored in the app folder caused an issue on iOS: the ID of the app can change especially when running debug builds in xcode, but the logging.json in the app folder of a previous debug run would contain a log.txt filepath that became invalid.
