### PR TITLE
backend/bitbox02: don't re-use same device instance after reset

### DIFF
--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -148,7 +148,6 @@ func (device *Device) Reset() error {
 		Subject: string(deviceevent.EventKeystoreGone),
 		Action:  action.Replace,
 	})
-	device.init()
 	return nil
 }
 


### PR DESCRIPTION
The `device.init()` after reset is causing issues on iOS, where the app sends the attestation request (first action during init) to a device that rebooted and connected, before the orientation screen passed, causing unexpected msgs and the app getting out of sync.

