### PR TITLE
frontend: mv GlobalBanners to app.tsx

### DIFF
--- a/frontends/web/src/app.module.css
+++ b/frontends/web/src/app.module.css
@@ -12,6 +12,19 @@
     padding-right: env(safe-area-inset-right, 0);
 }
 
+.contentContainer {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.appRouter {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
 @media (max-width: 900px) {
     .appContent {
         position: absolute;

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -43,6 +43,7 @@ import { AuthRequired } from './components/auth/authrequired';
 import { WCSigningRequest } from './components/wallet-connect/incoming-signing-request';
 import { Providers } from './contexts/providers';
 import { BottomNavigation } from './components/bottom-navigation/bottom-navigation';
+import { GlobalBanners } from '@/components/banners';
 import styles from './app.module.css';
 
 export const App = () => {
@@ -202,13 +203,16 @@ export const App = () => {
                 return null;
               })
             }
-            <AppRouter
-              accounts={accounts}
-              activeAccounts={activeAccounts}
-              deviceIDs={deviceIDs}
-              devices={devices}
-              devicesKey={devicesKey}
-            />
+            <div className={styles.contentContainer}>
+              <GlobalBanners />
+              <AppRouter
+                accounts={accounts}
+                activeAccounts={activeAccounts}
+                deviceIDs={deviceIDs}
+                devices={devices}
+                devicesKey={devicesKey}
+              />
+            </div>
             <RouterWatcher />
           </div>
           {showBottomNavigation && (

--- a/frontends/web/src/components/banners/banner.module.css
+++ b/frontends/web/src/components/banners/banner.module.css
@@ -5,3 +5,25 @@
 .link:focus {
   outline-color: inherit;
 }
+
+.container > div {
+  flex-shrink: 0;
+  margin: 0 auto;
+  margin-top: var(--spacing-default);
+  max-width: var(--content-width);
+  padding: var(--space-default);
+  padding-bottom: 0;
+  padding-top: 0;
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .container > div {
+      padding: 0 var(--space-half);
+  }
+
+  .container > div:last-child > div {
+    margin-bottom: 0;
+  }
+}
+

--- a/frontends/web/src/components/banners/index.tsx
+++ b/frontends/web/src/components/banners/index.tsx
@@ -19,10 +19,11 @@ import { Update } from './update';
 import { Banner } from './banner';
 import { MobileDataWarning } from './mobiledatawarning';
 import { Offline } from './offline';
+import styles from './banner.module.css';
 
 export const GlobalBanners = () => {
   return (
-    <>
+    <div className={styles.container}>
       <Testing />
       <Update />
       <Banner msgKey="bitbox01" />
@@ -30,6 +31,6 @@ export const GlobalBanners = () => {
       <Banner msgKey="bitbox02nova" />
       <MobileDataWarning />
       <Offline />
-    </>
+    </div>
   );
 };

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -45,7 +45,6 @@ import { A } from '@/components/anchor/anchor';
 import { getConfig, setConfig } from '@/utils/config';
 import { i18n } from '@/i18n/i18n';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { View, ViewContent, ViewHeader } from '@/components/view/view';
 import { Transaction } from '@/components/transactions/transaction';
 import { TransactionDetails } from '@/components/transactions/details';
@@ -254,7 +253,6 @@ const RemountAccount = ({
       <GuidedContent>
         <Main>
           <ContentWrapper>
-            <GlobalBanners />
             <Status hidden={!hasCard} type="warning">
               {t('warning.sdcard')}
             </Status>

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -38,7 +38,6 @@ import { AppContext } from '@/contexts/AppContext';
 import { getAccountsByKeystore, isAmbiguousName } from '@/routes/account/utils';
 import { RatesContext } from '@/contexts/RatesContext';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 
 type TProps = {
   accounts: accountApi.IAccount[];
@@ -175,7 +174,6 @@ export const AccountsSummary = ({
       <GuidedContent>
         <Main>
           <ContentWrapper>
-            <GlobalBanners />
             <Status hidden={!hasCard} type="warning">
               {t('warning.sdcard')}
             </Status>

--- a/frontends/web/src/routes/device/no-device-connected.tsx
+++ b/frontends/web/src/routes/device/no-device-connected.tsx
@@ -18,9 +18,7 @@ import { useTranslation } from 'react-i18next';
 import type { TPagePropsWithSettingsTabs } from '../settings/types';
 import { Bluetooth } from '@/components/bluetooth/bluetooth';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { ViewContent, View } from '@/components/view/view';
-import { GlobalBanners } from '@/components/banners';
 import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { WithSettingsTabs } from '@/routes/settings/components/tabs';
 import { ManageDeviceGuide } from './bitbox02/settings-guide';
@@ -36,9 +34,6 @@ export const NoDeviceConnected = ({
     <Main>
       <GuideWrapper>
         <GuidedContent>
-          <ContentWrapper>
-            <GlobalBanners />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -25,8 +25,6 @@ import { useKeystores } from '@/hooks/backend';
 import { useDarkmode } from '@/hooks/darkmode';
 import { useDefault } from '@/hooks/default';
 import { Bluetooth } from '@/components/bluetooth/bluetooth';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { Entry } from '@/components/guide/entry';
 import { Guide } from '@/components/guide/guide';
 import { Spinner } from '@/components/spinner/Spinner';
@@ -63,9 +61,6 @@ export const Waiting = () => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners />
-          </ContentWrapper>
           <Header title={<h2>{t('welcome.title')}</h2>}>
             <OutlinedSettingsButton />
           </Header>

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -50,13 +50,15 @@ import { ConnectScreenWalletConnect } from './account/walletconnect/connect';
 import { DashboardWalletConnect } from './account/walletconnect/dashboard';
 import { AllAccounts } from '@/routes/accounts/all-accounts';
 import { More } from '@/routes/settings/more';
+import styles from '../app.module.css';
+
 
 type TAppRouterProps = {
     devices: TDevices;
     deviceIDs: string[];
     accounts: IAccount[];
     activeAccounts: IAccount[];
-    devicesKey: ((input: string) => string)
+    devicesKey: ((input: string) => string);
 }
 
 type TInjectParamsProps = {
@@ -239,67 +241,69 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
   const AllAccountsEl = <InjectParams><AllAccounts accounts={activeAccounts} /></InjectParams>;
 
   return (
-    <Routes>
-      <Route path="/">
-        <Route index element={Homepage} />
-        <Route path="account/:code">
-          <Route index element={Acc} />
-          <Route path="send" element={AccSend} />
-          <Route path="receive" element={AccReceive} />
-          <Route path="info" element={AccInfo} />
-          <Route path="wallet-connect/connect" element={AccConnectScreenWC} />
-          <Route path="wallet-connect/dashboard" element={AccDashboardWC} />
-        </Route>
-        <Route path="add-account" element={<AddAccount accounts={accounts}/>} />
-        <Route path="account-summary" element={AccountsSummaryEl} />
-        <Route path="exchange">
-          <Route path="info" element={ExchangeInfoEl} >
-            <Route index element={ExchangeInfoEl} />
-            <Route path=":code" element={ExchangeInfoEl} />
+    <div className={styles.appRouter}>
+      <Routes>
+        <Route path="/">
+          <Route index element={Homepage} />
+          <Route path="account/:code">
+            <Route index element={Acc} />
+            <Route path="send" element={AccSend} />
+            <Route path="receive" element={AccReceive} />
+            <Route path="info" element={AccInfo} />
+            <Route path="wallet-connect/connect" element={AccConnectScreenWC} />
+            <Route path="wallet-connect/dashboard" element={AccDashboardWC} />
           </Route>
-          <Route path="btcdirect/buy/:code" element={BTCDirectEl} />
-          <Route path="moonpay/buy/:code" element={MoonpayEl} />
-          <Route path="pocket/buy/:code" element={PocketBuyEl} />
-          <Route path="pocket/sell/:code" element={PocketSellEl} />
-          <Route path="select/:code" element={ExchangeEl} />
-          <Route path="btcdirect-otc" element={<BTCDirectOTC/>} />
-        </Route>
-        <Route path="manage-backups/:deviceID" element={ManageBackupsEl} />
-        <Route path="accounts/select-receive" element={ReceiveAccountsSelectorEl} />
-        <Route path="accounts/all" element={AllAccountsEl} />
-        <Route path="bitsurance">
-          <Route path="bitsurance" element={<Bitsurance accounts={activeAccounts}/>}/>
-          <Route path="account" element={BitsuranceAccountEl} >
-            <Route index element={BitsuranceAccountEl} />
-            <Route path=":code" element={BitsuranceAccountEl} />
+          <Route path="add-account" element={<AddAccount accounts={accounts}/>} />
+          <Route path="account-summary" element={AccountsSummaryEl} />
+          <Route path="exchange">
+            <Route path="info" element={ExchangeInfoEl} >
+              <Route index element={ExchangeInfoEl} />
+              <Route path=":code" element={ExchangeInfoEl} />
+            </Route>
+            <Route path="btcdirect/buy/:code" element={BTCDirectEl} />
+            <Route path="moonpay/buy/:code" element={MoonpayEl} />
+            <Route path="pocket/buy/:code" element={PocketBuyEl} />
+            <Route path="pocket/sell/:code" element={PocketSellEl} />
+            <Route path="select/:code" element={ExchangeEl} />
+            <Route path="btcdirect-otc" element={<BTCDirectOTC/>} />
           </Route>
-          <Route path="widget" element={BitsuranceWidgetEl} >
-            <Route index element={BitsuranceWidgetEl} />
-            <Route path=":code" element={BitsuranceWidgetEl} />
+          <Route path="manage-backups/:deviceID" element={ManageBackupsEl} />
+          <Route path="accounts/select-receive" element={ReceiveAccountsSelectorEl} />
+          <Route path="accounts/all" element={AllAccountsEl} />
+          <Route path="bitsurance">
+            <Route path="bitsurance" element={<Bitsurance accounts={activeAccounts}/>}/>
+            <Route path="account" element={BitsuranceAccountEl} >
+              <Route index element={BitsuranceAccountEl} />
+              <Route path=":code" element={BitsuranceAccountEl} />
+            </Route>
+            <Route path="widget" element={BitsuranceWidgetEl} >
+              <Route index element={BitsuranceWidgetEl} />
+              <Route path=":code" element={BitsuranceWidgetEl} />
+            </Route>
+            <Route path="dashboard" element={<BitsuranceDashboard accounts={activeAccounts}/>}/>
           </Route>
-          <Route path="dashboard" element={<BitsuranceDashboard accounts={activeAccounts}/>}/>
+          <Route path="settings">
+            <Route index element={MobileSettingsEl} />
+            <Route path="more" element={MoreEl} />
+            <Route path="general" element={GeneralEl} />
+            <Route path="about" element={AboutEl} />
+            <Route path="device-settings/:deviceID" element={Device} />
+            <Route path="no-device-connected" element={NoDevice} />
+            <Route path="no-accounts" element={NoDevice} />
+            <Route path="device-settings/passphrase/:deviceID" element={PassphraseEl} />
+            <Route path="device-settings/bip85/:deviceID" element={Bip85El} />
+            <Route path="advanced-settings" element={AdvancedSettingsEl} />
+            <Route path="electrum" element={<ElectrumSettings />} />
+            <Route path="manage-accounts" element={
+              <ManageAccounts
+                accounts={accounts}
+                key="manage-accounts"
+                devices={devices}
+                hasAccounts={hasAccounts} />
+            } />
+          </Route>
         </Route>
-        <Route path="settings">
-          <Route index element={MobileSettingsEl} />
-          <Route path="more" element={MoreEl} />
-          <Route path="general" element={GeneralEl} />
-          <Route path="about" element={AboutEl} />
-          <Route path="device-settings/:deviceID" element={Device} />
-          <Route path="no-device-connected" element={NoDevice} />
-          <Route path="no-accounts" element={NoDevice} />
-          <Route path="device-settings/passphrase/:deviceID" element={PassphraseEl} />
-          <Route path="device-settings/bip85/:deviceID" element={Bip85El} />
-          <Route path="advanced-settings" element={AdvancedSettingsEl} />
-          <Route path="electrum" element={<ElectrumSettings />} />
-          <Route path="manage-accounts" element={
-            <ManageAccounts
-              accounts={accounts}
-              key="manage-accounts"
-              devices={devices}
-              hasAccounts={hasAccounts} />
-          } />
-        </Route>
-      </Route>
-    </Routes>
+      </Routes>
+    </div>
   );
 };

--- a/frontends/web/src/routes/settings/about.tsx
+++ b/frontends/web/src/routes/settings/about.tsx
@@ -23,8 +23,6 @@ import { MobileHeader } from './components/mobile-header';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
 import { TPagePropsWithSettingsTabs } from './types';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 
 export const About = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
@@ -32,9 +30,6 @@ export const About = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -33,8 +33,6 @@ import { MobileHeader } from './components/mobile-header';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
 import { EnableAuthSetting } from './components/advanced-settings/enable-auth-setting';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 
 export type TProxyConfig = {
   proxyAddress: string;
@@ -76,9 +74,6 @@ export const AdvancedSettings = ({ devices, hasAccounts }: TPagePropsWithSetting
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/settings/bb02-settings.tsx
@@ -40,8 +40,6 @@ import { RootFingerprintSetting } from './components/device-settings/root-finger
 import { Bip85Setting } from './components/device-settings/bip85-setting';
 import { ManageDeviceGuide } from '@/routes/device/bitbox02/settings-guide';
 import { MobileHeader } from './components/mobile-header';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { SubTitle } from '@/components/title';
 import styles from './bb02-settings.module.css';
 
@@ -65,9 +63,6 @@ const BB02Settings = ({ deviceID, devices, hasAccounts }: TWrapperProps) => {
     <Main>
       <GuideWrapper>
         <GuidedContent>
-          <ContentWrapper>
-            <GlobalBanners />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/general.tsx
+++ b/frontends/web/src/routes/settings/general.tsx
@@ -29,8 +29,6 @@ import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
 import { SubTitle } from '@/components/title';
 import { TPagePropsWithSettingsTabs } from './types';
-import { GlobalBanners } from '@/components/banners';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import style from './general.module.css';
 export const General = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
@@ -38,9 +36,6 @@ export const General = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) =>
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/manage-accounts.tsx
+++ b/frontends/web/src/routes/settings/manage-accounts.tsx
@@ -34,8 +34,6 @@ import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { Badge } from '@/components/badge/badge';
 import { AccountGuide } from './manage-account-guide';
 import { WatchonlySetting } from './components/manage-accounts/watchonlySetting';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import style from './manage-accounts.module.css';
 import { useNavigate } from 'react-router-dom';
 
@@ -205,9 +203,6 @@ export const ManageAccounts = ({ accounts, devices, hasAccounts }: Props) => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners />
-          </ContentWrapper>
           <Header
             hideSidebarToggler
             title={

--- a/frontends/web/src/routes/settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/settings/mobile-settings.tsx
@@ -19,8 +19,6 @@ import { View, ViewContent } from '@/components/view/view';
 import { Header, Main } from '@/components/layout';
 import { Tabs } from './components/tabs';
 import { TPagePropsWithSettingsTabs } from './types';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { useOnlyVisitableOnMobile } from '@/hooks/onlyvisitableonmobile';
 import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { useNavigate } from 'react-router-dom';
@@ -46,9 +44,6 @@ export const MobileSettings = ({ devices, hasAccounts }: TPagePropsWithSettingsT
   };
   return (
     <Main>
-      <ContentWrapper>
-        <GlobalBanners />
-      </ContentWrapper>
       <Header
         title={
           <MobileHeader onClick={handleClick} title={t('settings.title')} />

--- a/frontends/web/src/routes/settings/more.tsx
+++ b/frontends/web/src/routes/settings/more.tsx
@@ -18,8 +18,6 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { View, ViewContent } from '@/components/view/view';
 import { GuidedContent, GuideWrapper, Header, Main } from '@/components/layout';
-import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import { GlobalBanners } from '@/components/banners';
 import { ActionableItem } from '@/components/actionable-item/actionable-item';
 import { useOnlyVisitableOnMobile } from '@/hooks/onlyvisitableonmobile';
 import { Cog, ShieldGray } from '@/components/icon';
@@ -37,9 +35,6 @@ export const More = () => {
     <GuideWrapper>
       <GuidedContent>
         <Main>
-          <ContentWrapper>
-            <GlobalBanners />
-          </ContentWrapper>
           <Header
             title={<h2>{t('settings.more')}</h2>} />
           <View fullscreen={false}>


### PR DESCRIPTION
To prevent flickering of the banner (due to mount/remount), we are putting GlobalBanners on the top-level of the app - which is in the `app.tsx`.

2 banners:
<img width="1483" alt="Screenshot 2025-06-30 at 15 24 12" src="https://github.com/user-attachments/assets/dcda0fe3-e305-45af-925d-5c281235aed3" />

1 banner:
<img width="1483" alt="Screenshot 2025-06-30 at 15 24 14" src="https://github.com/user-attachments/assets/e2db470f-be43-4262-8c13-41aeb8192d31" />

no banner:
<img width="1483" alt="Screenshot 2025-06-30 at 15 24 44" src="https://github.com/user-attachments/assets/773e5eaf-b1c6-4eff-b099-45e08cf1bf80" />

