### PR TITLE
frontend: clear quote state when flipping.

### DIFF
--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -184,10 +184,10 @@ export const Swap = ({
   // flips sell and buy account
   const handleFlipAccounts = () => {
     if (buyAccountCode && sellAccountCode) {
+      clearQuoteState();
       setSellAccountCode(buyAccountCode);
       setSellAmount(expectedOutput);
       setBuyAccountCode(sellAccountCode);
-      setExpectedOutput(sellAmount);
     }
   };
 


### PR DESCRIPTION
When flipping sell and buy asset, the receive amount shown was not correct. We need to wait for a proper quote to be received, and in the meantime disable the swap button so that users can't proceed to an invalid state.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
