### PR TITLE
ios/android: fix screen lock bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Add support for New Zealand Dollar (NZD)
 - Fix empty suggested name for BTC account when only BTC is supported by the BitBox.
 - iOS: add launch screen and smooth transition upon opening the app for the first time.
+- Android: fix screen lock authentication loop bug
+- Android/iOS: fix screen lock bug when no authentication is configured on the device
 
 ## v4.48.4
 - macOS: fix potential USB communication issue with BitBox02 bootloaders <v1.1.2 and firmwares <v9.23.1

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -127,16 +127,35 @@ type deviceEvent struct {
 
 type authEventType string
 
+// AuthResultType represents the possible results of the authentication flow.
+type AuthResultType string
+
 const (
+	// authRequired is fired when we need the user to authenticate.
 	authRequired authEventType = "auth-required"
-	authForced   authEventType = "auth-forced"
-	authCanceled authEventType = "auth-canceled"
-	authOk       authEventType = "auth-ok"
-	authErr      authEventType = "auth-err"
+	// authForced is fired when we need the user to authenticate even if
+	// the authentication flag is not set in the settings. This allows to check
+	// that the user is able to authenticate before enabling the screen lock.
+	authForced authEventType = "auth-forced"
+	// authResult is fired when the authentication flow produced a result.
+	authResult authEventType = "auth-result"
+
+	// AuthResultOk means that the authentication succeeded.
+	AuthResultOk AuthResultType = "authres-ok"
+	// AuthResultErr means that there is an authentication error.
+	// E.g. on Android when a biometric is valid, but not recognized.
+	AuthResultErr AuthResultType = "authres-err"
+	// AuthResultCancel means that the authentication has been aborted
+	// by the user.
+	AuthResultCancel AuthResultType = "authres-cancel"
+	// AuthResultMissing means that there is no authentication method configured
+	// on the device.
+	AuthResultMissing AuthResultType = "authres-missing"
 )
 
 type authEventObject struct {
-	Typ authEventType `json:"typ"`
+	Typ    authEventType   `json:"typ"`
+	Result *AuthResultType `json:"result,omitempty"`
 }
 
 // Environment represents functionality where the implementation depends on the environment the app
@@ -373,7 +392,7 @@ func (backend *Backend) Authenticate(force bool) {
 	if backend.config.AppConfig().Backend.Authentication || force {
 		backend.environment.Auth()
 	} else {
-		backend.AuthResult(true)
+		backend.AuthResult(AuthResultOk)
 	}
 }
 
@@ -384,17 +403,6 @@ func (backend *Backend) TriggerAuth() {
 		Action:  action.Replace,
 		Object: authEventObject{
 			Typ: authRequired,
-		},
-	})
-}
-
-// CancelAuth triggers an auth-canceled notification.
-func (backend *Backend) CancelAuth() {
-	backend.Notify(observable.Event{
-		Subject: "auth",
-		Action:  action.Replace,
-		Object: authEventObject{
-			Typ: authCanceled,
 		},
 	})
 }
@@ -420,17 +428,14 @@ func (backend *Backend) ForceAuth() {
 
 // AuthResult triggers an auth-ok or auth-err notification
 // depending on the input value.
-func (backend *Backend) AuthResult(ok bool) {
-	backend.log.Infof("Auth result: %v", ok)
-	typ := authErr
-	if ok {
-		typ = authOk
-	}
+func (backend *Backend) AuthResult(result AuthResultType) {
+	backend.log.Infof("Auth result: %v", result)
 	backend.Notify(observable.Event{
 		Subject: "auth",
 		Action:  action.Replace,
 		Object: authEventObject{
-			Typ: typ,
+			Typ:    authResult,
+			Result: &result,
 		},
 	})
 }

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -143,25 +143,16 @@ func TriggerAuth() {
 	globalBackend.TriggerAuth()
 }
 
-// CancelAuth triggers an authentication canceled notification.
-func CancelAuth() {
-	mu.Lock()
-	defer mu.Unlock()
-	if globalBackend == nil {
-		return
-	}
-	globalBackend.CancelAuth()
-}
-
 // AuthResult triggers an authentication result notification
 // on the base of the input value.
-func AuthResult(ok bool) {
+func AuthResult(result backend.AuthResultType) {
 	mu.Lock()
 	defer mu.Unlock()
 	if globalBackend == nil {
 		return
 	}
-	globalBackend.AuthResult(ok)
+
+	globalBackend.AuthResult(result)
 }
 
 // UsingMobileDataChanged should be called when the network connnection changed.

--- a/backend/mobileserver/mobileserver.go
+++ b/backend/mobileserver/mobileserver.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/bridgecommon"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/usb"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/config"
@@ -32,6 +33,17 @@ import (
 
 var (
 	once sync.Once
+)
+
+const (
+	// AuthResultOk exports backend.AuthResultOk.
+	AuthResultOk string = string(backend.AuthResultOk)
+	// AuthResultErr exports backend.AuthResultErr.
+	AuthResultErr string = string(backend.AuthResultErr)
+	// AuthResultCancel exports backend.AuthResultCancel.
+	AuthResultCancel string = string(backend.AuthResultCancel)
+	// AuthResultMissing exports backend.AuthResultMissing.
+	AuthResultMissing string = string(backend.AuthResultMissing)
 )
 
 // fixTimezone sets the local timezone on Android. This is a workaround to the bug that on Android,
@@ -235,15 +247,10 @@ func TriggerAuth() {
 	bridgecommon.TriggerAuth()
 }
 
-// CancelAuth triggers an auth canceled notification towards the frontend.
-func CancelAuth() {
-	bridgecommon.CancelAuth()
-}
-
-// AuthResult triggers an auth feedback notification (auth-ok/auth-err) towards the frontend,
+// AuthResult triggers an auth feedback notification (auth-ok/auth-err/..) towards the frontend,
 // depending on the input value.
-func AuthResult(ok bool) {
-	bridgecommon.AuthResult(ok)
+func AuthResult(result string) {
+	bridgecommon.AuthResult(backend.AuthResultType(result))
 }
 
 // ManualReconnect wraps bridgecommon.ManualReconnect.

--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -87,7 +87,7 @@ func (webdevEnvironment) Auth() {
 	log := logging.Get().WithGroup("servewallet")
 	log.Info("Webdev Auth")
 	if backend != nil {
-		backend.AuthResult(true)
+		backend.AuthResult(backendPkg.AuthResultOk)
 		log.Info("Webdev Auth OK")
 	}
 }

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/BiometricAuthHelper.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/BiometricAuthHelper.java
@@ -17,9 +17,23 @@ public class BiometricAuthHelper {
         void onSuccess();
         void onFailure();
         void onCancel();
+        void noAuthConfigured();
     }
 
     public static void showAuthenticationPrompt(FragmentActivity activity, AuthCallback callback) {
+
+        BiometricManager biometricManager = BiometricManager.from(activity);
+        int canAuthenticate = biometricManager.canAuthenticate(
+                BiometricManager.Authenticators.DEVICE_CREDENTIAL |
+                        BiometricManager.Authenticators.BIOMETRIC_WEAK
+        );
+
+        if (canAuthenticate != BiometricManager.BIOMETRIC_SUCCESS) {
+            Util.log("Authentication not available: code " + canAuthenticate);
+            new Handler(Looper.getMainLooper()).post(callback::noAuthConfigured);
+            return;
+        }
+
         Executor executor = ContextCompat.getMainExecutor(activity);
         BiometricPrompt biometricPrompt = new BiometricPrompt(activity, executor, new BiometricPrompt.AuthenticationCallback() {
             @Override

--- a/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
+++ b/frontends/android/BitBoxApp/app/src/main/java/ch/shiftcrypto/bitboxapp/GoViewModel.java
@@ -202,7 +202,7 @@ public class GoViewModel extends AndroidViewModel {
     }
 
     private final MutableLiveData<Boolean> isDarkTheme = new MutableLiveData<>();
-    private final MutableLiveData<Boolean> authenticator = new MutableLiveData<>(false);
+    private final MutableLiveData<Boolean> authRequested = new MutableLiveData<>(false);
     // The value of the backend config's Authentication setting.
     private final MutableLiveData<Boolean> authSetting = new MutableLiveData<>(false);
     private final GoEnvironment goEnvironment;
@@ -218,8 +218,8 @@ public class GoViewModel extends AndroidViewModel {
         return isDarkTheme;
     }
 
-    public MutableLiveData<Boolean> getAuthenticator() {
-        return authenticator;
+    public MutableLiveData<Boolean> getAuthRequested() {
+        return authRequested;
     }
 
     public MutableLiveData<Boolean> getAuthSetting() {
@@ -235,11 +235,11 @@ public class GoViewModel extends AndroidViewModel {
     }
 
     public void requestAuth() {
-        this.authenticator.postValue(true);
+        this.authRequested.postValue(true);
     }
 
     public void closeAuth() {
-        this.authenticator.postValue(false);
+        this.authRequested.postValue(false);
     }
 
     public void setMessageHandlers(Handler callResponseHandler, Handler pushNotificationHandler) {

--- a/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
@@ -43,13 +43,13 @@ class GoEnvironment: NSObject, MobileserverGoEnvironmentInterfaceProtocol, UIDoc
             context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, authenticationError in
                 DispatchQueue.main.async {
                     if success {
-                        MobileserverAuthResult(true);
+                        MobileserverAuthResult(MobileserverAuthResultOk);
                     } else {
                         if let laError = authenticationError as? LAError,
                            laError.code == .userCancel {
-                            MobileserverCancelAuth();
+                            MobileserverAuthResult(MobileserverAuthResultCancel);
                         } else {
-                            MobileserverAuthResult(false);
+                            MobileserverAuthResult(MobileserverAuthResultErr);
                         }
                     }
                 }
@@ -57,7 +57,7 @@ class GoEnvironment: NSObject, MobileserverGoEnvironmentInterfaceProtocol, UIDoc
         } else {
             // Biometric authentication not available
             DispatchQueue.main.async {
-                MobileserverAuthResult(false);
+                MobileserverAuthResult(MobileserverAuthResultMissing);
             }
         }
     }

--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -69,6 +69,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/bridgecommon"
 	btctypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/types"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/usb"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/mobileserver"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/logging"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/system"
 )
@@ -189,7 +190,7 @@ func serve(
 			DetectDarkThemeFunc: detectDarkTheme,
 			AuthFunc: func() {
 				log.Info("Qt auth")
-				authResult(true)
+				authResult(mobileserver.AuthResultOk)
 			},
 			OnAuthSettingChangedFunc: func(bool) {},
 			BluetoothConnectFunc:     func(string) {},
@@ -216,8 +217,8 @@ func backendShutdown() {
 	bridgecommon.Shutdown()
 }
 
-func authResult(ok bool) {
-	bridgecommon.AuthResult(ok)
+func authResult(result string) {
+	mobileserver.AuthResult(result)
 }
 
 // Don't remove - needed for the C compilation.

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -124,7 +124,10 @@ export const forceAuth = (): Promise<void> => {
 };
 
 export type TAuthEventObject = {
-  typ: 'auth-required' | 'auth-forced' | 'auth-canceled' | 'auth-ok' | 'auth-err' ;
+  typ: 'auth-required' | 'auth-forced' ;
+} | {
+  typ: 'auth-result';
+  result: 'authres-cancel' | 'authres-ok' | 'authres-err' | 'authres-missing'
 };
 
 export const subscribeAuth = (

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -99,6 +99,8 @@
   },
   "auth": {
     "authButton": "Authenticate",
+    "dismissButton": "Cancel",
+    "missing": "Please setup a screen lock in your device settings",
     "title": "Please authenticate to continue"
   },
   "backup": {

--- a/frontends/web/src/routes/settings/components/advanced-settings/enable-auth-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/enable-auth-setting.tsx
@@ -36,13 +36,16 @@ export const EnableAuthSetting = ({ backendConfig, onChangeConfig }: TProps) => 
     // The forceAuth is needed to force the backend to execute the
     // authentication even if the auth config is disabled.
     const unsubscribe = subscribeAuth((data: TAuthEventObject) => {
-      if (data.typ === 'auth-ok') {
-        updateConfig(!e.target.checked);
-        unsubscribe();
-      }
-      if (data.typ === 'auth-canceled') {
+      if (data.typ === 'auth-result') {
+        if (data.result === 'authres-ok') {
+          updateConfig(!e.target.checked);
+          unsubscribe();
+        }
+        if (data.result === 'authres-cancel') {
         // if the user canceled the auth, we leave everything as is.
-        unsubscribe();
+          unsubscribe();
+        }
+
       }
     });
     forceAuth();


### PR DESCRIPTION
On some Android versions (e.g. Android 9) the authentication flow was causing an endless loop of auth requests. This was fixed by moving the setup of `BiometricAuthHelper` from `onStart` to `onCreate`.

In both Android and iOS the auth flow freezed if there was no authentication method setup on the device. This was fixed by refactoring the authentication flow code and adding a new possible authentication response `authres-missing`, that allows to handle this case.