### PR TITLE
frontend: fix swap gas-funds error CTA

### DIFF
--- a/frontends/web/src/routes/market/swap/components/swap-result.tsx
+++ b/frontends/web/src/routes/market/swap/components/swap-result.tsx
@@ -12,6 +12,7 @@ import { SubTitle } from '@/components/title';
 type TProps = {
   children?: ReactNode;
   buyAccountCode: AccountCode;
+  buyEthAccountCode: AccountCode | undefined;
   onContinue: () => void;
   result: TSendTx | undefined;
 };
@@ -19,6 +20,7 @@ type TProps = {
 export const SwapResult = ({
   children,
   buyAccountCode,
+  buyEthAccountCode,
   onContinue,
   result,
 }: TProps) => {
@@ -51,8 +53,31 @@ export const SwapResult = ({
       );
     }
 
-    // TODO: handle erc20InsufficientGasFunds similarly to
-    // frontends/web/src/routes/account/send/components/result.tsx
+    if (result.errorCode === 'erc20InsufficientGasFunds') {
+      return (
+        <View fullscreen textCenter verticallyCentered width="520px">
+          <ViewHeader />
+          <ViewContent withIcon="error">
+            <p>
+              {t(`send.error.${result.errorCode}`)}
+            </p>
+          </ViewContent>
+          <ViewButtons>
+            <Button primary onClick={() => navigate(`/account/${buyAccountCode}`)}>
+              {t('button.done')}
+            </Button>
+            {buyEthAccountCode && (
+              <Button
+                secondary
+                onClick={() => navigate(`/market/select/${buyEthAccountCode}`, { replace: true })}>
+                {t('send.buyEth')}
+              </Button>
+            )}
+          </ViewButtons>
+        </View>
+      );
+    }
+
     return (
       <View fullscreen textCenter verticallyCentered width="640px">
         <ViewHeader />

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -564,6 +564,7 @@ export const Swap = ({
 
           <SwapResult
             buyAccountCode={buyAccountCode}
+            buyEthAccountCode={sellAccount?.parentAccountCode ?? sellAccount?.code}
             onContinue={() => {
               setIsConfirming(false);
               setResult(undefined);


### PR DESCRIPTION
Handle erc20InsufficientGasFunds in swap result with same user-facing error message used in send.

Route the buy ETH CTA to the parent ETH account for token sells so users land on the correct funding flow.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced error handling for failed swap transactions due to insufficient gas funds. Users now see a dedicated error screen with guidance, including options to return to their account or navigate to select an alternative purchasing option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->