### PR TITLE
frontend/qt: add custom title bar with window controls

### DIFF
--- a/frontends/qt/BitBox.pro
+++ b/frontends/qt/BitBox.pro
@@ -33,6 +33,7 @@ DEFINES += QAPPLICATION_CLASS=QApplication
 
 win32 {
     LIBS += -L$$PWD/server/ -llibserver
+    LIBS += -ldwmapi
     DESTDIR = $$PWD/build/windows
     RC_ICONS += $$PWD/resources/win/icon.ico
     # These flags aren't currently being respected at build time on Windows

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -302,6 +302,8 @@ int main(int argc, char *argv[])
     QWebEngineUrlScheme::registerScheme(bbappScheme);
 
     view = new WebEngineView();
+    // Use frameless window for custom title bar on all platforms
+    view->setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
     view->setGeometry(0, 0, a.devicePixelRatio() * view->width(), a.devicePixelRatio() * view->height());
     view->setMinimumSize(360, 375);
 
@@ -338,6 +340,7 @@ int main(int argc, char *argv[])
     }
 
     webClass = new WebClass();
+    webClass->setWindow(view);
 
     setupReachabilityNotifier();
 

--- a/frontends/qt/webclass.h
+++ b/frontends/qt/webclass.h
@@ -1,14 +1,75 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <QApplication>
+#include <QWidget>
+#include <QWindow>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include "libserver.h"
 
 class WebClass : public QObject
 {
     Q_OBJECT
+private:
+    QWidget* m_window;
+
+public:
+    WebClass() : m_window(nullptr) {}
+
+    void setWindow(QWidget* window) {
+        m_window = window;
+    }
+
 public slots:
     void call(int queryID, const QString& query) {
+        // Check for window control actions
+        QJsonDocument doc = QJsonDocument::fromJson(query.toUtf8());
+        if (!doc.isNull() && doc.isObject()) {
+            QJsonObject obj = doc.object();
+            QString action = obj.value("action").toString();
+
+            // Window control actions - WebChannel callbacks run on the main thread,
+            // so we can call GUI methods directly without QMetaObject::invokeMethod.
+            // We emit gotResponse to resolve the frontend Promise and prevent memory leaks.
+            if (action == "windowMinimize") {
+                if (m_window) {
+                    m_window->showMinimized();
+                }
+                emit gotResponse(queryID, QStringLiteral("{\"success\":true}"));
+                return;
+            }
+            if (action == "windowMaximize") {
+                if (m_window) {
+                    if (m_window->isMaximized()) {
+                        m_window->showNormal();
+                    } else {
+                        m_window->showMaximized();
+                    }
+                }
+                emit gotResponse(queryID, QStringLiteral("{\"success\":true}"));
+                return;
+            }
+            if (action == "windowClose") {
+                if (m_window) {
+                    m_window->close();
+                }
+                emit gotResponse(queryID, QStringLiteral("{\"success\":true}"));
+                return;
+            }
+            if (action == "windowStartDrag") {
+                if (m_window) {
+                    QWindow* handle = m_window->windowHandle();
+                    if (handle) {
+                        handle->startSystemMove();
+                    }
+                }
+                emit gotResponse(queryID, QStringLiteral("{\"success\":true}"));
+                return;
+            }
+        }
+
+        // Default: pass to backend
         backendCall(queryID, query.toUtf8().constData());
     }
 signals:

--- a/frontends/web/src/app.module.css
+++ b/frontends/web/src/app.module.css
@@ -12,6 +12,11 @@
     padding-right: env(safe-area-inset-right, 0);
 }
 
+/* Add padding for custom title bar on desktop */
+.appContent.hasTitleBar {
+    padding-top: 32px;
+}
+
 @media (max-width: 900px) {
     .appContent {
         position: absolute;

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -29,6 +29,8 @@ import { AuthRequired } from './components/auth/authrequired';
 import { WCSigningRequest } from './components/wallet-connect/incoming-signing-request';
 import { Providers } from './contexts/providers';
 import { BottomNavigation } from './components/bottom-navigation/bottom-navigation';
+import { TitleBar } from './components/titlebar/titlebar';
+import { runningInQtWebEngine } from './utils/env';
 import styles from './app.module.css';
 
 export const App = () => {
@@ -37,6 +39,13 @@ export const App = () => {
   const navigate = useNavigate();
   useIgnoreDrop();
   useAppReady();
+
+  // Add body class for Qt desktop styling (frameless title bar)
+  useEffect(() => {
+    if (runningInQtWebEngine()) {
+      document.body.classList.add('qtwebengine');
+    }
+  }, []);
 
   const accounts = useDefault(useSync(getAccounts, syncAccountsList), []);
   const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});
@@ -165,12 +174,14 @@ export const App = () => {
 
   const isBitboxBootloader = firstDevice && devices[firstDevice] === 'bitbox02-bootloader';
   const showBottomNavigation = (deviceIDs.length > 0 || activeAccounts.length > 0) && !isBitboxBootloader;
+  const showTitleBar = runningInQtWebEngine();
 
 
   return (
     <ConnectedApp>
       <Providers>
         <Darkmode />
+        <TitleBar show={showTitleBar} />
         <div className="app">
           <AuthRequired/>
           <Sidebar
@@ -180,6 +191,7 @@ export const App = () => {
           <div className={`
             ${styles.appContent || ''}
             ${showBottomNavigation && styles.hasBottomNavigation || ''}
+            ${showTitleBar && styles.hasTitleBar || ''}
           `}>
             <WCSigningRequest />
             <Aopp />

--- a/frontends/web/src/components/guide/guide.module.css
+++ b/frontends/web/src/components/guide/guide.module.css
@@ -10,6 +10,14 @@
     z-index: -1;
 }
 
+/* Offset overlay for custom title bar in Qt desktop */
+@media (min-width: 1200px) {
+    :global(.qtwebengine) .overlay {
+        top: 32px;
+        height: calc(100% - 32px);
+    }
+}
+
 .close {
     display: flex;
     height: 2.4rem;
@@ -142,26 +150,33 @@
 }
 
 @media screen and (max-width: 1601px) {
-    .overlay.show {
+    .overlay {
+        z-index: 4001;
+        pointer-events: none;
+    }
+
+    :global(.guideOpen) .overlay {
         opacity: 1;
+        pointer-events: auto;
     }
 
     .guide {
         margin-right: 0;
         max-width: 460px;
-        opacity: 0;
         position: fixed;
         right: 0;
         top: 0;
         transform: translateX(100%);
+        transition: margin-right 0.2s ease, transform 0.2s ease;
         transition-delay: 0.2s;
         width: 100%;
-        z-index: -10;
+        z-index: 4002;
     }
 
-    .show {
-        opacity: 1;
-        z-index: 4002;
+    /* Offset guide for custom title bar in Qt desktop */
+    :global(.qtwebengine) .guide {
+        top: 32px;
+        height: calc(100vh - 32px);
     }
 
     .guide.show {

--- a/frontends/web/src/components/guide/guide.tsx
+++ b/frontends/web/src/components/guide/guide.tsx
@@ -25,10 +25,22 @@ const Guide = ({ children, title = t('guide.title') }: TProps) => {
     };
   }, [setGuideExists]);
 
+  // Add/remove body class for title bar dimming
+  useEffect(() => {
+    if (guideShown) {
+      document.body.classList.add('guideOpen');
+    } else {
+      document.body.classList.remove('guideOpen');
+    }
+    return () => {
+      document.body.classList.remove('guideOpen');
+    };
+  }, [guideShown]);
+
   const { t } = useTranslation();
   return (
     <div className={style.wrapper}>
-      <div className={[style.overlay, guideShown && style.show].join(' ')} onClick={toggleGuide}></div>
+      <div className={style.overlay} onClick={toggleGuide}></div>
       <div className={[style.guide, guideShown && style.show].join(' ')}>
         <div className={[style.header, 'flex flex-row flex-between flex-items-center'].join(' ')}>
           <h2>{title}</h2>

--- a/frontends/web/src/components/sidebar/sidebar.module.css
+++ b/frontends/web/src/components/sidebar/sidebar.module.css
@@ -195,6 +195,11 @@ a.sidebarActive .single img,
     }
 }
 
+/* Add padding for title bar when running in Qt desktop */
+:global(.qtwebengine) .sidebar {
+    padding-top: 32px;
+}
+
 @media (min-width: 1200px) {
     .sidebar {
         position: relative;

--- a/frontends/web/src/components/titlebar/titlebar.module.css
+++ b/frontends/web/src/components/titlebar/titlebar.module.css
@@ -48,7 +48,7 @@
     position: relative;
 }
 
-/* Dim overlay for content section when guide is open */
+/* Dim overlay for content section when guide is open (uses opacity transition - fades) */
 .contentSection::after {
     content: '';
     position: absolute;
@@ -64,6 +64,32 @@
 
 :global(.guideOpen) .contentSection::after {
     opacity: 1;
+}
+
+/* Separate overlay for sidebar dimming (uses visibility - instant hide) */
+.sidebarDimOverlay {
+    display: none;
+}
+
+@media (max-width: 1199px) {
+    .sidebarDimOverlay {
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: rgba(0, 0, 0, 0.3);
+        pointer-events: none;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity ease 0.2s;
+    }
+
+    .sidebarDimOverlayActive {
+        opacity: 1;
+        visibility: visible;
+    }
 }
 
 /* Blue section above the guide panel - matches guide's exact animation */
@@ -224,16 +250,34 @@
     }
 }
 
-/* Responsive: When sidebar is not fixed, hide sidebar section and reposition controls */
+/* Responsive: When sidebar is not fixed, collapse sidebar section with animation */
 @media (max-width: 1199px) {
     .sidebarSection {
-        display: none;
+        width: 0;
+        transition: width 0.2s ease;
     }
 
-    /* Move macOS traffic lights to left side of content area */
+    /* Expand dark section when sidebar is open */
+    .sidebarSectionExpanded {
+        width: var(--sidebar-width-large);
+    }
+
+    /* Keep macOS traffic lights fixed at left edge of viewport */
     :global(.os-macos) .windowControls {
-        position: static;
-        margin-left: 12px;
-        margin-right: auto;
+        position: fixed;
+        left: 12px;
+        top: 0;
+        height: 32px;
+    }
+}
+
+/* Very small screens: sidebar takes full width with slower animation */
+@media (max-width: 560px) {
+    .sidebarSection {
+        transition: width 0.3s ease;
+    }
+
+    .sidebarSectionExpanded {
+        width: 100vw;
     }
 }

--- a/frontends/web/src/components/titlebar/titlebar.module.css
+++ b/frontends/web/src/components/titlebar/titlebar.module.css
@@ -1,0 +1,239 @@
+.titleBar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 32px;
+    display: flex;
+    flex-direction: row;
+    z-index: 5000;
+    -webkit-app-region: drag;
+    user-select: none;
+    -webkit-user-select: none;
+}
+
+/* Dark section above the sidebar */
+.sidebarSection {
+    width: var(--sidebar-width-large);
+    background-color: var(--background-dark);
+    flex-shrink: 0;
+    position: relative;
+}
+
+/* Dim overlay for sidebar section when guide is open */
+.sidebarSection::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity ease 0.2s;
+}
+
+:global(.guideOpen) .sidebarSection::after {
+    opacity: 1;
+}
+
+/* Content section with theme-based background */
+.contentSection {
+    flex: 1;
+    background-color: var(--background);
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    position: relative;
+}
+
+/* Dim overlay for content section when guide is open */
+.contentSection::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity ease 0.2s;
+}
+
+:global(.guideOpen) .contentSection::after {
+    opacity: 1;
+}
+
+/* Blue section above the guide panel - matches guide's exact animation */
+.guideSection {
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 100%;
+    width: var(--guide-width);
+    background-color: var(--color-blue);
+    margin-right: calc(var(--guide-width) * -1);
+    transition: margin-right 0.2s ease, transform 0.2s ease;
+}
+
+:global(.guideOpen) .guideSection {
+    margin-right: 0;
+}
+
+/* Window control buttons container */
+.windowControls {
+    display: flex;
+    height: 100%;
+    -webkit-app-region: no-drag;
+}
+
+/* Individual control button */
+.controlButton {
+    width: 46px;
+    height: 32px;
+    border: none;
+    background-color: transparent;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    outline: none;
+    transition: background-color 0.15s ease;
+}
+
+.controlButton:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.controlButton:active {
+    background-color: rgba(0, 0, 0, 0.15);
+}
+
+/* Button type classes for platform-specific styling */
+.minimizeButton,
+.maximizeButton {
+    /* Base styles inherited from .controlButton */
+}
+
+/* Close button special styling (Windows/Linux) */
+.closeButton:hover {
+    background-color: #E81123;
+}
+
+.closeButton:hover .controlIcon {
+    stroke: white;
+}
+
+.closeButton:active {
+    background-color: #C50F1F;
+}
+
+/* SVG icon styling */
+.controlIcon {
+    width: 10px;
+    height: 10px;
+    stroke: var(--color-secondary);
+    stroke-width: 1;
+    fill: none;
+    transition: stroke 0.15s ease;
+}
+
+.controlButton:hover .controlIcon {
+    stroke: var(--color-default);
+}
+
+/* Dark mode adjustments */
+:global(.dark-mode) .controlButton:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+:global(.dark-mode) .controlButton:active {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+/* macOS: Position controls on the left in the dark sidebar area */
+/* Offset by sidebar width since windowControls is inside contentSection which has position:relative */
+:global(.os-macos) .windowControls {
+    position: absolute;
+    left: calc(-1 * var(--sidebar-width-large) + 12px);
+    top: 0;
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+
+:global(.os-macos) .controlButton {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    margin: 0 4px;
+    padding: 0;
+    min-width: 12px;
+}
+
+:global(.os-macos) .controlButton .controlIcon {
+    display: none;
+}
+
+/* macOS button order: close, minimize, maximize (left to right) */
+:global(.os-macos) .closeButton {
+    order: 1;
+    background-color: #FF5F57;
+}
+
+:global(.os-macos) .minimizeButton {
+    order: 2;
+    background-color: #FEBC2E;
+}
+
+:global(.os-macos) .maximizeButton {
+    order: 3;
+    background-color: #28C840;
+}
+
+:global(.os-macos) .closeButton:hover {
+    background-color: #FF5F57;
+    filter: brightness(0.85);
+}
+
+:global(.os-macos) .minimizeButton:hover {
+    background-color: #FEBC2E;
+    filter: brightness(0.85);
+}
+
+:global(.os-macos) .maximizeButton:hover {
+    background-color: #28C840;
+    filter: brightness(0.85);
+}
+
+/* Match guide panel's behavior on smaller desktop screens - switches to transform */
+@media screen and (max-width: 1601px) {
+    .guideSection {
+        width: 100%;
+        max-width: 460px;
+        margin-right: 0;
+        transform: translateX(100%);
+        transition-delay: 0.2s;
+    }
+
+    :global(.guideOpen) .guideSection {
+        transform: translateX(0%);
+    }
+}
+
+/* Responsive: When sidebar is not fixed, hide sidebar section and reposition controls */
+@media (max-width: 1199px) {
+    .sidebarSection {
+        display: none;
+    }
+
+    /* Move macOS traffic lights to left side of content area */
+    :global(.os-macos) .windowControls {
+        position: static;
+        margin-left: 12px;
+        margin-right: auto;
+    }
+}

--- a/frontends/web/src/components/titlebar/titlebar.tsx
+++ b/frontends/web/src/components/titlebar/titlebar.tsx
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { useContext } from 'react';
 import { call } from '@/utils/transport-qt';
 import { runningInQtWebEngine } from '@/utils/env';
+import { AppContext } from '@/contexts/AppContext';
 import styles from './titlebar.module.css';
 
 const callWindowControl = (action: string) => {
@@ -45,6 +47,8 @@ type TitleBarProps = {
 };
 
 export const TitleBar = ({ show }: TitleBarProps) => {
+  const { activeSidebar } = useContext(AppContext);
+
   if (!show) {
     return null;
   }
@@ -55,11 +59,13 @@ export const TitleBar = ({ show }: TitleBarProps) => {
       onMouseDown={handleStartDrag}
       onDoubleClick={handleDoubleClick}
     >
-      {/* Dark section above sidebar */}
-      <div className={styles.sidebarSection} />
+      {/* Dark section above sidebar - animates with sidebar expand/collapse */}
+      <div className={`${styles.sidebarSection || ''} ${activeSidebar ? styles.sidebarSectionExpanded || '' : ''}`} />
 
       {/* Content section with theme-based background */}
-      <div className={styles.contentSection}>
+      <div className={styles.contentSection || ''}>
+        {/* Separate overlay for sidebar dimming - uses visibility for instant hide */}
+        <div className={`${styles.sidebarDimOverlay || ''} ${activeSidebar ? styles.sidebarDimOverlayActive || '' : ''}`} />
         {/* Window controls - hidden on macOS (uses native traffic lights) */}
         <div className={styles.windowControls}>
           <button

--- a/frontends/web/src/components/titlebar/titlebar.tsx
+++ b/frontends/web/src/components/titlebar/titlebar.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { call } from '@/utils/transport-qt';
+import { runningInQtWebEngine } from '@/utils/env';
+import styles from './titlebar.module.css';
+
+const callWindowControl = (action: string) => {
+  if (!runningInQtWebEngine()) {
+    return;
+  }
+  // Use the existing Qt transport to call window control methods
+  call(JSON.stringify({ action }));
+};
+
+const handleMinimize = () => {
+  callWindowControl('windowMinimize');
+};
+
+const handleMaximize = () => {
+  callWindowControl('windowMaximize');
+};
+
+const handleClose = () => {
+  callWindowControl('windowClose');
+};
+
+const handleStartDrag = (e: React.MouseEvent) => {
+  // Only start drag if clicking directly on the title bar, not on buttons
+  if ((e.target as HTMLElement).closest('button')) {
+    return;
+  }
+  callWindowControl('windowStartDrag');
+};
+
+const handleDoubleClick = (e: React.MouseEvent) => {
+  // Toggle maximize on double-click (not on buttons)
+  if ((e.target as HTMLElement).closest('button')) {
+    return;
+  }
+  callWindowControl('windowMaximize');
+};
+
+type TitleBarProps = {
+  show: boolean;
+};
+
+export const TitleBar = ({ show }: TitleBarProps) => {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <div
+      className={styles.titleBar}
+      onMouseDown={handleStartDrag}
+      onDoubleClick={handleDoubleClick}
+    >
+      {/* Dark section above sidebar */}
+      <div className={styles.sidebarSection} />
+
+      {/* Content section with theme-based background */}
+      <div className={styles.contentSection}>
+        {/* Window controls - hidden on macOS (uses native traffic lights) */}
+        <div className={styles.windowControls}>
+          <button
+            type="button"
+            className={`${styles.controlButton || ''} ${styles.minimizeButton || ''}`}
+            onClick={handleMinimize}
+            aria-label="Minimize"
+          >
+            <svg viewBox="0 0 12 12" className={styles.controlIcon}>
+              <line x1="2" y1="6" x2="10" y2="6" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            className={`${styles.controlButton || ''} ${styles.maximizeButton || ''}`}
+            onClick={handleMaximize}
+            aria-label="Maximize"
+          >
+            <svg viewBox="0 0 12 12" className={styles.controlIcon}>
+              <rect x="2" y="2" width="8" height="8" fill="none" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            className={`${styles.controlButton || ''} ${styles.closeButton || ''}`}
+            onClick={handleClose}
+            aria-label="Close"
+          >
+            <svg viewBox="0 0 12 12" className={styles.controlIcon}>
+              <line x1="2" y1="2" x2="10" y2="10" />
+              <line x1="10" y1="2" x2="2" y2="10" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Blue section above guide - appears when guide is open */}
+      <div className={styles.guideSection} />
+    </div>
+  );
+};

--- a/frontends/web/src/style/base.css
+++ b/frontends/web/src/style/base.css
@@ -24,7 +24,6 @@ body {
     width: 100%;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-	  -webkit-app-region: drag;
 }
 
 /*


### PR DESCRIPTION
Replace native window frame with custom frameless title bar that provides  consistent styling across platforms.

Qt backend changes:
- Enable frameless window mode (Qt::FramelessWindowHint)
- Add window control handlers (minimize, maximize, close, drag)
- Use startSystemMove() for native window dragging

 Frontend changes:
- Add TitleBar component with minimize/maximize/close buttons
- Platform-specific styling: macOS traffic lights on left,  Windows/Linux controls on right
- Title bar sections match app layout (dark sidebar, themed content,  blue guide)
- Dim title bar sections when guide panel is open
- Adjust sidebar, guide, and content padding to accommodate 32px title  bar
- Responsive behavior: hide sidebar section when sidebar is not fixed

Remove -webkit-app-region: drag from body as dragging is now handled by the title bar component.
