### PR TITLE
frontend: show selected coin's address on confirmation screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added BTC Direct sell option
 - Added a banner to remind user to backup their seed phrase when an account reaches a certain threshold.
 - Gracefully shut down Electrum connections upon closing the app
+- Show the selected coin's address on the confirmation screen
 
 ## v4.48.2
 - iOS: Fix blank screens after prolonged inactivity

--- a/frontends/web/src/routes/account/send/components/confirm/confirm.module.css
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.module.css
@@ -29,6 +29,14 @@
   padding-left: var(--space-half);
 }
 
+.address {
+  color: var(--color-secondary);
+}
+
+.addressGroup {
+  margin-top: var(--space-quarter);
+}
+
 .unit {
   color: var(--color-secondary);
   font-size: var(--size-default);

--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -23,6 +23,7 @@ import { View, ViewContent, ViewHeader } from '@/components/view/view';
 import { Message } from '@/components/message/message';
 import { PointToBitBox02 } from '@/components/icon';
 import { FiatValue } from '../fiat-value';
+import type { TSelectedUTXOs } from '../../utxos';
 import style from './confirm.module.css';
 
 type TransactionDetails = {
@@ -40,10 +41,14 @@ type TConfirmSendProps = {
   note: string;
   hasSelectedUTXOs: boolean;
   isConfirming: boolean;
-  selectedUTXOs: string[];
+  selectedUTXOs: TSelectedUTXOs;
   coinCode: CoinCode;
   transactionDetails: TransactionDetails;
 }
+
+type TUTXOsByAddress = {
+  [address: string]: string[];
+};
 
 export const ConfirmSend = ({
   baseCurrencyUnit,
@@ -66,6 +71,16 @@ export const ConfirmSend = ({
     activeCurrency: fiatUnit
   } = transactionDetails;
 
+  const groupUTXOsByAddress = (selectedUTXOs: TSelectedUTXOs): TUTXOsByAddress => {
+    const utxosByAddress: TUTXOsByAddress = {};
+    for (const [outpoint, address] of Object.entries(selectedUTXOs)) {
+      if (!utxosByAddress[address]) {
+        utxosByAddress[address] = [];
+      }
+      utxosByAddress[address].push(outpoint);
+    }
+    return utxosByAddress;
+  };
 
   if (!isConfirming) {
     return null;
@@ -123,24 +138,28 @@ export const ConfirmSend = ({
           </div>
         ) : null}
 
-        {/*Selected UTXOs*/}
+        {/*Selected UTXOs grouped by address*/}
         {
           hasSelectedUTXOs && (
             <div className={style.confirmItem}>
               <label>{t('send.confirm.selected-coins')}</label>
-              <ul>
+              <div>
                 {
-                  selectedUTXOs.map((uxto, i) => (
-                    <li className={style.valueOriginal} key={`selectedCoin-${i}`}>{uxto}</li>
+                  Object.entries(groupUTXOsByAddress(selectedUTXOs)).map(([address, outpoints]) => (
+                    <div className={style.addressGroup} key={address}>
+                      <div className={style.address}>{address}</div>
+                      <ul>
+                        {outpoints.map((outpoint, i) => (
+                          <li className={style.valueOriginal} key={`selectedCoin-${i}`}>{outpoint}</li>
+                        ))}
+                      </ul>
+                    </div>
                   ))
                 }
-
-              </ul>
-
+              </div>
             </div>
           )
         }
-
 
         {/*Fee*/}
         <div className={style.confirmItem}>

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -461,7 +461,7 @@ export const Send = ({
               note={note}
               hasSelectedUTXOs={hasSelectedUTXOs()}
               isConfirming={isConfirming}
-              selectedUTXOs={Object.keys(selectedUTXOsRef.current)}
+              selectedUTXOs={selectedUTXOsRef.current}
               coinCode={account.coinCode}
               transactionDetails={{
                 proposedFee,

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -38,7 +38,7 @@ import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import style from './utxos.module.css';
 
 export type TSelectedUTXOs = {
-  [key: string]: boolean;
+  [key: string]: string;
 };
 
 type Props = {
@@ -83,7 +83,7 @@ export const UTXOs = ({
     const target = event.target;
     const proposedUTXOs = Object.assign({}, selectedUTXOs);
     if (target.checked) {
-      proposedUTXOs[utxo.outPoint] = true;
+      proposedUTXOs[utxo.outPoint] = utxo.address;
       if (utxo.addressReused) {
         setReusedAddressUTXOs(reusedAddressUTXOs + 1);
       }


### PR DESCRIPTION
Display the selected coin’s address on the confirmation screen to make it clearer which address is being used. UTXOs are now grouped under their address.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
