### PR TITLE
frontend: disable swap when changing amount

### DIFF
--- a/frontends/web/src/routes/market/swap/components/swap-service-selector.test.tsx
+++ b/frontends/web/src/routes/market/swap/components/swap-service-selector.test.tsx
@@ -37,6 +37,7 @@ describe('routes/market/swap/components/swap-service-selector', () => {
           providers: ['THORCHAIN_STREAMING', 'MAYACHAIN', 'JUPITER', 'OKX'],
           routeId: 'route-1',
         }]}
+        selectedRouteId="route-1"
       />,
     );
 
@@ -56,6 +57,7 @@ describe('routes/market/swap/components/swap-service-selector', () => {
           providers: ['mysterydex'],
           routeId: 'route-1',
         }]}
+        selectedRouteId="route-1"
       />,
     );
 

--- a/frontends/web/src/routes/market/swap/components/swap-service-selector.tsx
+++ b/frontends/web/src/routes/market/swap/components/swap-service-selector.tsx
@@ -152,7 +152,9 @@ export const SwapServiceSelector = ({
     value: route.routeId,
   })) : [];
 
-  const selectedOption = options.find(option => option.value === selectedRouteId) || options[0];
+  const selectedOption = selectedRouteId
+    ? options.find(option => option.value === selectedRouteId)
+    : undefined;
   const hasMultipleRoutes = options.length > 1;
 
   return (

--- a/frontends/web/src/routes/market/swap/swap.test.tsx
+++ b/frontends/web/src/routes/market/swap/swap.test.tsx
@@ -244,4 +244,54 @@ describe('routes/market/swap', () => {
       });
     });
   });
+
+  it('disables swap button immediately when sell amount changes', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(swapApi.getSwapQuote)
+      .mockResolvedValueOnce({
+        success: true,
+        quote: {
+          routes: [{
+            expectedBuyAmount: '1.23',
+            providers: ['thorchain', 'mayachain'],
+            routeId: 'route-1',
+          }],
+        },
+      })
+      .mockImplementationOnce(() => new Promise(() => {}));
+
+    render(
+      <RatesContext.Provider
+        value={{
+          activeCurrencies: [],
+          addToActiveCurrencies: vi.fn(),
+          btcUnit: 'default',
+          defaultCurrency: 'USD',
+          removeFromActiveCurrencies: vi.fn(),
+          rotateBtcUnit: vi.fn(),
+          rotateDefaultCurrency: vi.fn(),
+          updateDefaultCurrency: vi.fn(),
+        }}>
+        <MemoryRouter>
+          <Swap accounts={[sellAccount, buyAccount]} />
+        </MemoryRouter>
+      </RatesContext.Provider>,
+    );
+
+    await user.click(await screen.findByTestId('agree-swap-terms'));
+
+    const sellAmountInput = await screen.findByLabelText('swapSendAmount');
+    const swapButton = screen.getByRole('button', { name: 'Swap' });
+
+    await user.type(sellAmountInput, '1');
+
+    await waitFor(() => expect(swapButton).toBeEnabled());
+    expect(screen.getByText('THORChain + Mayachain')).toBeInTheDocument();
+
+    await user.type(sellAmountInput, '2');
+
+    expect(swapButton).toBeDisabled();
+    expect(screen.queryByText('THORChain + Mayachain')).not.toBeInTheDocument();
+  });
 });

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -228,6 +228,11 @@ export const Swap = ({
     const buyCoinCode = buyAccount?.coinCode;
     const amount = Number(sellAmount);
 
+    setRoutes([]);
+    setSelectedRouteId(undefined);
+    setExpectedOutput('');
+    setExpectedOutputUnit(undefined);
+
     if (
       !sellCoinCode
       || !buyCoinCode


### PR DESCRIPTION
When editing the amount to sell, the Swap button needs to be disabled, and we need to also clear the dropdown menu since the route is not valid anymore.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
