### PR TITLE
frontend: add marketplace blue dot and swap/OTC new badge

### DIFF
--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -42,7 +42,6 @@ export const App = () => {
 
   const accounts = useDefault(useSync(getAccounts, syncAccountsList), []);
   const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});
-
   const prevDevices = usePrevious(devices);
 
   const deviceIDs = Object.keys(devices);

--- a/frontends/web/src/components/bottom-navigation/bottom-navigation.module.css
+++ b/frontends/web/src/components/bottom-navigation/bottom-navigation.module.css
@@ -48,6 +48,21 @@
     border-radius: var(--radius-xl);
 }
 
+.marketplaceLabel {
+    align-items: center;
+    display: inline-flex;
+    gap: 2px;
+}
+
+.marketplaceNudgeDot {
+    background: var(--color-blue);
+    border-radius: var(--radius-full);
+    display: inline-block;
+    flex-shrink: 0;
+    height: 6px;
+    width: 6px;
+}
+
 @media (max-width: 768px) {
     .container {
         display: flex;

--- a/frontends/web/src/components/bottom-navigation/bottom-navigation.tsx
+++ b/frontends/web/src/components/bottom-navigation/bottom-navigation.tsx
@@ -8,6 +8,7 @@ import { AccountIconSVG, MarketIconSVG, MoreIconSVG, PortfolioIconSVG } from '@/
 import { useLoad } from '@/hooks/api';
 import { getVersion } from '@/api/bitbox02';
 import { RedDot } from '@/components/icon';
+import { NewBadge } from '@/components/new-badge/new-badge';
 import styles from './bottom-navigation.module.css';
 
 type Props = {
@@ -15,7 +16,10 @@ type Props = {
   devices: TDevices;
 };
 
-export const BottomNavigation = ({ activeAccounts, devices }: Props) => {
+export const BottomNavigation = ({
+  activeAccounts,
+  devices,
+}: Props) => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
   const deviceID = Object.keys(devices)[0];
@@ -60,7 +64,16 @@ export const BottomNavigation = ({ activeAccounts, devices }: Props) => {
         to="/market/select"
       >
         <MarketIconSVG />
-        {t('generic.buySell')}
+        <span className={styles.marketplaceLabel}>
+          {t('generic.buySell')}
+          <NewBadge
+            className={styles.marketplaceNudgeDot}
+            configKey="hasSeenMarketplaceNudge"
+            hideOnPathPrefix="/market/"
+            pathname={pathname}
+            type="dot"
+          />
+        </span>
       </Link>
       <Link
         className={`

--- a/frontends/web/src/components/new-badge/new-badge.tsx
+++ b/frontends/web/src/components/new-badge/new-badge.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/badge/badge';
+import { useLoad } from '@/hooks/api';
+import { getConfig, setConfig } from '@/utils/config';
+
+type TConfigKey = 'hasSeenMarketplaceNudge' | 'hasSeenSwapMarketTab' | 'hasSeenOtcMarketTab';
+
+type TProps = {
+  className?: string;
+  configKey: TConfigKey;
+  hideOnPathPrefix?: string;
+  markAsSeen?: boolean;
+  pathname?: string;
+  testID?: string;
+  type?: 'dot' | 'new';
+};
+
+export const NewBadge = ({
+  className,
+  configKey,
+  hideOnPathPrefix,
+  markAsSeen = false,
+  pathname,
+  testID,
+  type = 'new',
+}: TProps) => {
+  const { t } = useTranslation();
+  const config = useLoad(getConfig);
+  const [showBadge, setShowBadge] = useState<boolean | undefined>(undefined);
+
+  const persistAsSeen = useCallback(() => {
+    if (showBadge === false) {
+      return;
+    }
+    setShowBadge(false);
+    setConfig({ frontend: { [configKey]: true } });
+  }, [configKey, showBadge]);
+
+  useEffect(() => {
+    if (!config) {
+      return;
+    }
+    const frontendConfig = config.frontend as Record<string, unknown> | undefined;
+    const hasSeenBadge = Boolean(frontendConfig?.[configKey]);
+    setShowBadge(currentShowBadge => (
+      currentShowBadge === false ? false : !hasSeenBadge
+    ));
+  }, [config, configKey]);
+
+  useEffect(() => {
+    if (markAsSeen) {
+      persistAsSeen();
+    }
+  }, [markAsSeen, persistAsSeen]);
+
+  useEffect(() => {
+    if (!hideOnPathPrefix || !pathname || !pathname.startsWith(hideOnPathPrefix)) {
+      return;
+    }
+    persistAsSeen();
+  }, [hideOnPathPrefix, pathname, persistAsSeen]);
+
+  if (showBadge !== true) {
+    return null;
+  }
+
+  if (type === 'dot') {
+    return <span className={className} data-testid={testID} aria-hidden />;
+  }
+
+  return (
+    <Badge className={className} data-testid={testID} type="info">
+      {t('generic.new')}
+    </Badge>
+  );
+};

--- a/frontends/web/src/components/sidebar/sidebar.module.css
+++ b/frontends/web/src/components/sidebar/sidebar.module.css
@@ -193,6 +193,21 @@ a.sidebarActive .single img,
     word-break: break-word;
 }
 
+.marketplaceLabel {
+    align-items: center;
+    display: inline-flex;
+    gap: var(--space-eight);
+}
+
+.marketplaceNudgeDot {
+    background: var(--color-blue);
+    border-radius: var(--radius-full);
+    display: inline-block;
+    flex-shrink: 0;
+    height: 8px;
+    width: 8px;
+}
+
 @media (max-width: 1199px) {
     .sidebar {
         transition: margin-left 0.2s ease;

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -15,6 +15,7 @@ import { getAccountsByKeystore } from '@/routes/account/utils';
 import { SkipForTesting } from '@/routes/device/components/skipfortesting';
 import { AppContext } from '@/contexts/AppContext';
 import { Button } from '@/components/forms';
+import { NewBadge } from '@/components/new-badge/new-badge';
 import { ConnectedKeystore } from '../keystore/connected-keystore';
 import style from './sidebar.module.css';
 
@@ -154,8 +155,15 @@ const Sidebar = ({
                 <div className={style.single}>
                   <Coins />
                 </div>
-                <span className={style.sidebarLabel}>
+                <span className={`${style.sidebarLabel || ''} ${style.marketplaceLabel || ''}`}>
                   {t('generic.buySell')}
+                  <NewBadge
+                    className={style.marketplaceNudgeDot}
+                    configKey="hasSeenMarketplaceNudge"
+                    hideOnPathPrefix="/market/"
+                    pathname={pathname}
+                    type="dot"
+                  />
                 </span>
               </NavLink>
             </div>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -986,6 +986,7 @@
     "enabled_false": "Disabled",
     "enabled_true": "Enabled",
     "max": "Max",
+    "new": "New",
     "noOptionOnIos": "Not available on iOS",
     "noOptions": "No options found",
     "paymentRequestNote": "{{name}} payment {{orderId}}",

--- a/frontends/web/src/routes/market/components/markettab.module.css
+++ b/frontends/web/src/routes/market/components/markettab.module.css
@@ -1,0 +1,13 @@
+.tabLabel {
+  display: inline-block;
+  position: relative;
+}
+
+.newBadge {
+  line-height: 1;
+  pointer-events: none;
+  position: absolute;
+  right: -24px;
+  top: -16px;
+  z-index: 1;
+}

--- a/frontends/web/src/routes/market/components/markettab.test.tsx
+++ b/frontends/web/src/routes/market/components/markettab.test.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../../__mocks__/i18n';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MarketTab } from './markettab';
+import { getConfig } from '@/utils/config';
+
+vi.mock('@/utils/config', () => ({
+  getConfig: vi.fn(),
+  setConfig: vi.fn(),
+}));
+
+const mockedGetConfig = vi.mocked(getConfig);
+
+describe('routes/market/components/markettab', () => {
+  beforeEach(() => {
+    mockedGetConfig.mockResolvedValue({ frontend: {} });
+  });
+
+  it('shows the new badge on swap when enabled', async () => {
+    mockedGetConfig.mockResolvedValue({
+      frontend: {
+        hasSeenOtcMarketTab: true,
+        hasSeenSwapMarketTab: false,
+      }
+    });
+
+    render(
+      <MarketTab
+        activeTab="buy"
+        onChangeTab={vi.fn()}
+        showSwap
+      />,
+    );
+
+    expect(await screen.findByTestId('swap-new-badge')).toBeInTheDocument();
+  });
+
+  it('hides the new badge on swap when disabled', async () => {
+    mockedGetConfig.mockResolvedValue({
+      frontend: {
+        hasSeenOtcMarketTab: true,
+        hasSeenSwapMarketTab: true,
+      }
+    });
+
+    render(
+      <MarketTab
+        activeTab="buy"
+        onChangeTab={vi.fn()}
+        showSwap
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockedGetConfig).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId('swap-new-badge')).not.toBeInTheDocument();
+  });
+
+  it('emits swap tab selection when swap is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangeTab = vi.fn();
+
+    render(
+      <MarketTab
+        activeTab="buy"
+        onChangeTab={onChangeTab}
+        showSwap
+      />,
+    );
+
+    const swapButton = screen.getByText('generic.swap').closest('button');
+    expect(swapButton).not.toBeNull();
+    await user.click(swapButton as HTMLButtonElement);
+
+    expect(onChangeTab).toHaveBeenCalledWith('swap');
+  });
+
+  it('shows the new badge on otc when enabled', async () => {
+    mockedGetConfig.mockResolvedValue({
+      frontend: {
+        hasSeenOtcMarketTab: false,
+        hasSeenSwapMarketTab: true,
+      }
+    });
+
+    render(
+      <MarketTab
+        activeTab="buy"
+        onChangeTab={vi.fn()}
+        showSwap
+      />,
+    );
+
+    expect(await screen.findByTestId('otc-new-badge')).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/market/components/markettab.tsx
+++ b/frontends/web/src/routes/market/components/markettab.tsx
@@ -3,6 +3,8 @@
 import { useTranslation } from 'react-i18next';
 import { PillButton, PillButtonGroup } from '../../../components/pillbuttongroup/pillbuttongroup';
 import { TMarketAction } from '@/api/market';
+import { NewBadge } from '@/components/new-badge/new-badge';
+import style from './markettab.module.css';
 
 
 type TProps = {
@@ -43,15 +45,31 @@ export const MarketTab = ({
           active={activeTab === 'swap'}
           onClick={() => onChangeTab('swap')}
         >
-          {t('generic.swap')}
+          <span className={style.tabLabel}>
+            {t('generic.swap')}
+            <NewBadge
+              className={style.newBadge}
+              configKey="hasSeenSwapMarketTab"
+              markAsSeen={activeTab === 'swap'}
+              testID="swap-new-badge"
+            />
+          </span>
         </PillButton>
       )}
       <PillButton
         active={activeTab === 'otc'}
         onClick={() => onChangeTab('otc')}
       >
-        {/* OTC doesn't need to be translated, but is explained in t('buy.exchange.otcInfo') */}
-        OTC
+        <span className={style.tabLabel}>
+          {/* OTC doesn't need to be translated, but is explained in t('buy.exchange.otcInfo') */}
+          OTC
+          <NewBadge
+            className={style.newBadge}
+            configKey="hasSeenOtcMarketTab"
+            markAsSeen={activeTab === 'otc'}
+            testID="otc-new-badge"
+          />
+        </span>
       </PillButton>
     </PillButtonGroup>
   );

--- a/frontends/web/src/routes/market/market.tsx
+++ b/frontends/web/src/routes/market/market.tsx
@@ -186,6 +186,10 @@ export const Market = ({
     }
   };
 
+  const handleChangeTab = (tab: marketAPI.TMarketAction) => {
+    setActiveTab(tab);
+  };
+
   const goToVendor = async (vendor: marketAPI.TVendorName) => {
     if (!vendor) {
       return;
@@ -267,7 +271,7 @@ export const Market = ({
                 {regions.length ? (
                   <>
                     <MarketTab
-                      onChangeTab={setActiveTab}
+                      onChangeTab={handleChangeTab}
                       activeTab={activeTab}
                       showSwap={!!swapStatus?.available}
                     />


### PR DESCRIPTION
Add UI blue dot nudge to Marketplace and new badge to Swap and OTC. Blue dot and new badges are hidden once clicked and persisted in frontend config.