### PR TITLE
qt: fix Wayland also for AppImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 - Added BTC Direct sell option
 
+## v4.48.3
+- Linux: fix compatiblity with some versions of Mesa also when using the AppImage
+
 ## v4.48.2
 - iOS: Fix blank screens after prolonged inactivity
 

--- a/backend/update.go
+++ b/backend/update.go
@@ -27,7 +27,7 @@ const updateFileURL = "https://bitboxapp.shiftcrypto.io/desktop.json"
 
 var (
 	// Version of the backend as displayed to the user.
-	Version = semver.NewSemVer(4, 48, 2)
+	Version = semver.NewSemVer(4, 48, 3)
 )
 
 // UpdateFile is retrieved from the server.

--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -14,6 +14,15 @@
 
 include ../../env.mk.inc
 
+# Add Wayland libs so the app can run natively on Wayland too.
+# The linuxdeployqt maintainer unfortunately refuses to support it automatically: https://github.com/probonopd/linuxdeployqt/issues/189
+# The list of related plugins was found by: `find $(qmake -query QT_INSTALL_PLUGINS) | grep wayland`
+#
+# Exclude libwayland-client.so.0, see https://github.com/AppImageCommunity/pkg2appimage/commit/15a64c20dc23a0154622ba25829364323903b6b5,
+# but that is yet in the default exclusion lib of linuxdeployqt.
+# See also: https://github.com/probonopd/linuxdeployqt/issues/631 - we can remove the libwayland-client.so.0 exclusion once this is merged and we updated our linuxdeployqt binary.
+EXCLUDE_LIBS:=libwayland-client.so.0
+
 base:
 	mkdir build
 	./genassets.sh
@@ -30,20 +39,13 @@ linux:
 	mv build/BitBox build/linux-tmp
 	cp build/assets.rcc build/linux-tmp/
 	cp server/libserver.so build/linux-tmp
-	# Add Wayland libs so the app can run natively on Wayland too.
-	# The linuxdeployqt maintainer unfortunately refuses to support it automatically: https://github.com/probonopd/linuxdeployqt/issues/189
-	# The list of related plugins was found by: `find $(qmake -query QT_INSTALL_PLUGINS) | grep wayland`
-	#
-	# Exclude libwayland-client.so.0, see https://github.com/AppImageCommunity/pkg2appimage/commit/15a64c20dc23a0154622ba25829364323903b6b5,
-	# but that is yet in the default exclusion lib of linuxdeployqt.
-	# See also: https://github.com/probonopd/linuxdeployqt/issues/631 - we can remove the libwayland-client.so.0 exclusion once this is merged and we updated our linuxdeployqt binary.
 	cd build/linux-tmp && \
 		/opt/linuxdeployqt-continuous-x86_64.AppImage --appimage-extract && \
 		./squashfs-root/AppRun BitBox \
 			-bundle-non-qt-libs \
 			-unsupported-allow-new-glibc \
 			-extra-plugins=platforms/libqwayland-generic.so,platforms/libqwayland-egl.so,wayland-graphics-integration-client,wayland-decoration-client,wayland-shell-integration \
-			-exclude-libs=libwayland-client.so.0
+			-exclude-libs=$(EXCLUDE_LIBS)
 	cp /usr/lib/x86_64-linux-gnu/nss/* build/linux-tmp/lib
 	# See https://github.com/probonopd/linuxdeployqt/issues/554#issuecomment-1761834180
 	cp "$(shell qmake -query QT_INSTALL_DATA)/resources/v8_context_snapshot.bin" build/linux-tmp/resources
@@ -58,7 +60,8 @@ linux:
 	cd build/linux-tmp && \
 		./squashfs-root/AppRun BitBox \
 			-appimage \
-			-unsupported-allow-new-glibc
+			-unsupported-allow-new-glibc \
+			-exclude-libs=$(EXCLUDE_LIBS)
 	mv build/linux-tmp/BitBoxApp*-x86_64.AppImage build/linux/
 osx:
 	$(MAKE) clean


### PR DESCRIPTION
Same as 5655e639b9ae531baa7865c3b7f2be5f30f0efc6, but the excluded libwayland-client.so.0 made its way back in the second call to linuxdeployqt, so the issue fixed in the original commit was still present when using the AppImage.

