### PR TITLE
frontend: gate swap behind connected multi.

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -65,6 +65,7 @@ type Backend interface {
 	Accounts() backend.AccountsList
 	PrepareSwap(buyAccountCode, sellAccountCode accountsTypes.Code, routeID, sellAmount string) (*backend.SwapPreparation, error)
 	SwapAccounts() (backend.SwapAccounts, error)
+	SwapStatus() backend.SwapStatus
 	AccountsByKeystore() (backend.KeystoresAccountsListMap, error)
 	AccountsFiatAndCoinBalance(backend.AccountsList, string) (*big.Rat, map[coinpkg.Code]*big.Int, error)
 	Keystore() keystore.Keystore
@@ -216,6 +217,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/keystore/{rootFingerprint}/features", handlers.getKeystoreFeatures).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts", handlers.getAccounts).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/swap/accounts", handlers.getSwapAccounts).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/swap/status", handlers.getSwapStatus).Methods("GET")
 	getAPIRouter(apiRouter)("/accounts/balance-summary", handlers.getAccountsBalanceSummary).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/set-account-active", handlers.postSetAccountActive).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/set-token-active", handlers.postSetTokenActive).Methods("POST")
@@ -793,6 +795,10 @@ func (handlers *Handlers) getSwapAccounts(*http.Request) interface{} {
 		result.BuyAccounts[i] = newSwapAccountJSON(account)
 	}
 	return result
+}
+
+func (handlers *Handlers) getSwapStatus(*http.Request) interface{} {
+	return handlers.backend.SwapStatus()
 }
 
 func (handlers *Handlers) lookupEthAccountCode(r *http.Request) interface{} {

--- a/backend/swap.go
+++ b/backend/swap.go
@@ -55,6 +55,21 @@ type SwapAccounts struct {
 	DefaultBuyAccountCode  *accountsTypes.Code
 }
 
+// SwapConnectedKeystore describes whether the currently connected keystore is absent, multi, or btc-only.
+type SwapConnectedKeystore string
+
+const (
+	swapConnectedKeystoreNone    SwapConnectedKeystore = "none"
+	swapConnectedKeystoreMulti   SwapConnectedKeystore = "multi"
+	swapConnectedKeystoreBTCOnly SwapConnectedKeystore = "btc-only"
+)
+
+// SwapStatus summarizes whether swap should be shown at all and what kind of keystore is connected right now.
+type SwapStatus struct {
+	Available         bool                  `json:"available"`
+	ConnectedKeystore SwapConnectedKeystore `json:"connectedKeystore"`
+}
+
 // SwapAccounts returns the accounts that can be selected in the swap screen.
 func (backend *Backend) SwapAccounts() (SwapAccounts, error) {
 	sellAccounts, buyAccounts, err := backend.swapAccounts()
@@ -69,6 +84,52 @@ func (backend *Backend) SwapAccounts() (SwapAccounts, error) {
 		DefaultSellAccountCode: defaultSellAccountCode,
 		DefaultBuyAccountCode:  defaultBuyAccountCode,
 	}, nil
+}
+
+// swapAvailable reports whether swap can be shown. It is available when there is at least one
+// non-Bitcoin account currently available, including watch-only and inactive accounts.
+func (backend *Backend) swapAvailable() bool {
+	for _, account := range backend.Accounts() {
+		accountConfig := account.Config().Config
+		if accountConfig.HiddenBecauseUnused {
+			continue
+		}
+		if _, isTestnet := coinpkg.TestnetCoins[accountConfig.CoinCode]; isTestnet != backend.Testing() {
+			continue
+		}
+		if account.Coin().Code() == coinpkg.CodeBTC {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// swapConnectedKeystore reports whether the currently connected keystore is absent, multi, or btc-only.
+func (backend *Backend) swapConnectedKeystore() SwapConnectedKeystore {
+	connectedKeystore := backend.Keystore()
+	if connectedKeystore == nil {
+		return swapConnectedKeystoreNone
+	}
+	for _, coinCode := range []coinpkg.Code{coinpkg.CodeLTC, coinpkg.CodeETH} {
+		coin, err := backend.Coin(coinCode)
+		if err != nil {
+			continue
+		}
+		if connectedKeystore.SupportsCoin(coin) {
+			return swapConnectedKeystoreMulti
+		}
+	}
+	return swapConnectedKeystoreBTCOnly
+}
+
+// SwapStatus combines the broad swap availability signal with the current connected keystore state.
+// This lets callers distinguish between "swap exists", "a multi device is connected", and "only a btc-only device is connected".
+func (backend *Backend) SwapStatus() SwapStatus {
+	return SwapStatus{
+		Available:         backend.swapAvailable(),
+		ConnectedKeystore: backend.swapConnectedKeystore(),
+	}
 }
 
 func (backend *Backend) connectedKeystoreConfig() (*config.Keystore, error) {

--- a/backend/swap_test.go
+++ b/backend/swap_test.go
@@ -410,3 +410,182 @@ func TestSwapAccountsDefaultSellFallsBackToFirstAvailableWhenAllBalancesAreZero(
 	require.NotNil(t, swapAccounts.DefaultBuyAccountCode)
 	require.Equal(t, accountsTypes.Code("v0-55555555-eth-0"), *swapAccounts.DefaultBuyAccountCode)
 }
+
+func TestSwapAvailable(t *testing.T) {
+	t.Run("false when no keystore is connected", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		require.False(t, b.swapAvailable())
+	})
+
+	t.Run("false when connected keystore has only bitcoin accounts", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		ks := makeBitBox02BTCOnly()
+		ks.RootFingerprintFunc = func() ([]byte, error) {
+			return rootFingerprint1, nil
+		}
+		b.registerKeystore(ks)
+
+		require.False(t, b.swapAvailable())
+	})
+
+	t.Run("true when connected keystore has inactive non-bitcoin account", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		ks := makeBitBox02Multi()
+		ks.RootFingerprintFunc = func() ([]byte, error) {
+			return rootFingerprint1, nil
+		}
+		b.registerKeystore(ks)
+		require.NoError(t, b.SetAccountActive("v0-55555555-eth-0", false))
+
+		ltcAccountCode, err := b.CreateAndPersistAccountConfig(coinpkg.CodeLTC, "Litecoin account name 2", ks)
+		require.NoError(t, err)
+		require.NoError(t, b.SetAccountActive(ltcAccountCode, false))
+
+		require.True(t, b.swapAvailable())
+	})
+
+	t.Run("true when watch-only account is enabled", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		ks := makeBitBox02Multi()
+		rootFingerprint, err := ks.RootFingerprint()
+		require.NoError(t, err)
+
+		b.registerKeystore(ks)
+		require.NoError(t, b.SetWatchonly(rootFingerprint, true))
+		b.DeregisterKeystore()
+
+		require.True(t, b.swapAvailable())
+	})
+
+	t.Run("false when only bitcoin watch-only account is enabled", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		ks := makeBitBox02BTCOnly()
+		rootFingerprint, err := ks.RootFingerprint()
+		require.NoError(t, err)
+
+		b.registerKeystore(ks)
+		require.NoError(t, b.SetWatchonly(rootFingerprint, true))
+		b.DeregisterKeystore()
+
+		require.False(t, b.swapAvailable())
+	})
+
+	t.Run("false when btc-only keystore shares a seed with previously persisted multi accounts", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		multi := makeBitBox02Multi()
+		btcOnly := makeBitBox02BTCOnly()
+
+		rootFingerprint, err := multi.RootFingerprint()
+		require.NoError(t, err)
+		btcOnlyRootFingerprint, err := btcOnly.RootFingerprint()
+		require.NoError(t, err)
+		require.Equal(t, rootFingerprint, btcOnlyRootFingerprint)
+
+		b.registerKeystore(multi)
+		b.DeregisterKeystore()
+		b.registerKeystore(btcOnly)
+
+		require.False(t, b.swapAvailable())
+	})
+}
+
+func TestSwapConnectedKeystore(t *testing.T) {
+	t.Run("false when no keystore is connected", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		require.Equal(t, swapConnectedKeystoreNone, b.swapConnectedKeystore())
+	})
+
+	t.Run("true when a multi keystore is connected", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		ks := makeBitBox02Multi()
+		ks.RootFingerprintFunc = func() ([]byte, error) {
+			return rootFingerprint1, nil
+		}
+		b.registerKeystore(ks)
+
+		require.Equal(t, swapConnectedKeystoreMulti, b.swapConnectedKeystore())
+	})
+
+	t.Run("false when a bitcoin-only keystore is connected", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		ks := makeBitBox02BTCOnly()
+		ks.RootFingerprintFunc = func() ([]byte, error) {
+			return rootFingerprint1, nil
+		}
+		b.registerKeystore(ks)
+
+		require.Equal(t, swapConnectedKeystoreBTCOnly, b.swapConnectedKeystore())
+	})
+
+	t.Run("false when only watch-only multi accounts are available", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		ks := makeBitBox02Multi()
+		rootFingerprint, err := ks.RootFingerprint()
+		require.NoError(t, err)
+
+		b.registerKeystore(ks)
+		require.NoError(t, b.SetWatchonly(rootFingerprint, true))
+		b.DeregisterKeystore()
+
+		require.Equal(t, swapConnectedKeystoreNone, b.swapConnectedKeystore())
+	})
+
+	t.Run("false when btc-only keystore shares a seed with previously persisted multi accounts", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		multi := makeBitBox02Multi()
+		btcOnly := makeBitBox02BTCOnly()
+
+		rootFingerprint, err := multi.RootFingerprint()
+		require.NoError(t, err)
+		btcOnlyRootFingerprint, err := btcOnly.RootFingerprint()
+		require.NoError(t, err)
+		require.Equal(t, rootFingerprint, btcOnlyRootFingerprint)
+
+		b.registerKeystore(multi)
+		b.DeregisterKeystore()
+		b.registerKeystore(btcOnly)
+
+		require.Equal(t, swapConnectedKeystoreBTCOnly, b.swapConnectedKeystore())
+	})
+}
+
+func TestSwapStatus(t *testing.T) {
+	t.Run("reports availability and connected multi keystore separately", func(t *testing.T) {
+		b := newBackend(t, testnetDisabled, regtestDisabled)
+		defer b.Close()
+
+		ks := makeBitBox02Multi()
+		rootFingerprint, err := ks.RootFingerprint()
+		require.NoError(t, err)
+
+		b.registerKeystore(ks)
+		require.NoError(t, b.SetWatchonly(rootFingerprint, true))
+		b.DeregisterKeystore()
+
+		swapStatus := b.SwapStatus()
+		require.True(t, swapStatus.Available)
+		require.Equal(t, swapConnectedKeystoreNone, swapStatus.ConnectedKeystore)
+	})
+}

--- a/frontends/web/src/api/swap.ts
+++ b/frontends/web/src/api/swap.ts
@@ -74,6 +74,15 @@ export type TSwapSignResponse = {
   errorMessage: string;
 };
 
+export type TSwapStatusResponse = {
+  available: boolean;
+  connectedKeystore: 'none' | 'multi' | 'btc-only';
+};
+
+export const getSwapStatus = (): Promise<TSwapStatusResponse> => {
+  return apiGet('swap/status');
+};
+
 export const signSwap = (
   data: TSwapSignRequest,
 ): Promise<TSwapSignResponse> => {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -744,7 +744,8 @@
   "confirmOnDevice": "Please confirm on your device.",
   "connectKeystore": {
     "promptNoName": "Please connect your BitBox to continue",
-    "promptWithName": "Please connect your BitBox named \"{{name}}\" to continue"
+    "promptWithName": "Please connect your BitBox named \"{{name}}\" to continue",
+    "swapHint": "Please connect a BitBox Multi to Swap."
   },
   "darkmode": {
     "toggle": "Dark mode"

--- a/frontends/web/src/routes/market/components/markettab.tsx
+++ b/frontends/web/src/routes/market/components/markettab.tsx
@@ -8,12 +8,14 @@ import { TMarketAction } from '@/api/market';
 type TProps = {
   onChangeTab: (tab: TMarketAction) => void;
   activeTab: TMarketAction;
+  showSwap: boolean;
 };
 
 
 export const MarketTab = ({
   onChangeTab,
-  activeTab
+  activeTab,
+  showSwap,
 }: TProps) => {
   const { t } = useTranslation();
   return (
@@ -36,12 +38,14 @@ export const MarketTab = ({
       >
         {t('buy.exchange.spend')}
       </PillButton>
-      <PillButton
-        active={activeTab === 'swap'}
-        onClick={() => onChangeTab('swap')}
-      >
-        {t('generic.swap')}
-      </PillButton>
+      {showSwap && (
+        <PillButton
+          active={activeTab === 'swap'}
+          onClick={() => onChangeTab('swap')}
+        >
+          {t('generic.swap')}
+        </PillButton>
+      )}
       <PillButton
         active={activeTab === 'otc'}
         onClick={() => onChangeTab('otc')}

--- a/frontends/web/src/routes/market/market.tsx
+++ b/frontends/web/src/routes/market/market.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { SingleValue } from 'react-select';
 import { i18n } from '@/i18n/i18n';
 import * as marketAPI from '@/api/market';
+import { getSwapStatus } from '@/api/swap';
 import { AccountCode, TAccount } from '@/api/account';
 import { GuidedContent, GuideWrapper, Header, Main } from '@/components/layout';
 import { View, ViewContent } from '@/components/view/view';
@@ -17,6 +18,7 @@ import { getRegionNameFromLocale } from '@/i18n/utils';
 import { getVendorFormattedName } from './utils';
 import { Spinner } from '@/components/spinner/Spinner';
 import { Dialog } from '@/components/dialog/dialog';
+import { alertUser } from '@/components/alert/Alert';
 import { InfoButton } from '@/components/infobutton/infobutton';
 import { MarketTab } from './components/markettab';
 import { Deals } from './components/deals';
@@ -52,7 +54,7 @@ export const Market = ({
   const regionCodes = useLoad(marketAPI.getMarketRegionCodes);
   const nativeLocale = useLoad(getNativeLocale);
   const config = useLoad(getConfig);
-  const connectedSwapAccounts = accounts.filter(account => account.keystore.connected);
+  const swapStatus = useLoad(getSwapStatus, [accounts]);
 
   const hasOnlyBTCAccounts = accounts.every(({ coinCode }) => isBitcoinOnly(coinCode));
 
@@ -60,19 +62,28 @@ export const Market = ({
 
   const [agreedBTCDirectOTCTerms, setAgreedBTCDirectOTCTerms] = useState(false);
 
+  // sync the OTC disclaimer state from persisted frontend config.
   useEffect(() => {
     if (config) {
       setAgreedBTCDirectOTCTerms(config.frontend.skipBTCDirectOTCDisclaimer);
     }
   }, [config]);
 
+  // finish pending swap navigation after a keystore connection attempt resolves.
   useEffect(() => {
-    if (!pendingSwapNavigation || connectedSwapAccounts.length === 0) {
+    if (!pendingSwapNavigation) {
       return;
     }
-    setPendingSwapNavigation(false);
-    navigate('/market/swap');
-  }, [connectedSwapAccounts.length, navigate, pendingSwapNavigation]);
+    if (swapStatus?.connectedKeystore === 'multi') {
+      setPendingSwapNavigation(false);
+      navigate('/market/swap');
+      return;
+    }
+    if (swapStatus?.connectedKeystore === 'btc-only') {
+      setPendingSwapNavigation(false);
+      alertUser(t('connectKeystore.swapHint'));
+    }
+  }, [navigate, pendingSwapNavigation, swapStatus, t]);
 
   // keep account list in sync and ensure a valid selected account.
   useEffect(() => {
@@ -180,7 +191,7 @@ export const Market = ({
       return;
     }
     if (activeTab === 'swap') {
-      if (connectedSwapAccounts.length > 0) {
+      if (swapStatus?.connectedKeystore === 'multi') {
         navigate('/market/swap');
         return;
       }
@@ -248,6 +259,7 @@ export const Market = ({
                     <MarketTab
                       onChangeTab={setActiveTab}
                       activeTab={activeTab}
+                      showSwap={!!swapStatus?.available}
                     />
                     {activeTab !== 'swap' && (
                       <>

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -137,12 +137,13 @@ export const Swap = ({
     [routes, selectedRouteId],
   );
 
+  // initialize swap account selections once the swap accounts payload has loaded.
   useEffect(() => {
     if (!swapAccounts || !swapAccounts.success) {
       return;
     }
     if (swapAccounts.sellAccounts.length === 0 || swapAccounts.buyAccounts.length === 0) {
-      navigate('/', { replace: true });
+      navigate('/market/select', { replace: true });
       return;
     }
     if (!swapAccounts.sellAccounts.some(account => account.code === sellAccountCode)) {
@@ -198,6 +199,7 @@ export const Swap = ({
     }
   }, [sellAccountCode]);
 
+  // fetch swap quotes whenever the selected pair or sell amount changes.
   useEffect(() => {
     let isCancelled = false;
     const sellCoinCode = sellAccount?.coinCode;
@@ -396,7 +398,14 @@ export const Swap = ({
     }
   };
 
-  if (!swapAccounts || !swapAccounts.success || swapAccounts.sellAccounts.length === 0 || !sellAccounts || !buyAccounts || !buyAccountCode) {
+  if (
+    !swapAccounts
+    || !swapAccounts.success
+    || swapAccounts.sellAccounts.length === 0
+    || !sellAccounts
+    || !buyAccounts
+    || !buyAccountCode
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Note for @thisconnect: you can review this one if you want, but it is pending OK from Jad :) I just went ahead with the code while I was at it :)

We don't want to show swap to BTC only users, meaning we only show it if there is at least one non-btc account in the backend (either watch-only, or there is a multi device attached)

Add a swap-available API that returns true only when the currently connected keystore has at least one non-BTC account, including inactive accounts, and use that flag to show or hide the market swap tab and guard the swap route. Also refresh the flag when account state changes so disconnecting the device immediately removes swap access.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
