### PR TITLE
ios: fix dialog X button cant be tapped on ipad landscape

### DIFF
--- a/frontends/web/src/components/dialog/dialog.module.css
+++ b/frontends/web/src/components/dialog/dialog.module.css
@@ -24,9 +24,7 @@
     border-radius: 2px;
     box-shadow: 0px 3px 5px rgba(0, 0, 0, 0.3);
     text-align: left;
-    max-height: 100vh;
-    /* mobile viewport bug fix */
-    max-height: -webkit-fill-available;
+    max-height: calc(100dvh - calc(env(safe-area-inset-top) * 2));
     overflow: auto;
 }
 /* guard dialog and wait-dialog from view styles */
@@ -210,6 +208,8 @@
 
     .modal {
         padding: 0;
+        height: auto;
+        max-height: 100dvh;
     }
 
     .overlay {

--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -19,7 +19,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { CloseXDark, CloseXWhite } from '@/components/icon';
 import { UseBackButton } from '@/hooks/backbutton';
 import { useEsc, useKeydown } from '@/hooks/keyboard';
-import { useMediaQuery } from '@/hooks/mediaquery';
 import style from './dialog.module.css';
 
 type TProps = {
@@ -51,7 +50,6 @@ export const Dialog = ({
   const modalRef = useRef<HTMLDivElement>(null);
   const modalContentRef = useRef<HTMLDivElement>(null);
   const timerIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isMobile = useMediaQuery('(max-width: 768px)');
 
   const getFocusables = useCallback((): (NodeListOf<HTMLElement> | null) => {
     if (!modalContentRef.current) {
@@ -191,7 +189,7 @@ export const Dialog = ({
 
   const handleTap = (e: React.MouseEvent<HTMLDivElement>) => {
     const validTap = e.target === e.currentTarget;
-    if (validTap && isMobile) {
+    if (validTap) {
       closeHandler();
     }
   };


### PR DESCRIPTION
The "X" button falls in the safe area making it impossible to tap on ipad landscape orientation. Also enabled tap-to-close on the overlay for all screen sizes (not just mobile).
