### PR TITLE
backend: change connectKeystore to take the keystore fingerprint.

### DIFF
--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -76,7 +76,6 @@ func NewHandlers(
 	handleFunc("/has-secure-output", handlers.ensureAccountInitialized(handlers.getHasSecureOutput)).Methods("GET")
 	handleFunc("/has-payment-request", handlers.ensureAccountInitialized(handlers.getHasPaymentRequest)).Methods("GET")
 	handleFunc("/notes/tx", handlers.ensureAccountInitialized(handlers.postSetTxNote)).Methods("POST")
-	handleFunc("/connect-keystore", handlers.ensureAccountInitialized(handlers.postConnectKeystore)).Methods("POST")
 	handleFunc("/eth-sign-msg", handlers.ensureAccountInitialized(handlers.postEthSignMsg)).Methods("POST")
 	handleFunc("/eth-sign-typed-msg", handlers.ensureAccountInitialized(handlers.postEthSignTypedMsg)).Methods("POST")
 	handleFunc("/eth-sign-wallet-connect-tx", handlers.ensureAccountInitialized(handlers.postEthSignWalletConnectTx)).Methods("POST")
@@ -661,15 +660,6 @@ func (handlers *Handlers) postSetTxNote(r *http.Request) (interface{}, error) {
 	}
 
 	return nil, handlers.account.SetTxNote(args.InternalTxID, args.Note)
-}
-
-func (handlers *Handlers) postConnectKeystore(r *http.Request) (interface{}, error) {
-	type response struct {
-		Success bool `json:"success"`
-	}
-
-	_, err := handlers.account.Config().ConnectKeystore()
-	return response{Success: err == nil}, nil
 }
 
 type signingResponse struct {

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -452,10 +452,6 @@ export const addAccount = (coinCode: string, name: string): Promise<TAddAccount>
   });
 };
 
-export const connectKeystore = (code: AccountCode): Promise<{ success: boolean; }> => {
-  return apiPost(`account/${code}/connect-keystore`);
-};
-
 export type TSignMessage = { success: false, aborted?: boolean; errorMessage?: string; } | { success: true; signature: string; }
 
 export type TSignWalletConnectTx = {

--- a/frontends/web/src/api/keystores.ts
+++ b/frontends/web/src/api/keystores.ts
@@ -39,3 +39,7 @@ export const registerTest = (pin: string): Promise<null> => {
 export const deregisterTest = (): Promise<null> => {
   return apiPost('test/deregister');
 };
+
+export const connectKeystore = (rootFingerprint: string): Promise<{ success: boolean; }> => {
+  return apiPost('connect-keystore', { rootFingerprint });
+};

--- a/frontends/web/src/routes/account/actionButtons.tsx
+++ b/frontends/web/src/routes/account/actionButtons.tsx
@@ -19,9 +19,10 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { WalletConnectLight } from '@/components/icon';
 import { useMediaQuery } from '@/hooks/mediaquery';
-import { connectKeystore, AccountCode, IAccount, CoinCode } from '@/api/account';
+import { AccountCode, IAccount, CoinCode } from '@/api/account';
 import { isEthereumBased } from './utils';
 import { ButtonLink } from '@/components/forms';
+import { connectKeystore } from '@/api/keystores';
 import style from './account.module.css';
 
 type TProps = {
@@ -46,7 +47,7 @@ export const ActionButtons = ({ canSend, code, coinCode, exchangeSupported, acco
   const sendLink = `/account/${code}/send`;
   const maybeRouteSend = async (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    const connectResult = await connectKeystore(code);
+    const connectResult = await connectKeystore(account.keystore.rootFingerprint);
     if (connectResult.success) {
       // Proceed to the send screen if the keystore was connected.
       navigate(sendLink);

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -30,6 +30,7 @@ import { ReceiveGuide } from './components/guide';
 import { Header } from '@/components/layout';
 import { QRCode } from '@/components/qrcode/qrcode';
 import { ArrowCirlceLeft, ArrowCirlceLeftActive, ArrowCirlceRight, ArrowCirlceRightActive } from '@/components/icon';
+import { connectKeystore } from '@/api/keystores';
 import style from './receive.module.css';
 
 type TProps = {
@@ -160,10 +161,10 @@ export const Receive = ({
   };
 
   const verifyAddress = async (addressesIndex: number) => {
-    if (!receiveAddresses || code === undefined) {
+    if (!receiveAddresses || account === undefined) {
       return;
     }
-    const connectResult = await accountApi.connectKeystore(code);
+    const connectResult = await connectKeystore(account.keystore.rootFingerprint);
     if (!connectResult.success) {
       return;
     }

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -41,6 +41,7 @@ import { FiatValue } from './components/fiat-value';
 import { TSelectedUTXOs } from './utxos';
 import { TProposalError, txProposalErrorHandling } from './services';
 import { CoinControl } from './coin-control';
+import { connectKeystore } from '@/api/keystores';
 import style from './send.module.css';
 
 type SendProps = {
@@ -134,7 +135,8 @@ class Send extends Component<Props, State> {
 
   private send = async () => {
     const code = this.props.account.code;
-    const connectResult = await accountApi.connectKeystore(code);
+    const rootFingerprint = this.props.account.keystore.rootFingerprint;
+    const connectResult = await connectKeystore(rootFingerprint);
     if (!connectResult.success) {
       return;
     }

--- a/frontends/web/src/routes/bitsurance/account.tsx
+++ b/frontends/web/src/routes/bitsurance/account.tsx
@@ -17,7 +17,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { IAccount, connectKeystore } from '@/api/account';
+import { IAccount } from '@/api/account';
 import { BitsuranceGuide } from './guide';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
 import { GuidedContent, GuideWrapper, Header, Main } from '@/components/layout';
@@ -25,6 +25,7 @@ import { Spinner } from '@/components/spinner/Spinner';
 import { View, ViewContent } from '@/components/view/view';
 import { bitsuranceLookup } from '@/api/bitsurance';
 import { alertUser } from '@/components/alert/Alert';
+import { connectKeystore } from '@/api/keystores';
 
 type TProps = {
     accounts: IAccount[];
@@ -66,7 +67,7 @@ export const BitsuranceAccount = ({ code, accounts }: TProps) => {
   // if there is only one account available let's automatically redirect to the widget
   useEffect(() => {
     if (btcAccounts !== undefined && btcAccounts.length === 1) {
-      connectKeystore(btcAccounts[0].code).then(connectResult => {
+      connectKeystore(btcAccounts[0].keystore.rootFingerprint).then(connectResult => {
         if (!connectResult.success) {
           return;
         }
@@ -79,7 +80,11 @@ export const BitsuranceAccount = ({ code, accounts }: TProps) => {
   const handleProceed = async () => {
     setDisabled(true);
     try {
-      const connectResult = await connectKeystore(selected);
+      const account = btcAccounts?.find(acc => acc.code === selected);
+      if (account === undefined) {
+        return;
+      }
+      const connectResult = await connectKeystore(account.keystore.rootFingerprint);
       if (!connectResult.success) {
         return;
       }


### PR DESCRIPTION
Instead of taking an account code, and then computing the fingerprint from it, we now directly pass the root fingerprint to the connectKeystore API endpoint; this way, the function can be called to connect a keystore regardless of a specific account.

Tested by going through all paths that used the old `connectKeystore`, adding logs to make sure they are invoked with the correct fingerprint, and checking that the keystore name is correctly retrieved.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
