### PR TITLE
frontend: align sidebar icons

### DIFF
--- a/frontends/web/src/components/sidebar/sidebar.module.css
+++ b/frontends/web/src/components/sidebar/sidebar.module.css
@@ -139,9 +139,13 @@
 
 .sidebarItem :global(.stacked),
 .sidebarItem .single {
+    align-items: center;
+    display: flex;
+    justify-content: center;
     margin: 0 var(--sidebar-icon-margin) 0 var(--sidebar-margin);
     margin-left: 20px;
     height: var(--sidebar-icon-size);
+    width: var(--sidebar-icon-size);
 }
 
 a.sidebarActive .sidebarLabel,
@@ -173,6 +177,9 @@ a.sidebarActive :global(.stacked) img:last-child,
 }
 
 .single img {
+    width: var(--sidebar-icon-size);
+    height: var(--sidebar-icon-size);
+    object-fit: contain;
     opacity: .6;
     transition: opacity 0.2s ease;
 }


### PR DESCRIPTION
Lightning icon centering in the sidebar was wrong. This fixes it using flex centering to bring it onto the same vertical alignment as the other sidebar icons.

Before:
<img width="205" height="303" alt="image" src="https://github.com/user-attachments/assets/8d0dc842-ab95-4805-b697-856a04767c5e" />

After:
<img width="226" height="311" alt="image" src="https://github.com/user-attachments/assets/a9049942-b0e7-497c-bc06-2898976c259f" />


