### PR TITLE
frontend: add testnet warning to recieve view

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1745,7 +1745,8 @@
     "title": "Receive {{accountName}}",
     "verify": "Verify address securely",
     "verifyBitBox02": "Verify address on BitBox",
-    "verifyInstruction": "Please verify that the following address matches the one displayed on your device."
+    "verifyInstruction": "Please verify that the following address matches the one displayed on your device.",
+    "verifyTestnetWarning": "This is a testnet account, coins received to this address have no value"
   },
   "reset": {
     "description": "All data will be deleted from this device. That includes your Private Key!",

--- a/frontends/web/src/routes/account/receive/receive.tsx
+++ b/frontends/web/src/routes/account/receive/receive.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { AppContext } from '@/contexts/AppContext';
 import { useLoad } from '@/hooks/api';
 import { UseBackButton } from '@/hooks/backbutton';
 import * as accountApi from '@/api/account';
@@ -144,6 +145,8 @@ export const Receive = ({
   const receiveAddresses = useLoad(accountApi.getReceiveAddressList(code));
   const availableScriptTypes = receiveAddresses ? getAvailableScriptTypes(receiveAddresses) : undefined;
   const hasManyScriptTypes = availableScriptTypes && availableScriptTypes.length > 1;
+
+  const { isTesting } = useContext(AppContext);
 
   useEffect(() => {
     if (receiveAddresses) {
@@ -360,6 +363,11 @@ export const Receive = ({
                             flexibleHeight
                           />
                         </div>
+                        {isTesting && (
+                          <Message type="warning">
+                            {t('receive.verifyTestnetWarning')}
+                          </Message>
+                        )}
                       </>
                     )}
                   </Dialog>


### PR DESCRIPTION
In recent commit the testnet banner is now dismissible, added another warning in receive workflow just to be sure the user does not forget.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
