### PR TITLE
frontend: gray out disabled export transactions action

### DIFF
--- a/frontends/web/src/components/actionable-item/actionable-item.module.css
+++ b/frontends/web/src/components/actionable-item/actionable-item.module.css
@@ -21,6 +21,12 @@
   background-color: var(--background-tap-active);
 }
 
+.disabled {
+  color: var(--color-secondary);
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .content {
   align-items: center;
   display: flex;

--- a/frontends/web/src/components/actionable-item/actionable-item.tsx
+++ b/frontends/web/src/components/actionable-item/actionable-item.tsx
@@ -24,7 +24,7 @@ export const ActionableItem = ({
   return (
     <>
       {notButton ? (
-        <div className={`${styles.container || ''} ${className}`}>
+        <div className={`${styles.container || ''} ${disabled ? styles.disabled || '' : ''} ${className}`}>
           {children}
           {icon && icon}
         </div>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -30,6 +30,7 @@
     "contractAddress": "Contract address",
     "contractAddressWarning": "Do not send any coins to the contract address otherwise they will be lost. Contract address is just for informational purposes.",
     "exportTransactions": "Export transaction history",
+    "exportTransactionsDisabled": "No transactions",
     "extendedPublicKey": "Extended public key",
     "label": "Account info",
     "descriptorWarning": "To ensure smooth compatibility with other wallets, apps, or services, please copy the entire descriptor. Selecting and copying only the xpub might cause the account to be imported with an incorrect script type, which could lead to issues.",

--- a/frontends/web/src/routes/account/info/info.module.css
+++ b/frontends/web/src/routes/account/info/info.module.css
@@ -11,6 +11,15 @@
     min-width: 0;
 }
 
+.actionText {
+    display: flex;
+    flex-direction: column;
+}
+
+.actionHint {
+    font-size: var(--size-smaller);
+}
+
 .actionIcon {
     display: block;
     height: 24px;

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useSync } from '@/hooks/api';
+import { useMountedRef } from '@/hooks/mount';
 import { TAccount, AccountCode, TStatus, getStatus, exportAccount, getTransactionList, TTransactions } from '@/api/account';
 import { findAccount, isBitcoinBased, isMessageSigningSupported } from '@/routes/account/utils';
 import { TDevices } from '@/api/devices';
@@ -17,7 +18,7 @@ import { ActionableItem } from '@/components/actionable-item/actionable-item';
 import { QRCodeLight, QRCodeDark, OutlinedUploadDark, OutlinedUploadLight, OutlinedUnorderedListDark, OutlinedUnorderedListLight, OutlinedFileProtectDark, OutlinedFileProtectLight } from '@/components/icon';
 import { useDarkmode } from '@/hooks/darkmode';
 import { alertUser } from '@/components/alert/Alert';
-import { statusChanged } from '@/api/accountsync';
+import { statusChanged, syncdone } from '@/api/accountsync';
 import style from './info.module.css';
 
 type TProps = {
@@ -34,19 +35,39 @@ export const Info = ({
   const { t } = useTranslation();
   const { isDarkMode } = useDarkmode();
   const navigate = useNavigate();
-  const [transactions, setTransactions] = useState<TTransactions>();
   const status: TStatus | undefined = useSync(
     () => getStatus(code),
     cb => statusChanged(code, cb),
   );
+  const accountReady = (
+    status !== undefined
+    && !status.fatalError
+    && status.synced
+    && status.offlineError === null
+  );
+  const mounted = useMountedRef();
+  const [transactions, setTransactions] = useState<TTransactions | undefined>();
 
   useEffect(() => {
-    getTransactionList(code)
-      .then(setTransactions)
-      .catch(console.error);
-  }, [code]);
+    if (!accountReady) {
+      setTransactions(undefined);
+      return;
+    }
+    const fetch = () => {
+      getTransactionList(code)
+        .then(txs => {
+          if (mounted.current) {
+            setTransactions(txs);
+          }
+        })
+        .catch(console.error);
+    };
+    fetch();
+    return syncdone(code, fetch);
+  }, [code, accountReady, mounted]);
 
-  const hasTransactions = transactions?.success && transactions.list.length > 0;
+  const transactionsLoaded = transactions?.success === true;
+  const hasTransactions = transactionsLoaded && transactions.list.length > 0;
 
   const account = findAccount(accounts, code);
   if (!account) {
@@ -86,11 +107,16 @@ export const Info = ({
           <div className={style.menuList}>
             <ActionableItem
               onClick={handleExport}
-              disabled={!hasTransactions}
+              disabled={hasTransactions !== true}
             >
               <div className={style.actionItem}>
                 {isDarkMode ? <OutlinedUploadLight className={style.actionIcon} aria-hidden alt="" /> : <OutlinedUploadDark className={style.actionIcon} aria-hidden alt="" />}
-                <span>{t('accountInfo.exportTransactions')}</span>
+                <div className={style.actionText}>
+                  <span>{t('accountInfo.exportTransactions')}</span>
+                  {transactionsLoaded && !hasTransactions && (
+                    <span className={style.actionHint}>{t('accountInfo.exportTransactionsDisabled')}</span>
+                  )}
+                </div>
               </div>
             </ActionableItem>
             <ActionableItem


### PR DESCRIPTION
- disable the export action while transactions are loading
- show "No transactions" when the account has no transactions
- enable the action once transactions are available
- refresh the transaction state when new transactions arrive on the account info screen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show localized hint text when transactions finish loading but none are available to export.

* **Style**
  * Visual update for disabled actions: secondary text color, reduced opacity, not-allowed cursor.
  * Added layout and smaller hint styling to structure action labels and de-emphasize helper text.

* **Bug Fixes**
  * Refined transaction-loading and export-button state handling to prevent incorrect enabled/disabled behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->