### PR TITLE
maintenance: do not call feeTargets for Sepolia.

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -702,11 +702,13 @@ func (account *Account) SendTx(txNote string) (string, error) {
 // If the service should not be reachable, we fallback to only one priority, estimated by
 // the ETH RPC eth_gasPrice endpoint.
 func (account *Account) feeTargets() []*ethtypes.FeeTarget {
-	etherscanFeeTargets, err := account.coin.client.FeeTargets(context.TODO())
-	if err == nil {
-		return etherscanFeeTargets
+	if account.coin.code != coin.CodeSEPETH {
+		etherscanFeeTargets, err := account.coin.client.FeeTargets(context.TODO())
+		if err == nil {
+			return etherscanFeeTargets
+		}
+		account.log.WithError(err).Error("Could not get fee targets from eth gas station, falling back to RPC eth_gasPrice")
 	}
-	account.log.WithError(err).Error("Could not get fee targets from eth gas station, falling back to RPC eth_gasPrice")
 	suggestedGasPrice, err := account.coin.client.SuggestGasPrice(context.TODO())
 	if err != nil {
 		account.log.WithError(err).Error("Fallback to RPC eth_gasPrice failed")


### PR DESCRIPTION
Etherscan's gasoracle endpoint is not supported for Sepolia, so there is no point in wasting an API call that will always return an error. For Sepolia, we immediately go to the fallback solution.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
