### PR TITLE
frontend: send to self dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - More efficient account initialization by fetching all account Bitcoin xpubs at once
 - Enable search transactions by note, address, or txid
 - Move "Export" (export transactions) to account info page
+- Add a dropdown on the "Receiver address" input in the send screen to select an account
 
 ## v4.48.7
 - ios: fix Pocket user verification button

--- a/frontends/web/src/components/dropdown/dropdown.tsx
+++ b/frontends/web/src/components/dropdown/dropdown.tsx
@@ -37,7 +37,7 @@ type SelectProps<T = any, IsMulti extends boolean = false> = Omit<
   ReactSelectProps<TOption<T>>,
   'onChange'
 > & {
-  renderOptions: (selectedItem: TOption<T>) => ReactNode; // Function to render options and selected value for single dropdown
+  renderOptions?: (selectedItem: TOption<T>, isSelectedValue: boolean) => ReactNode; // Function to render options and selected value for single dropdown
   onChange: (
     newValue: IsMulti extends true ? TOption<T>[] : TOption<T>,
     actionMeta: ActionMeta<TOption<T>>
@@ -46,6 +46,7 @@ type SelectProps<T = any, IsMulti extends boolean = false> = Omit<
   isOpen?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   title?: string;
+  mobileTriggerComponent?: ReactNode | ((props: { onClick: () => void }) => ReactNode);
 };
 
 const DropdownIndicator = (props: DropdownIndicatorProps<TOption>) => (
@@ -59,7 +60,7 @@ const SelectSingleValue = (props: SingleValueProps<TOption> & { selectProps: any
 
   return (
     <components.SingleValue {...props}>
-      {renderOptions(props.data)}
+      {renderOptions(props.data, true)}
     </components.SingleValue>
   );
 };
@@ -68,7 +69,7 @@ const Option = (props: OptionProps<TOption> & { selectProps: any }) => {
   const { renderOptions } = props.selectProps;
   return (
     <components.Option {...props}>
-      {renderOptions(props.data)}
+      {renderOptions(props.data, false)}
     </components.Option>
   );
 };
@@ -109,6 +110,7 @@ export const Dropdown = <T, IsMulti extends boolean = false>({
   mobileFullScreen = false,
   isOpen,
   onOpenChange,
+  mobileTriggerComponent,
   ...props
 }: SelectProps<T, IsMulti>) => {
   const isMobile = useMediaQuery('(max-width: 768px)');
@@ -128,12 +130,13 @@ export const Dropdown = <T, IsMulti extends boolean = false>({
       <MobileFullscreenSelector
         title={title}
         options={options}
-        renderOptions={renderOptions}
+        renderOptions={renderOptions || (() => null)}
         value={props.value as any}
         onSelect={onChange}
         isMulti={props.isMulti}
         isOpen={isOpen}
         onOpenChange={onOpenChange}
+        triggerComponent={mobileTriggerComponent}
       />
     );
   }

--- a/frontends/web/src/components/dropdown/mobile-fullscreen-selector.module.css
+++ b/frontends/web/src/components/dropdown/mobile-fullscreen-selector.module.css
@@ -87,18 +87,21 @@
     padding-top: 0;
 }
 
-.searchInput {
+input.searchInput {
     background-color: var(--background-secondary);
     border: 1px solid var(--background-secondary);
     border-radius: 4px;
+    height: auto;
     color: var(--color-default);
     font-size: var(--size-default);
     width: 100%;
     padding: var(--space-quarter) var(--space-half);
 }
-.searchInput:focus {
+
+input.searchInput:focus {
     outline: none;
 }
+
 .optionsList {
     flex: 1;
     overflow-y: auto;

--- a/frontends/web/src/components/dropdown/mobile-fullscreen-selector.tsx
+++ b/frontends/web/src/components/dropdown/mobile-fullscreen-selector.tsx
@@ -25,12 +25,13 @@ import styles from './mobile-fullscreen-selector.module.css';
 type Props<T, IsMulti extends boolean = false> = {
   title: string;
   options: TOption<T>[];
-  renderOptions: (option: TOption<T>) => ReactNode;
+  renderOptions: (option: TOption<T>, isSelectedValue: boolean) => ReactNode;
   value: IsMulti extends true ? TOption<T>[] : TOption<T>;
   onSelect: (newValue: IsMulti extends true ? TOption<T>[] : TOption<T>, actionMeta: ActionMeta<TOption<T>>) => void;
   isMulti?: boolean;
   isOpen?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
+  triggerComponent?: ReactNode | ((props: { onClick: () => void }) => ReactNode);
 }
 
 export const MobileFullscreenSelector = <T, IsMulti extends boolean = false>({
@@ -42,6 +43,7 @@ export const MobileFullscreenSelector = <T, IsMulti extends boolean = false>({
   isMulti,
   isOpen: controlledIsOpen,
   onOpenChange,
+  triggerComponent,
 }: Props<T, IsMulti>) => {
   const [localIsOpen, setLocalIsOpen] = useState(false);
   const [searchText, setSearchText] = useState('');
@@ -112,10 +114,12 @@ export const MobileFullscreenSelector = <T, IsMulti extends boolean = false>({
         return false;
       }}
       />
-      {onOpenChange ? (
-        <div
-          className={styles.mobileSelectorTrigger}
-        >
+      {triggerComponent ? (
+        typeof triggerComponent === 'function' ?
+          triggerComponent({ onClick: handleOpen }) :
+          triggerComponent
+      ) : onOpenChange ? (
+        <div className={styles.mobileSelectorTrigger}>
           <span className={styles.mobileSelectorValue}>{displayValue}</span>
         </div>
       ) : (
@@ -125,8 +129,7 @@ export const MobileFullscreenSelector = <T, IsMulti extends boolean = false>({
         >
           <span className={styles.mobileSelectorValue}>{displayValue}</span>
         </button>
-      )
-      }
+      )}
 
       {isOpen && (
         <div className={styles.fullscreenOverlay}>
@@ -148,6 +151,7 @@ export const MobileFullscreenSelector = <T, IsMulti extends boolean = false>({
 
             <div className={styles.searchContainer}>
               <input
+                id="search"
                 type="text"
                 className={styles.searchInput}
                 placeholder={`${t('generic.search')}`}
@@ -160,14 +164,16 @@ export const MobileFullscreenSelector = <T, IsMulti extends boolean = false>({
               {filteredOptions.length > 0 ? (
                 filteredOptions.map((option) => (
                   <button
-                    key={String(option.value)}
+                    key={JSON.stringify(option.value)}
                     className={`
-                      ${styles.optionItem || ''}
-                      ${isSelected(option) && styles.selectedOption || ''}
-                    `}
+                    ${styles.optionItem || ''} 
+                    ${isSelected(option) ?
+                    styles.selectedOption || ''
+                    : ''}`
+                    }
                     onClick={(e) => handleSelect(option, e)}
                   >
-                    <div className={styles.optionContent}>{renderOptions(option)}</div>
+                    <div className={styles.optionContent}>{renderOptions(option, false)}</div>
                   </button>
                 ))
               ) : (

--- a/frontends/web/src/components/forms/input-with-dropdown.module.css
+++ b/frontends/web/src/components/forms/input-with-dropdown.module.css
@@ -1,0 +1,132 @@
+.inputDropdownWrapper {
+    display: grid;
+    grid-template-columns: 1fr minmax(160px, 280px);
+    min-width: 0;
+}
+
+input.inputField {
+    background-color: var(--background-secondary);
+    border-color: var(--background-quaternary);
+    border-radius: 2px;
+    border-style: solid;
+    border-width: 1px;
+    border-right: none;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    font-family: var(--font-family);
+    font-size: var(--size-default);
+    font-weight: 400;
+    height: 52px !important;
+    padding: 0 var(--space-half);
+    width: 100%;
+    transition: border-color .2s ease-out;
+    will-change: border-color;
+    padding-left: 50px;
+    padding-right: 0;
+}
+
+input.inputField:disabled {
+    border-color: var(--background-quaternary) !important;
+    color: var(--color-secondary);
+    cursor: not-allowed;
+}
+
+input.inputField:focus {
+    border-color: var(--color-blue);
+    outline: none;
+}
+
+input.inputField::placeholder {
+    color: var(--color-secondary);
+}
+
+.dropdown {
+    font-size: var(--size-small);
+    max-width: 280px;
+    min-width: 160px;
+    width: 100%;
+}
+
+.chevron {
+    height: 24px;
+    rotate: 270deg;
+    width: 24px;
+}
+
+.dropdown :global(.react-select__control) {
+    border: 1px solid var(--background-quaternary);
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: none;
+    height: 52px;
+    padding: 0;
+}
+
+.dropdown :global(.react-select__value-container) {
+    padding: 0;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.dropdown :global(.react-select__control):hover {
+    border-color: var(--background-quaternary);
+}
+
+.dropdown :global(.react-select__input) {
+    height: 0;
+}
+
+.dropdown :global(.react-select__single-value) {
+    color: var(--color-blue);
+    display: flex;
+    font-size: 14px;
+    justify-content: flex-end;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dropdown :global(.react-select__input):hover {
+    border-color: var(--color-blue);
+}
+
+.inputDropdownWrapper:focus-within .dropdown :global(.react-select__control) {
+    border-color: var(--color-blue) !important;
+    border-left: none !important;
+    box-shadow: none !important;
+}
+
+.inputDropdownWrapper:focus-within .inputField {
+    border-color: var(--color-blue);
+    border-right: none;
+}
+
+.inputDropdownWrapper:focus-within .inputField:disabled {
+    border-color: var(--color-blue) !important;
+    border-right: none;
+}
+
+.inputDropdownWrapper:focus-within .dropdownTrigger {
+    border-color: var(--color-blue);
+}
+
+.dropdownTrigger {
+    align-items: center;
+    background-color: #fff;
+    border: 1px solid var(--background-quaternary);
+    border-left: hidden;
+    display: flex;
+    height: 52px;
+    justify-content: center;
+    padding-left: 0;
+    transition: border-color .2s ease-out;
+    width: 100%;
+    will-change: border-color;
+}
+
+@media (max-width: 768px) {
+    .inputDropdownWrapper {
+        grid-template-columns: 90% 10%;
+    }
+}

--- a/frontends/web/src/components/forms/input-with-dropdown.tsx
+++ b/frontends/web/src/components/forms/input-with-dropdown.tsx
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2025 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { forwardRef } from 'react';
+import { TBaseInputProps } from './types';
+import { Dropdown, TOption } from '@/components/dropdown/dropdown';
+import { ChevronLeftDark } from '@/components/icon';
+import baseStyles from './input.module.css';
+import styles from './input-with-dropdown.module.css';
+
+export type TInputWithDropdownProps<T> = TBaseInputProps & {
+  dropdownOptions?: TOption<T>[];
+  dropdownValue?: TOption<T> | null;
+  onDropdownChange?: (selected: TOption<T>) => void;
+  dropdownPlaceholder?: string;
+  dropdownTitle?: string;
+  isOptionDisabled?: (option: TOption<T>) => boolean;
+  renderOptions?: (option: TOption<T>, isSelectedValue: boolean) => React.ReactNode;
+}
+
+export const InputWithDropdown = forwardRef<HTMLInputElement, TInputWithDropdownProps<any>>(({
+  id,
+  label = '',
+  error,
+  align = 'left',
+  className = '',
+  transparent = false,
+  type = 'text',
+  labelSection,
+  dropdownOptions = [],
+  dropdownValue,
+  onDropdownChange,
+  dropdownPlaceholder = 'Select...',
+  dropdownTitle = '',
+  isOptionDisabled,
+  children,
+  renderOptions,
+  ...props
+}: TInputWithDropdownProps<any>, ref) => {
+  return (
+    <div className={`
+      ${baseStyles.input || ''}
+      ${baseStyles[`align-${align}`] || ''}
+      ${className}
+      ${transparent ? baseStyles.isTransparent || '' : ''}
+      `}>
+      {label ? (
+        <div className="flex flex-row flex-between">
+          <label htmlFor={id} className={error ? baseStyles.errorText : ''}>
+            {label}
+            {error ? (
+              <span>:<span>{error.toString()}</span></span>
+            ) : null}
+          </label>
+          {labelSection && labelSection}
+        </div>
+      ) : null}
+      <div className={styles.inputDropdownWrapper}>
+        <input
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          type={type}
+          className={styles.inputField}
+          id={id}
+          ref={ref}
+          {...props}
+        />
+        {children}
+        {dropdownOptions.length > 0 && (
+          <div>
+            <Dropdown
+              options={dropdownOptions}
+              onChange={(selected) => {
+                if (selected && selected.value !== null && onDropdownChange) {
+                  onDropdownChange(selected as TOption<any>);
+                }
+              }}
+              value={dropdownValue || { label: dropdownPlaceholder, value: null }}
+              className={styles.dropdown}
+              classNamePrefix="react-select"
+              isClearable={false}
+              isOptionDisabled={isOptionDisabled}
+              mobileTriggerComponent={({ onClick }) => (
+                <button className={styles.dropdownTrigger} onClick={onClick}>
+                  <ChevronLeftDark className={styles.chevron} />
+                </button>
+              )}
+              isSearchable={false}
+              title={dropdownTitle}
+              mobileFullScreen
+              renderOptions={renderOptions}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});
+

--- a/frontends/web/src/components/forms/input.tsx
+++ b/frontends/web/src/components/forms/input.tsx
@@ -15,19 +15,11 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, HTMLProps, forwardRef } from 'react';
+import { forwardRef } from 'react';
+import { TBaseInputProps } from './types';
 import styles from './input.module.css';
 
-export type TInputProps = {
-    align?: 'left' | 'right';
-    children?: React.ReactNode;
-    className?: string;
-    error?: string | object;
-    onInput?: (e: ChangeEvent<HTMLInputElement>) => void;
-    transparent?: boolean;
-    labelSection?: JSX.Element | undefined;
-    label?: string;
-} & Omit<HTMLProps<HTMLInputElement>, 'onInput'>
+export type TInputProps = TBaseInputProps;
 
 export const Input = forwardRef<HTMLInputElement, TInputProps>(({
   id,
@@ -60,6 +52,7 @@ export const Input = forwardRef<HTMLInputElement, TInputProps>(({
         </div>
       ) : null }
       <input
+        className={styles.inputField}
         autoComplete="off"
         autoCorrect="off"
         spellCheck={false}

--- a/frontends/web/src/components/forms/types.ts
+++ b/frontends/web/src/components/forms/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2025 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeEvent, HTMLProps } from 'react';
+
+export type TBaseInputProps = {
+  align?: 'left' | 'right';
+  children?: React.ReactNode;
+  className?: string;
+  error?: string | object;
+  onInput?: (e: ChangeEvent<HTMLInputElement>) => void;
+  transparent?: boolean;
+  labelSection?: JSX.Element | undefined;
+  label?: string;
+} & Omit<HTMLProps<HTMLInputElement>, 'onInput'>
+

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -891,6 +891,7 @@
     "receive": "Receive {{coinCode}}",
     "receive_bitcoin": "Receive Bitcoin",
     "receive_crypto": "Receive crypto",
+    "reset": "Reset",
     "resetToDefault": "Reset to default",
     "search": "Search…",
     "searchButton": "Search",
@@ -1707,6 +1708,10 @@
     "priority": "Priority",
     "scanQR": "Scan QR code",
     "scanQRNoCameraMessage": "Camera not found. Please ensure that your device supports a camera and permissions are correctly set.",
+    "sendToAccount": {
+      "placeholder": "Select account",
+      "title": "Send to account"
+    },
     "success": "The transaction has been signed and sent.",
     "title": "Send {{accountName}}",
     "toggleCoinControl": "Toggle coin control",

--- a/frontends/web/src/routes/account/send/components/confirm/confirm.module.css
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.module.css
@@ -1,3 +1,8 @@
+.address {
+  color: var(--color-secondary);
+  font-weight: 500;
+}
+
 .bitBoxContainer {
   margin-bottom: var(--space-half);
 }
@@ -6,6 +11,12 @@
   align-items: baseline;
   display: flex;
   justify-content: space-between;
+}
+
+.toWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-quarter);
 }
 
 .confirmItem {
@@ -61,6 +72,10 @@
 
 .valueOriginal {
   font-weight: 500;
+}
+
+.valueOriginal span {
+  font-size: 16px;
 }
 
 .valueOriginalLarge {

--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -15,10 +15,10 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { CoinCode, ConversionUnit, FeeTargetCode, Fiat, TAmountWithConversions } from '@/api/account';
+import { CoinCode, ConversionUnit, FeeTargetCode, Fiat, IAccount, TAmountWithConversions } from '@/api/account';
 import { UseDisableBackButton } from '@/hooks/backbutton';
 import { Amount } from '@/components/amount/amount';
-import { customFeeUnit } from '@/routes/account/utils';
+import { customFeeUnit, getAccountNumber } from '@/routes/account/utils';
 import { View, ViewContent, ViewHeader } from '@/components/view/view';
 import { Message } from '@/components/message/message';
 import { PointToBitBox02 } from '@/components/icon';
@@ -27,6 +27,7 @@ import type { TSelectedUTXOs } from '../../utxos';
 import style from './confirm.module.css';
 
 type TransactionDetails = {
+  selectedReceiverAccount?: IAccount;
   proposedAmount?: TAmountWithConversions;
   proposedFee?: TAmountWithConversions;
   proposedTotal?: TAmountWithConversions;
@@ -44,6 +45,7 @@ type TConfirmSendProps = {
   selectedUTXOs: TSelectedUTXOs;
   coinCode: CoinCode;
   transactionDetails: TransactionDetails;
+  activeAccounts?: IAccount[];
 }
 
 type TUTXOsByAddress = {
@@ -57,19 +59,32 @@ export const ConfirmSend = ({
   isConfirming,
   selectedUTXOs,
   coinCode,
-  transactionDetails
+  transactionDetails,
+  activeAccounts: allAccounts
 }: TConfirmSendProps) => {
 
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const {
     proposedFee,
     proposedAmount,
     proposedTotal,
     customFee,
     feeTarget,
+    selectedReceiverAccount,
     recipientAddress,
     activeCurrency: fiatUnit
   } = transactionDetails;
+
+  const receiverAccountNumberAndName = selectedReceiverAccount && allAccounts ?
+    {
+      name: selectedReceiverAccount.name,
+      number: getAccountNumber(
+        selectedReceiverAccount,
+        allAccounts,
+        i18n.language
+      )
+    }
+    : undefined;
 
   const groupUTXOsByAddress = (selectedUTXOs: TSelectedUTXOs): TUTXOsByAddress => {
     const utxosByAddress: TUTXOsByAddress = {};
@@ -123,10 +138,25 @@ export const ConfirmSend = ({
         {/*To (recipient address)*/}
         <div className={style.confirmItem}>
           <label>{t('send.confirm.to')}</label>
-          <div className={style.confirmationItemWrapper}>
-            <p className={style.valueOriginal}>
-              {recipientAddress || 'N/A'}
+          <div className={style.toWrapper}>
+            <p className={`${style.valueOriginal || ''}`}>
+              {receiverAccountNumberAndName?.name ?
+                receiverAccountNumberAndName.name :
+                recipientAddress
+              }
+              {' '}
+              {receiverAccountNumberAndName?.number && (
+                <span className={style.address}>
+                (Account #{receiverAccountNumberAndName.number})
+                </span>
+              )}
             </p>
+
+            {receiverAccountNumberAndName && (
+              <span className={style.address}>
+                {recipientAddress}
+              </span>
+            )}
           </div>
         </div>
 

--- a/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.module.css
+++ b/frontends/web/src/routes/account/send/components/inputs/receiver-address-input.module.css
@@ -7,13 +7,17 @@
 }
 
 .action {
-  color: var(--color-blue);
+  color: var(--color-danger);
   font-size: var(--size-small);
   font-weight: 400;
   line-height: 1;
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
+}
+
+.sendToSelf {
+  color: var(--color-blue);
 }
 
 .qrButton {
@@ -34,4 +38,9 @@
 .qrButton img {
   width: 18px;
   height: 18px;
+}
+
+.withDropdown {
+  left: 8px;
+  margin-top: 3px;
 }

--- a/frontends/web/src/routes/account/send/components/inputs/receiver-address-wrapper.module.css
+++ b/frontends/web/src/routes/account/send/components/inputs/receiver-address-wrapper.module.css
@@ -1,0 +1,27 @@
+.accountName {
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.accountOption {
+    align-items: center;
+    display: flex;
+    justify-content: flex-start;
+    gap: 8px;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.spinner img {
+    height: 14px;
+    margin-top: 3px;
+    width: 14px;
+}
+
+.coinLogo {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+}

--- a/frontends/web/src/routes/account/send/components/inputs/receiver-address-wrapper.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/receiver-address-wrapper.tsx
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2025 Shift Crypto AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeEvent, useCallback, useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TOption } from '@/components/dropdown/dropdown';
+import { InputWithDropdown } from '@/components/forms/input-with-dropdown';
+import * as accountApi from '@/api/account';
+import { getReceiveAddressList, IAccount } from '@/api/account';
+import { statusChanged, syncdone } from '@/api/accountsync';
+import { unsubscribe } from '@/utils/subscriptions';
+import { TUnsubscribe } from '@/utils/transport-common';
+import { useMountedRef } from '@/hooks/mount';
+import { useMediaQuery } from '@/hooks/mediaquery';
+import { SpinnerRingAnimated } from '@/components/spinner/SpinnerAnimation';
+import { Logo } from '@/components/icon';
+import { getAccountNumber } from '@/routes/account/utils';
+import receiverStyles from './receiver-address-input.module.css';
+import styles from './receiver-address-wrapper.module.css';
+
+type TAccountOption = TOption<IAccount | null> & { disabled?: boolean };
+
+type Props = {
+  option: TAccountOption,
+  isSelectedValue: boolean
+}
+
+type TReceiverAddressWrapperProps = {
+  accounts?: IAccount[];
+  allAccounts?: IAccount[];
+  error?: string | object;
+  onInputChange: (value: string) => void;
+  onAccountChange?: (account: IAccount | null) => void;
+  recipientAddress: string;
+  children?: React.ReactNode;
+}
+
+const AccountOption = ({ option, isSelectedValue }: Props) => {
+  if (!option.value) {
+    return <span>{option.label}</span>;
+  }
+
+  return (
+    <div className={`${styles.accountOption || ''}`}>
+      <Logo coinCode={option.value.coinCode} alt={option.value.coinName} className={styles.coinLogo} />
+      <span className={
+        isSelectedValue ?
+          styles.accountName : ''
+      }>{option.label}</span>
+      {option.disabled && <span className={styles.spinner}><SpinnerRingAnimated /></span>}
+    </div>
+  );
+};
+
+
+export const ReceiverAddressWrapper = ({
+  accounts,
+  allAccounts,
+  error,
+  onInputChange,
+  onAccountChange,
+  recipientAddress,
+  children,
+}: TReceiverAddressWrapperProps) => {
+  const { t, i18n } = useTranslation();
+  const mounted = useMountedRef();
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const [selectedAccount, setSelectedAccount] = useState<TOption<IAccount | null> | null>(null);
+  const [accountSyncStatus, setAccountSyncStatus] = useState<{ [code: string]: accountApi.IStatus }>({});
+
+  const accountOptions: TAccountOption[] = accounts && accounts.length > 0 ? accounts.map(account => {
+    const accountNumber = getAccountNumber(account, allAccounts || accounts, i18n.language);
+
+    return {
+      label: `${account.name} ${accountNumber ? `(Account #${accountNumber})` : ''}`,
+      value: account,
+      disabled: !accountSyncStatus[account.code]?.synced
+    };
+  }) : [];
+
+  const handleSendToAccount = useCallback(async (selectedOption: TAccountOption) => {
+    if (selectedOption.value === null || selectedOption.disabled) {
+      return;
+    }
+    const selectedAccountValue = selectedOption.value;
+    setSelectedAccount(selectedOption);
+    try {
+      const receiveAddresses = await getReceiveAddressList(selectedAccountValue.code)();
+      if (receiveAddresses && receiveAddresses.length > 0 && receiveAddresses[0].addresses.length > 0) {
+        const address = receiveAddresses[0].addresses[0].address;
+        onInputChange(address);
+        onAccountChange?.(selectedAccountValue);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }, [onInputChange, onAccountChange]);
+
+  const handleReset = useCallback(() => {
+    setSelectedAccount(null);
+    onInputChange('');
+    onAccountChange?.(null);
+  }, [onInputChange, onAccountChange]);
+
+  const checkAccountStatus = useCallback(async (accountCode: accountApi.AccountCode) => {
+    if (!mounted.current) {
+      return;
+    }
+    const status = await accountApi.getStatus(accountCode);
+    if (!mounted.current) {
+      return;
+    }
+    setAccountSyncStatus(prev => ({
+      ...prev,
+      [accountCode]: status
+    }));
+  }, [mounted]);
+
+  useEffect(() => {
+    if (!accounts || accounts.length === 0) {
+      return;
+    }
+
+    const subscriptions: TUnsubscribe[] = [];
+    accounts.forEach(account => {
+      checkAccountStatus(account.code);
+      subscriptions.push(statusChanged(account.code, () => checkAccountStatus(account.code)));
+      subscriptions.push(syncdone(account.code, () => checkAccountStatus(account.code)));
+    });
+    return () => unsubscribe(subscriptions);
+  }, [accounts, checkAccountStatus]);
+
+  return (
+    <InputWithDropdown
+      id="recipientAddress"
+      label={t('send.address.label')}
+      error={error}
+      align="left"
+      placeholder={t('send.address.placeholder')}
+      onInput={(e: ChangeEvent<HTMLInputElement>) => onInputChange(e.target.value)}
+      value={recipientAddress}
+      disabled={selectedAccount !== null}
+      autoFocus={!isMobile}
+      dropdownOptions={accountOptions}
+      dropdownValue={selectedAccount}
+      onDropdownChange={(selected) => {
+        if (selected && selected.value !== null && !(selected as TAccountOption).disabled) {
+          handleSendToAccount(selected as TAccountOption);
+        }
+      }}
+      dropdownPlaceholder={t('send.sendToAccount.placeholder')}
+      dropdownTitle={t('send.sendToAccount.title')}
+      renderOptions={(e, isSelectedValue) => <AccountOption option={e} isSelectedValue={isSelectedValue} />}
+      isOptionDisabled={(option) => (option as TAccountOption).disabled || false}
+      labelSection={selectedAccount ? (
+        <span role="button" id="sendToSelf" className={receiverStyles.action} onClick={handleReset}>
+          {t('generic.reset')}
+        </span>
+      ) : undefined}
+    >
+      {children}
+    </InputWithDropdown>
+  );
+};

--- a/frontends/web/src/routes/account/send/send-wrapper.tsx
+++ b/frontends/web/src/routes/account/send/send-wrapper.tsx
@@ -21,19 +21,19 @@ import { findAccount } from '@/routes/account/utils';
 import { Send } from './send';
 
 type TSendProps = {
-  accounts: IAccount[];
+  activeAccounts: IAccount[];
   code: AccountCode;
 }
 
-export const SendWrapper = ({ accounts, code }: TSendProps) => {
+export const SendWrapper = ({ activeAccounts, code }: TSendProps) => {
   const { defaultCurrency } = useContext(RatesContext);
-
-  const account = findAccount(accounts, code);
+  const account = findAccount(activeAccounts, code);
 
   return (
     account ? (
       <Send
         account={account}
+        activeAccounts={activeAccounts}
         activeCurrency={defaultCurrency}
       />
     ) : (null)

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -47,6 +47,7 @@ import style from './send.module.css';
 
 type TProps = {
   account: accountApi.IAccount;
+  activeAccounts?: accountApi.IAccount[];
   activeCurrency: accountApi.Fiat;
 }
 
@@ -73,6 +74,7 @@ const useAccountBalance = (accountCode: accountApi.AccountCode) => {
 
 export const Send = ({
   account,
+  activeAccounts,
   activeCurrency,
 }: TProps) => {
   const { t } = useTranslation();
@@ -83,7 +85,10 @@ export const Send = ({
   const lastProposal = useRef<Promise<accountApi.TTxProposalResult> | null>(null);
   const proposeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const [recipientAddress, setRecipientAddress] = useState<string>('');
+  // state used for the "Receiver address" input - what the user types or the account's address that is selected
+  const [recipientInput, setRecipientInput] = useState<string>('');
+  // the selected account when sending to another account (for confirmation display with account name and number)
+  const [selectedReceiverAccount, setSelectedReceiverAccount] = useState<accountApi.IAccount | null>(null);
   const [amount, setAmount] = useState<string>('');
   const [fiatAmount, setFiatAmount] = useState<string>('');
   const [valid, setValid] = useState<boolean>(false);
@@ -107,7 +112,8 @@ export const Send = ({
   const handleContinue = () => {
     setSendAll(false);
     setIsConfirming(false);
-    setRecipientAddress('');
+    setRecipientInput('');
+    setSelectedReceiverAccount(null);
     setProposedAmount(undefined);
     setProposedFee(undefined);
     setProposedTotal(undefined);
@@ -144,7 +150,7 @@ export const Send = ({
 
   const getValidTxInputData = useCallback((): Required<accountApi.TTxInput> | false => {
     if (
-      !recipientAddress
+      !recipientInput
       || feeTarget === undefined
       || (!sendAll && !amount)
       || (feeTarget === 'custom' && !customFee)
@@ -152,7 +158,7 @@ export const Send = ({
       return false;
     }
     return {
-      address: recipientAddress,
+      address: recipientInput,
       amount,
       feeTarget,
       customFee,
@@ -161,7 +167,7 @@ export const Send = ({
       paymentRequest: null,
       useHighestFee: false
     };
-  }, [recipientAddress, feeTarget, sendAll, amount, customFee]);
+  }, [recipientInput, feeTarget, sendAll, amount, customFee]);
 
   const convertToFiat = useCallback(async (amount: string) => {
     if (amount) {
@@ -295,10 +301,13 @@ export const Send = ({
     return Object.keys(selectedUTXOsRef.current).length !== 0;
   };
 
-  const handleReceiverAddressInputChange = (recipientAddress: string) => {
-    setRecipientAddress(recipientAddress);
+  // when user types in the input field or selects from dropdown
+  const handleRecipientInputChange = (input: string) => {
+    setRecipientInput(input);
     setUpdateFiat(true);
+    setSelectedReceiverAccount(null);
   };
+
 
   const parseQRResult = async (uri: string) => {
     let qrAddress;
@@ -323,7 +332,7 @@ export const Send = ({
         if (result.success) {
           setAmount(result.amount);
         } else {
-          setRecipientAddress(qrAddress);
+          setRecipientInput(qrAddress);
           setSendAll(false);
           setFiatAmount('');
           setErrorHandling({ amountError: t('send.error.invalidAmount') });
@@ -333,7 +342,8 @@ export const Send = ({
         setAmount(qrAmount);
       }
     }
-    setRecipientAddress(qrAddress);
+    setRecipientInput(qrAddress);
+    setSelectedReceiverAccount(null);
     setSendAll(false);
     setFiatAmount('');
     convertToFiat(qrAmount);
@@ -389,10 +399,12 @@ export const Send = ({
               <Grid col="1">
                 <Column>
                   <ReceiverAddressInput
-                    accountCode={account.code}
+                    account={account}
+                    activeAccounts={activeAccounts}
                     addressError={errorHandling.addressError}
-                    onInputChange={handleReceiverAddressInputChange}
-                    recipientAddress={recipientAddress}
+                    onInputChange={handleRecipientInputChange}
+                    onAccountChange={setSelectedReceiverAccount}
+                    recipientAddress={recipientInput}
                     parseQRResult={parseQRResult}
                   />
                 </Column>
@@ -467,14 +479,16 @@ export const Send = ({
               selectedUTXOs={selectedUTXOsRef.current}
               coinCode={account.coinCode}
               transactionDetails={{
+                selectedReceiverAccount: selectedReceiverAccount || undefined,
                 proposedFee,
                 proposedAmount,
                 proposedTotal,
                 customFee,
                 feeTarget,
-                recipientAddress,
+                recipientAddress: recipientInput,
                 activeCurrency,
               }}
+              activeAccounts={activeAccounts}
             />
             {sendResult && (
               <SendResult

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -148,3 +148,19 @@ export const getAccountsPerCoin = (accounts: IAccount[]): TAccountCoinMap => {
     return accountPerCoin;
   }, {});
 };
+
+export const getAccountNumber = (targetAccount: IAccount, allAccounts: IAccount[], language: string): number | null => {
+  try {
+    const sameKeystoreAndCoin = allAccounts.filter(account =>
+      account.keystore.rootFingerprint === targetAccount.keystore.rootFingerprint &&
+      account.coinCode === targetAccount.coinCode
+    );
+
+    sameKeystoreAndCoin.sort((a, b) => a.code.localeCompare(b.code, language));
+    const position = sameKeystoreAndCoin.findIndex(account => account.code === targetAccount.code);
+    return position >= 0 ? position + 1 : null;
+  } catch (error) {
+    console.error('Error determining account number:', error);
+    return null;
+  }
+};

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -114,7 +114,8 @@ export const AppRouter = ({ devices, deviceIDs, devicesKey, accounts, activeAcco
   const AccSend = (<InjectParams>
     <SendWrapper
       code={'' /* dummy to satisfy TS */}
-      accounts={activeAccounts} />
+      activeAccounts={activeAccounts}
+    />
   </InjectParams>);
 
   const AccReceive = (<InjectParams>


### PR DESCRIPTION
Created a new reusable component `InputWithDropdown` and used it for the Send screen (Receiver address input field). 

When there's no eligible account for send-to-self (same like prod):
<img width="1552" height="987" alt="Screenshot 2025-09-16 at 14 38 59" src="https://github.com/user-attachments/assets/aa6676f1-b701-42f8-90a8-7f09865a3069" />

When there are eligible accounts:
<img width="1552" height="987" alt="Screenshot 2025-09-16 at 14 37 14" src="https://github.com/user-attachments/assets/5a4ee74f-5e95-4094-9244-c7c799b2b658" />

<img width="1552" height="987" alt="Screenshot 2025-09-16 at 14 43 00" src="https://github.com/user-attachments/assets/59a05567-3feb-4fd0-bb1e-7c985e6192a5" />

<img width="1552" height="987" alt="Screenshot 2025-09-16 at 14 37 18" src="https://github.com/user-attachments/assets/8c1ac90c-73cd-46dc-ba9d-0d28a07cd44d" />

<img width="612" height="987" alt="Screenshot 2025-09-16 at 14 37 20" src="https://github.com/user-attachments/assets/eafd07c6-8a57-4086-bc63-65f74ead2dc7" />


<img width="612" height="987" alt="Screenshot 2025-09-16 at 14 37 22" src="https://github.com/user-attachments/assets/a05ba762-9cc9-4282-8600-97d70f0e9bae" />
