### PR TITLE
frontend: scroll up after accepting (widget) terms

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -203,7 +203,7 @@ export const App = () => {
                 return null;
               })
             }
-            <div className={styles.contentContainer}>
+            <div id="content-container" className={styles.contentContainer}>
               <GlobalBanners />
               <AppRouter
                 accounts={accounts}

--- a/frontends/web/src/hooks/scrolltotop.ts
+++ b/frontends/web/src/hooks/scrolltotop.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2025 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback } from 'react';
+
+/**
+ * Hook to manage scrolling in the main app content container
+ * The scrollable container is in app.tsx with id="content-container"
+ */
+export const useScrollToTop = () => {
+  return useCallback((behavior: ScrollBehavior = 'smooth') => {
+    const container = document.getElementById('content-container');
+    if (container) {
+      container.scrollTo({
+        top: 0,
+        behavior
+      });
+    }
+  }, []);
+};

--- a/frontends/web/src/routes/bitsurance/widget.tsx
+++ b/frontends/web/src/routes/bitsurance/widget.tsx
@@ -30,6 +30,7 @@ import { alertUser } from '@/components/alert/Alert';
 import { BitsuranceGuide } from './guide';
 import { getBitsuranceURL } from '@/api/bitsurance';
 import { convertScriptType } from '@/utils/request-addess';
+import { useScrollToTop } from '@/hooks/scrolltotop';
 import style from './widget.module.css';
 
 type TProps = {
@@ -39,6 +40,7 @@ type TProps = {
 export const BitsuranceWidget = ({ code }: TProps) => {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const scrollToTop = useScrollToTop();
 
   const [height, setHeight] = useState(0);
   const [iframeLoaded, setIframeLoaded] = useState(false);
@@ -183,7 +185,10 @@ export const BitsuranceWidget = ({ code }: TProps) => {
         <div ref={ref} className={style.container}>
           { !agreedTerms ? (
             <BitsuranceTerms
-              onAgreedTerms={() => setAgreedTerms(true)}
+              onAgreedTerms={() => {
+                setAgreedTerms(true);
+                scrollToTop();
+              }}
             />
           ) : (
             <div style={{ height }}>

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -23,6 +23,7 @@ import { AccountCode, IAccount } from '@/api/account';
 import { useLoad } from '@/hooks/api';
 import { useDarkmode } from '@/hooks/darkmode';
 import { UseDisableBackButton } from '@/hooks/backbutton';
+import { useScrollToTop } from '@/hooks/scrolltotop';
 import { getConfig } from '@/utils/config';
 import { Header } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
@@ -61,6 +62,7 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const btcdirectInfo = useLoad(() => getBTCDirectInfo('buy', code));
+  const scrollToTop = useScrollToTop();
 
   const [agreedTerms, setAgreedTerms] = useState(false);
   const [iframeLoaded, setIframeLoaded] = useState(false);
@@ -159,7 +161,10 @@ export const BTCDirect = ({ accounts, code }: TProps) => {
             { !agreedTerms ? (
               <BTCDirectTerms
                 account={account}
-                onAgreedTerms={() => setAgreedTerms(true)}
+                onAgreedTerms={() => {
+                  setAgreedTerms(true);
+                  scrollToTop();
+                }}
               />
             ) : (
               <div style={{ height }}>

--- a/frontends/web/src/routes/exchange/moonpay.tsx
+++ b/frontends/web/src/routes/exchange/moonpay.tsx
@@ -28,6 +28,7 @@ import { Header } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
 import { findAccount, isBitcoinOnly } from '@/routes/account/utils';
 import { MoonpayTerms } from '@/components/terms/moonpay-terms';
+import { useScrollToTop } from '@/hooks/scrolltotop';
 import style from './iframe.module.css';
 
 type TProps = {
@@ -37,6 +38,7 @@ type TProps = {
 
 export const Moonpay = ({ accounts, code }: TProps) => {
   const { t } = useTranslation();
+  const scrollToTop = useScrollToTop();
   const [agreedTerms, setAgreedTerms] = useState(false);
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const [height, setHeight] = useState(0);
@@ -96,7 +98,10 @@ export const Moonpay = ({ accounts, code }: TProps) => {
             { !agreedTerms ? (
               <MoonpayTerms
                 account={account}
-                onAgreedTerms={() => setAgreedTerms(true)}
+                onAgreedTerms={() => {
+                  setAgreedTerms(true);
+                  scrollToTop();
+                }}
               />
             ) : (
               <div style={{ height }}>

--- a/frontends/web/src/routes/exchange/pocket.tsx
+++ b/frontends/web/src/routes/exchange/pocket.tsx
@@ -31,8 +31,9 @@ import { UseDisableBackButton } from '@/hooks/backbutton';
 import { alertUser } from '@/components/alert/Alert';
 import { ExchangeGuide } from './guide';
 import { convertScriptType } from '@/utils/request-addess';
-import style from './iframe.module.css';
 import { parseExternalBtcAmount } from '@/api/coins';
+import { useScrollToTop } from '@/hooks/scrolltotop';
+import style from './iframe.module.css';
 
 interface TProps {
     code: AccountCode;
@@ -42,6 +43,7 @@ interface TProps {
 export const Pocket = ({ code, action }: TProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const scrollToTop = useScrollToTop();
 
   const [height, setHeight] = useState(0);
   const [iframeLoaded, setIframeLoaded] = useState(false);
@@ -287,7 +289,10 @@ export const Pocket = ({ code, action }: TProps) => {
         <div ref={ref} className={style.container}>
           { !agreedTerms ? (
             <PocketTerms
-              onAgreedTerms={() => setAgreedTerms(true)}
+              onAgreedTerms={() => {
+                setAgreedTerms(true);
+                scrollToTop();
+              }}
             />
           ) : (
             <div style={{ height }}>


### PR DESCRIPTION
Currently, after accepting a widget's terms the scroll position will stay in the bottom. This is not ideal because to use the widget we'd need to manually scroll up. This happens because the route did not change when the screen changes from the terms 'screen' to the widget 'screen'.

This commit intends to ensure that after every click on the accept btn of any widget terms, the scrollable container scrolls up, mimicking a scroll reset as if the user were to change route.
