### PR TITLE
backend/banners: fetch banners from staging when app is in dev mode

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -293,7 +293,7 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	backend.ratesUpdater = rates.NewRateUpdater(hclient, ratesCache)
 	backend.ratesUpdater.Observe(backend.Notify)
 
-	backend.banners = banners.NewBanners()
+	backend.banners = banners.NewBanners(backend.DevServers())
 	backend.banners.Observe(backend.Notify)
 
 	backend.bluetooth = bluetooth.New(log)

--- a/backend/banners/banners.go
+++ b/backend/banners/banners.go
@@ -26,7 +26,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const bannersURL = "https://bitboxapp.shiftcrypto.io/banners.json"
+const (
+	bannersDevURL = "https://bitboxapp.shiftcrypto.dev/banners.json"
+
+	bannersProdURL = "https://bitboxapp.shiftcrypto.io/banners.json"
+)
 
 // MessageKey enumerates the possible keys in the banners json.
 type MessageKey string
@@ -84,9 +88,13 @@ type Banners struct {
 }
 
 // NewBanners makes a new Banners instance.
-func NewBanners() *Banners {
+func NewBanners(devServers bool) *Banners {
+	url := bannersProdURL
+	if devServers {
+		url = bannersDevURL
+	}
 	return &Banners{
-		url:    bannersURL,
+		url:    url,
 		active: map[MessageKey]struct{}{},
 		log:    logging.Get().WithGroup("banners"),
 	}

--- a/backend/banners/banners_test.go
+++ b/backend/banners/banners_test.go
@@ -45,7 +45,7 @@ func TestInit(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	banners := NewBanners()
+	banners := NewBanners(true)
 	banners.url = server.URL
 	banners.Init(server.Client())
 	require.Nil(t, banners.GetMessage(KeyBitBox01))


### PR DESCRIPTION
Previously the app was always fetching banners from the production server. Now when built in dev mode it fetches them from staging, which allows to test new banners before releasing them in production.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
