### PR TITLE
frontend: fix supress esc key when confirming an address

### DIFF
--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -93,7 +93,7 @@ export const Dialog = ({
 
   // ESC closes dialog (fires onClose)
   useEsc(() => {
-    if (open) {
+    if (open && onClose) {
       deactivate(true);
     }
   });
@@ -109,6 +109,8 @@ export const Dialog = ({
     if (
       mouseDownTarget.current === e.currentTarget
       && e.target === e.currentTarget
+      && open
+      && onClose
     ) {
       deactivate(true);
     }
@@ -117,8 +119,10 @@ export const Dialog = ({
 
   // Close button handler
   const handleCloseClick = useCallback(() => {
-    deactivate(true);
-  }, [deactivate]);
+    if (open && onClose) {
+      deactivate(true);
+    }
+  }, [deactivate, onClose, open]);
 
   // Back button handler (mobile)
   const closeHandler = useCallback(() => {


### PR DESCRIPTION
Pressing the ESC key during address verification reloads the page with the QR code dialog.

ESC or clicking on the dialog background, should be disabled (as in previous versions) when confirming the address.
