### PR TITLE
frontend: style disabled react-select option

### DIFF
--- a/frontends/web/src/components/dropdown/dropdown.module.css
+++ b/frontends/web/src/components/dropdown/dropdown.module.css
@@ -24,7 +24,6 @@
     color: var(--color-default);
 }
 
-
 .select :global(.react-select__menu) {
     background-color: var(--background-secondary);
     z-index: 99;
@@ -35,9 +34,17 @@
     color: var(--color-default);
 }
 
+.select :global(.react-select__option--is-disabled) {
+    color: var(--color-disabled);
+}
+
 /*Hovered option color*/
 .select :global(.react-select__option):hover {
     background-color: var(--background-custom-select-hover);
+}
+
+.select :global(.react-select__option--is-disabled):hover {
+    background-color: transparent;
 }
 
 /*Selected option color*/

--- a/frontends/web/src/routes/account/add/components/coin-dropdown.module.css
+++ b/frontends/web/src/routes/account/add/components/coin-dropdown.module.css
@@ -1,7 +1,5 @@
-
 .valueContainer {
     align-items: center;
-    color: var(--color-default);
     display: flex;
 }
 


### PR DESCRIPTION
This fixes the missing disabled styles for disabled options in react-select dropdowns.

Example in Manage accounts > Add account coin option should be visible disabled if maximum unused accounts limit is reached.