### PR TITLE
frontend: fix misplaced cursor on region select

### DIFF
--- a/frontends/web/src/routes/market/components/countryselect.module.css
+++ b/frontends/web/src/routes/market/components/countryselect.module.css
@@ -6,7 +6,7 @@
     padding: 0;
 }
 
-.select :global(.react-select__input-container) {
+.select :global(.react-select__value-container--has-value .react-select__input-container) {
     padding-left: calc(var(--space-default) + var(--space-eight));
 }
 


### PR DESCRIPTION
Before:

<img width="735" height="555" alt="Screenshot 2026-04-26 at 11 27 12" src="https://github.com/user-attachments/assets/da5fd494-21d2-4026-94a8-a2dc027ff83e" />


After:
<img width="811" height="548" alt="Screenshot 2026-04-26 at 11 23 45" src="https://github.com/user-attachments/assets/90e323dd-d67a-48a5-835d-e567a39bb3f2" />

<img width="776" height="550" alt="Screenshot 2026-04-26 at 11 24 03" src="https://github.com/user-attachments/assets/65cf7f7b-1b75-4361-b107-ff14b1ff82a8" />
