### PR TITLE
frontend: support dismissing testing warning per session

### DIFF
--- a/frontends/web/src/components/banners/backup.tsx
+++ b/frontends/web/src/components/banners/backup.tsx
@@ -61,7 +61,7 @@ export const BackupReminder = ({ keystore, accountsBalanceSummary }: BackupRemin
     <Status
       type="info"
       hidden={!bannerResponse.show}
-      dismissible={`banner-backup-${keystore.rootFingerprint}`}>
+      dismissibleKey={`banner-backup-${keystore.rootFingerprint}`}>
       <MultilineMarkup
         tagName="span"
         withBreaks

--- a/frontends/web/src/components/banners/banner.tsx
+++ b/frontends/web/src/components/banners/banner.tsx
@@ -38,7 +38,7 @@ export const Banner = ({ msgKey }: TBannerProps) => {
 
   return (
     <Status
-      dismissible={banner.dismissible ? `banner-${msgKey}-${banner.id}` : ''}
+      dismissibleKey={banner.dismissible ? `banner-${msgKey}-${banner.id}` : ''}
       type={banner.type ? banner.type : 'warning'}>
       {message[i18n.resolvedLanguage] || message[maybeFallbackLng || 'en']}
       &nbsp;

--- a/frontends/web/src/components/banners/mobiledatawarning.tsx
+++ b/frontends/web/src/components/banners/mobiledatawarning.tsx
@@ -13,7 +13,7 @@ export const MobileDataWarning = () => {
   }
   return (
     <Status
-      dismissible="mobile-data-warning"
+      dismissibleKey="mobile-data-warning"
       type="warning"
       hidden={!isUsingMobileData}>
       {t('mobile.usingMobileDataWarning')}

--- a/frontends/web/src/components/banners/testing.tsx
+++ b/frontends/web/src/components/banners/testing.tsx
@@ -16,7 +16,7 @@ export const Testing = () => {
   return (
     <SessionStatus
       type="warning"
-      dismissible="omg">
+      dismissibleKey="skipTestingWarning">
       {t('warning.testnet')}
     </SessionStatus>
   );

--- a/frontends/web/src/components/banners/testing.tsx
+++ b/frontends/web/src/components/banners/testing.tsx
@@ -3,7 +3,7 @@
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppContext } from '@/contexts/AppContext';
-import { Message } from '@/components/message/message';
+import { SessionStatus } from '@/components/status/status-session';
 
 export const Testing = () => {
   const { t } = useTranslation();
@@ -14,8 +14,10 @@ export const Testing = () => {
   }
 
   return (
-    <Message type="warning">
+    <SessionStatus
+      type="warning"
+      dismissible="omg">
       {t('warning.testnet')}
-    </Message>
+    </SessionStatus>
   );
 };

--- a/frontends/web/src/components/banners/update.tsx
+++ b/frontends/web/src/components/banners/update.tsx
@@ -15,7 +15,7 @@ export const Update = () => {
     return null;
   }
   return (
-    <Status dismissible={`update-${file.version}`} type="info">
+    <Status dismissibleKey={`update-${file.version}`} type="info">
       {t('app.upgrade', {
         current: file.current,
         version: file.version,

--- a/frontends/web/src/components/status/status-session.tsx
+++ b/frontends/web/src/components/status/status-session.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactNode, useCallback, useEffect, useState } from 'react';
-import { getConfig, setConfig } from '@/utils/config';
+import { ReactNode, useContext, useEffect, useState } from 'react';
+import { AppContext } from '@/contexts/AppContext';
 import { CloseXDark, CloseXWhite } from '@/components/icon';
 import { useDarkmode } from '@/hooks/darkmode';
 import { Message } from '@/components/message/message';
@@ -12,15 +12,15 @@ type TProps = {
   hidden?: boolean;
   type?: TMessageTypes;
   noIcon?: boolean;
-  // used as keyName in the config if dismissing the status should be persisted, so it is not
-  // shown again. Use an empty string if it should be dismissible without storing it in the
+  // used as keyName in a temporary config object. Dismissing the status is temporary and kept per session (until app is closed)
+  // Use an empty string if it should be dismissible without storing it in the
   // config, so the status will be shown again the next time.
   dismissible: string;
   className?: string;
   children: ReactNode;
 };
 
-export const Status = ({
+export const SessionStatus = ({
   hidden,
   type = 'warning',
   noIcon = false,
@@ -28,30 +28,24 @@ export const Status = ({
   className = '',
   children,
 }: TProps) => {
+  const { sessionConfig, updateSessionConfig } = useContext(AppContext);
   // note: dismissible can be falsy i.e. empty string ''
   const [show, setShow] = useState(dismissible ? false : true);
 
   const { isDarkMode } = useDarkmode();
 
-  const checkConfig = useCallback(async () => {
-    if (dismissible) {
-      const config = await getConfig();
-      setShow(!config ? true : !config.frontend[dismissible]);
-    }
-  }, [dismissible]);
-
   useEffect(() => {
-    checkConfig();
-  }, [checkConfig]);
+    if (dismissible) {
+      setShow(!sessionConfig[dismissible]);
+    }
+  }, [dismissible, sessionConfig]);
 
   const dismiss = async () => {
     if (!dismissible) {
       return;
     }
-    setConfig({
-      frontend: {
-        [dismissible]: true,
-      }
+    updateSessionConfig({
+      [dismissible]: true,
     });
     setShow(false);
   };

--- a/frontends/web/src/components/status/status-session.tsx
+++ b/frontends/web/src/components/status/status-session.tsx
@@ -13,9 +13,9 @@ type TProps = {
   type?: TMessageTypes;
   noIcon?: boolean;
   // used as keyName in a temporary config object. Dismissing the status is temporary and kept per session (until app is closed)
-  // Use an empty string if it should be dismissible without storing it in the
-  // config, so the status will be shown again the next time.
-  dismissible: string;
+  // Use an empty string if it should be dismissible without storing it in the session  config,
+  // so the status will be shown again on next mount.
+  dismissibleKey: string;
   className?: string;
   children: ReactNode;
 };
@@ -24,28 +24,28 @@ export const SessionStatus = ({
   hidden,
   type = 'warning',
   noIcon = false,
-  dismissible,
+  dismissibleKey,
   className = '',
   children,
 }: TProps) => {
   const { sessionConfig, updateSessionConfig } = useContext(AppContext);
   // note: dismissible can be falsy i.e. empty string ''
-  const [show, setShow] = useState(dismissible ? false : true);
+  const [show, setShow] = useState(dismissibleKey ? false : true);
 
   const { isDarkMode } = useDarkmode();
 
   useEffect(() => {
-    if (dismissible) {
-      setShow(!sessionConfig[dismissible]);
+    if (dismissibleKey) {
+      setShow(!sessionConfig[dismissibleKey]);
     }
-  }, [dismissible, sessionConfig]);
+  }, [dismissibleKey, sessionConfig]);
 
   const dismiss = async () => {
-    if (!dismissible) {
+    if (!dismissibleKey) {
       return;
     }
     updateSessionConfig({
-      [dismissible]: true,
+      [dismissibleKey]: true,
     });
     setShow(false);
   };
@@ -62,7 +62,7 @@ export const SessionStatus = ({
             {children}
           </div>
           <button
-            hidden={!dismissible}
+            hidden={!dismissibleKey}
             className={style.closeButton}
             onClick={dismiss}
           >

--- a/frontends/web/src/components/status/status.tsx
+++ b/frontends/web/src/components/status/status.tsx
@@ -15,7 +15,7 @@ type TProps = {
   // used as keyName in the config if dismissing the status should be persisted, so it is not
   // shown again. Use an empty string if it should be dismissible without storing it in the
   // config, so the status will be shown again the next time.
-  dismissible: string;
+  dismissibleKey: string;
   className?: string;
   children: ReactNode;
 };
@@ -24,33 +24,33 @@ export const Status = ({
   hidden,
   type = 'warning',
   noIcon = false,
-  dismissible,
+  dismissibleKey,
   className = '',
   children,
 }: TProps) => {
   // note: dismissible can be falsy i.e. empty string ''
-  const [show, setShow] = useState(dismissible ? false : true);
+  const [show, setShow] = useState(dismissibleKey ? false : true);
 
   const { isDarkMode } = useDarkmode();
 
   const checkConfig = useCallback(async () => {
-    if (dismissible) {
+    if (dismissibleKey) {
       const config = await getConfig();
-      setShow(!config ? true : !config.frontend[dismissible]);
+      setShow(!config ? true : !config.frontend[dismissibleKey]);
     }
-  }, [dismissible]);
+  }, [dismissibleKey]);
 
   useEffect(() => {
     checkConfig();
   }, [checkConfig]);
 
   const dismiss = async () => {
-    if (!dismissible) {
+    if (!dismissibleKey) {
       return;
     }
     setConfig({
       frontend: {
-        [dismissible]: true,
+        [dismissibleKey]: true,
       }
     });
     setShow(false);
@@ -68,7 +68,7 @@ export const Status = ({
             {children}
           </div>
           <button
-            hidden={!dismissible}
+            hidden={!dismissibleKey}
             className={style.closeButton}
             onClick={dismiss}
           >

--- a/frontends/web/src/contexts/AppContext.tsx
+++ b/frontends/web/src/contexts/AppContext.tsx
@@ -4,6 +4,10 @@ import { Dispatch, SetStateAction, createContext } from 'react';
 
 export type TChartDisplay = 'week' | 'month' | 'year' | 'all';
 
+export type TSessionConfig = {
+  [key: string]: boolean;
+};
+
 type AppContextProps = {
   activeSidebar: boolean;
   guideShown: boolean;
@@ -23,6 +27,8 @@ type AppContextProps = {
   toggleGuide: () => void;
   toggleHideAmounts: () => void;
   toggleSidebar: () => void;
+  sessionConfig: TSessionConfig;
+  updateSessionConfig: (config: TSessionConfig) => void;
 };
 
 const AppContext = createContext<AppContextProps>({} as AppContextProps);

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -9,7 +9,7 @@ import { getNativeLocale } from '@/api/nativelocale';
 import { getDevServers, getTesting } from '@/api/backend';
 import { getOnline, subscribeOnline } from '@/api/online';
 import { i18nextFormat } from '@/i18n/utils';
-import type { TChartDisplay } from './AppContext';
+import type { TChartDisplay, TSessionConfig } from './AppContext';
 import { useOrientation } from '@/hooks/orientation';
 import { useMediaQuery } from '@/hooks/mediaquery';
 import { useSync } from '@/hooks/api';
@@ -29,6 +29,7 @@ export const AppProvider = ({ children }: TProps) => {
   const [activeSidebar, setActiveSidebar] = useState(false);
   const [chartDisplay, setChartDisplay] = useState<TChartDisplay>('all');
   const [firmwareUpdateDialogOpen, setFirmwareUpdateDialogOpen] = useState(false);
+  const [tmpConfig, setTmpConfig] = useState<TSessionConfig>({});
 
   const orientation = useOrientation();
   const isMobile = useMediaQuery('(max-width: 768px)');
@@ -45,6 +46,13 @@ export const AppProvider = ({ children }: TProps) => {
 
   const toggleSidebar = () => {
     setActiveSidebar(prev => !prev);
+  };
+
+  const updateSessionConfig = (object: TSessionConfig) => {
+    setTmpConfig(old => ({
+      ...old,
+      ...object,
+    }));
   };
 
   useEffect(() => {
@@ -88,7 +96,9 @@ export const AppProvider = ({ children }: TProps) => {
         toggleHideAmounts,
         toggleSidebar,
         setFirmwareUpdateDialogOpen,
-        firmwareUpdateDialogOpen
+        firmwareUpdateDialogOpen,
+        sessionConfig: tmpConfig,
+        updateSessionConfig,
       }}>
       {children}
     </AppContext.Provider>

--- a/frontends/web/src/routes/account/walletconnect/dashboard.tsx
+++ b/frontends/web/src/routes/account/walletconnect/dashboard.tsx
@@ -76,7 +76,7 @@ export const DashboardWalletConnect = ({ code, accounts }: TProps) => {
           <ContentWrapper>
             <Status
               type="info"
-              dismissible="walletConnectDisclaimerDismissed"
+              dismissibleKey="walletConnectDisclaimerDismissed"
             >
               {t('walletConnect.dashboard.disclaimer')}
             </Status>


### PR DESCRIPTION
- Added SessionStatus component that can be dismissed per session

The testnet warning should show up everytime the app starts in testnet mode, but can now be dismissed per app session. This helps removing clutter for demonstration purpuses.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
