### PR TITLE
frontend: add QR for descriptor (account info)

### DIFF
--- a/frontends/web/src/components/qrcode/qrcode.module.css
+++ b/frontends/web/src/components/qrcode/qrcode.module.css
@@ -32,8 +32,10 @@
 }
 
 .outerContainer {
+  border-radius: var(--radius-xl);
   display: flex;
   margin: auto;
+  overflow: hidden;
   position: relative;
 }
 
@@ -48,6 +50,10 @@
 
 .qrCodeContainer:hover {
   cursor: pointer;
+}
+
+.qrImage {
+  border-radius: var(--radius-xl);
 }
 
 .show {

--- a/frontends/web/src/components/qrcode/qrcode.tsx
+++ b/frontends/web/src/components/qrcode/qrcode.tsx
@@ -38,7 +38,7 @@ export const QRCode = ({
   return (
     tapToCopy ?
       <TapToCopyQRCode data={data} qrCodeData={qrCode.data} size={size} /> :
-      <img width={size} height={size} src={qrCode.data} />
+      <img className={style.qrImage} width={size} height={size} src={qrCode.data} />
   );
 };
 

--- a/frontends/web/src/routes/account/info/info.module.css
+++ b/frontends/web/src/routes/account/info/info.module.css
@@ -43,6 +43,7 @@
 .address {
     display: grid;
     gap: var(--space-default);
+    margin-top: var(--space-default);
 }
 
 .details {
@@ -74,15 +75,29 @@
 }
 
 .qrCode {
-    align-items: flex-start;
+    align-items: center;
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    gap: var(--space-eight);
     min-height: 0;
 }
 
 .qrCode img {
     height: auto;
     max-width: 100%;
+}
+
+.qrItem {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-quarter);
+}
+
+.qrLabel {
+    color: var(--color-secondary);
+    font-size: var(--size-small);
+    text-align: center;
 }
 
 .buttons {
@@ -119,6 +134,7 @@
             "warning warning"
             "buttons buttons";
         grid-template-columns: minmax(0, 1fr) 220px;
+        margin-top: 0;
     }
 
     .details {
@@ -128,6 +144,7 @@
     .qrCode {
         grid-area: qr;
         justify-content: flex-end;
+        gap: var(--space-default);
     }
 
     .warningMessage {

--- a/frontends/web/src/routes/account/info/signingconfiguration.tsx
+++ b/frontends/web/src/routes/account/info/signingconfiguration.tsx
@@ -63,9 +63,26 @@ export const SigningConfiguration = ({ account, info, code, signingConfigIndex, 
     <div className={style.address}>
       <div className={style.qrCode}>
         { (bitcoinBased && !isTaproot) ? (
-          <QRCode
-            data={config.keyInfo.xpub}
-            size={220} />
+          <div className={style.qrItem}>
+            <span className={style.qrLabel}>
+              {t('accountInfo.extendedPublicKey')}
+            </span>
+            <QRCode
+              data={config.keyInfo.xpub}
+              size={180}
+            />
+          </div>
+        ) : null }
+        { info.bitcoinSimple ? (
+          <div className={style.qrItem}>
+            <span className={style.qrLabel}>
+              Descriptor
+            </span>
+            <QRCode
+              data={info.bitcoinSimple.descriptor}
+              size={180}
+            />
+          </div>
         ) : null }
       </div>
       <div className={style.details}>


### PR DESCRIPTION
1. Add QR for descriptor
2. Also adds border radius for QR component.

<img width="1079" height="990" alt="image" src="https://github.com/user-attachments/assets/684ac172-dc52-4c0f-90aa-623a7fc53898" />

<img width="1061" height="977" alt="image" src="https://github.com/user-attachments/assets/5b15bc1a-f4c6-46c7-a15e-0937d1ac594d" />

<img width="413" height="1031" alt="image" src="https://github.com/user-attachments/assets/0d8b8d77-ae3b-4958-951b-4bf3907ffa9f" />
