### PR TITLE
frontend: use numeric keyboard for coin and fiat input on ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Revamp portfolio / account summary detail (table)
 - Sort wallets by name first, then by root fingerprint when names match.
 - Persist account receive script type
+- Use numeric keyboard for coin and fiat input on ios
 
 ## v4.50.1
 - Fix a bug that would delay showing watch-only accounts.

--- a/frontends/web/src/components/forms/input-number.tsx
+++ b/frontends/web/src/components/forms/input-number.tsx
@@ -75,6 +75,7 @@ export const NumberInput = (({
     <Input
       {...props}
       type="number"
+      inputMode="numeric"
       onInput={onChange}
       onPaste={handlePaste}
     />

--- a/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
@@ -31,6 +31,7 @@ export const CoinInput = ({
   return (
     <Input
       type="number"
+      inputMode="numeric"
       step="any"
       min="0"
       label={balance ? balance.available.unit : t('send.amount.label')}


### PR DESCRIPTION
For better UX any input that can only hold number as a value should use number-keyboad.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [x] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
