### PR TITLE
qt/windows: don't link libssp

### DIFF
--- a/frontends/qt/BitBox.pro
+++ b/frontends/qt/BitBox.pro
@@ -32,7 +32,6 @@ include(external/singleapplication/singleapplication.pri)
 DEFINES += QAPPLICATION_CLASS=QApplication
 
 win32 {
-    # -llibssp would be nice to have on Windows
     LIBS += -L$$PWD/server/ -llibserver
     DESTDIR = $$PWD/build/windows
     RC_ICONS += $$PWD/resources/win/icon.ico

--- a/frontends/qt/make_windows.sh
+++ b/frontends/qt/make_windows.sh
@@ -21,4 +21,3 @@ env -u MAKE -u MAKEFLAGS cmd "/C compile_windows.bat"
 cp build/assets.rcc build/windows/
 cp server/libserver.dll build/windows/
 windeployqt build/windows/BitBox.exe
-cp "$MINGW_BIN/libssp-0.dll" build/windows/

--- a/hardening.mk.inc
+++ b/hardening.mk.inc
@@ -12,7 +12,7 @@ WDEP=-Wl,--nxcompat
 WASLR=-Wl,--dynamicbase
 WASLR_UNUSED=-Wl,--high-entropy-va
 WEXPORT=-Wl,--export-all-symbols
-WLIBS=-lwinmm -lhid -lsetupapi -lws2_32 -llibssp
+WLIBS=-lwinmm -lhid -lsetupapi -lws2_32
 
 GOLNXSECFLAGS=${CFORTIFY} ${CSTACK}
 GODARWINSECFLAGS=${CFORTIFY} ${CSTACK}


### PR DESCRIPTION
https://www.msys2.org/news/?utm_source=chatgpt.com#2022-10-10-libssp-is-no-longer-required

> Building with _FORTIFY_SOURCE no longer requires explicitly linking
with libssp (-lssp) and enabling stack protection no longer pulls in libssp. This brings things in line with other platforms. Thanks to Martin Storsjö for implementing this in mingw-w64. Once all our affected packages are rebuilt we will remove the libssp package from our repo.

It seems maybe a recent GitHub Windows-2022 runner image update bumped the toolchain to one that removed libssp, as copying libssp failed with `cp: cannot stat 'C:/mingw64/bin/libssp-0.dll': No such file or directory`.

