### PR TITLE
frontend: block esc key when coincontrol dialog is open

### DIFF
--- a/frontends/web/src/routes/account/send/coin-control.tsx
+++ b/frontends/web/src/routes/account/send/coin-control.tsx
@@ -25,11 +25,13 @@ import { isBitcoinBased } from '../utils';
 type TProps = {
   account: IAccount;
   onSelectedUTXOsChange: (selectedUTXOs: TSelectedUTXOs) => void;
+  onCoinControlDialogActiveChange?: (active: boolean) => void;
 }
 
 export const CoinControl = ({
   account,
   onSelectedUTXOsChange,
+  onCoinControlDialogActiveChange,
 }: TProps) => {
   const { t } = useTranslation();
 
@@ -43,6 +45,13 @@ export const CoinControl = ({
       });
     }
   }, [account.coinCode]);
+
+  // Notify parent whenever dialog visibility changes
+  useEffect(() => {
+    if (onCoinControlDialogActiveChange) {
+      onCoinControlDialogActiveChange(showUTXODialog);
+    }
+  }, [showUTXODialog, onCoinControlDialogActiveChange]);
 
   if (!coinControlEnabled) {
     return null;

--- a/frontends/web/src/routes/account/send/send.tsx
+++ b/frontends/web/src/routes/account/send/send.tsx
@@ -78,6 +78,7 @@ export const Send = ({
   const { t } = useTranslation();
 
   const selectedUTXOsRef = useRef<TSelectedUTXOs>({});
+  const [utxoDialogActive, setUtxoDialogActive] = useState(false);
   // in case there are multiple parallel tx proposals we can ignore all other but the last one
   const lastProposal = useRef<Promise<accountApi.TTxProposalResult> | null>(null);
   const proposeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -381,6 +382,7 @@ export const Send = ({
                   <CoinControl
                     account={account}
                     onSelectedUTXOsChange={handleSelectedUTXOsChange}
+                    onCoinControlDialogActiveChange={setUtxoDialogActive}
                   />
                 </div>
               </div>
@@ -449,7 +451,7 @@ export const Send = ({
                       {t('send.button')}
                     </Button>
                     <BackButton
-                      enableEsc={!isConfirming}
+                      enableEsc={!isConfirming && !utxoDialogActive}
                     >
                       {t('button.back')}
                     </BackButton>


### PR DESCRIPTION
Pressing ESC should close the active coincontrol dialog but not
exit the Send workflow.

Regression introduced in:
- d1a2916d3c02eaf192c2743d940e412aa839ba61