### PR TITLE
frontend: fix isMounted.current

### DIFF
--- a/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
+++ b/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
@@ -61,7 +61,7 @@ export const InputWithAccountSelector = <T extends TAccountBase, >({
         fiatUnit: defaultCurrency,
       })
         .then(response => {
-          if (requestId !== requestIdRef.current || !isMounted) {
+          if (requestId !== requestIdRef.current || !isMounted.current) {
             return;
           }
 
@@ -72,7 +72,7 @@ export const InputWithAccountSelector = <T extends TAccountBase, >({
           }
         })
         .catch(() => {
-          if (requestId !== requestIdRef.current || !isMounted) {
+          if (requestId !== requestIdRef.current || !isMounted.current) {
             return;
           }
           setEstimatedFiatValue(null);


### PR DESCRIPTION
useMountedRef() returns a ref. !isMounted is always false, so an in-flight conversion can still call setEstimatedFiatValue() after unmount.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
