### PR TITLE
backend: update decimal formatting for stablecoin txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Enable search transactions by note, address, or txid
 - Move "Export" (export transactions) to account info page
 - Show coinfinty logo when requesting an address
+- Update decimal formatting for stablecoin transactions
 
 ## v4.48.7
 - ios: fix Pocket user verification button

--- a/backend/coins/eth/coin.go
+++ b/backend/coins/eth/coin.go
@@ -158,7 +158,15 @@ func (coin *Coin) unitFactor(isFee bool) *big.Int {
 func (coin *Coin) FormatAmount(amount coinpkg.Amount, isFee bool) string {
 	factor := coin.unitFactor(isFee)
 	s := new(big.Rat).SetFrac(amount.BigInt(), factor).FloatString(18)
-	return strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	// For USDC/USDT, display 2 decimals when there's only 1
+	if coin.unit == "USDC" || coin.unit == "USDT" {
+		parts := strings.Split(s, ".")
+		if len(parts) == 2 && len(parts[1]) == 1 {
+			s += "0"
+		}
+	}
+	return s
 }
 
 // ToUnit implements coin.Coin.

--- a/backend/coins/eth/coin_test.go
+++ b/backend/coins/eth/coin_test.go
@@ -28,6 +28,8 @@ type testSuite struct {
 	suite.Suite
 	coin      *Coin
 	ERC20Coin *Coin
+	USDTCoin  *Coin
+	USDCCoin  *Coin
 }
 
 func (s *testSuite) SetupTest() {
@@ -53,6 +55,30 @@ func (s *testSuite) SetupTest() {
 		"",
 		nil,
 		erc20.NewToken("0x0000000000000000000000000000000000000001", 12),
+	)
+
+	s.USDTCoin = NewCoin(
+		nil,
+		"eth-erc20-usdt",
+		"Tether USD",
+		"USDT",
+		"ETH",
+		params.MainnetChainConfig,
+		"",
+		nil,
+		erc20.NewToken("0xdac17f958d2ee523a2206206994597c13d831ec7", 6),
+	)
+
+	s.USDCCoin = NewCoin(
+		nil,
+		"eth-erc20-usdc",
+		"USD Coin",
+		"USDC",
+		"ETH",
+		params.MainnetChainConfig,
+		"",
+		nil,
+		erc20.NewToken("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", 6),
 	)
 }
 
@@ -92,6 +118,29 @@ func (s *testSuite) TestFormatAmount() {
 		"0.123456789012345678",
 		s.ERC20Coin.FormatAmount(coin.NewAmountFromInt64(123456789012345678), true),
 	)
+
+	stablecoinTests := []struct {
+		amount   int64
+		expected string
+	}{
+		{1100000, "1.10"},
+		{1000000, "1"},
+		{1120000, "1.12"},
+		{1123000, "1.123"},
+		{100000, "0.10"},
+		{1000000000, "1000"},
+	}
+
+	for _, test := range stablecoinTests {
+		s.Require().Equal(
+			test.expected,
+			s.USDTCoin.FormatAmount(coin.NewAmountFromInt64(test.amount), false),
+		)
+		s.Require().Equal(
+			test.expected,
+			s.USDCCoin.FormatAmount(coin.NewAmountFromInt64(test.amount), false),
+		)
+	}
 }
 
 func (s *testSuite) TestSetAmount() {


### PR DESCRIPTION
Display USDT and USDC amounts with two decimal places (for values that have only one) to improve user experience.

