### PR TITLE
frontend: fix btcdirect sell currencies

### DIFF
--- a/frontends/web/public/btcdirect/coin-to-fiat.html
+++ b/frontends/web/public/btcdirect/coin-to-fiat.html
@@ -32,7 +32,6 @@
       case 'configuration':
         const {
           apiKey,
-          address,
           baseCurrency,
           locale,
           mode,
@@ -88,21 +87,13 @@
           theme: theme || 'light',
         });
 
-        // FIXME: The address should not be needed for the sell flow: this is a temporary workaround to
-        // force the coin type in the widget. Without this, the widget UI allows the user to pick a
-        // coin, potentially breaking the flow.
-        btcdirect('wallet-addresses', {
-          addresses: {
-            address,
-            currency,
-            id: 'BTC Direct',
-            name: 'BTC Direct'
-          }
-        });
-
         btcdirect('currencies', {
           crypto: currency,
           fiat: quoteCurrency,
+        });
+
+        btcdirect('lock-cryptocurrency', {
+          lockCryptocurrency: true
         });
 
         break;

--- a/frontends/web/src/routes/exchange/btcdirect.tsx
+++ b/frontends/web/src/routes/exchange/btcdirect.tsx
@@ -195,9 +195,9 @@ export const BTCDirect = ({
     }
     event.source?.postMessage({
       action: 'configuration',
-      // address should not be needed for sell, but we provide it to lock the coin option
-      // in the widget. See coin-to-fiat.html for details.
-      address: btcdirectInfo.address,
+      ...(action === 'buy' && {
+        address: btcdirectInfo.address
+      }),
       locale,
       theme: isDarkMode ? 'dark' : 'light',
       baseCurrency: account.coinUnit,
@@ -207,7 +207,7 @@ export const BTCDirect = ({
     }, {
       targetOrigin: event.origin
     });
-  }, [account, btcdirectInfo, isDarkMode, isDevServers, locale]);
+  }, [account, action, btcdirectInfo, isDarkMode, isDevServers, locale]);
 
   const onMessage = useCallback((event: MessageEvent) => {
     if (


### PR DESCRIPTION
Disabled coin selection option in BTC Direct sell widget, by setting lockCryptocurrency instead of passing an address.

See:
- https://developer.btcdirect.eu/widget/sell-order-form#lock-cryptocurrency

Todo:
- [x] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)

