### PR TITLE
frontend/tx-detail-dialog: fix To label

### DIFF
--- a/frontends/web/src/components/transactions/components/tx-detail-dialog/tx-detail-dialog.tsx
+++ b/frontends/web/src/components/transactions/components/tx-detail-dialog/tx-detail-dialog.tsx
@@ -99,7 +99,7 @@ export const TxDetailsDialog = ({
 
           {/* to or send address */}
           <TxDetailRow>
-            <p className={styles.label}>{type === 'receive' ? t('transaction.details.from') : t('send.confirm.to')}</p>
+            <p className={styles.label}>{t('send.confirm.to')}</p>
             <AddressOrTxId values={transactionInfo.addresses} />
           </TxDetailRow>
 

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1958,7 +1958,6 @@
       "currentValue": "Current value",
       "date": "Date",
       "fiatAmount": "Fiat amount",
-      "from": "From",
       "historicalValue": "Historical value",
       "sentToSelf": "Sent to self",
       "status": "Status",


### PR DESCRIPTION
The field always shows recipient address(es), not the sending address.
