### PR TITLE
Eth stream - enable large streamed payloads via Wallet Connect and etherscan proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Scroll to tx search field on mobile
 - iOS: Haptic feedback on copy and chart filters change
 - Subtle tab transition (mobile navigation)
+- Enable large streamed payloads (Wallet Connect)
 
 ## v4.50.1
 - Fix a bug that would delay showing watch-only accounts.

--- a/backend/coins/eth/etherscan/etherscan.go
+++ b/backend/coins/eth/etherscan/etherscan.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -35,6 +36,7 @@ var CallsPerSec = 3.8
 
 const (
 	maxAddressesForBalances      = 20
+	maxGetRequestTargetLength    = 6000
 	maxTokenTransactionsPerQuery = 10000
 )
 
@@ -60,11 +62,35 @@ func NewEtherScan(chainId string, httpClient *http.Client, limiter *rate.Limiter
 }
 
 func (etherScan *EtherScan) call(ctx context.Context, params url.Values, result interface{}) error {
+	return etherScan.callWithMethod(ctx, http.MethodGet, params, result)
+}
+
+func (etherScan *EtherScan) callWithMethod(
+	ctx context.Context,
+	method string,
+	params url.Values,
+	result interface{},
+) error {
 	if err := etherScan.limiter.Wait(ctx); err != nil {
 		return errp.WithStack(err)
 	}
 	params.Set("chainId", etherScan.chainId)
-	response, err := etherScan.httpClient.Get(etherScan.url + "?" + params.Encode())
+	encodedParams := params.Encode()
+	requestURL := etherScan.url
+	var requestBody io.Reader
+	if method == http.MethodGet {
+		requestURL += "?" + encodedParams
+	} else {
+		requestBody = strings.NewReader(encodedParams)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, requestURL, requestBody)
+	if err != nil {
+		return errp.WithStack(err)
+	}
+	if method == http.MethodPost {
+		request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	response, err := etherScan.httpClient.Do(request)
 	if err != nil {
 		return errp.WithStack(err)
 	}
@@ -80,6 +106,15 @@ func (etherScan *EtherScan) call(ctx context.Context, params url.Values, result 
 		return errp.Newf("unexpected response from EtherScan: %s", string(body))
 	}
 	return nil
+}
+
+// shouldPostRPC returns true when the encoded request would exceed the GET
+// request target length the upstream proxy accepts; the caller falls back to
+// POST in that case.
+func (etherScan *EtherScan) shouldPostRPC(params url.Values) bool {
+	candidate := maps.Clone(params)
+	candidate.Set("chainId", etherScan.chainId)
+	return len(candidate.Encode()) > maxGetRequestTargetLength
 }
 
 type jsonBigInt big.Int
@@ -479,7 +514,11 @@ func (etherScan *EtherScan) rpcCall(ctx context.Context, params url.Values, resu
 		} `json:"error"`
 		Result *json.RawMessage `json:"result"`
 	}
-	if err := etherScan.call(ctx, params, &wrapped); err != nil {
+	method := http.MethodGet
+	if etherScan.shouldPostRPC(params) {
+		method = http.MethodPost
+	}
+	if err := etherScan.callWithMethod(ctx, method, params, &wrapped); err != nil {
 		return err
 	}
 	if wrapped.Error != nil {

--- a/backend/coins/eth/etherscan/etherscan_test.go
+++ b/backend/coins/eth/etherscan/etherscan_test.go
@@ -4,14 +4,18 @@ package etherscan
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
 	"net/http"
+	"net/url"
 	"testing"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 )
@@ -36,6 +40,128 @@ func makeTokenTx(hash, blockNumber string, from, to, contract common.Address) ma
 		"gasUsed":         "1",
 		"isError":         "0",
 	}
+}
+
+func newTestEtherScan(handler func(*http.Request) *http.Response) *EtherScan {
+	etherScan := NewEtherScan("1", &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return handler(req), nil
+		}),
+	}, rate.NewLimiter(rate.Inf, 1))
+	etherScan.url = "https://example.test/v2/api"
+	return etherScan
+}
+
+func jsonRPCResponse(t *testing.T, body string) *http.Response {
+	t.Helper()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+		Header:     make(http.Header),
+	}
+}
+
+func formValues(t *testing.T, req *http.Request) url.Values {
+	t.Helper()
+	switch req.Method {
+	case http.MethodGet:
+		return req.URL.Query()
+	case http.MethodPost:
+		require.NoError(t, req.ParseForm())
+		return req.PostForm
+	default:
+		t.Fatalf("unexpected method: %s", req.Method)
+		return nil
+	}
+}
+
+func TestRPCProxyUsesGETForSmallEstimateGasRequest(t *testing.T) {
+	to := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	etherScan := newTestEtherScan(func(req *http.Request) *http.Response {
+		require.Equal(t, http.MethodGet, req.Method)
+		params := formValues(t, req)
+		require.Equal(t, "1", params.Get("chainId"))
+		require.Equal(t, "proxy", params.Get("module"))
+		require.Equal(t, "eth_estimateGas", params.Get("action"))
+		require.Equal(t, to.Hex(), params.Get("to"))
+		return jsonRPCResponse(t, `{"jsonrpc":"2.0","id":1,"result":"0x5208"}`)
+	})
+
+	gas, err := etherScan.EstimateGas(context.Background(), ethereum.CallMsg{
+		To: &to,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(21000), gas)
+}
+
+func TestRPCProxyUsesPOSTForLargeEstimateGasRequest(t *testing.T) {
+	to := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	etherScan := newTestEtherScan(func(req *http.Request) *http.Response {
+		require.Equal(t, http.MethodPost, req.Method)
+		require.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
+		require.Empty(t, req.URL.RawQuery)
+		params := formValues(t, req)
+		require.Equal(t, "1", params.Get("chainId"))
+		require.Equal(t, "proxy", params.Get("module"))
+		require.Equal(t, "eth_estimateGas", params.Get("action"))
+		require.Equal(t, to.Hex(), params.Get("to"))
+		require.Greater(t, len(params.Get("data")), maxGetRequestTargetLength)
+		return jsonRPCResponse(t, `{"jsonrpc":"2.0","id":1,"result":"0x5208"}`)
+	})
+
+	gas, err := etherScan.EstimateGas(context.Background(), ethereum.CallMsg{
+		To:   &to,
+		Data: bytes.Repeat([]byte{0xab}, 3000),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(21000), gas)
+}
+
+func TestRPCProxyUsesGETForSmallSendTransactionRequest(t *testing.T) {
+	to := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	etherScan := newTestEtherScan(func(req *http.Request) *http.Response {
+		require.Equal(t, http.MethodGet, req.Method)
+		params := formValues(t, req)
+		require.Equal(t, "1", params.Get("chainId"))
+		require.Equal(t, "proxy", params.Get("module"))
+		require.Equal(t, "eth_sendRawTransaction", params.Get("action"))
+		require.LessOrEqual(t, len(params.Get("hex")), maxGetRequestTargetLength)
+		return jsonRPCResponse(t, `{"jsonrpc":"2.0","id":1,"result":"0x1"}`)
+	})
+
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    1,
+		GasPrice: big.NewInt(1),
+		Gas:      100000,
+		To:       &to,
+		Value:    big.NewInt(0),
+	})
+	require.NoError(t, etherScan.SendTransaction(context.Background(), tx))
+}
+
+func TestRPCProxyUsesPOSTForLargeSendTransactionRequest(t *testing.T) {
+	to := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	etherScan := newTestEtherScan(func(req *http.Request) *http.Response {
+		require.Equal(t, http.MethodPost, req.Method)
+		require.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
+		require.Empty(t, req.URL.RawQuery)
+		params := formValues(t, req)
+		require.Equal(t, "1", params.Get("chainId"))
+		require.Equal(t, "proxy", params.Get("module"))
+		require.Equal(t, "eth_sendRawTransaction", params.Get("action"))
+		require.Greater(t, len(params.Get("hex")), maxGetRequestTargetLength)
+		return jsonRPCResponse(t, `{"jsonrpc":"2.0","id":1,"result":"0x1"}`)
+	})
+
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    1,
+		GasPrice: big.NewInt(1),
+		Gas:      100000,
+		To:       &to,
+		Value:    big.NewInt(0),
+		Data:     bytes.Repeat([]byte{0xab}, 3000),
+	})
+	require.NoError(t, etherScan.SendTransaction(context.Background(), tx))
 }
 
 func TestTokenTransactionsByContractPaginationDedup(t *testing.T) {

--- a/backend/devices/bitbox02/keystore.go
+++ b/backend/devices/bitbox02/keystore.go
@@ -424,6 +424,7 @@ func (keystore *keystore) signETHTransaction(txProposal *eth.TxProposal) error {
 			tx.Value(),
 			tx.Data(),
 			firmware.ETHIdentifyCase(txProposal.RecipientAddress),
+			nil, // paymentRequest
 		)
 	case 0:
 		signature, err = keystore.device.ETHSign(

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/BitBoxSwiss/bitbox-wallet-app
 go 1.26.0
 
 require (
-	github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20260303104349-15a1f0c828a6
+	github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20260420184007-d546462995df
 	github.com/BitBoxSwiss/block-client-go v0.0.0-20250813114605-c276f6470c3d
 	github.com/btcsuite/btcd v0.25.0
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20260303104349-15a1f0c828a6 h1:uZ6N/P5shP6SWHCx6Ta6kemxGV/vkF2b5E1mi7zEEFw=
-github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20260303104349-15a1f0c828a6/go.mod h1:0A/jvQgsh2/nLvbFTF9cCwO0QXlAsx0fZqkFNbsCCnM=
+github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20260420184007-d546462995df h1:VED96kXmXl3mqPaE9lhm9/ZXcWVJdLPZ7RKK1R98T7I=
+github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20260420184007-d546462995df/go.mod h1:0A/jvQgsh2/nLvbFTF9cCwO0QXlAsx0fZqkFNbsCCnM=
 github.com/BitBoxSwiss/block-client-go v0.0.0-20250813114605-c276f6470c3d h1:HdoIlaUcNyEBajUoQgsxZtDMyCFyE7qv1kpeFe/u7nQ=
 github.com/BitBoxSwiss/block-client-go v0.0.0-20250813114605-c276f6470c3d/go.mod h1:SJTiQZU9ggBzVKMni97rpNS9GddPKErndFXNSDrfEGc=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/attestation.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/attestation.go
@@ -8,6 +8,7 @@ import (
 	"crypto/elliptic"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -134,6 +135,8 @@ var attestationPubkeys = []string{
 // The identifier is sha256(pubkey).
 var attestationPubkeysMap map[string]string
 
+const attestationPayloadLength = 32 + 64 + 64 + 32 + 64
+
 func unhex(s string) []byte {
 	b, err := hex.DecodeString(s)
 	if err != nil {
@@ -151,6 +154,91 @@ func init() {
 	}
 }
 
+func verifyECDSASignature(pubkey *ecdsa.PublicKey, message []byte, signature []byte) bool {
+	sigR := new(big.Int).SetBytes(signature[:32])
+	sigS := new(big.Int).SetBytes(signature[32:])
+	sigHash := sha256.Sum256(message)
+	return ecdsa.Verify(pubkey, sigHash[:], sigR, sigS)
+}
+
+type invalidAttestationError struct {
+	message string
+}
+
+func (err invalidAttestationError) Error() string {
+	return err.message
+}
+
+// VerifyAttestation verifies the 256-byte attestation payload returned by the device, excluding the
+// first success byte, against Shift's root attestation pubkeys and the original challenge.
+func VerifyAttestation(challenge []byte, attestation []byte) error {
+	if len(attestation) != attestationPayloadLength {
+		return errp.Newf(
+			"attestation must be %d bytes, got %d", attestationPayloadLength, len(attestation))
+	}
+
+	var bootloaderHash, devicePubkeyBytes, certificate, rootPubkeyIdentifier, challengeSignature []byte
+	bootloaderHash, attestation = attestation[:32], attestation[32:]
+	devicePubkeyBytes, attestation = attestation[:64], attestation[64:]
+	certificate, attestation = attestation[:64], attestation[64:]
+	rootPubkeyIdentifier, attestation = attestation[:32], attestation[32:]
+	challengeSignature = attestation[:64]
+
+	pubkeyHex, ok := attestationPubkeysMap[hex.EncodeToString(rootPubkeyIdentifier)]
+	if !ok {
+		return errp.Newf("could not find root pubkey. identifier=%x", rootPubkeyIdentifier)
+	}
+
+	rootPubkeyBytes, err := hex.DecodeString(pubkeyHex)
+	if err != nil {
+		return errp.WithStack(err)
+	}
+	rootPubkey, err := btcec.ParsePubKey(rootPubkeyBytes)
+	if err != nil {
+		return errp.WithStack(err)
+	}
+
+	devicePubkey := ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     new(big.Int).SetBytes(devicePubkeyBytes[:32]),
+		Y:     new(big.Int).SetBytes(devicePubkeyBytes[32:]),
+	}
+
+	var certMsg bytes.Buffer
+	certMsg.Write(bootloaderHash)
+	certMsg.Write(devicePubkeyBytes)
+	if !verifyECDSASignature(rootPubkey.ToECDSA(), certMsg.Bytes(), certificate) {
+		return errp.New("could not verify certificate")
+	}
+	if !verifyECDSASignature(&devicePubkey, challenge, challengeSignature) {
+		return errp.New("could not verify challenge signature")
+	}
+
+	return nil
+}
+
+// GetAttestation sends challenge to the device and returns the 256-byte attestation payload,
+// excluding the first success byte.
+func (device *Device) GetAttestation(challenge []byte) ([]byte, error) {
+	if !device.version.AtLeast(semver.NewSemVer(2, 0, 0)) {
+		return nil, errp.New("attestation not supported")
+	}
+
+	response, err := device.rawQuery(append([]byte(opAttestation), challenge...))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(response) < 1+attestationPayloadLength {
+		return nil, invalidAttestationError{message: "response too short"}
+	}
+	if string(response[:1]) != responseSuccess {
+		return nil, invalidAttestationError{message: "expected success"}
+	}
+
+	return response[1 : 1+attestationPayloadLength], nil
+}
+
 // performAttestation sends a random challenge and verifies that the response can be verified with
 // Shift's root attestation pubkeys. Returns true if the verification is successful.
 func (device *Device) performAttestation() (bool, error) {
@@ -159,74 +247,21 @@ func (device *Device) performAttestation() (bool, error) {
 		return true, nil
 	}
 	challenge := bytesOrPanic(32)
-	response, err := device.rawQuery(append([]byte(opAttestation), challenge...))
+	attestation, err := device.GetAttestation(challenge)
 	if err != nil {
+		var invalidErr invalidAttestationError
+		if errors.As(err, &invalidErr) {
+			device.log.Error(fmt.Sprintf("attestation: %v. challenge=%x", err, challenge), nil)
+			return false, nil
+		}
 		device.log.Error(fmt.Sprintf("attestation: could not perform request. challenge=%x", challenge), err)
 		return false, err
 	}
 
-	// See parsing below for what the sizes mean.
-	if len(response) < 1+32+64+64+32+64 {
-		device.log.Error(
-			fmt.Sprintf("attestation: response too short. challenge=%x, response=%x", challenge, response), nil)
-		return false, nil
-	}
-	if string(response[:1]) != responseSuccess {
-		device.log.Error(
-			fmt.Sprintf("attestation: expected success. challenge=%x, response=%x", challenge, response), nil)
-		return false, nil
-	}
-	rsp := response[1:]
-	var bootloaderHash, devicePubkeyBytes, certificate, rootPubkeyIdentifier, challengeSignature []byte
-	bootloaderHash, rsp = rsp[:32], rsp[32:]
-	devicePubkeyBytes, rsp = rsp[:64], rsp[64:]
-	certificate, rsp = rsp[:64], rsp[64:]
-	rootPubkeyIdentifier, rsp = rsp[:32], rsp[32:]
-	challengeSignature = rsp[:64]
-
-	pubkeyHex, ok := attestationPubkeysMap[hex.EncodeToString(rootPubkeyIdentifier)]
-	if !ok {
-		device.log.Error(fmt.Sprintf(
-			"could not find root pubkey. challenge=%x, response=%x, identifier=%x",
-			challenge,
-			response,
-			rootPubkeyIdentifier), nil)
-		return false, nil
-	}
-	rootPubkeyBytes, err := hex.DecodeString(pubkeyHex)
+	err = VerifyAttestation(challenge, attestation)
 	if err != nil {
-		panic(errp.WithStack(err))
-	}
-	rootPubkey, err := btcec.ParsePubKey(rootPubkeyBytes)
-	if err != nil {
-		panic(errp.WithStack(err))
-	}
-	devicePubkey := ecdsa.PublicKey{
-		Curve: elliptic.P256(),
-		X:     new(big.Int).SetBytes(devicePubkeyBytes[:32]),
-		Y:     new(big.Int).SetBytes(devicePubkeyBytes[32:]),
-	}
-
-	verify := func(pubkey *ecdsa.PublicKey, message []byte, signature []byte) bool {
-		sigR := new(big.Int).SetBytes(signature[:32])
-		sigS := new(big.Int).SetBytes(signature[32:])
-		sigHash := sha256.Sum256(message)
-		return ecdsa.Verify(pubkey, sigHash[:], sigR, sigS)
-	}
-
-	// Verify certificate
-	var certMsg bytes.Buffer
-	certMsg.Write(bootloaderHash)
-	certMsg.Write(devicePubkeyBytes)
-	if !verify(rootPubkey.ToECDSA(), certMsg.Bytes(), certificate) {
 		device.log.Error(
-			fmt.Sprintf("attestation: could not verify certificate. challenge=%x, response=%x", challenge, response), nil)
-		return false, nil
-	}
-	// Verify challenge
-	if !verify(&devicePubkey, challenge, challengeSignature) {
-		device.log.Error(
-			fmt.Sprintf("attestation: could not verify challgege signature. challenge=%x, response=%x", challenge, response), nil)
+			fmt.Sprintf("attestation: %v. challenge=%x, attestation=%x", err, challenge, attestation), nil)
 		return false, nil
 	}
 	return true, nil

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/eth.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/eth.go
@@ -15,9 +15,14 @@ import (
 	"github.com/BitBoxSwiss/bitbox02-api-go/util/semver"
 )
 
-// queryETH is like query, but nested one level deeper for Ethereum.
-func (device *Device) queryETH(request *messages.ETHRequest) (*messages.ETHResponse, error) {
-	response, err := device.query(&messages.Request{
+// ethStreamingThreshold is the firmware limit above which ETH data/bytes values
+// must be streamed instead of sent inline. Typed-message strings larger than
+// this limit are rejected instead of streamed.
+const ethStreamingThreshold = 6144
+
+// nonAtomicQueryETH is like nonAtomicQuery, but nested one level deeper for Ethereum.
+func (device *Device) nonAtomicQueryETH(request *messages.ETHRequest) (*messages.ETHResponse, error) {
+	response, err := device.nonAtomicQuery(&messages.Request{
 		Request: &messages.Request_Eth{
 			Eth: request,
 		},
@@ -30,6 +35,13 @@ func (device *Device) queryETH(request *messages.ETHRequest) (*messages.ETHRespo
 		return nil, errp.New("unexpected reply")
 	}
 	return ethResponse.Eth, nil
+}
+
+// queryETH is like query, but nested one level deeper for Ethereum.
+func (device *Device) queryETH(request *messages.ETHRequest) (*messages.ETHResponse, error) {
+	return atomicQueriesValue(device, func() (*messages.ETHResponse, error) {
+		return device.nonAtomicQueryETH(request)
+	})
 }
 
 // ethCoin the deprecated `coin` enum value for a given chain_id. Only ETH, Ropsten and Rinkeby are
@@ -98,12 +110,15 @@ func handleHostNonceCommitment() (*messages.AntiKleptoHostNonceCommitment, []byt
 	return hostNonceCommitment, hostNonce, nil
 }
 
-func (device *Device) handleSignerNonceCommitment(response *messages.ETHResponse, hostNonce []byte) ([]byte, error) {
+func (device *Device) nonAtomicHandleSignerNonceCommitment(
+	response *messages.ETHResponse,
+	hostNonce []byte,
+) ([]byte, error) {
 	signerCommitment, ok := response.Response.(*messages.ETHResponse_AntikleptoSignerCommitment)
 	if !ok {
 		return nil, errp.New("unexpected response")
 	}
-	response, err := device.queryETH(&messages.ETHRequest{
+	response, err := device.nonAtomicQueryETH(&messages.ETHRequest{
 		Request: &messages.ETHRequest_AntikleptoSignature{
 			AntikleptoSignature: &messages.AntiKleptoSignatureRequest{
 				HostNonce: hostNonce,
@@ -129,6 +144,34 @@ func (device *Device) handleSignerNonceCommitment(response *messages.ETHResponse
 	return signature, nil
 }
 
+func (device *Device) nonAtomicHandleETHDataStreaming(
+	data []byte,
+	response *messages.ETHResponse,
+) (*messages.ETHResponse, error) {
+	for {
+		chunkRequest, ok := response.Response.(*messages.ETHResponse_DataRequestChunk)
+		if !ok {
+			return response, nil
+		}
+		offset := int(chunkRequest.DataRequestChunk.Offset)
+		length := int(chunkRequest.DataRequestChunk.Length)
+		if offset < 0 || length < 0 || offset+length > len(data) {
+			return nil, errp.New("unexpected response")
+		}
+		var err error
+		response, err = device.nonAtomicQueryETH(&messages.ETHRequest{
+			Request: &messages.ETHRequest_DataResponseChunk{
+				DataResponseChunk: &messages.ETHSignDataResponseChunkRequest{
+					Chunk: data[offset : offset+length],
+				},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
 // ETHIdentifyCase identifies the case of the recipient address given as hexadecimal string.
 // This function exists as a convenience to potentially help clients to determine the case of the
 // recipient address. The output of the function goes to ETHSign and ETHSignEIP1559 as the
@@ -145,7 +188,9 @@ func ETHIdentifyCase(recipientAddress string) messages.ETHAddressCase {
 	}
 }
 
-// ETHSign signs an ethereum transaction. It returns a 65 byte signature (R, S, and 1 byte recID).
+// ETHSign signs an ethereum transaction. It returns a 65 byte signature (R, S,
+// and 1 byte recID). If len(data) > 6144, firmware v9.26.0 or newer is
+// required.
 func (device *Device) ETHSign(
 	chainID uint64,
 	keypath []uint32,
@@ -156,7 +201,37 @@ func (device *Device) ETHSign(
 	value *big.Int,
 	data []byte,
 	recipientAddressCase messages.ETHAddressCase) ([]byte, error) {
+	return atomicQueriesValue(device, func() ([]byte, error) {
+		return device.nonAtomicETHSign(
+			chainID,
+			keypath,
+			nonce,
+			gasPrice,
+			gasLimit,
+			recipient,
+			value,
+			data,
+			recipientAddressCase,
+		)
+	})
+}
+
+func (device *Device) nonAtomicETHSign(
+	chainID uint64,
+	keypath []uint32,
+	nonce uint64,
+	gasPrice *big.Int,
+	gasLimit uint64,
+	recipient [20]byte,
+	value *big.Int,
+	data []byte,
+	recipientAddressCase messages.ETHAddressCase,
+) ([]byte, error) {
 	supportsAntiklepto := device.version.AtLeast(semver.NewSemVer(9, 5, 0))
+	useStreaming := len(data) > ethStreamingThreshold
+	if useStreaming && !device.version.AtLeast(semver.NewSemVer(9, 26, 0)) {
+		return nil, UnsupportedError("9.26.0")
+	}
 
 	var hostNonceCommitment *messages.AntiKleptoHostNonceCommitment
 	var err error
@@ -174,34 +249,42 @@ func (device *Device) ETHSign(
 		return nil, err
 	}
 
+	signReq := &messages.ETHSignRequest{
+		Coin:                coin,
+		ChainId:             chainID,
+		Keypath:             keypath,
+		Nonce:               new(big.Int).SetUint64(nonce).Bytes(),
+		GasPrice:            gasPrice.Bytes(),
+		GasLimit:            new(big.Int).SetUint64(gasLimit).Bytes(),
+		Recipient:           recipient[:],
+		Value:               value.Bytes(),
+		Data:                data,
+		HostNonceCommitment: hostNonceCommitment,
+		AddressCase:         recipientAddressCase,
+	}
+	if useStreaming {
+		signReq.Data = nil
+		signReq.DataLength = uint32(len(data))
+	}
+
 	request := &messages.ETHRequest{
 		Request: &messages.ETHRequest_Sign{
-			Sign: &messages.ETHSignRequest{
-				Coin:                coin,
-				ChainId:             chainID,
-				Keypath:             keypath,
-				Nonce:               new(big.Int).SetUint64(nonce).Bytes(),
-				GasPrice:            gasPrice.Bytes(),
-				GasLimit:            new(big.Int).SetUint64(gasLimit).Bytes(),
-				Recipient:           recipient[:],
-				Value:               value.Bytes(),
-				Data:                data,
-				HostNonceCommitment: hostNonceCommitment,
-				AddressCase:         recipientAddressCase,
-			},
+			Sign: signReq,
 		},
 	}
-	response, err := device.queryETH(request)
+	response, err := device.nonAtomicQueryETH(request)
 	if err != nil {
 		return nil, err
 	}
-
-	if supportsAntiklepto {
-		signature, err := device.handleSignerNonceCommitment(response, hostNonce)
+	if useStreaming {
+		response, err = device.nonAtomicHandleETHDataStreaming(data, response)
 		if err != nil {
 			return nil, err
 		}
-		return signature, nil
+	}
+
+	if supportsAntiklepto {
+		return device.nonAtomicHandleSignerNonceCommitment(response, hostNonce)
 	}
 	signResponse, ok := response.Response.(*messages.ETHResponse_Sign)
 	if !ok {
@@ -210,7 +293,9 @@ func (device *Device) ETHSign(
 	return signResponse.Sign.Signature, nil
 }
 
-// ETHSignEIP1559 signs an ethereum EIP1559 transaction. It returns a 65 byte signature (R, S, and 1 byte recID).
+// ETHSignEIP1559 signs an ethereum EIP1559 transaction. It returns a 65 byte
+// signature (R, S, and 1 byte recID). If paymentRequest is provided or
+// len(data) > 6144, firmware v9.26.0 or newer is required.
 func (device *Device) ETHSignEIP1559(
 	chainID uint64,
 	keypath []uint32,
@@ -221,10 +306,45 @@ func (device *Device) ETHSignEIP1559(
 	recipient [20]byte,
 	value *big.Int,
 	data []byte,
-	recipientAddressCase messages.ETHAddressCase) ([]byte, error) {
+	recipientAddressCase messages.ETHAddressCase,
+	paymentRequest *messages.BTCPaymentRequestRequest,
+) ([]byte, error) {
+	return atomicQueriesValue(device, func() ([]byte, error) {
+		return device.nonAtomicETHSignEIP1559(
+			chainID,
+			keypath,
+			nonce,
+			maxPriorityFeePerGas,
+			maxFeePerGas,
+			gasLimit,
+			recipient,
+			value,
+			data,
+			recipientAddressCase,
+			paymentRequest,
+		)
+	})
+}
 
+func (device *Device) nonAtomicETHSignEIP1559(
+	chainID uint64,
+	keypath []uint32,
+	nonce uint64,
+	maxPriorityFeePerGas *big.Int,
+	maxFeePerGas *big.Int,
+	gasLimit uint64,
+	recipient [20]byte,
+	value *big.Int,
+	data []byte,
+	recipientAddressCase messages.ETHAddressCase,
+	paymentRequest *messages.BTCPaymentRequestRequest,
+) ([]byte, error) {
 	if !device.version.AtLeast(semver.NewSemVer(9, 16, 0)) {
 		return nil, UnsupportedError("9.16.0")
+	}
+	useStreaming := len(data) > ethStreamingThreshold
+	if (paymentRequest != nil || useStreaming) && !device.version.AtLeast(semver.NewSemVer(9, 26, 0)) {
+		return nil, UnsupportedError("9.26.0")
 	}
 
 	hostNonceCommitment, hostNonce, err := handleHostNonceCommitment()
@@ -232,33 +352,42 @@ func (device *Device) ETHSignEIP1559(
 		return nil, err
 	}
 
-	request := &messages.ETHRequest{
-		Request: &messages.ETHRequest_SignEip1559{
-			SignEip1559: &messages.ETHSignEIP1559Request{
-				ChainId:              chainID,
-				Keypath:              keypath,
-				Nonce:                new(big.Int).SetUint64(nonce).Bytes(),
-				MaxPriorityFeePerGas: maxPriorityFeePerGas.Bytes(),
-				MaxFeePerGas:         maxFeePerGas.Bytes(),
-				GasLimit:             new(big.Int).SetUint64(gasLimit).Bytes(),
-				Recipient:            recipient[:],
-				Value:                value.Bytes(),
-				Data:                 data,
-				HostNonceCommitment:  hostNonceCommitment,
-				AddressCase:          recipientAddressCase,
-			},
-		},
+	signEIP1559Req := &messages.ETHSignEIP1559Request{
+		ChainId:              chainID,
+		Keypath:              keypath,
+		Nonce:                new(big.Int).SetUint64(nonce).Bytes(),
+		MaxPriorityFeePerGas: maxPriorityFeePerGas.Bytes(),
+		MaxFeePerGas:         maxFeePerGas.Bytes(),
+		GasLimit:             new(big.Int).SetUint64(gasLimit).Bytes(),
+		Recipient:            recipient[:],
+		Value:                value.Bytes(),
+		Data:                 data,
+		HostNonceCommitment:  hostNonceCommitment,
+		AddressCase:          recipientAddressCase,
+		PaymentRequest:       paymentRequest,
 	}
-	response, err := device.queryETH(request)
-	if err != nil {
-		return nil, err
+	if useStreaming {
+		signEIP1559Req.Data = nil
+		signEIP1559Req.DataLength = uint32(len(data))
 	}
 
-	signature, err := device.handleSignerNonceCommitment(response, hostNonce)
+	request := &messages.ETHRequest{
+		Request: &messages.ETHRequest_SignEip1559{
+			SignEip1559: signEIP1559Req,
+		},
+	}
+	response, err := device.nonAtomicQueryETH(request)
 	if err != nil {
 		return nil, err
 	}
-	return signature, nil
+	if useStreaming {
+		response, err = device.nonAtomicHandleETHDataStreaming(data, response)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return device.nonAtomicHandleSignerNonceCommitment(response, hostNonce)
 }
 
 // ETHSignMessage signs an Ethereum message. The provided msg will be prefixed with "\x19Ethereum
@@ -266,6 +395,16 @@ func (device *Device) ETHSignEIP1559(
 // ascii representation with no fixed size or delimiter, WTF).
 // 27 is added to the recID to denote an uncompressed pubkey.
 func (device *Device) ETHSignMessage(
+	chainID uint64,
+	keypath []uint32,
+	msg []byte,
+) ([]byte, error) {
+	return atomicQueriesValue(device, func() ([]byte, error) {
+		return device.nonAtomicETHSignMessage(chainID, keypath, msg)
+	})
+}
+
+func (device *Device) nonAtomicETHSignMessage(
 	chainID uint64,
 	keypath []uint32,
 	msg []byte,
@@ -304,37 +443,13 @@ func (device *Device) ETHSignMessage(
 			},
 		},
 	}
-	response, err := device.queryETH(request)
+	response, err := device.nonAtomicQueryETH(request)
 	if err != nil {
 		return nil, err
 	}
 
 	if supportsAntiklepto {
-		signerCommitment, ok := response.Response.(*messages.ETHResponse_AntikleptoSignerCommitment)
-		if !ok {
-			return nil, errp.New("unexpected response")
-		}
-		response, err := device.queryETH(&messages.ETHRequest{
-			Request: &messages.ETHRequest_AntikleptoSignature{
-				AntikleptoSignature: &messages.AntiKleptoSignatureRequest{
-					HostNonce: hostNonce,
-				},
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		signResponse, ok := response.Response.(*messages.ETHResponse_Sign)
-		if !ok {
-			return nil, errp.New("unexpected response")
-		}
-		signature := signResponse.Sign.Signature
-		err = antikleptoVerify(
-			hostNonce,
-			signerCommitment.AntikleptoSignerCommitment.Commitment,
-			signature[:64],
-		)
+		signature, err := device.nonAtomicHandleSignerNonceCommitment(response, hostNonce)
 		if err != nil {
 			return nil, err
 		}
@@ -529,7 +644,10 @@ func encodeValue(typ *messages.ETHSignTypedMessageRequest_MemberType, value inte
 	return nil, errp.New("couldn't encode value")
 }
 
-func getValue(what *messages.ETHTypedMessageValueResponse, msg map[string]interface{}) ([]byte, error) {
+func getValue(
+	what *messages.ETHTypedMessageValueResponse,
+	msg map[string]interface{},
+) ([]byte, messages.ETHSignTypedMessageRequest_DataType, error) {
 	types := msg["types"].(map[string]interface{})
 
 	var value interface{}
@@ -541,17 +659,17 @@ func getValue(what *messages.ETHTypedMessageValueResponse, msg map[string]interf
 		var err error
 		typ, err = parseType("EIP712Domain", types)
 		if err != nil {
-			return nil, err
+			return nil, messages.ETHSignTypedMessageRequest_UNKNOWN, err
 		}
 	case messages.ETHTypedMessageValueResponse_MESSAGE:
 		value = msg["message"]
 		var err error
 		typ, err = parseType(msg["primaryType"].(string), types)
 		if err != nil {
-			return nil, err
+			return nil, messages.ETHSignTypedMessageRequest_UNKNOWN, err
 		}
 	default:
-		return nil, errp.Newf("unknown root: %v", what.RootObject)
+		return nil, messages.ETHSignTypedMessageRequest_UNKNOWN, errp.Newf("unknown root: %v", what.RootObject)
 	}
 	for _, element := range what.Path {
 		switch typ.Type {
@@ -561,22 +679,39 @@ func getValue(what *messages.ETHTypedMessageValueResponse, msg map[string]interf
 			var err error
 			typ, err = parseType(structMember["type"].(string), types)
 			if err != nil {
-				return nil, err
+				return nil, messages.ETHSignTypedMessageRequest_UNKNOWN, err
 			}
 		case messages.ETHSignTypedMessageRequest_ARRAY:
 			value = value.([]interface{})[element]
 			typ = typ.ArrayType
 		default:
-			return nil, errp.New("path element does not point to struct or array")
+			return nil, messages.ETHSignTypedMessageRequest_UNKNOWN, errp.New("path element does not point to struct or array")
 		}
 	}
-	return encodeValue(typ, value)
+	encoded, err := encodeValue(typ, value)
+	if err != nil {
+		return nil, messages.ETHSignTypedMessageRequest_UNKNOWN, err
+	}
+	return encoded, typ.Type, nil
 }
 
-// ETHSignTypedMessage signs an Ethereum EIP-712 typed message. 27 is added to the recID to denote
-// an uncompressed pubkey. If useAntiklepto is false, signing is deterministic and requires
-// firmware >= 9.26.0.
+// ETHSignTypedMessage signs an Ethereum EIP-712 typed message. 27 is added to
+// the recID to denote an uncompressed pubkey. If useAntiklepto is false,
+// signing is deterministic and requires firmware >= 9.26.0. If a typed-message
+// bytes value exceeds 6144 bytes, firmware >= 9.26.0 is required to stream it.
+// Typed-message string values larger than 6144 bytes are rejected.
 func (device *Device) ETHSignTypedMessage(
+	chainID uint64,
+	keypath []uint32,
+	jsonMsg []byte,
+	useAntiklepto bool,
+) ([]byte, error) {
+	return atomicQueriesValue(device, func() ([]byte, error) {
+		return device.nonAtomicETHSignTypedMessage(chainID, keypath, jsonMsg, useAntiklepto)
+	})
+}
+
+func (device *Device) nonAtomicETHSignTypedMessage(
 	chainID uint64,
 	keypath []uint32,
 	jsonMsg []byte,
@@ -638,56 +773,50 @@ func (device *Device) ETHSignTypedMessage(
 			},
 		},
 	}
-	response, err := device.queryETH(request)
+	response, err := device.nonAtomicQueryETH(request)
 	if err != nil {
 		return nil, err
 	}
 
 	typedMsgValueResponse, ok := response.Response.(*messages.ETHResponse_TypedMsgValue)
 	for ok {
-		value, err := getValue(typedMsgValueResponse.TypedMsgValue, msg)
+		value, dataType, err := getValue(typedMsgValueResponse.TypedMsgValue, msg)
 		if err != nil {
 			return nil, err
 		}
-		response, err = device.queryETH(&messages.ETHRequest{
+		useStreaming := len(value) > ethStreamingThreshold
+		if dataType == messages.ETHSignTypedMessageRequest_STRING && useStreaming {
+			return nil, errp.New("string value exceeds maximum size")
+		}
+		if useStreaming && !device.version.AtLeast(semver.NewSemVer(9, 26, 0)) {
+			return nil, UnsupportedError("9.26.0")
+		}
+		valueRequest := &messages.ETHTypedMessageValueRequest{
+			Value: value,
+		}
+		if useStreaming {
+			valueRequest.Value = nil
+			valueRequest.DataLength = uint32(len(value))
+		}
+		response, err = device.nonAtomicQueryETH(&messages.ETHRequest{
 			Request: &messages.ETHRequest_TypedMsgValue{
-				TypedMsgValue: &messages.ETHTypedMessageValueRequest{
-					Value: value,
-				},
+				TypedMsgValue: valueRequest,
 			},
 		})
 		if err != nil {
 			return nil, err
+		}
+		if useStreaming {
+			response, err = device.nonAtomicHandleETHDataStreaming(value, response)
+			if err != nil {
+				return nil, err
+			}
 		}
 		typedMsgValueResponse, ok = response.Response.(*messages.ETHResponse_TypedMsgValue)
 	}
 
 	if useAntiklepto {
-		signerCommitment, ok := response.Response.(*messages.ETHResponse_AntikleptoSignerCommitment)
-		if !ok {
-			return nil, errp.New("unexpected response")
-		}
-		response, err = device.queryETH(&messages.ETHRequest{
-			Request: &messages.ETHRequest_AntikleptoSignature{
-				AntikleptoSignature: &messages.AntiKleptoSignatureRequest{
-					HostNonce: hostNonce,
-				},
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		signResponse, ok := response.Response.(*messages.ETHResponse_Sign)
-		if !ok {
-			return nil, errp.New("unexpected response")
-		}
-		signature := signResponse.Sign.Signature
-		err = antikleptoVerify(
-			hostNonce,
-			signerCommitment.AntikleptoSignerCommitment.Commitment,
-			signature[:64],
-		)
+		signature, err := device.nonAtomicHandleSignerNonceCommitment(response, hostNonce)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages/btc.pb.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages/btc.pb.go
@@ -2397,6 +2397,7 @@ type BTCPaymentRequestRequest_Memo struct {
 	// Types that are valid to be assigned to Memo:
 	//
 	//	*BTCPaymentRequestRequest_Memo_TextMemo_
+	//	*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_
 	Memo          isBTCPaymentRequestRequest_Memo_Memo `protobuf_oneof:"memo"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2448,6 +2449,15 @@ func (x *BTCPaymentRequestRequest_Memo) GetTextMemo() *BTCPaymentRequestRequest_
 	return nil
 }
 
+func (x *BTCPaymentRequestRequest_Memo) GetCoinPurchaseMemo() *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo {
+	if x != nil {
+		if x, ok := x.Memo.(*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_); ok {
+			return x.CoinPurchaseMemo
+		}
+	}
+	return nil
+}
+
 type isBTCPaymentRequestRequest_Memo_Memo interface {
 	isBTCPaymentRequestRequest_Memo_Memo()
 }
@@ -2456,7 +2466,13 @@ type BTCPaymentRequestRequest_Memo_TextMemo_ struct {
 	TextMemo *BTCPaymentRequestRequest_Memo_TextMemo `protobuf:"bytes,1,opt,name=text_memo,json=textMemo,proto3,oneof"`
 }
 
+type BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_ struct {
+	CoinPurchaseMemo *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo `protobuf:"bytes,2,opt,name=coin_purchase_memo,json=coinPurchaseMemo,proto3,oneof"`
+}
+
 func (*BTCPaymentRequestRequest_Memo_TextMemo_) isBTCPaymentRequestRequest_Memo_Memo() {}
+
+func (*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_) isBTCPaymentRequestRequest_Memo_Memo() {}
 
 type BTCPaymentRequestRequest_Memo_TextMemo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2500,6 +2516,205 @@ func (x *BTCPaymentRequestRequest_Memo_TextMemo) GetNote() string {
 		return x.Note
 	}
 	return ""
+}
+
+type BTCPaymentRequestRequest_Memo_CoinPurchaseMemo struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	CoinType uint32                 `protobuf:"varint,1,opt,name=coin_type,json=coinType,proto3" json:"coin_type,omitempty"` // SLIP-44 coin type
+	Amount   string                 `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount,omitempty"`                      // Human-readable amount (e.g. "0.25 ETH")
+	Address  string                 `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`                    // Address to send the purchased coins to
+	// Types that are valid to be assigned to AddressDerivation:
+	//
+	//	*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Eth
+	//	*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Btc
+	AddressDerivation isBTCPaymentRequestRequest_Memo_CoinPurchaseMemo_AddressDerivation `protobuf_oneof:"address_derivation"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) Reset() {
+	*x = BTCPaymentRequestRequest_Memo_CoinPurchaseMemo{}
+	mi := &file_btc_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) ProtoMessage() {}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) ProtoReflect() protoreflect.Message {
+	mi := &file_btc_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BTCPaymentRequestRequest_Memo_CoinPurchaseMemo.ProtoReflect.Descriptor instead.
+func (*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) Descriptor() ([]byte, []int) {
+	return file_btc_proto_rawDescGZIP(), []int{16, 0, 1}
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) GetCoinType() uint32 {
+	if x != nil {
+		return x.CoinType
+	}
+	return 0
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) GetAmount() string {
+	if x != nil {
+		return x.Amount
+	}
+	return ""
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) GetAddressDerivation() isBTCPaymentRequestRequest_Memo_CoinPurchaseMemo_AddressDerivation {
+	if x != nil {
+		return x.AddressDerivation
+	}
+	return nil
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) GetEth() *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation {
+	if x != nil {
+		if x, ok := x.AddressDerivation.(*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Eth); ok {
+			return x.Eth
+		}
+	}
+	return nil
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo) GetBtc() *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation {
+	if x != nil {
+		if x, ok := x.AddressDerivation.(*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Btc); ok {
+			return x.Btc
+		}
+	}
+	return nil
+}
+
+type isBTCPaymentRequestRequest_Memo_CoinPurchaseMemo_AddressDerivation interface {
+	isBTCPaymentRequestRequest_Memo_CoinPurchaseMemo_AddressDerivation()
+}
+
+type BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Eth struct {
+	Eth *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation `protobuf:"bytes,4,opt,name=eth,proto3,oneof"`
+}
+
+type BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Btc struct {
+	Btc *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation `protobuf:"bytes,5,opt,name=btc,proto3,oneof"`
+}
+
+func (*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Eth) isBTCPaymentRequestRequest_Memo_CoinPurchaseMemo_AddressDerivation() {
+}
+
+func (*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Btc) isBTCPaymentRequestRequest_Memo_CoinPurchaseMemo_AddressDerivation() {
+}
+
+// Derivation info for verifying address ownership.
+// NOT part of the SLIP-24 sighash.
+type BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keypath       []uint32               `protobuf:"varint,1,rep,packed,name=keypath,proto3" json:"keypath,omitempty"` // Keypath to the address
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation) Reset() {
+	*x = BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation{}
+	mi := &file_btc_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation) ProtoMessage() {}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation) ProtoReflect() protoreflect.Message {
+	mi := &file_btc_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation.ProtoReflect.Descriptor instead.
+func (*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation) Descriptor() ([]byte, []int) {
+	return file_btc_proto_rawDescGZIP(), []int{16, 0, 1, 0}
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation) GetKeypath() []uint32 {
+	if x != nil {
+		return x.Keypath
+	}
+	return nil
+}
+
+type BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Script config + keypath are needed to derive BTC/LTC-family addresses.
+	ScriptConfig  *BTCScriptConfigWithKeypath `protobuf:"bytes,1,opt,name=script_config,json=scriptConfig,proto3" json:"script_config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation) Reset() {
+	*x = BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation{}
+	mi := &file_btc_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation) ProtoMessage() {}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation) ProtoReflect() protoreflect.Message {
+	mi := &file_btc_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation.ProtoReflect.Descriptor instead.
+func (*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation) Descriptor() ([]byte, []int) {
+	return file_btc_proto_rawDescGZIP(), []int{16, 0, 1, 1}
+}
+
+func (x *BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation) GetScriptConfig() *BTCScriptConfigWithKeypath {
+	if x != nil {
+		return x.ScriptConfig
+	}
+	return nil
 }
 
 var File_btc_proto protoreflect.FileDescriptor
@@ -2654,17 +2869,29 @@ const file_btc_proto_rawDesc = "" +
 	"\bsequence\x18\x04 \x01(\rR\bsequence\"S\n" +
 	"\x16BTCPrevTxOutputRequest\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\x04R\x05value\x12#\n" +
-	"\rpubkey_script\x18\x02 \x01(\fR\fpubkeyScript\"\xf1\x02\n" +
+	"\rpubkey_script\x18\x02 \x01(\fR\fpubkeyScript\"\xe0\a\n" +
 	"\x18BTCPaymentRequestRequest\x12%\n" +
 	"\x0erecipient_name\x18\x01 \x01(\tR\rrecipientName\x12I\n" +
 	"\x05memos\x18\x02 \x03(\v23.shiftcrypto.bitbox02.BTCPaymentRequestRequest.MemoR\x05memos\x12\x14\n" +
 	"\x05nonce\x18\x03 \x01(\fR\x05nonce\x12!\n" +
 	"\ftotal_amount\x18\x04 \x01(\x04R\vtotalAmount\x12\x1c\n" +
-	"\tsignature\x18\x05 \x01(\fR\tsignature\x1a\x8b\x01\n" +
+	"\tsignature\x18\x05 \x01(\fR\tsignature\x1a\xfa\x05\n" +
 	"\x04Memo\x12[\n" +
-	"\ttext_memo\x18\x01 \x01(\v2<.shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.TextMemoH\x00R\btextMemo\x1a\x1e\n" +
+	"\ttext_memo\x18\x01 \x01(\v2<.shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.TextMemoH\x00R\btextMemo\x12t\n" +
+	"\x12coin_purchase_memo\x18\x02 \x01(\v2D.shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemoH\x00R\x10coinPurchaseMemo\x1a\x1e\n" +
 	"\bTextMemo\x12\x12\n" +
-	"\x04note\x18\x01 \x01(\tR\x04noteB\x06\n" +
+	"\x04note\x18\x01 \x01(\tR\x04note\x1a\xf6\x03\n" +
+	"\x10CoinPurchaseMemo\x12\x1b\n" +
+	"\tcoin_type\x18\x01 \x01(\rR\bcoinType\x12\x16\n" +
+	"\x06amount\x18\x02 \x01(\tR\x06amount\x12\x18\n" +
+	"\aaddress\x18\x03 \x01(\tR\aaddress\x12m\n" +
+	"\x03eth\x18\x04 \x01(\v2Y.shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo.EthAddressDerivationH\x00R\x03eth\x12m\n" +
+	"\x03btc\x18\x05 \x01(\v2Y.shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo.BtcAddressDerivationH\x00R\x03btc\x1a0\n" +
+	"\x14EthAddressDerivation\x12\x18\n" +
+	"\akeypath\x18\x01 \x03(\rR\akeypath\x1am\n" +
+	"\x14BtcAddressDerivation\x12U\n" +
+	"\rscript_config\x18\x01 \x01(\v20.shiftcrypto.bitbox02.BTCScriptConfigWithKeypathR\fscriptConfigB\x14\n" +
+	"\x12address_derivationB\x06\n" +
 	"\x04memo\"\x9c\x02\n" +
 	"\x15BTCSignMessageRequest\x121\n" +
 	"\x04coin\x18\x01 \x01(\x0e2\x1d.shiftcrypto.bitbox02.BTCCoinR\x04coin\x12U\n" +
@@ -2724,50 +2951,53 @@ func file_btc_proto_rawDescGZIP() []byte {
 }
 
 var file_btc_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_btc_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_btc_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_btc_proto_goTypes = []any{
-	(BTCCoin)(0),                                   // 0: shiftcrypto.bitbox02.BTCCoin
-	(BTCOutputType)(0),                             // 1: shiftcrypto.bitbox02.BTCOutputType
-	(BTCScriptConfig_SimpleType)(0),                // 2: shiftcrypto.bitbox02.BTCScriptConfig.SimpleType
-	(BTCScriptConfig_Multisig_ScriptType)(0),       // 3: shiftcrypto.bitbox02.BTCScriptConfig.Multisig.ScriptType
-	(BTCPubRequest_XPubType)(0),                    // 4: shiftcrypto.bitbox02.BTCPubRequest.XPubType
-	(BTCXpubsRequest_XPubType)(0),                  // 5: shiftcrypto.bitbox02.BTCXpubsRequest.XPubType
-	(BTCSignInitRequest_FormatUnit)(0),             // 6: shiftcrypto.bitbox02.BTCSignInitRequest.FormatUnit
-	(BTCSignNextResponse_Type)(0),                  // 7: shiftcrypto.bitbox02.BTCSignNextResponse.Type
-	(BTCRegisterScriptConfigRequest_XPubType)(0),   // 8: shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest.XPubType
-	(*BTCScriptConfig)(nil),                        // 9: shiftcrypto.bitbox02.BTCScriptConfig
-	(*BTCPubRequest)(nil),                          // 10: shiftcrypto.bitbox02.BTCPubRequest
-	(*BTCXpubsRequest)(nil),                        // 11: shiftcrypto.bitbox02.BTCXpubsRequest
-	(*BTCScriptConfigWithKeypath)(nil),             // 12: shiftcrypto.bitbox02.BTCScriptConfigWithKeypath
-	(*BTCSignInitRequest)(nil),                     // 13: shiftcrypto.bitbox02.BTCSignInitRequest
-	(*BTCSignNextResponse)(nil),                    // 14: shiftcrypto.bitbox02.BTCSignNextResponse
-	(*BTCSignInputRequest)(nil),                    // 15: shiftcrypto.bitbox02.BTCSignInputRequest
-	(*BTCSignOutputRequest)(nil),                   // 16: shiftcrypto.bitbox02.BTCSignOutputRequest
-	(*BTCScriptConfigRegistration)(nil),            // 17: shiftcrypto.bitbox02.BTCScriptConfigRegistration
-	(*BTCSuccess)(nil),                             // 18: shiftcrypto.bitbox02.BTCSuccess
-	(*BTCIsScriptConfigRegisteredRequest)(nil),     // 19: shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequest
-	(*BTCIsScriptConfigRegisteredResponse)(nil),    // 20: shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponse
-	(*BTCRegisterScriptConfigRequest)(nil),         // 21: shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest
-	(*BTCPrevTxInitRequest)(nil),                   // 22: shiftcrypto.bitbox02.BTCPrevTxInitRequest
-	(*BTCPrevTxInputRequest)(nil),                  // 23: shiftcrypto.bitbox02.BTCPrevTxInputRequest
-	(*BTCPrevTxOutputRequest)(nil),                 // 24: shiftcrypto.bitbox02.BTCPrevTxOutputRequest
-	(*BTCPaymentRequestRequest)(nil),               // 25: shiftcrypto.bitbox02.BTCPaymentRequestRequest
-	(*BTCSignMessageRequest)(nil),                  // 26: shiftcrypto.bitbox02.BTCSignMessageRequest
-	(*BTCSignMessageResponse)(nil),                 // 27: shiftcrypto.bitbox02.BTCSignMessageResponse
-	(*BTCRequest)(nil),                             // 28: shiftcrypto.bitbox02.BTCRequest
-	(*BTCResponse)(nil),                            // 29: shiftcrypto.bitbox02.BTCResponse
-	(*BTCScriptConfig_Multisig)(nil),               // 30: shiftcrypto.bitbox02.BTCScriptConfig.Multisig
-	(*BTCScriptConfig_Policy)(nil),                 // 31: shiftcrypto.bitbox02.BTCScriptConfig.Policy
-	(*BTCSignOutputRequest_SilentPayment)(nil),     // 32: shiftcrypto.bitbox02.BTCSignOutputRequest.SilentPayment
-	(*BTCPaymentRequestRequest_Memo)(nil),          // 33: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo
-	(*BTCPaymentRequestRequest_Memo_TextMemo)(nil), // 34: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.TextMemo
-	(*Keypath)(nil),                                // 35: shiftcrypto.bitbox02.Keypath
-	(*AntiKleptoSignerCommitment)(nil),             // 36: shiftcrypto.bitbox02.AntiKleptoSignerCommitment
-	(*AntiKleptoHostNonceCommitment)(nil),          // 37: shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
-	(*AntiKleptoSignatureRequest)(nil),             // 38: shiftcrypto.bitbox02.AntiKleptoSignatureRequest
-	(*PubsResponse)(nil),                           // 39: shiftcrypto.bitbox02.PubsResponse
-	(*XPub)(nil),                                   // 40: shiftcrypto.bitbox02.XPub
-	(*KeyOriginInfo)(nil),                          // 41: shiftcrypto.bitbox02.KeyOriginInfo
+	(BTCCoin)(0),                                           // 0: shiftcrypto.bitbox02.BTCCoin
+	(BTCOutputType)(0),                                     // 1: shiftcrypto.bitbox02.BTCOutputType
+	(BTCScriptConfig_SimpleType)(0),                        // 2: shiftcrypto.bitbox02.BTCScriptConfig.SimpleType
+	(BTCScriptConfig_Multisig_ScriptType)(0),               // 3: shiftcrypto.bitbox02.BTCScriptConfig.Multisig.ScriptType
+	(BTCPubRequest_XPubType)(0),                            // 4: shiftcrypto.bitbox02.BTCPubRequest.XPubType
+	(BTCXpubsRequest_XPubType)(0),                          // 5: shiftcrypto.bitbox02.BTCXpubsRequest.XPubType
+	(BTCSignInitRequest_FormatUnit)(0),                     // 6: shiftcrypto.bitbox02.BTCSignInitRequest.FormatUnit
+	(BTCSignNextResponse_Type)(0),                          // 7: shiftcrypto.bitbox02.BTCSignNextResponse.Type
+	(BTCRegisterScriptConfigRequest_XPubType)(0),           // 8: shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest.XPubType
+	(*BTCScriptConfig)(nil),                                // 9: shiftcrypto.bitbox02.BTCScriptConfig
+	(*BTCPubRequest)(nil),                                  // 10: shiftcrypto.bitbox02.BTCPubRequest
+	(*BTCXpubsRequest)(nil),                                // 11: shiftcrypto.bitbox02.BTCXpubsRequest
+	(*BTCScriptConfigWithKeypath)(nil),                     // 12: shiftcrypto.bitbox02.BTCScriptConfigWithKeypath
+	(*BTCSignInitRequest)(nil),                             // 13: shiftcrypto.bitbox02.BTCSignInitRequest
+	(*BTCSignNextResponse)(nil),                            // 14: shiftcrypto.bitbox02.BTCSignNextResponse
+	(*BTCSignInputRequest)(nil),                            // 15: shiftcrypto.bitbox02.BTCSignInputRequest
+	(*BTCSignOutputRequest)(nil),                           // 16: shiftcrypto.bitbox02.BTCSignOutputRequest
+	(*BTCScriptConfigRegistration)(nil),                    // 17: shiftcrypto.bitbox02.BTCScriptConfigRegistration
+	(*BTCSuccess)(nil),                                     // 18: shiftcrypto.bitbox02.BTCSuccess
+	(*BTCIsScriptConfigRegisteredRequest)(nil),             // 19: shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequest
+	(*BTCIsScriptConfigRegisteredResponse)(nil),            // 20: shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponse
+	(*BTCRegisterScriptConfigRequest)(nil),                 // 21: shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest
+	(*BTCPrevTxInitRequest)(nil),                           // 22: shiftcrypto.bitbox02.BTCPrevTxInitRequest
+	(*BTCPrevTxInputRequest)(nil),                          // 23: shiftcrypto.bitbox02.BTCPrevTxInputRequest
+	(*BTCPrevTxOutputRequest)(nil),                         // 24: shiftcrypto.bitbox02.BTCPrevTxOutputRequest
+	(*BTCPaymentRequestRequest)(nil),                       // 25: shiftcrypto.bitbox02.BTCPaymentRequestRequest
+	(*BTCSignMessageRequest)(nil),                          // 26: shiftcrypto.bitbox02.BTCSignMessageRequest
+	(*BTCSignMessageResponse)(nil),                         // 27: shiftcrypto.bitbox02.BTCSignMessageResponse
+	(*BTCRequest)(nil),                                     // 28: shiftcrypto.bitbox02.BTCRequest
+	(*BTCResponse)(nil),                                    // 29: shiftcrypto.bitbox02.BTCResponse
+	(*BTCScriptConfig_Multisig)(nil),                       // 30: shiftcrypto.bitbox02.BTCScriptConfig.Multisig
+	(*BTCScriptConfig_Policy)(nil),                         // 31: shiftcrypto.bitbox02.BTCScriptConfig.Policy
+	(*BTCSignOutputRequest_SilentPayment)(nil),             // 32: shiftcrypto.bitbox02.BTCSignOutputRequest.SilentPayment
+	(*BTCPaymentRequestRequest_Memo)(nil),                  // 33: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo
+	(*BTCPaymentRequestRequest_Memo_TextMemo)(nil),         // 34: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.TextMemo
+	(*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo)(nil), // 35: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo
+	(*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_EthAddressDerivation)(nil), // 36: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo.EthAddressDerivation
+	(*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_BtcAddressDerivation)(nil), // 37: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo.BtcAddressDerivation
+	(*Keypath)(nil),                       // 38: shiftcrypto.bitbox02.Keypath
+	(*AntiKleptoSignerCommitment)(nil),    // 39: shiftcrypto.bitbox02.AntiKleptoSignerCommitment
+	(*AntiKleptoHostNonceCommitment)(nil), // 40: shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
+	(*AntiKleptoSignatureRequest)(nil),    // 41: shiftcrypto.bitbox02.AntiKleptoSignatureRequest
+	(*PubsResponse)(nil),                  // 42: shiftcrypto.bitbox02.PubsResponse
+	(*XPub)(nil),                          // 43: shiftcrypto.bitbox02.XPub
+	(*KeyOriginInfo)(nil),                 // 44: shiftcrypto.bitbox02.KeyOriginInfo
 }
 var file_btc_proto_depIdxs = []int32{
 	2,  // 0: shiftcrypto.bitbox02.BTCScriptConfig.simple_type:type_name -> shiftcrypto.bitbox02.BTCScriptConfig.SimpleType
@@ -2778,15 +3008,15 @@ var file_btc_proto_depIdxs = []int32{
 	9,  // 5: shiftcrypto.bitbox02.BTCPubRequest.script_config:type_name -> shiftcrypto.bitbox02.BTCScriptConfig
 	0,  // 6: shiftcrypto.bitbox02.BTCXpubsRequest.coin:type_name -> shiftcrypto.bitbox02.BTCCoin
 	5,  // 7: shiftcrypto.bitbox02.BTCXpubsRequest.xpub_type:type_name -> shiftcrypto.bitbox02.BTCXpubsRequest.XPubType
-	35, // 8: shiftcrypto.bitbox02.BTCXpubsRequest.keypaths:type_name -> shiftcrypto.bitbox02.Keypath
+	38, // 8: shiftcrypto.bitbox02.BTCXpubsRequest.keypaths:type_name -> shiftcrypto.bitbox02.Keypath
 	9,  // 9: shiftcrypto.bitbox02.BTCScriptConfigWithKeypath.script_config:type_name -> shiftcrypto.bitbox02.BTCScriptConfig
 	0,  // 10: shiftcrypto.bitbox02.BTCSignInitRequest.coin:type_name -> shiftcrypto.bitbox02.BTCCoin
 	12, // 11: shiftcrypto.bitbox02.BTCSignInitRequest.script_configs:type_name -> shiftcrypto.bitbox02.BTCScriptConfigWithKeypath
 	6,  // 12: shiftcrypto.bitbox02.BTCSignInitRequest.format_unit:type_name -> shiftcrypto.bitbox02.BTCSignInitRequest.FormatUnit
 	12, // 13: shiftcrypto.bitbox02.BTCSignInitRequest.output_script_configs:type_name -> shiftcrypto.bitbox02.BTCScriptConfigWithKeypath
 	7,  // 14: shiftcrypto.bitbox02.BTCSignNextResponse.type:type_name -> shiftcrypto.bitbox02.BTCSignNextResponse.Type
-	36, // 15: shiftcrypto.bitbox02.BTCSignNextResponse.anti_klepto_signer_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoSignerCommitment
-	37, // 16: shiftcrypto.bitbox02.BTCSignInputRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
+	39, // 15: shiftcrypto.bitbox02.BTCSignNextResponse.anti_klepto_signer_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoSignerCommitment
+	40, // 16: shiftcrypto.bitbox02.BTCSignInputRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
 	1,  // 17: shiftcrypto.bitbox02.BTCSignOutputRequest.type:type_name -> shiftcrypto.bitbox02.BTCOutputType
 	32, // 18: shiftcrypto.bitbox02.BTCSignOutputRequest.silent_payment:type_name -> shiftcrypto.bitbox02.BTCSignOutputRequest.SilentPayment
 	0,  // 19: shiftcrypto.bitbox02.BTCScriptConfigRegistration.coin:type_name -> shiftcrypto.bitbox02.BTCCoin
@@ -2797,31 +3027,35 @@ var file_btc_proto_depIdxs = []int32{
 	33, // 24: shiftcrypto.bitbox02.BTCPaymentRequestRequest.memos:type_name -> shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo
 	0,  // 25: shiftcrypto.bitbox02.BTCSignMessageRequest.coin:type_name -> shiftcrypto.bitbox02.BTCCoin
 	12, // 26: shiftcrypto.bitbox02.BTCSignMessageRequest.script_config:type_name -> shiftcrypto.bitbox02.BTCScriptConfigWithKeypath
-	37, // 27: shiftcrypto.bitbox02.BTCSignMessageRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
+	40, // 27: shiftcrypto.bitbox02.BTCSignMessageRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
 	19, // 28: shiftcrypto.bitbox02.BTCRequest.is_script_config_registered:type_name -> shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredRequest
 	21, // 29: shiftcrypto.bitbox02.BTCRequest.register_script_config:type_name -> shiftcrypto.bitbox02.BTCRegisterScriptConfigRequest
 	22, // 30: shiftcrypto.bitbox02.BTCRequest.prevtx_init:type_name -> shiftcrypto.bitbox02.BTCPrevTxInitRequest
 	23, // 31: shiftcrypto.bitbox02.BTCRequest.prevtx_input:type_name -> shiftcrypto.bitbox02.BTCPrevTxInputRequest
 	24, // 32: shiftcrypto.bitbox02.BTCRequest.prevtx_output:type_name -> shiftcrypto.bitbox02.BTCPrevTxOutputRequest
 	26, // 33: shiftcrypto.bitbox02.BTCRequest.sign_message:type_name -> shiftcrypto.bitbox02.BTCSignMessageRequest
-	38, // 34: shiftcrypto.bitbox02.BTCRequest.antiklepto_signature:type_name -> shiftcrypto.bitbox02.AntiKleptoSignatureRequest
+	41, // 34: shiftcrypto.bitbox02.BTCRequest.antiklepto_signature:type_name -> shiftcrypto.bitbox02.AntiKleptoSignatureRequest
 	25, // 35: shiftcrypto.bitbox02.BTCRequest.payment_request:type_name -> shiftcrypto.bitbox02.BTCPaymentRequestRequest
 	11, // 36: shiftcrypto.bitbox02.BTCRequest.xpubs:type_name -> shiftcrypto.bitbox02.BTCXpubsRequest
 	18, // 37: shiftcrypto.bitbox02.BTCResponse.success:type_name -> shiftcrypto.bitbox02.BTCSuccess
 	20, // 38: shiftcrypto.bitbox02.BTCResponse.is_script_config_registered:type_name -> shiftcrypto.bitbox02.BTCIsScriptConfigRegisteredResponse
 	14, // 39: shiftcrypto.bitbox02.BTCResponse.sign_next:type_name -> shiftcrypto.bitbox02.BTCSignNextResponse
 	27, // 40: shiftcrypto.bitbox02.BTCResponse.sign_message:type_name -> shiftcrypto.bitbox02.BTCSignMessageResponse
-	36, // 41: shiftcrypto.bitbox02.BTCResponse.antiklepto_signer_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoSignerCommitment
-	39, // 42: shiftcrypto.bitbox02.BTCResponse.pubs:type_name -> shiftcrypto.bitbox02.PubsResponse
-	40, // 43: shiftcrypto.bitbox02.BTCScriptConfig.Multisig.xpubs:type_name -> shiftcrypto.bitbox02.XPub
+	39, // 41: shiftcrypto.bitbox02.BTCResponse.antiklepto_signer_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoSignerCommitment
+	42, // 42: shiftcrypto.bitbox02.BTCResponse.pubs:type_name -> shiftcrypto.bitbox02.PubsResponse
+	43, // 43: shiftcrypto.bitbox02.BTCScriptConfig.Multisig.xpubs:type_name -> shiftcrypto.bitbox02.XPub
 	3,  // 44: shiftcrypto.bitbox02.BTCScriptConfig.Multisig.script_type:type_name -> shiftcrypto.bitbox02.BTCScriptConfig.Multisig.ScriptType
-	41, // 45: shiftcrypto.bitbox02.BTCScriptConfig.Policy.keys:type_name -> shiftcrypto.bitbox02.KeyOriginInfo
+	44, // 45: shiftcrypto.bitbox02.BTCScriptConfig.Policy.keys:type_name -> shiftcrypto.bitbox02.KeyOriginInfo
 	34, // 46: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.text_memo:type_name -> shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.TextMemo
-	47, // [47:47] is the sub-list for method output_type
-	47, // [47:47] is the sub-list for method input_type
-	47, // [47:47] is the sub-list for extension type_name
-	47, // [47:47] is the sub-list for extension extendee
-	0,  // [0:47] is the sub-list for field type_name
+	35, // 47: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.coin_purchase_memo:type_name -> shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo
+	36, // 48: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo.eth:type_name -> shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo.EthAddressDerivation
+	37, // 49: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo.btc:type_name -> shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo.BtcAddressDerivation
+	12, // 50: shiftcrypto.bitbox02.BTCPaymentRequestRequest.Memo.CoinPurchaseMemo.BtcAddressDerivation.script_config:type_name -> shiftcrypto.bitbox02.BTCScriptConfigWithKeypath
+	51, // [51:51] is the sub-list for method output_type
+	51, // [51:51] is the sub-list for method input_type
+	51, // [51:51] is the sub-list for extension type_name
+	51, // [51:51] is the sub-list for extension extendee
+	0,  // [0:51] is the sub-list for field type_name
 }
 
 func init() { file_btc_proto_init() }
@@ -2862,6 +3096,11 @@ func file_btc_proto_init() {
 	}
 	file_btc_proto_msgTypes[24].OneofWrappers = []any{
 		(*BTCPaymentRequestRequest_Memo_TextMemo_)(nil),
+		(*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_)(nil),
+	}
+	file_btc_proto_msgTypes[26].OneofWrappers = []any{
+		(*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Eth)(nil),
+		(*BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_Btc)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2869,7 +3108,7 @@ func file_btc_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_btc_proto_rawDesc), len(file_btc_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   26,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages/btc.proto
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages/btc.proto
@@ -246,8 +246,27 @@ message BTCPaymentRequestRequest {
     message TextMemo {
       string note = 1;
     }
+    message CoinPurchaseMemo {
+      uint32 coin_type = 1; // SLIP-44 coin type
+      string amount = 2; // Human-readable amount (e.g. "0.25 ETH")
+      string address = 3; // Address to send the purchased coins to
+      // Derivation info for verifying address ownership.
+      // NOT part of the SLIP-24 sighash.
+      message EthAddressDerivation {
+        repeated uint32 keypath = 1; // Keypath to the address
+      }
+      message BtcAddressDerivation {
+        // Script config + keypath are needed to derive BTC/LTC-family addresses.
+        BTCScriptConfigWithKeypath script_config = 1;
+      }
+      oneof address_derivation {
+        EthAddressDerivation eth = 4;
+        BtcAddressDerivation btc = 5;
+      }
+    }
     oneof memo {
       TextMemo text_memo = 1;
+      CoinPurchaseMemo coin_purchase_memo = 2;
     }
   }
 

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages/eth.pb.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages/eth.pb.go
@@ -234,7 +234,7 @@ func (x ETHSignTypedMessageRequest_DataType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ETHSignTypedMessageRequest_DataType.Descriptor instead.
 func (ETHSignTypedMessageRequest_DataType) EnumDescriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{5, 0}
+	return file_eth_proto_rawDescGZIP(), []int{7, 0}
 }
 
 type ETHTypedMessageValueResponse_RootObject int32
@@ -283,7 +283,7 @@ func (x ETHTypedMessageValueResponse_RootObject) Number() protoreflect.EnumNumbe
 
 // Deprecated: Use ETHTypedMessageValueResponse_RootObject.Descriptor instead.
 func (ETHTypedMessageValueResponse_RootObject) EnumDescriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{6, 0}
+	return file_eth_proto_rawDescGZIP(), []int{8, 0}
 }
 
 type ETHPubRequest struct {
@@ -386,8 +386,10 @@ type ETHSignRequest struct {
 	Data                []byte                         `protobuf:"bytes,8,opt,name=data,proto3" json:"data,omitempty"`
 	HostNonceCommitment *AntiKleptoHostNonceCommitment `protobuf:"bytes,9,opt,name=host_nonce_commitment,json=hostNonceCommitment,proto3" json:"host_nonce_commitment,omitempty"`
 	// If non-zero, `coin` is ignored and `chain_id` is used to identify the network.
-	ChainId       uint64         `protobuf:"varint,10,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
-	AddressCase   ETHAddressCase `protobuf:"varint,11,opt,name=address_case,json=addressCase,proto3,enum=shiftcrypto.bitbox02.ETHAddressCase" json:"address_case,omitempty"`
+	ChainId     uint64         `protobuf:"varint,10,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
+	AddressCase ETHAddressCase `protobuf:"varint,11,opt,name=address_case,json=addressCase,proto3,enum=shiftcrypto.bitbox02.ETHAddressCase" json:"address_case,omitempty"`
+	// For streaming: if non-zero, data field should be empty and data will be requested in chunks
+	DataLength    uint32 `protobuf:"varint,12,opt,name=data_length,json=dataLength,proto3" json:"data_length,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -499,6 +501,13 @@ func (x *ETHSignRequest) GetAddressCase() ETHAddressCase {
 	return ETHAddressCase_ETH_ADDRESS_CASE_MIXED
 }
 
+func (x *ETHSignRequest) GetDataLength() uint32 {
+	if x != nil {
+		return x.DataLength
+	}
+	return 0
+}
+
 // TX payload for an EIP-1559 (type 2) transaction: https://eips.ethereum.org/EIPS/eip-1559
 type ETHSignEIP1559Request struct {
 	state                protoimpl.MessageState         `protogen:"open.v1"`
@@ -513,8 +522,11 @@ type ETHSignEIP1559Request struct {
 	Data                 []byte                         `protobuf:"bytes,9,opt,name=data,proto3" json:"data,omitempty"`
 	HostNonceCommitment  *AntiKleptoHostNonceCommitment `protobuf:"bytes,10,opt,name=host_nonce_commitment,json=hostNonceCommitment,proto3" json:"host_nonce_commitment,omitempty"`
 	AddressCase          ETHAddressCase                 `protobuf:"varint,11,opt,name=address_case,json=addressCase,proto3,enum=shiftcrypto.bitbox02.ETHAddressCase" json:"address_case,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// For streaming: if non-zero, data field should be empty and data will be requested in chunks
+	DataLength     uint32                    `protobuf:"varint,12,opt,name=data_length,json=dataLength,proto3" json:"data_length,omitempty"`
+	PaymentRequest *BTCPaymentRequestRequest `protobuf:"bytes,13,opt,name=payment_request,json=paymentRequest,proto3" json:"payment_request,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ETHSignEIP1559Request) Reset() {
@@ -624,6 +636,116 @@ func (x *ETHSignEIP1559Request) GetAddressCase() ETHAddressCase {
 	return ETHAddressCase_ETH_ADDRESS_CASE_MIXED
 }
 
+func (x *ETHSignEIP1559Request) GetDataLength() uint32 {
+	if x != nil {
+		return x.DataLength
+	}
+	return 0
+}
+
+func (x *ETHSignEIP1559Request) GetPaymentRequest() *BTCPaymentRequestRequest {
+	if x != nil {
+		return x.PaymentRequest
+	}
+	return nil
+}
+
+type ETHSignDataRequestChunkResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Offset        uint32                 `protobuf:"varint,1,opt,name=offset,proto3" json:"offset,omitempty"`
+	Length        uint32                 `protobuf:"varint,2,opt,name=length,proto3" json:"length,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ETHSignDataRequestChunkResponse) Reset() {
+	*x = ETHSignDataRequestChunkResponse{}
+	mi := &file_eth_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ETHSignDataRequestChunkResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ETHSignDataRequestChunkResponse) ProtoMessage() {}
+
+func (x *ETHSignDataRequestChunkResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_eth_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ETHSignDataRequestChunkResponse.ProtoReflect.Descriptor instead.
+func (*ETHSignDataRequestChunkResponse) Descriptor() ([]byte, []int) {
+	return file_eth_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ETHSignDataRequestChunkResponse) GetOffset() uint32 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *ETHSignDataRequestChunkResponse) GetLength() uint32 {
+	if x != nil {
+		return x.Length
+	}
+	return 0
+}
+
+type ETHSignDataResponseChunkRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Chunk         []byte                 `protobuf:"bytes,1,opt,name=chunk,proto3" json:"chunk,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ETHSignDataResponseChunkRequest) Reset() {
+	*x = ETHSignDataResponseChunkRequest{}
+	mi := &file_eth_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ETHSignDataResponseChunkRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ETHSignDataResponseChunkRequest) ProtoMessage() {}
+
+func (x *ETHSignDataResponseChunkRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_eth_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ETHSignDataResponseChunkRequest.ProtoReflect.Descriptor instead.
+func (*ETHSignDataResponseChunkRequest) Descriptor() ([]byte, []int) {
+	return file_eth_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ETHSignDataResponseChunkRequest) GetChunk() []byte {
+	if x != nil {
+		return x.Chunk
+	}
+	return nil
+}
+
 type ETHSignMessageRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Deprecated: use chain_id instead.
@@ -639,7 +761,7 @@ type ETHSignMessageRequest struct {
 
 func (x *ETHSignMessageRequest) Reset() {
 	*x = ETHSignMessageRequest{}
-	mi := &file_eth_proto_msgTypes[3]
+	mi := &file_eth_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -651,7 +773,7 @@ func (x *ETHSignMessageRequest) String() string {
 func (*ETHSignMessageRequest) ProtoMessage() {}
 
 func (x *ETHSignMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[3]
+	mi := &file_eth_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -664,7 +786,7 @@ func (x *ETHSignMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ETHSignMessageRequest.ProtoReflect.Descriptor instead.
 func (*ETHSignMessageRequest) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{3}
+	return file_eth_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ETHSignMessageRequest) GetCoin() ETHCoin {
@@ -711,7 +833,7 @@ type ETHSignResponse struct {
 
 func (x *ETHSignResponse) Reset() {
 	*x = ETHSignResponse{}
-	mi := &file_eth_proto_msgTypes[4]
+	mi := &file_eth_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -723,7 +845,7 @@ func (x *ETHSignResponse) String() string {
 func (*ETHSignResponse) ProtoMessage() {}
 
 func (x *ETHSignResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[4]
+	mi := &file_eth_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -736,7 +858,7 @@ func (x *ETHSignResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ETHSignResponse.ProtoReflect.Descriptor instead.
 func (*ETHSignResponse) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{4}
+	return file_eth_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ETHSignResponse) GetSignature() []byte {
@@ -759,7 +881,7 @@ type ETHSignTypedMessageRequest struct {
 
 func (x *ETHSignTypedMessageRequest) Reset() {
 	*x = ETHSignTypedMessageRequest{}
-	mi := &file_eth_proto_msgTypes[5]
+	mi := &file_eth_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -771,7 +893,7 @@ func (x *ETHSignTypedMessageRequest) String() string {
 func (*ETHSignTypedMessageRequest) ProtoMessage() {}
 
 func (x *ETHSignTypedMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[5]
+	mi := &file_eth_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -784,7 +906,7 @@ func (x *ETHSignTypedMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ETHSignTypedMessageRequest.ProtoReflect.Descriptor instead.
 func (*ETHSignTypedMessageRequest) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{5}
+	return file_eth_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ETHSignTypedMessageRequest) GetChainId() uint64 {
@@ -832,7 +954,7 @@ type ETHTypedMessageValueResponse struct {
 
 func (x *ETHTypedMessageValueResponse) Reset() {
 	*x = ETHTypedMessageValueResponse{}
-	mi := &file_eth_proto_msgTypes[6]
+	mi := &file_eth_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -844,7 +966,7 @@ func (x *ETHTypedMessageValueResponse) String() string {
 func (*ETHTypedMessageValueResponse) ProtoMessage() {}
 
 func (x *ETHTypedMessageValueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[6]
+	mi := &file_eth_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -857,7 +979,7 @@ func (x *ETHTypedMessageValueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ETHTypedMessageValueResponse.ProtoReflect.Descriptor instead.
 func (*ETHTypedMessageValueResponse) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{6}
+	return file_eth_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ETHTypedMessageValueResponse) GetRootObject() ETHTypedMessageValueResponse_RootObject {
@@ -875,15 +997,18 @@ func (x *ETHTypedMessageValueResponse) GetPath() []uint32 {
 }
 
 type ETHTypedMessageValueRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Value         []byte                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Value []byte                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+	// If non-zero, value should be empty and data will be streamed via
+	// DataRequestChunk/DataResponseChunk.
+	DataLength    uint32 `protobuf:"varint,2,opt,name=data_length,json=dataLength,proto3" json:"data_length,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ETHTypedMessageValueRequest) Reset() {
 	*x = ETHTypedMessageValueRequest{}
-	mi := &file_eth_proto_msgTypes[7]
+	mi := &file_eth_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -895,7 +1020,7 @@ func (x *ETHTypedMessageValueRequest) String() string {
 func (*ETHTypedMessageValueRequest) ProtoMessage() {}
 
 func (x *ETHTypedMessageValueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[7]
+	mi := &file_eth_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -908,7 +1033,7 @@ func (x *ETHTypedMessageValueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ETHTypedMessageValueRequest.ProtoReflect.Descriptor instead.
 func (*ETHTypedMessageValueRequest) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{7}
+	return file_eth_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ETHTypedMessageValueRequest) GetValue() []byte {
@@ -916,6 +1041,13 @@ func (x *ETHTypedMessageValueRequest) GetValue() []byte {
 		return x.Value
 	}
 	return nil
+}
+
+func (x *ETHTypedMessageValueRequest) GetDataLength() uint32 {
+	if x != nil {
+		return x.DataLength
+	}
+	return 0
 }
 
 type ETHRequest struct {
@@ -929,6 +1061,7 @@ type ETHRequest struct {
 	//	*ETHRequest_SignTypedMsg
 	//	*ETHRequest_TypedMsgValue
 	//	*ETHRequest_SignEip1559
+	//	*ETHRequest_DataResponseChunk
 	Request       isETHRequest_Request `protobuf_oneof:"request"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -936,7 +1069,7 @@ type ETHRequest struct {
 
 func (x *ETHRequest) Reset() {
 	*x = ETHRequest{}
-	mi := &file_eth_proto_msgTypes[8]
+	mi := &file_eth_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -948,7 +1081,7 @@ func (x *ETHRequest) String() string {
 func (*ETHRequest) ProtoMessage() {}
 
 func (x *ETHRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[8]
+	mi := &file_eth_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -961,7 +1094,7 @@ func (x *ETHRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ETHRequest.ProtoReflect.Descriptor instead.
 func (*ETHRequest) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{8}
+	return file_eth_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ETHRequest) GetRequest() isETHRequest_Request {
@@ -1034,6 +1167,15 @@ func (x *ETHRequest) GetSignEip1559() *ETHSignEIP1559Request {
 	return nil
 }
 
+func (x *ETHRequest) GetDataResponseChunk() *ETHSignDataResponseChunkRequest {
+	if x != nil {
+		if x, ok := x.Request.(*ETHRequest_DataResponseChunk); ok {
+			return x.DataResponseChunk
+		}
+	}
+	return nil
+}
+
 type isETHRequest_Request interface {
 	isETHRequest_Request()
 }
@@ -1066,6 +1208,10 @@ type ETHRequest_SignEip1559 struct {
 	SignEip1559 *ETHSignEIP1559Request `protobuf:"bytes,7,opt,name=sign_eip1559,json=signEip1559,proto3,oneof"`
 }
 
+type ETHRequest_DataResponseChunk struct {
+	DataResponseChunk *ETHSignDataResponseChunkRequest `protobuf:"bytes,8,opt,name=data_response_chunk,json=dataResponseChunk,proto3,oneof"`
+}
+
 func (*ETHRequest_Pub) isETHRequest_Request() {}
 
 func (*ETHRequest_Sign) isETHRequest_Request() {}
@@ -1080,6 +1226,8 @@ func (*ETHRequest_TypedMsgValue) isETHRequest_Request() {}
 
 func (*ETHRequest_SignEip1559) isETHRequest_Request() {}
 
+func (*ETHRequest_DataResponseChunk) isETHRequest_Request() {}
+
 type ETHResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Response:
@@ -1088,6 +1236,7 @@ type ETHResponse struct {
 	//	*ETHResponse_Sign
 	//	*ETHResponse_AntikleptoSignerCommitment
 	//	*ETHResponse_TypedMsgValue
+	//	*ETHResponse_DataRequestChunk
 	Response      isETHResponse_Response `protobuf_oneof:"response"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1095,7 +1244,7 @@ type ETHResponse struct {
 
 func (x *ETHResponse) Reset() {
 	*x = ETHResponse{}
-	mi := &file_eth_proto_msgTypes[9]
+	mi := &file_eth_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1107,7 +1256,7 @@ func (x *ETHResponse) String() string {
 func (*ETHResponse) ProtoMessage() {}
 
 func (x *ETHResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[9]
+	mi := &file_eth_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1120,7 +1269,7 @@ func (x *ETHResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ETHResponse.ProtoReflect.Descriptor instead.
 func (*ETHResponse) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{9}
+	return file_eth_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ETHResponse) GetResponse() isETHResponse_Response {
@@ -1166,6 +1315,15 @@ func (x *ETHResponse) GetTypedMsgValue() *ETHTypedMessageValueResponse {
 	return nil
 }
 
+func (x *ETHResponse) GetDataRequestChunk() *ETHSignDataRequestChunkResponse {
+	if x != nil {
+		if x, ok := x.Response.(*ETHResponse_DataRequestChunk); ok {
+			return x.DataRequestChunk
+		}
+	}
+	return nil
+}
+
 type isETHResponse_Response interface {
 	isETHResponse_Response()
 }
@@ -1186,6 +1344,10 @@ type ETHResponse_TypedMsgValue struct {
 	TypedMsgValue *ETHTypedMessageValueResponse `protobuf:"bytes,4,opt,name=typed_msg_value,json=typedMsgValue,proto3,oneof"`
 }
 
+type ETHResponse_DataRequestChunk struct {
+	DataRequestChunk *ETHSignDataRequestChunkResponse `protobuf:"bytes,5,opt,name=data_request_chunk,json=dataRequestChunk,proto3,oneof"`
+}
+
 func (*ETHResponse_Pub) isETHResponse_Response() {}
 
 func (*ETHResponse_Sign) isETHResponse_Response() {}
@@ -1193,6 +1355,8 @@ func (*ETHResponse_Sign) isETHResponse_Response() {}
 func (*ETHResponse_AntikleptoSignerCommitment) isETHResponse_Response() {}
 
 func (*ETHResponse_TypedMsgValue) isETHResponse_Response() {}
+
+func (*ETHResponse_DataRequestChunk) isETHResponse_Response() {}
 
 type ETHSignTypedMessageRequest_MemberType struct {
 	state         protoimpl.MessageState                 `protogen:"open.v1"`
@@ -1206,7 +1370,7 @@ type ETHSignTypedMessageRequest_MemberType struct {
 
 func (x *ETHSignTypedMessageRequest_MemberType) Reset() {
 	*x = ETHSignTypedMessageRequest_MemberType{}
-	mi := &file_eth_proto_msgTypes[10]
+	mi := &file_eth_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1218,7 +1382,7 @@ func (x *ETHSignTypedMessageRequest_MemberType) String() string {
 func (*ETHSignTypedMessageRequest_MemberType) ProtoMessage() {}
 
 func (x *ETHSignTypedMessageRequest_MemberType) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[10]
+	mi := &file_eth_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1231,7 +1395,7 @@ func (x *ETHSignTypedMessageRequest_MemberType) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use ETHSignTypedMessageRequest_MemberType.ProtoReflect.Descriptor instead.
 func (*ETHSignTypedMessageRequest_MemberType) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{5, 0}
+	return file_eth_proto_rawDescGZIP(), []int{7, 0}
 }
 
 func (x *ETHSignTypedMessageRequest_MemberType) GetType() ETHSignTypedMessageRequest_DataType {
@@ -1272,7 +1436,7 @@ type ETHSignTypedMessageRequest_Member struct {
 
 func (x *ETHSignTypedMessageRequest_Member) Reset() {
 	*x = ETHSignTypedMessageRequest_Member{}
-	mi := &file_eth_proto_msgTypes[11]
+	mi := &file_eth_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1284,7 +1448,7 @@ func (x *ETHSignTypedMessageRequest_Member) String() string {
 func (*ETHSignTypedMessageRequest_Member) ProtoMessage() {}
 
 func (x *ETHSignTypedMessageRequest_Member) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[11]
+	mi := &file_eth_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1297,7 +1461,7 @@ func (x *ETHSignTypedMessageRequest_Member) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ETHSignTypedMessageRequest_Member.ProtoReflect.Descriptor instead.
 func (*ETHSignTypedMessageRequest_Member) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{5, 1}
+	return file_eth_proto_rawDescGZIP(), []int{7, 1}
 }
 
 func (x *ETHSignTypedMessageRequest_Member) GetName() string {
@@ -1324,7 +1488,7 @@ type ETHSignTypedMessageRequest_StructType struct {
 
 func (x *ETHSignTypedMessageRequest_StructType) Reset() {
 	*x = ETHSignTypedMessageRequest_StructType{}
-	mi := &file_eth_proto_msgTypes[12]
+	mi := &file_eth_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1336,7 +1500,7 @@ func (x *ETHSignTypedMessageRequest_StructType) String() string {
 func (*ETHSignTypedMessageRequest_StructType) ProtoMessage() {}
 
 func (x *ETHSignTypedMessageRequest_StructType) ProtoReflect() protoreflect.Message {
-	mi := &file_eth_proto_msgTypes[12]
+	mi := &file_eth_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1349,7 +1513,7 @@ func (x *ETHSignTypedMessageRequest_StructType) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use ETHSignTypedMessageRequest_StructType.ProtoReflect.Descriptor instead.
 func (*ETHSignTypedMessageRequest_StructType) Descriptor() ([]byte, []int) {
-	return file_eth_proto_rawDescGZIP(), []int{5, 2}
+	return file_eth_proto_rawDescGZIP(), []int{7, 2}
 }
 
 func (x *ETHSignTypedMessageRequest_StructType) GetName() string {
@@ -1370,7 +1534,7 @@ var File_eth_proto protoreflect.FileDescriptor
 
 const file_eth_proto_rawDesc = "" +
 	"\n" +
-	"\teth.proto\x12\x14shiftcrypto.bitbox02\x1a\fcommon.proto\x1a\x10antiklepto.proto\"\xb2\x02\n" +
+	"\teth.proto\x12\x14shiftcrypto.bitbox02\x1a\fcommon.proto\x1a\x10antiklepto.proto\x1a\tbtc.proto\"\xb2\x02\n" +
 	"\rETHPubRequest\x12\x18\n" +
 	"\akeypath\x18\x01 \x03(\rR\akeypath\x121\n" +
 	"\x04coin\x18\x02 \x01(\x0e2\x1d.shiftcrypto.bitbox02.ETHCoinR\x04coin\x12O\n" +
@@ -1382,7 +1546,7 @@ const file_eth_proto_rawDesc = "" +
 	"\n" +
 	"OutputType\x12\v\n" +
 	"\aADDRESS\x10\x00\x12\b\n" +
-	"\x04XPUB\x10\x01\"\xc2\x03\n" +
+	"\x04XPUB\x10\x01\"\xe3\x03\n" +
 	"\x0eETHSignRequest\x121\n" +
 	"\x04coin\x18\x01 \x01(\x0e2\x1d.shiftcrypto.bitbox02.ETHCoinR\x04coin\x12\x18\n" +
 	"\akeypath\x18\x02 \x03(\rR\akeypath\x12\x14\n" +
@@ -1395,7 +1559,9 @@ const file_eth_proto_rawDesc = "" +
 	"\x15host_nonce_commitment\x18\t \x01(\v23.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitmentR\x13hostNonceCommitment\x12\x19\n" +
 	"\bchain_id\x18\n" +
 	" \x01(\x04R\achainId\x12G\n" +
-	"\faddress_case\x18\v \x01(\x0e2$.shiftcrypto.bitbox02.ETHAddressCaseR\vaddressCase\"\xd8\x03\n" +
+	"\faddress_case\x18\v \x01(\x0e2$.shiftcrypto.bitbox02.ETHAddressCaseR\vaddressCase\x12\x1f\n" +
+	"\vdata_length\x18\f \x01(\rR\n" +
+	"dataLength\"\xd2\x04\n" +
 	"\x15ETHSignEIP1559Request\x12\x19\n" +
 	"\bchain_id\x18\x01 \x01(\x04R\achainId\x12\x18\n" +
 	"\akeypath\x18\x02 \x03(\rR\akeypath\x12\x14\n" +
@@ -1408,7 +1574,15 @@ const file_eth_proto_rawDesc = "" +
 	"\x04data\x18\t \x01(\fR\x04data\x12g\n" +
 	"\x15host_nonce_commitment\x18\n" +
 	" \x01(\v23.shiftcrypto.bitbox02.AntiKleptoHostNonceCommitmentR\x13hostNonceCommitment\x12G\n" +
-	"\faddress_case\x18\v \x01(\x0e2$.shiftcrypto.bitbox02.ETHAddressCaseR\vaddressCase\"\xfa\x01\n" +
+	"\faddress_case\x18\v \x01(\x0e2$.shiftcrypto.bitbox02.ETHAddressCaseR\vaddressCase\x12\x1f\n" +
+	"\vdata_length\x18\f \x01(\rR\n" +
+	"dataLength\x12W\n" +
+	"\x0fpayment_request\x18\r \x01(\v2..shiftcrypto.bitbox02.BTCPaymentRequestRequestR\x0epaymentRequest\"Q\n" +
+	"\x1fETHSignDataRequestChunkResponse\x12\x16\n" +
+	"\x06offset\x18\x01 \x01(\rR\x06offset\x12\x16\n" +
+	"\x06length\x18\x02 \x01(\rR\x06length\"7\n" +
+	"\x1fETHSignDataResponseChunkRequest\x12\x14\n" +
+	"\x05chunk\x18\x01 \x01(\fR\x05chunk\"\xfa\x01\n" +
 	"\x15ETHSignMessageRequest\x121\n" +
 	"\x04coin\x18\x01 \x01(\x0e2\x1d.shiftcrypto.bitbox02.ETHCoinR\x04coin\x12\x18\n" +
 	"\akeypath\x18\x02 \x03(\rR\akeypath\x12\x10\n" +
@@ -1459,9 +1633,11 @@ const file_eth_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\n" +
 	"\n" +
 	"\x06DOMAIN\x10\x01\x12\v\n" +
-	"\aMESSAGE\x10\x02\"3\n" +
+	"\aMESSAGE\x10\x02\"T\n" +
 	"\x1bETHTypedMessageValueRequest\x12\x14\n" +
-	"\x05value\x18\x01 \x01(\fR\x05value\"\xc6\x04\n" +
+	"\x05value\x18\x01 \x01(\fR\x05value\x12\x1f\n" +
+	"\vdata_length\x18\x02 \x01(\rR\n" +
+	"dataLength\"\xaf\x05\n" +
 	"\n" +
 	"ETHRequest\x127\n" +
 	"\x03pub\x18\x01 \x01(\v2#.shiftcrypto.bitbox02.ETHPubRequestH\x00R\x03pub\x12:\n" +
@@ -1470,13 +1646,15 @@ const file_eth_proto_rawDesc = "" +
 	"\x14antiklepto_signature\x18\x04 \x01(\v20.shiftcrypto.bitbox02.AntiKleptoSignatureRequestH\x00R\x13antikleptoSignature\x12X\n" +
 	"\x0esign_typed_msg\x18\x05 \x01(\v20.shiftcrypto.bitbox02.ETHSignTypedMessageRequestH\x00R\fsignTypedMsg\x12[\n" +
 	"\x0ftyped_msg_value\x18\x06 \x01(\v21.shiftcrypto.bitbox02.ETHTypedMessageValueRequestH\x00R\rtypedMsgValue\x12P\n" +
-	"\fsign_eip1559\x18\a \x01(\v2+.shiftcrypto.bitbox02.ETHSignEIP1559RequestH\x00R\vsignEip1559B\t\n" +
-	"\arequest\"\xe1\x02\n" +
+	"\fsign_eip1559\x18\a \x01(\v2+.shiftcrypto.bitbox02.ETHSignEIP1559RequestH\x00R\vsignEip1559\x12g\n" +
+	"\x13data_response_chunk\x18\b \x01(\v25.shiftcrypto.bitbox02.ETHSignDataResponseChunkRequestH\x00R\x11dataResponseChunkB\t\n" +
+	"\arequest\"\xc8\x03\n" +
 	"\vETHResponse\x125\n" +
 	"\x03pub\x18\x01 \x01(\v2!.shiftcrypto.bitbox02.PubResponseH\x00R\x03pub\x12;\n" +
 	"\x04sign\x18\x02 \x01(\v2%.shiftcrypto.bitbox02.ETHSignResponseH\x00R\x04sign\x12t\n" +
 	"\x1cantiklepto_signer_commitment\x18\x03 \x01(\v20.shiftcrypto.bitbox02.AntiKleptoSignerCommitmentH\x00R\x1aantikleptoSignerCommitment\x12\\\n" +
-	"\x0ftyped_msg_value\x18\x04 \x01(\v22.shiftcrypto.bitbox02.ETHTypedMessageValueResponseH\x00R\rtypedMsgValueB\n" +
+	"\x0ftyped_msg_value\x18\x04 \x01(\v22.shiftcrypto.bitbox02.ETHTypedMessageValueResponseH\x00R\rtypedMsgValue\x12e\n" +
+	"\x12data_request_chunk\x18\x05 \x01(\v25.shiftcrypto.bitbox02.ETHSignDataRequestChunkResponseH\x00R\x10dataRequestChunkB\n" +
 	"\n" +
 	"\bresponse*2\n" +
 	"\aETHCoin\x12\a\n" +
@@ -1503,7 +1681,7 @@ func file_eth_proto_rawDescGZIP() []byte {
 }
 
 var file_eth_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_eth_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_eth_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_eth_proto_goTypes = []any{
 	(ETHCoin)(0),                                  // 0: shiftcrypto.bitbox02.ETHCoin
 	(ETHAddressCase)(0),                           // 1: shiftcrypto.bitbox02.ETHAddressCase
@@ -1513,54 +1691,60 @@ var file_eth_proto_goTypes = []any{
 	(*ETHPubRequest)(nil),                         // 5: shiftcrypto.bitbox02.ETHPubRequest
 	(*ETHSignRequest)(nil),                        // 6: shiftcrypto.bitbox02.ETHSignRequest
 	(*ETHSignEIP1559Request)(nil),                 // 7: shiftcrypto.bitbox02.ETHSignEIP1559Request
-	(*ETHSignMessageRequest)(nil),                 // 8: shiftcrypto.bitbox02.ETHSignMessageRequest
-	(*ETHSignResponse)(nil),                       // 9: shiftcrypto.bitbox02.ETHSignResponse
-	(*ETHSignTypedMessageRequest)(nil),            // 10: shiftcrypto.bitbox02.ETHSignTypedMessageRequest
-	(*ETHTypedMessageValueResponse)(nil),          // 11: shiftcrypto.bitbox02.ETHTypedMessageValueResponse
-	(*ETHTypedMessageValueRequest)(nil),           // 12: shiftcrypto.bitbox02.ETHTypedMessageValueRequest
-	(*ETHRequest)(nil),                            // 13: shiftcrypto.bitbox02.ETHRequest
-	(*ETHResponse)(nil),                           // 14: shiftcrypto.bitbox02.ETHResponse
-	(*ETHSignTypedMessageRequest_MemberType)(nil), // 15: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType
-	(*ETHSignTypedMessageRequest_Member)(nil),     // 16: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.Member
-	(*ETHSignTypedMessageRequest_StructType)(nil), // 17: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.StructType
-	(*AntiKleptoHostNonceCommitment)(nil),         // 18: shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
-	(*AntiKleptoSignatureRequest)(nil),            // 19: shiftcrypto.bitbox02.AntiKleptoSignatureRequest
-	(*PubResponse)(nil),                           // 20: shiftcrypto.bitbox02.PubResponse
-	(*AntiKleptoSignerCommitment)(nil),            // 21: shiftcrypto.bitbox02.AntiKleptoSignerCommitment
+	(*ETHSignDataRequestChunkResponse)(nil),       // 8: shiftcrypto.bitbox02.ETHSignDataRequestChunkResponse
+	(*ETHSignDataResponseChunkRequest)(nil),       // 9: shiftcrypto.bitbox02.ETHSignDataResponseChunkRequest
+	(*ETHSignMessageRequest)(nil),                 // 10: shiftcrypto.bitbox02.ETHSignMessageRequest
+	(*ETHSignResponse)(nil),                       // 11: shiftcrypto.bitbox02.ETHSignResponse
+	(*ETHSignTypedMessageRequest)(nil),            // 12: shiftcrypto.bitbox02.ETHSignTypedMessageRequest
+	(*ETHTypedMessageValueResponse)(nil),          // 13: shiftcrypto.bitbox02.ETHTypedMessageValueResponse
+	(*ETHTypedMessageValueRequest)(nil),           // 14: shiftcrypto.bitbox02.ETHTypedMessageValueRequest
+	(*ETHRequest)(nil),                            // 15: shiftcrypto.bitbox02.ETHRequest
+	(*ETHResponse)(nil),                           // 16: shiftcrypto.bitbox02.ETHResponse
+	(*ETHSignTypedMessageRequest_MemberType)(nil), // 17: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType
+	(*ETHSignTypedMessageRequest_Member)(nil),     // 18: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.Member
+	(*ETHSignTypedMessageRequest_StructType)(nil), // 19: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.StructType
+	(*AntiKleptoHostNonceCommitment)(nil),         // 20: shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
+	(*BTCPaymentRequestRequest)(nil),              // 21: shiftcrypto.bitbox02.BTCPaymentRequestRequest
+	(*AntiKleptoSignatureRequest)(nil),            // 22: shiftcrypto.bitbox02.AntiKleptoSignatureRequest
+	(*PubResponse)(nil),                           // 23: shiftcrypto.bitbox02.PubResponse
+	(*AntiKleptoSignerCommitment)(nil),            // 24: shiftcrypto.bitbox02.AntiKleptoSignerCommitment
 }
 var file_eth_proto_depIdxs = []int32{
 	0,  // 0: shiftcrypto.bitbox02.ETHPubRequest.coin:type_name -> shiftcrypto.bitbox02.ETHCoin
 	2,  // 1: shiftcrypto.bitbox02.ETHPubRequest.output_type:type_name -> shiftcrypto.bitbox02.ETHPubRequest.OutputType
 	0,  // 2: shiftcrypto.bitbox02.ETHSignRequest.coin:type_name -> shiftcrypto.bitbox02.ETHCoin
-	18, // 3: shiftcrypto.bitbox02.ETHSignRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
+	20, // 3: shiftcrypto.bitbox02.ETHSignRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
 	1,  // 4: shiftcrypto.bitbox02.ETHSignRequest.address_case:type_name -> shiftcrypto.bitbox02.ETHAddressCase
-	18, // 5: shiftcrypto.bitbox02.ETHSignEIP1559Request.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
+	20, // 5: shiftcrypto.bitbox02.ETHSignEIP1559Request.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
 	1,  // 6: shiftcrypto.bitbox02.ETHSignEIP1559Request.address_case:type_name -> shiftcrypto.bitbox02.ETHAddressCase
-	0,  // 7: shiftcrypto.bitbox02.ETHSignMessageRequest.coin:type_name -> shiftcrypto.bitbox02.ETHCoin
-	18, // 8: shiftcrypto.bitbox02.ETHSignMessageRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
-	17, // 9: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.types:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.StructType
-	18, // 10: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
-	4,  // 11: shiftcrypto.bitbox02.ETHTypedMessageValueResponse.root_object:type_name -> shiftcrypto.bitbox02.ETHTypedMessageValueResponse.RootObject
-	5,  // 12: shiftcrypto.bitbox02.ETHRequest.pub:type_name -> shiftcrypto.bitbox02.ETHPubRequest
-	6,  // 13: shiftcrypto.bitbox02.ETHRequest.sign:type_name -> shiftcrypto.bitbox02.ETHSignRequest
-	8,  // 14: shiftcrypto.bitbox02.ETHRequest.sign_msg:type_name -> shiftcrypto.bitbox02.ETHSignMessageRequest
-	19, // 15: shiftcrypto.bitbox02.ETHRequest.antiklepto_signature:type_name -> shiftcrypto.bitbox02.AntiKleptoSignatureRequest
-	10, // 16: shiftcrypto.bitbox02.ETHRequest.sign_typed_msg:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest
-	12, // 17: shiftcrypto.bitbox02.ETHRequest.typed_msg_value:type_name -> shiftcrypto.bitbox02.ETHTypedMessageValueRequest
-	7,  // 18: shiftcrypto.bitbox02.ETHRequest.sign_eip1559:type_name -> shiftcrypto.bitbox02.ETHSignEIP1559Request
-	20, // 19: shiftcrypto.bitbox02.ETHResponse.pub:type_name -> shiftcrypto.bitbox02.PubResponse
-	9,  // 20: shiftcrypto.bitbox02.ETHResponse.sign:type_name -> shiftcrypto.bitbox02.ETHSignResponse
-	21, // 21: shiftcrypto.bitbox02.ETHResponse.antiklepto_signer_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoSignerCommitment
-	11, // 22: shiftcrypto.bitbox02.ETHResponse.typed_msg_value:type_name -> shiftcrypto.bitbox02.ETHTypedMessageValueResponse
-	3,  // 23: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType.type:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.DataType
-	15, // 24: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType.array_type:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType
-	15, // 25: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.Member.type:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType
-	16, // 26: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.StructType.members:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.Member
-	27, // [27:27] is the sub-list for method output_type
-	27, // [27:27] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	21, // 7: shiftcrypto.bitbox02.ETHSignEIP1559Request.payment_request:type_name -> shiftcrypto.bitbox02.BTCPaymentRequestRequest
+	0,  // 8: shiftcrypto.bitbox02.ETHSignMessageRequest.coin:type_name -> shiftcrypto.bitbox02.ETHCoin
+	20, // 9: shiftcrypto.bitbox02.ETHSignMessageRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
+	19, // 10: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.types:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.StructType
+	20, // 11: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.host_nonce_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoHostNonceCommitment
+	4,  // 12: shiftcrypto.bitbox02.ETHTypedMessageValueResponse.root_object:type_name -> shiftcrypto.bitbox02.ETHTypedMessageValueResponse.RootObject
+	5,  // 13: shiftcrypto.bitbox02.ETHRequest.pub:type_name -> shiftcrypto.bitbox02.ETHPubRequest
+	6,  // 14: shiftcrypto.bitbox02.ETHRequest.sign:type_name -> shiftcrypto.bitbox02.ETHSignRequest
+	10, // 15: shiftcrypto.bitbox02.ETHRequest.sign_msg:type_name -> shiftcrypto.bitbox02.ETHSignMessageRequest
+	22, // 16: shiftcrypto.bitbox02.ETHRequest.antiklepto_signature:type_name -> shiftcrypto.bitbox02.AntiKleptoSignatureRequest
+	12, // 17: shiftcrypto.bitbox02.ETHRequest.sign_typed_msg:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest
+	14, // 18: shiftcrypto.bitbox02.ETHRequest.typed_msg_value:type_name -> shiftcrypto.bitbox02.ETHTypedMessageValueRequest
+	7,  // 19: shiftcrypto.bitbox02.ETHRequest.sign_eip1559:type_name -> shiftcrypto.bitbox02.ETHSignEIP1559Request
+	9,  // 20: shiftcrypto.bitbox02.ETHRequest.data_response_chunk:type_name -> shiftcrypto.bitbox02.ETHSignDataResponseChunkRequest
+	23, // 21: shiftcrypto.bitbox02.ETHResponse.pub:type_name -> shiftcrypto.bitbox02.PubResponse
+	11, // 22: shiftcrypto.bitbox02.ETHResponse.sign:type_name -> shiftcrypto.bitbox02.ETHSignResponse
+	24, // 23: shiftcrypto.bitbox02.ETHResponse.antiklepto_signer_commitment:type_name -> shiftcrypto.bitbox02.AntiKleptoSignerCommitment
+	13, // 24: shiftcrypto.bitbox02.ETHResponse.typed_msg_value:type_name -> shiftcrypto.bitbox02.ETHTypedMessageValueResponse
+	8,  // 25: shiftcrypto.bitbox02.ETHResponse.data_request_chunk:type_name -> shiftcrypto.bitbox02.ETHSignDataRequestChunkResponse
+	3,  // 26: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType.type:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.DataType
+	17, // 27: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType.array_type:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType
+	17, // 28: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.Member.type:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.MemberType
+	18, // 29: shiftcrypto.bitbox02.ETHSignTypedMessageRequest.StructType.members:type_name -> shiftcrypto.bitbox02.ETHSignTypedMessageRequest.Member
+	30, // [30:30] is the sub-list for method output_type
+	30, // [30:30] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_eth_proto_init() }
@@ -1570,7 +1754,8 @@ func file_eth_proto_init() {
 	}
 	file_common_proto_init()
 	file_antiklepto_proto_init()
-	file_eth_proto_msgTypes[8].OneofWrappers = []any{
+	file_btc_proto_init()
+	file_eth_proto_msgTypes[10].OneofWrappers = []any{
 		(*ETHRequest_Pub)(nil),
 		(*ETHRequest_Sign)(nil),
 		(*ETHRequest_SignMsg)(nil),
@@ -1578,12 +1763,14 @@ func file_eth_proto_init() {
 		(*ETHRequest_SignTypedMsg)(nil),
 		(*ETHRequest_TypedMsgValue)(nil),
 		(*ETHRequest_SignEip1559)(nil),
+		(*ETHRequest_DataResponseChunk)(nil),
 	}
-	file_eth_proto_msgTypes[9].OneofWrappers = []any{
+	file_eth_proto_msgTypes[11].OneofWrappers = []any{
 		(*ETHResponse_Pub)(nil),
 		(*ETHResponse_Sign)(nil),
 		(*ETHResponse_AntikleptoSignerCommitment)(nil),
 		(*ETHResponse_TypedMsgValue)(nil),
+		(*ETHResponse_DataRequestChunk)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -1591,7 +1778,7 @@ func file_eth_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_eth_proto_rawDesc), len(file_eth_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   13,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages/eth.proto
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages/eth.proto
@@ -5,6 +5,7 @@ package shiftcrypto.bitbox02;
 
 import "common.proto";
 import "antiklepto.proto";
+import "btc.proto";
 
 // Kept for backwards compatibility. Use chain_id instead, introduced in v9.10.0.
 enum ETHCoin {
@@ -51,6 +52,8 @@ message ETHSignRequest {
   // If non-zero, `coin` is ignored and `chain_id` is used to identify the network.
   uint64 chain_id = 10;
   ETHAddressCase address_case = 11;
+  // For streaming: if non-zero, data field should be empty and data will be requested in chunks
+  uint32 data_length = 12;
 }
 
 // TX payload for an EIP-1559 (type 2) transaction: https://eips.ethereum.org/EIPS/eip-1559
@@ -66,6 +69,18 @@ message ETHSignEIP1559Request {
   bytes data = 9;
   AntiKleptoHostNonceCommitment host_nonce_commitment = 10;
   ETHAddressCase address_case = 11;
+  // For streaming: if non-zero, data field should be empty and data will be requested in chunks
+  uint32 data_length = 12;
+  BTCPaymentRequestRequest payment_request = 13;
+}
+
+message ETHSignDataRequestChunkResponse {
+  uint32 offset = 1;
+  uint32 length = 2;
+}
+
+message ETHSignDataResponseChunkRequest {
+  bytes chunk = 1;
 }
 
 message ETHSignMessageRequest {
@@ -131,6 +146,9 @@ message ETHTypedMessageValueResponse {
 
 message ETHTypedMessageValueRequest {
   bytes value = 1;
+  // If non-zero, value should be empty and data will be streamed via
+  // DataRequestChunk/DataResponseChunk.
+  uint32 data_length = 2;
 }
 
 message ETHRequest {
@@ -142,6 +160,7 @@ message ETHRequest {
     ETHSignTypedMessageRequest sign_typed_msg = 5;
     ETHTypedMessageValueRequest typed_msg_value = 6;
     ETHSignEIP1559Request sign_eip1559 = 7;
+    ETHSignDataResponseChunkRequest data_response_chunk = 8;
   }
 }
 
@@ -151,5 +170,6 @@ message ETHResponse {
     ETHSignResponse sign = 2;
     AntiKleptoSignerCommitment antiklepto_signer_commitment = 3;
     ETHTypedMessageValueResponse typed_msg_value = 4;
+    ETHSignDataRequestChunkResponse data_request_chunk = 5;
   }
 }

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/paymentrequests.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/paymentrequests.go
@@ -17,11 +17,12 @@ func hashDataLenPrefixed(hasher hash.Hash, data []byte) {
 	_, _ = hasher.Write(data)
 }
 
-// ComputePaymentRequestSighash returns the sighash to be signed for a SLIP-24 payment request.
-func ComputePaymentRequestSighash(
+// ComputePaymentRequestSighashBytes returns the sighash to be signed for a SLIP-24 payment
+// request using the normalized output value bytes as-is.
+func ComputePaymentRequestSighashBytes(
 	paymentRequest *messages.BTCPaymentRequestRequest,
 	slip44 uint32,
-	outputValue uint64,
+	outputValueBytes []byte,
 	outputAddress string,
 ) ([]byte, error) {
 	// The write results are ignored because sighash.Write cannot fail.
@@ -44,6 +45,11 @@ func ComputePaymentRequestSighash(
 		case *messages.BTCPaymentRequestRequest_Memo_TextMemo_:
 			_ = binary.Write(sighash, binary.LittleEndian, uint32(1))
 			hashDataLenPrefixed(sighash, []byte(m.TextMemo.Note))
+		case *messages.BTCPaymentRequestRequest_Memo_CoinPurchaseMemo_:
+			_ = binary.Write(sighash, binary.LittleEndian, uint32(3))
+			_ = binary.Write(sighash, binary.LittleEndian, m.CoinPurchaseMemo.CoinType)
+			hashDataLenPrefixed(sighash, []byte(m.CoinPurchaseMemo.Amount))
+			hashDataLenPrefixed(sighash, []byte(m.CoinPurchaseMemo.Address))
 		default:
 			return nil, errors.New("unsupported memo type")
 		}
@@ -54,9 +60,23 @@ func ComputePaymentRequestSighash(
 
 	// outputsHash (only one output for now)
 	outputHasher := sha256.New()
-	_ = binary.Write(outputHasher, binary.LittleEndian, outputValue)
+	_, _ = outputHasher.Write(outputValueBytes)
 	hashDataLenPrefixed(outputHasher, []byte(outputAddress))
 	_, _ = sighash.Write(outputHasher.Sum(nil))
 
 	return sighash.Sum(nil), nil
+}
+
+// ComputePaymentRequestSighash returns the sighash to be signed for a SLIP-24 payment request.
+// It is kept for backwards compatibility.
+// It is a BTC-oriented convenience wrapper that normalizes the output value as 8-byte
+// little-endian before delegating to ComputePaymentRequestSighashBytes.
+func ComputePaymentRequestSighash(
+	paymentRequest *messages.BTCPaymentRequestRequest,
+	slip44 uint32,
+	outputValue uint64,
+	outputAddress string,
+) ([]byte, error) {
+	outputValueBytes := binary.LittleEndian.AppendUint64(nil, outputValue)
+	return ComputePaymentRequestSighashBytes(paymentRequest, slip44, outputValueBytes, outputAddress)
 }

--- a/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/psbt.go
+++ b/vendor/github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/psbt.go
@@ -595,7 +595,7 @@ func newBTCTxFromPSBT(
 }
 
 // BTCSignPSBT signs a PSBT. If `options` is nil, the default options are used. The PSBT input signatures will be
-// populated.
+// populated. If a (partial) signature for the public key of the device already exists, it will be overwritten.
 func (device *Device) BTCSignPSBT(
 	coin messages.BTCCoin,
 	psbt_ *psbt.Packet,
@@ -630,12 +630,16 @@ func (device *Device) BTCSignPSBT(
 		ourKey := txResult.ourKeys[inputIndex]
 		switch {
 		case ourKey.segwit != nil:
-			psbtInput.PartialSigs = []*psbt.PartialSig{
-				{
-					PubKey:    ourKey.segwit.PubKey,
-					Signature: append(signatureDER, byte(txscript.SigHashAll)),
-				},
-			}
+			// Check if we already have a partial signature for this
+			// public key. If we do, we overwrite it. Duplicate
+			// entries would lead to an invalid PSBT. Erroring out
+			// is suboptimal as well, since we've already gone
+			// through the signing process. It's the caller's
+			// responsibility to check if this device has already
+			// signed the PSBT to avoid this behavior.
+			setPartialSig(
+				signatureDER, psbtInput, ourKey.segwit.PubKey,
+				txscript.SigHashAll)
 		case ourKey.taprootInternal != nil:
 			psbtInput.TaprootKeySpendSig = signatureCompact
 		case ourKey.taprootScript != nil:
@@ -657,6 +661,32 @@ func (device *Device) BTCSignPSBT(
 	}
 
 	return nil
+}
+
+// setPartialSig replaces or adds a partial signature for the given public key,
+// depending on whether a partial signature already exists for the key or not.
+func setPartialSig(
+	sig []byte,
+	psbtInput *psbt.PInput,
+	pubKey []byte,
+	sigHash txscript.SigHashType,
+) {
+	for idx, partialSig := range psbtInput.PartialSigs {
+		if bytes.Equal(partialSig.PubKey, pubKey) {
+			psbtInput.PartialSigs[idx] = &psbt.PartialSig{
+				PubKey:    pubKey,
+				Signature: append(sig, byte(sigHash)),
+			}
+
+			return
+		}
+	}
+	psbtInput.PartialSigs = append(
+		psbtInput.PartialSigs, &psbt.PartialSig{
+			PubKey:    pubKey,
+			Signature: append(sig, byte(sigHash)),
+		},
+	)
 }
 
 // BTCSignNeedsNonWitnessUTXOs returns true if the BitBox requires the NON_WITNESS_UTXO fields of

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20260303104349-15a1f0c828a6
+# github.com/BitBoxSwiss/bitbox02-api-go v0.0.0-20260420184007-d546462995df
 ## explicit; go 1.24
 github.com/BitBoxSwiss/bitbox02-api-go/api/bootloader
 github.com/BitBoxSwiss/bitbox02-api-go/api/common


### PR DESCRIPTION
Switch large Etherscan proxy RPC calls to form POST once the encoded
request target exceeds a conservative limit. This avoids 414 errors when
WalletConnect transactions include large calldata for gas estimation or
raw transaction broadcast.

Adapt the BitBox02 EIP-1559 signing call to the updated API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable large streamed payloads over Wallet Connect for Ethereum transactions
  * Add coin-purchase memo support to payment requests (coin, amount, destination)

* **Improvements**
  * Dynamic GET/POST selection for Ethereum RPC calls to handle large payloads
  * Stronger device attestation verification and safer handling of large ETH signing/typed-message streaming
  * PSBT signing now overwrites or appends partial signatures for the device key
<!-- end of auto-generated comment: release notes by coderabbit.ai -->