### PR TITLE
frontend: simplify account summary unit price

### DIFF
--- a/frontends/web/src/components/amount/amount-with-unit.tsx
+++ b/frontends/web/src/components/amount/amount-with-unit.tsx
@@ -13,6 +13,7 @@ type TAmountWithUnitProps = {
   sign?: string;
   alwaysShowAmounts?: boolean;
   convertToFiat?: boolean;
+  removeTrailingZeros?: boolean;
   amountClassName?: string;
   unitClassName?: string;
   maxDecimals?: number;
@@ -23,6 +24,7 @@ export const AmountWithUnit = ({
   enableRotateUnit,
   sign,
   convertToFiat,
+  removeTrailingZeros,
   alwaysShowAmounts = false,
   amountClassName = '',
   unitClassName = '',
@@ -51,6 +53,7 @@ export const AmountWithUnit = ({
   }
 
   const enableClick = enableRotateUnit && (convertToFiat || isBitcoinCoin(amount.unit));
+  const stripTrailingZeros = removeTrailingZeros && displayedUnit === 'BTC';
 
   return (
     <span className={`
@@ -67,6 +70,7 @@ export const AmountWithUnit = ({
           unit={displayedUnit}
           onMobileClick={enableClick ? onClick : undefined}
           maxDecimals={maxDecimals}
+          removeTrailingZeros={stripTrailingZeros}
         />
       ) : '---'}
       {' '}

--- a/frontends/web/src/components/amount/amount.test.tsx
+++ b/frontends/web/src/components/amount/amount.test.tsx
@@ -208,6 +208,80 @@ describe('Amount formatting', () => {
     });
   });
 
+  describe('remove trailing zeros from amounts', () => {
+
+    it('0.00 CHF becomes 0', () => {
+      const { container } = render(<Amount amount="0.00" unit="CHF" removeTrailingZeros/>);
+      expect(container.textContent).toBe('0');
+    });
+
+    it('0.10 CHF becomes 0.1', () => {
+      const { container } = render(<Amount amount="0.10" unit="CHF" removeTrailingZeros/>);
+      expect(container.textContent).toBe('0.1');
+    });
+
+    it('1\'000 CHF stays 1’000', () => {
+      const { container } = render(<Amount amount="1'000" unit="CHF" removeTrailingZeros/>);
+      expect(container.textContent).toBe('1’000');
+    });
+
+    it('1\'000.00 CHF becomes 1’000', () => {
+      const { container } = render(<Amount amount="1'000.00" unit="CHF" removeTrailingZeros/>);
+      expect(container.textContent).toBe('1’000');
+    });
+
+    it('10 BTC stays 10', () => {
+      const { container } = render(<Amount amount="10" unit="BTC" removeTrailingZeros/>);
+      expect(container.textContent).toBe('10');
+    });
+
+    it('10\'000\'000 BTC stays 10’000’000', () => {
+      const { container } = render(<Amount amount="10'000'000" unit="BTC" removeTrailingZeros/>);
+      expect(container.textContent).toBe('10’000’000');
+    });
+
+    it('10\'000\'000.00000000 BTC becomes 10’000’000', () => {
+      const { container } = render(<Amount amount="10'000'000.00000000" unit="BTC" removeTrailingZeros/>);
+      expect(container.textContent).toBe('10’000’000');
+    });
+
+    it('10\'000.00 BTC becomes 10’000', () => {
+      const { container } = render(<Amount amount="10'000.00" unit="BTC" removeTrailingZeros/>);
+      expect(container.textContent).toBe('10’000');
+    });
+
+    it('10.010000000 BTC trims to 10.01', () => {
+      const { container } = render(<Amount amount="10.010000000" unit="BTC" removeTrailingZeros/>);
+      expect(container.textContent).toBe('10.01');
+    });
+
+    it('1.0 BTC becomes 1', () => {
+      const { container } = render(<Amount amount="1.0" unit="BTC" removeTrailingZeros/>);
+      expect(container.textContent).toBe('1');
+    });
+
+    it('1.00000001 BTC stays 1.00000001 (no false strip)', () => {
+      const { container } = render(<Amount amount="1.00000001" unit="BTC" removeTrailingZeros/>);
+      expect(container.textContent).toBe('1.00000001');
+    });
+
+    it('10\'000 ETH stays 10’000', () => {
+      const { container } = render(<Amount amount="10'000" unit="ETH" removeTrailingZeros/>);
+      expect(container.textContent).toBe('10’000');
+    });
+
+    it('10.10000000 ETH trims to 10.1', () => {
+      const { container } = render(<Amount amount="10.10000000" unit="ETH" removeTrailingZeros/>);
+      expect(container.textContent).toBe('10.1');
+    });
+
+    it('10100000000 sat stays 10100000000', () => {
+      const { container } = render(<Amount amount="10100000000" unit="sat" removeTrailingZeros/>);
+      expect(container.textContent).toBe('10100000000');
+    });
+
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/frontends/web/src/components/amount/amount.tsx
+++ b/frontends/web/src/components/amount/amount.tsx
@@ -7,6 +7,13 @@ import { LocalizationContext } from '@/contexts/localization-context';
 import { useMediaQuery } from '@/hooks/mediaquery';
 import style from './amount.module.css';
 
+const stripTrailingZeros = (value: string): string => {
+  if (!value.includes('.')) {
+    return value;
+  }
+  return value.replace(/\.?0+$/, '');
+};
+
 const formatSats = (amount: string): JSX.Element => {
   const blocks: JSX.Element[] = [];
   const blockSize = 3;
@@ -67,7 +74,7 @@ const formatBtc = (
 ) => {
   const dot = amount.indexOf('.');
   if (dot === -1) {
-    return amount;
+    return formatLocalizedAmount(amount, group, decimal);
   }
   // localize the first part, everything up to the second decimal place, the rest is grouped by spaces
   const formattedPart = formatLocalizedAmount(amount.slice(0, dot + 3), group, decimal);
@@ -96,7 +103,7 @@ const formatEth = (
 ): string => {
   const dot = amount.indexOf('.');
   if (dot === -1) {
-    return amount;
+    return formatLocalizedAmount(amount, group, decimal);
   }
   const truncated = amount.slice(0, dot + maxDecimals + 1);
   return formatLocalizedAmount(truncated, group, decimal);
@@ -108,6 +115,7 @@ type TProps = {
   alwaysShowAmounts?: boolean;
   onMobileClick?: () => Promise<void>;
   maxDecimals?: number;
+  removeTrailingZeros?: boolean;
 };
 
 export const Amount = ({
@@ -116,6 +124,7 @@ export const Amount = ({
   alwaysShowAmounts = false,
   onMobileClick,
   maxDecimals,
+  removeTrailingZeros,
 }: TProps) => {
   const isMobile = useMediaQuery('(max-width: 768px)');
 
@@ -132,6 +141,7 @@ export const Amount = ({
         unit={unit}
         alwaysShowAmounts={alwaysShowAmounts}
         maxDecimals={maxDecimals}
+        removeTrailingZeros={removeTrailingZeros}
       />
     </span>
   );
@@ -142,6 +152,7 @@ export const FormattedAmount = ({
   unit,
   alwaysShowAmounts = false,
   maxDecimals,
+  removeTrailingZeros,
 }: Omit<TProps, 'onMobileClick'>) => {
   const { hideAmounts } = useContext(AppContext);
   const { decimal, group } = useContext(LocalizationContext);
@@ -154,20 +165,22 @@ export const FormattedAmount = ({
     return '***';
   }
 
+  const displayedAmount = removeTrailingZeros ? stripTrailingZeros(amount) : amount;
+
   switch (unit) {
   case 'BTC':
   case 'TBTC':
   case 'LTC':
   case 'TLTC':
   case 'RBTC':
-    return formatBtc(amount, group, decimal);
+    return formatBtc(displayedAmount, group, decimal);
   case 'sat':
   case 'tsat':
-    return formatSats(amount);
+    return formatSats(displayedAmount);
   case 'ETH':
   case 'SEPETH':
-    return formatEth(amount, group, decimal, maxDecimals);
+    return formatEth(displayedAmount, group, decimal, maxDecimals);
   }
 
-  return formatLocalizedAmount(amount, group, decimal);
+  return formatLocalizedAmount(displayedAmount, group, decimal);
 };

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -172,8 +172,3 @@
 .unitPrice {
     color: var(--color-secondary);
 }
-
-.pairUnit {
-    color: var(--color-secondary);
-    font-size: var(--size-smaller);
-}

--- a/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
+++ b/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
@@ -37,10 +37,8 @@ export const AssetBalanceWithUnitPrice = ({ amount, coinCode, coinName, dataTest
                 amountClassName={style.unitPrice}
                 amount={unitPrice}
                 convertToFiat
+                removeTrailingZeros
               />
-              {amount?.unit && (
-                <span className={style.pairUnit}>/{amount.unit}</span>
-              )}
             </div>
           </div>
           <div className={style.assetBalanceAmounts}>


### PR DESCRIPTION
Drop the trailing `/<coin>` suffix on the unit-price line and
add an opt-in `removeTrailingZeros` flag on
`Amount`/`AmountWithUnit` (BTC only) so `1.00000000 BTC`
renders as `1 BTC`. Sat and fiat formatting are unchanged.