### PR TITLE
backend/btcdirect: move btc direct sell addresses to the backend

### DIFF
--- a/backend/exchanges/btcdirect.go
+++ b/backend/exchanges/btcdirect.go
@@ -15,6 +15,7 @@
 package exchanges
 
 import (
+	"errors"
 	"slices"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
@@ -38,10 +39,24 @@ const (
 	btcDirectSellPage = "coin-to-fiat.html"
 )
 
+// This maps supported coin units to sell addresses.
+var sellAddresses = map[string]string{
+	"BTC":  "bc1qnkku53ue3fud8pquec7jrp4jmtn3tmqmwtelr6",
+	"LTC":  "ltc1qldx5037gn4u4nu6nfrwskhtdngzxzgjefygk8r",
+	"ETH":  "0xE5b1F760BA4334bc311695e125861Eb5870018aD",
+	"USDC": "0xE5b1F760BA4334bc311695e125861Eb5870018aD",
+	"LINK": "0xE5b1F760BA4334bc311695e125861Eb5870018aD",
+}
+
 type btcDirectInfo struct {
-	Url     string
-	ApiKey  string
-	Address *string
+	// Url is the url of the page integrating the BTC Direct widget.
+	Url string
+	// ApiKey is the api key that will be passed to the widget
+	ApiKey string
+	// Address is the address used to buy/sell coins.
+	Address string
+	// CoinUnit is the unit of the exchanged coin.
+	CoinUnit string
 }
 
 var regions = []string{
@@ -64,8 +79,7 @@ func isRegionSupportedBtcDirect(region string) bool {
 // IsBtcDirectSupported is true if coin.Code is supported by BtcDirect.
 func IsBtcDirectSupported(coinCode coin.Code) bool {
 	supportedCoins := []coin.Code{
-		coin.CodeBTC, coin.CodeTBTC, coin.CodeLTC, coin.CodeTLTC, coin.CodeETH, coin.CodeSEPETH,
-		"eth-erc20-usdc", "eth-erc20-link"}
+		coin.CodeBTC, coin.CodeLTC, coin.CodeETH, "eth-erc20-usdc", "eth-erc20-link"}
 
 	coinSupported := slices.Contains(supportedCoins, coinCode)
 
@@ -122,7 +136,7 @@ func BtcDirectDeals(action ExchangeAction) *ExchangeDealsList {
 
 // BtcDirectInfo returns the information needed to interact with BtcDirect.
 // If `devServers` is true, it returns testing URL and ApiKey.
-func BtcDirectInfo(action ExchangeAction, acct accounts.Interface, devServers bool) btcDirectInfo {
+func BtcDirectInfo(action ExchangeAction, acct accounts.Interface, devServers bool) (*btcDirectInfo, error) {
 	res := btcDirectInfo{
 		Url:    btcDirectBaseProdUrl,
 		ApiKey: btcDirectProdAPiKey,
@@ -135,10 +149,16 @@ func BtcDirectInfo(action ExchangeAction, acct accounts.Interface, devServers bo
 
 	if action == BuyAction {
 		res.Url += btcDirectBuyPage
-		addr := acct.GetUnusedReceiveAddresses()[0].Addresses[0].EncodeForHumans()
-		res.Address = &addr
+		res.Address = acct.GetUnusedReceiveAddresses()[0].Addresses[0].EncodeForHumans()
 	} else {
+		coinUnit := acct.Coin().Unit(false)
+		address, ok := sellAddresses[coinUnit]
+		if !ok {
+			return nil, errors.New("Coin type not supported")
+		}
 		res.Url += btcDirectSellPage
+		res.Address = address
+		res.CoinUnit = coinUnit
 	}
-	return res
+	return &res, nil
 }

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -1421,11 +1421,12 @@ func (handlers *Handlers) getExchangeMoonpayBuyInfo(r *http.Request) (interface{
 
 func (handlers *Handlers) getExchangeBtcDirectInfo(r *http.Request) interface{} {
 	type result struct {
-		Success      bool    `json:"success"`
-		ErrorMessage string  `json:"errorMessage,omitempty"`
-		Url          string  `json:"url"`
-		ApiKey       string  `json:"apiKey"`
-		Address      *string `json:"address,omitempty"`
+		Success      bool   `json:"success"`
+		ErrorMessage string `json:"errorMessage,omitempty"`
+		Url          string `json:"url,omitempty"`
+		ApiKey       string `json:"apiKey,omitempty"`
+		Address      string `json:"address,omitempty"`
+		CoinUnit     string `json:"coinUnit,omitempty"`
 	}
 
 	code := accountsTypes.Code(mux.Vars(r)["code"])
@@ -1436,13 +1437,17 @@ func (handlers *Handlers) getExchangeBtcDirectInfo(r *http.Request) interface{} 
 	}
 
 	action := exchanges.ExchangeAction(mux.Vars(r)["action"])
-	btcInfo := exchanges.BtcDirectInfo(action, acct, handlers.backend.DevServers())
+	btcInfo, err := exchanges.BtcDirectInfo(action, acct, handlers.backend.DevServers())
+	if err != nil {
+		return result{Success: false, ErrorMessage: err.Error()}
+	}
 
 	return result{
-		Success: true,
-		Url:     btcInfo.Url,
-		ApiKey:  btcInfo.ApiKey,
-		Address: btcInfo.Address,
+		Success:  true,
+		Url:      btcInfo.Url,
+		ApiKey:   btcInfo.ApiKey,
+		Address:  btcInfo.Address,
+		CoinUnit: btcInfo.CoinUnit,
 	}
 }
 

--- a/frontends/web/src/api/exchanges.ts
+++ b/frontends/web/src/api/exchanges.ts
@@ -94,7 +94,8 @@ export type TBTCDirectInfoResponse = {
   success: true;
   url: string;
   apiKey: string;
-  address?: string;
+  address: string;
+  coinUnit?: string;
 } | {
   success: false;
   errorMessage: string;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -761,6 +761,10 @@
     "wrongKeystore2": " If you are using the optional passphrase, make sure you have entered the correct passphrase for the account."
   },
   "exchange": {
+    "btcdirect": {
+      "currencyMismatch": "Unexpected currency in payment request",
+      "insufficientFunds": "Insufficient funds on the selected account."
+    },
     "buySell": {
       "coinNotSupported": "No options available for this coin type.",
       "regionNotSupported": "No options available for this region."


### PR DESCRIPTION
so that they are fetched from there instead of being in the frontend logic.
