### PR TITLE
frontend: warn user if swap sell amount is higher than available

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
+	accountErrors "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
 	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/banners"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/bitsurance"
@@ -1908,6 +1909,16 @@ func (handlers *Handlers) postSwapkitQuote(r *http.Request) interface{} {
 	if request.SellAccountCode != "" {
 		account, err := handlers.backend.GetAccountFromCode(request.SellAccountCode)
 		if err != nil {
+			return errorResult(swapkit.ErrInvalidRequest, err.Error())
+		}
+		parsedAmount, err := account.Coin().ParseAmount(request.SellAmount)
+		if err != nil {
+			return errorResult(swapkit.ErrInvalidRequest, err.Error())
+		}
+		if err := swapkit.ValidateSwapSellAmount(account, parsedAmount); err != nil {
+			if validationErr, ok := errp.Cause(err).(accountErrors.TxValidationError); ok {
+				return errorResult(errp.ErrorCode(validationErr.Error()), validationErr.Error())
+			}
 			return errorResult(swapkit.ErrInvalidRequest, err.Error())
 		}
 		sellAmount, err = swapkit.FormatAmount(account.Coin(), request.SellAmount)

--- a/backend/market/swapkit/helpers.go
+++ b/backend/market/swapkit/helpers.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
+	accountErrors "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 )
@@ -53,6 +55,18 @@ func FormatAmount(coin coinpkg.Coin, amount string) (string, error) {
 		return "0", nil
 	}
 	return formattedAmount, nil
+}
+
+// ValidateSwapSellAmount checks that sell amount fits into available balance.
+func ValidateSwapSellAmount(account accounts.Interface, sellAmount coinpkg.Amount) error {
+	balance, err := account.Balance()
+	if err != nil {
+		return err
+	}
+	if sellAmount.BigInt().Cmp(balance.Available().BigInt()) > 0 {
+		return errp.WithStack(accountErrors.ErrInsufficientFunds)
+	}
+	return nil
 }
 
 func newQuoteRequestFromCoinCodes(sellCoinCode, buyCoinCode, sellAmount string, providers []string) (*QuoteRequest, *APIError) {

--- a/backend/market/swapkit/helpers_test.go
+++ b/backend/market/swapkit/helpers_test.go
@@ -11,10 +11,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
+	accountErrors "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
+	accountMocks "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/mocks"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	coinMocks "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin/mocks"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/erc20"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/socksproxy"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/ethereum/go-ethereum/params"
@@ -25,6 +30,30 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func TestValidateSwapSellAmount(t *testing.T) {
+	newAccount := func(available int64) accounts.Interface {
+		return &accountMocks.InterfaceMock{
+			BalanceFunc: func() (*accounts.Balance, error) {
+				return accounts.NewBalance(coinpkg.NewAmountFromInt64(available), coinpkg.NewAmountFromInt64(0)), nil
+			},
+			CoinFunc: func() coinpkg.Coin {
+				return &coinMocks.CoinMock{}
+			},
+		}
+	}
+
+	t.Run("returns insufficient funds error", func(t *testing.T) {
+		err := ValidateSwapSellAmount(newAccount(1), coinpkg.NewAmountFromInt64(2))
+		require.Error(t, err)
+		require.Equal(t, accountErrors.ErrInsufficientFunds, errp.Cause(err))
+	})
+
+	t.Run("accepts sell amount within balance", func(t *testing.T) {
+		err := ValidateSwapSellAmount(newAccount(2), coinpkg.NewAmountFromInt64(2))
+		require.NoError(t, err)
+	})
 }
 
 func TestFormatAmount(t *testing.T) {

--- a/frontends/web/src/routes/market/swap/swap.module.css
+++ b/frontends/web/src/routes/market/swap/swap.module.css
@@ -20,6 +20,10 @@
     padding: 0;
 }
 
+.sellWarning {
+  margin-bottom: var(--space-half);
+}
+
 .flipContainer {
   text-align: center;
 }

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -30,6 +30,7 @@ import { SubTitle } from '@/components/title';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
 import { alertUser } from '@/components/alert/Alert';
+import { Message } from '@/components/message/message';
 import { Button, Label } from '@/components/forms';
 import { BackButton } from '@/components/backbutton/backbutton';
 import { Amount } from '@/components/amount/amount';
@@ -112,6 +113,7 @@ export const Swap = ({
   const [routes, setRoutes] = useState<TSwapQuoteRoute[]>([]);
   const [selectedRouteId, setSelectedRouteId] = useState<string | undefined>();
   const [isFetchingRoutes, setIsFetchingRoutes] = useState<boolean>(false);
+  const [quoteErrorCode, setQuoteErrorCode] = useState<string | undefined>();
   const [routeError, setRouteError] = useState<string | undefined>();
   // Drives the button disabled/loading state for the whole confirm flow.
   const [isConfirmInFlight, setIsConfirmInFlight] = useState(false);
@@ -134,6 +136,12 @@ export const Swap = ({
   const selectedRoute = useMemo(
     () => routes.find(route => route.routeId === selectedRouteId),
     [routes, selectedRouteId],
+  );
+  const sellDisplayUnit = useMemo(
+    () => sellAccount
+      ? getDisplayedCoinUnit(sellAccount.coinCode, sellAccount.coinUnit, btcUnit)
+      : undefined,
+    [btcUnit, sellAccount],
   );
 
   const isSameCoinAccount = (
@@ -180,11 +188,12 @@ export const Swap = ({
     );
   }, [buyAccount, sellAccountCode]);
 
-  const clearQuoteState = (error?: string) => {
+  const clearQuoteState = (error?: string, errorCode?: string) => {
     setRoutes([]);
     setSelectedRouteId(undefined);
     setExpectedOutput('');
     setExpectedOutputUnit(undefined);
+    setQuoteErrorCode(errorCode);
     setRouteError(error);
   };
 
@@ -226,6 +235,7 @@ export const Swap = ({
     }
 
     setIsFetchingRoutes(true);
+    setQuoteErrorCode(undefined);
     setRouteError(undefined);
 
     const fetchRoutes = async () => {
@@ -241,6 +251,7 @@ export const Swap = ({
         }
         const nextRoutes = response.success ? response.quote.routes : [];
         if (nextRoutes.length > 0) {
+          setQuoteErrorCode(undefined);
           setRoutes(nextRoutes);
           const firstRouteId = nextRoutes[0]?.routeId;
           setSelectedRouteId(currentRouteId => (
@@ -253,7 +264,10 @@ export const Swap = ({
         clearQuoteState(
           response.success
             ? t('swap.noRouteFound')
-            : response.errorMessage || t('swap.unexpectedError'),
+            : response.errorCode === 'insufficientFunds'
+              ? undefined
+              : response.errorMessage,
+          response.success ? undefined : response.errorCode,
         );
       } catch (error: unknown) {
         if (isCancelled) {
@@ -465,6 +479,15 @@ export const Swap = ({
                 value={sellAmount}
                 onChangeValue={setSellAmount}
               />
+              <Message
+                hidden={quoteErrorCode !== 'insufficientFunds'}
+                type="warning"
+                className={style.sellWarning}
+              >
+                {sellDisplayUnit}
+                {': '}
+                {t('send.error.insufficientFunds')}
+              </Message>
               <div className={style.flipContainer}>
                 <Button
                   disabled={!canFlip}


### PR DESCRIPTION
Similarly to what we do in send, if an user selects an amount that is higher than the available, we show a warning and disable the swap button.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
