### PR TITLE
frontend: disable same-coin swap options

### DIFF
--- a/frontends/web/src/components/dropdown/mobile-fullscreen-selector.module.css
+++ b/frontends/web/src/components/dropdown/mobile-fullscreen-selector.module.css
@@ -134,6 +134,13 @@ input.searchInput:focus {
     background-color: var(--background-custom-select-hover);
 }
 
+.disabledOption,
+.disabledOption:hover {
+    background-color: transparent;
+    color: var(--color-secondary);
+    cursor: default;
+}
+
 .selectedOption {
     background-color: var(--background-custom-select-selected);
 }

--- a/frontends/web/src/components/dropdown/mobile-fullscreen-selector.tsx
+++ b/frontends/web/src/components/dropdown/mobile-fullscreen-selector.tsx
@@ -68,8 +68,15 @@ export const MobileFullscreenSelector = <T, IsMulti extends boolean = false, TEx
     return value ? (value as TOption<T>).value === option.value : false;
   };
 
+  const isDisabledOption = (option: TOption<T> & TOptionExt) => (
+    Boolean((option as TOption<T> & TOptionExt & { disabled?: boolean }).disabled)
+  );
+
   const handleSelect = (option: TOption<T>, e: React.MouseEvent) => {
     e.stopPropagation();
+    if ((option as TOption<T> & { disabled?: boolean }).disabled) {
+      return;
+    }
     if (isMulti) {
       const currentValues = value as TOption<T>[];
       const isCurrentlySelected = currentValues.some((v) => v.value === option.value);
@@ -122,8 +129,10 @@ export const MobileFullscreenSelector = <T, IsMulti extends boolean = false, TEx
         key={JSON.stringify(option.value)}
         className={`
           ${styles.optionItem || ''} 
+          ${isDisabledOption(option) ? styles.disabledOption || '' : ''}
           ${isSelected(option) ? styles.selectedOption || '' : ''}`
         }
+        disabled={isDisabledOption(option)}
         onClick={(e) => handleSelect(option, e)}
       >
         <div className={styles.optionContent}>{renderOptions(option, false)}</div>
@@ -141,7 +150,8 @@ export const MobileFullscreenSelector = <T, IsMulti extends boolean = false, TEx
           <button
             key={JSON.stringify(option.value)}
             type="button"
-            className={`${styles.optionItem || ''} ${isSelected(option) ? styles.selectedOption || '' : ''}`}
+            className={`${styles.optionItem || ''} ${isDisabledOption(option) ? styles.disabledOption || '' : ''} ${isSelected(option) ? styles.selectedOption || '' : ''}`}
+            disabled={isDisabledOption(option)}
             onClick={(e) => handleSelect(option, e)}
           >
             <div className={styles.optionContent}>{renderOptions(option, false)}</div>

--- a/frontends/web/src/components/groupedaccountselector/groupedaccountselector.tsx
+++ b/frontends/web/src/components/groupedaccountselector/groupedaccountselector.tsx
@@ -98,6 +98,7 @@ const renderGroupHeader = (group: TGroupedOption) => (
 type TAccountSelector<T extends TAccountBase> = {
   title?: string;
   disabled?: boolean;
+  isAccountDisabled?: (account: T) => boolean;
   selected?: string;
   onChange: (value: string) => void;
   onProceed?: () => void;
@@ -109,6 +110,7 @@ type TAccountSelector<T extends TAccountBase> = {
 export const GroupedAccountSelector = <T extends TAccountBase, >({
   title,
   disabled,
+  isAccountDisabled,
   selected,
   onChange,
   onProceed,
@@ -123,11 +125,11 @@ export const GroupedAccountSelector = <T extends TAccountBase, >({
   useEffect(() => {
     //setting options without balance
     const accountsByKeystore = getAccountsByKeystore(accounts);
-    const groupedOpts: TGroupedOption[] = createGroupedOptions(accountsByKeystore);
+    const groupedOpts: TGroupedOption[] = createGroupedOptions(accountsByKeystore, isAccountDisabled);
     setOptions(groupedOpts);
     //asynchronously fetching each account's balance
     getBalancesForGroupedAccountSelector(groupedOpts).then(setOptions);
-  }, [accounts]);
+  }, [accounts, isAccountDisabled]);
 
   if (!options) {
     return null;
@@ -190,6 +192,7 @@ export const GroupedAccountSelector = <T extends TAccountBase, >({
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         renderTrigger={renderTrigger}
+        isOptionDisabled={option => Boolean((option as TOption).disabled)}
       />
       {onProceed && (
         <div className={styles.buttons}>

--- a/frontends/web/src/components/groupedaccountselector/services.ts
+++ b/frontends/web/src/components/groupedaccountselector/services.ts
@@ -5,7 +5,10 @@ import { getBalance } from '@/api/account';
 import { TAccountsByKeystore, isAmbiguousName } from '@/routes/account/utils';
 import { TGroupedOption, TOption } from './groupedaccountselector';
 
-export const createGroupedOptions = <T extends TAccountBase>(accountsByKeystore: TAccountsByKeystore<T>[]) => {
+export const createGroupedOptions = <T extends TAccountBase>(
+  accountsByKeystore: TAccountsByKeystore<T>[],
+  isAccountDisabled?: (account: T) => boolean,
+) => {
   return accountsByKeystore.map(({ keystore, accounts }) => ({
     label: `${keystore.name} ${isAmbiguousName(keystore.name, accountsByKeystore) ? `(${keystore.rootFingerprint})` : ''}`,
     connected: keystore.connected,
@@ -15,7 +18,7 @@ export const createGroupedOptions = <T extends TAccountBase>(accountsByKeystore:
       coinCode: account.coinCode,
       coinUnit: account.coinUnit,
       active: account.active,
-      disabled: false,
+      disabled: isAccountDisabled ? isAccountDisabled(account) : false,
     })) as TOption[]
   }));
 };

--- a/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
+++ b/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
@@ -15,6 +15,7 @@ type Props<T extends TAccountBase> = {
   accountCode: AccountCode | undefined;
   accounts: T[];
   id: string;
+  isAccountDisabled?: (account: T) => boolean;
   onChangeAccountCode: (accountCode: AccountCode) => void;
   onChangeValue?: (value: string) => void;
   readOnlyAmount?: boolean;
@@ -25,6 +26,7 @@ export const InputWithAccountSelector = <T extends TAccountBase, >({
   accountCode,
   accounts,
   id,
+  isAccountDisabled,
   onChangeAccountCode,
   onChangeValue,
   value,
@@ -77,6 +79,7 @@ export const InputWithAccountSelector = <T extends TAccountBase, >({
               setSelectedAccount(account);
               onChangeAccountCode(accountCode);
             })}
+            isAccountDisabled={isAccountDisabled}
             stackedLayout
             className={style.accountSelectorDropdown}
           />

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -137,7 +137,12 @@ export const Swap = ({
     [routes, selectedRouteId],
   );
 
-  // initialize swap account selections once the swap accounts payload has loaded.
+  const isSameCoinAccount = (
+    candidate: TSwapAccount,
+    oppositeAccount: TSwapAccount | undefined,
+  ) => candidate.coinCode === oppositeAccount?.coinCode;
+
+  // Keeps the selected swap accounts aligned with the latest available options and redirects away if no swap is possible.
   useEffect(() => {
     if (!swapAccounts || !swapAccounts.success) {
       return;
@@ -155,13 +160,15 @@ export const Swap = ({
           : swapAccounts.sellAccounts[0]?.code,
       );
     }
+    const selectedSellAccount = swapAccounts.sellAccounts.find(account => account.code === sellAccountCode);
     if (!swapAccounts.buyAccounts.some(account => account.code === buyAccountCode)) {
       setBuyAccountCode(
         swapAccounts.defaultBuyAccountCode && swapAccounts.buyAccounts.some(
-          account => account.code === swapAccounts.defaultBuyAccountCode,
+          account => account.code === swapAccounts.defaultBuyAccountCode
+            && !isSameCoinAccount(account, selectedSellAccount),
         )
           ? swapAccounts.defaultBuyAccountCode
-          : swapAccounts.buyAccounts.find(account => account.code !== sellAccountCode)?.code,
+          : swapAccounts.buyAccounts.find(account => !isSameCoinAccount(account, selectedSellAccount))?.code,
       );
     }
   }, [buyAccountCode, navigate, sellAccountCode, swapAccounts]);
@@ -450,6 +457,7 @@ export const Swap = ({
                 accounts={sellAccounts}
                 id="swapSendAmount"
                 accountCode={sellAccountCode}
+                isAccountDisabled={account => isSameCoinAccount(account, buyAccount)}
                 onChangeAccountCode={setSellAccountCode}
                 value={sellAmount}
                 onChangeValue={setSellAmount}
@@ -487,6 +495,7 @@ export const Swap = ({
                 accounts={buyAccounts}
                 id="swapGetAmount"
                 accountCode={buyAccountCode}
+                isAccountDisabled={account => isSameCoinAccount(account, sellAccount)}
                 onChangeAccountCode={setBuyAccountCode}
                 value={expectedOutput}
                 readOnlyAmount


### PR DESCRIPTION
On setting/chaning either buy or sell asset, disable the corresponding same coin on the other selector. This is done since it makes no sense to try and swapping BTC to BTC, for example.


@thisconnect I tried to give it a go here; I believe this is something that can be done entirely in the frontend, and it seems a fairly quick change, that to me looks ok. Let me know if you think there are better ways to achieve this; the only thing I can't really follow very clearly is the `isDisabledOption` part, to be honest :)

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
