### PR TITLE
frontend: use amount's unit as displayed unit for receive txs.

### DIFF
--- a/frontends/web/src/components/transactions/transaction.tsx
+++ b/frontends/web/src/components/transactions/transaction.tsx
@@ -162,6 +162,7 @@ const Amounts = ({
   const txTypeClass = `txAmount-${type}`;
   const recv = type === 'receive';
   const displayAmount = recv ? amount.amount : deductedAmount.amount;
+  const displayUnit = recv ? amount.unit : deductedAmount.unit;
   const sign = displayAmount ? getTxSign(type) : '';
 
   return (
@@ -171,11 +172,11 @@ const Amounts = ({
         {sign}
         <Amount
           amount={displayAmount}
-          unit={recv ? amount.unit : deductedAmount.unit}
+          unit={displayUnit}
         />
         <span className={styles.txUnit}>
           {' '}
-          {deductedAmount.unit}
+          {displayUnit}
         </span>
       </span>
       {/* </data> */}


### PR DESCRIPTION
The old implementation used deductedAmount.unit, which just happened to be always be the same as amount.unit.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
