### PR TITLE
frontend: show decimal keyboard for amount inputs

### DIFF
--- a/frontends/web/src/components/forms/input-number.test.tsx
+++ b/frontends/web/src/components/forms/input-number.test.tsx
@@ -11,6 +11,11 @@ describe('components/forms/input-number', () => {
     expect(container.querySelector('[type="number"')).toBeTruthy();
   });
 
+  it('uses a decimal input mode by default', () => {
+    render(<NumberInput id="amount" label="Amount" defaultValue="" />);
+    expect(screen.getByLabelText('Amount')).toHaveAttribute('inputmode', 'decimal');
+  });
+
   it('should have children', () => {
     render(<NumberInput defaultValue=""><span>label</span></NumberInput>);
     expect(screen.getByText('label')).toBeTruthy();

--- a/frontends/web/src/components/forms/input-number.tsx
+++ b/frontends/web/src/components/forms/input-number.tsx
@@ -6,6 +6,7 @@ import { Input, TInputProps } from './input';
 type Props = Omit<TInputProps, 'ref' | 'onInput'>;
 
 export const NumberInput = (({
+  inputMode = 'decimal',
   onChange,
   ...props
 }: Props) => {
@@ -75,7 +76,7 @@ export const NumberInput = (({
     <Input
       {...props}
       type="number"
-      inputMode="numeric"
+      inputMode={inputMode}
       onInput={onChange}
       onPaste={handlePaste}
     />

--- a/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
@@ -3,7 +3,7 @@
 import type { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TAmountWithConversions, TBalance } from '@/api/account';
-import { Checkbox, Input } from '@/components/forms';
+import { Checkbox, NumberInput } from '@/components/forms';
 import style from './coin-input.module.css';
 
 type TProps = {
@@ -29,14 +29,12 @@ export const CoinInput = ({
 }: TProps) => {
   const { t } = useTranslation();
   return (
-    <Input
-      type="number"
-      inputMode="numeric"
+    <NumberInput
       step="any"
       min="0"
       label={balance ? balance.available.unit : t('send.amount.label')}
       id="amount"
-      onInput={(e: ChangeEvent<HTMLInputElement>) => onAmountChange(e.target.value)}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => onAmountChange(e.target.value)}
       disabled={sendAll}
       error={amountError}
       value={sendAll ? (proposedAmount ? proposedAmount.amount : '') : amount}


### PR DESCRIPTION
iOS uses the inputmode hint to choose the virtual keyboard for number fields. The previous numeric hint can show a keypad without a decimal separator, which prevents entering fractional send or swap amounts such as 0.1 ETH.

Default NumberInput to decimal input mode so the existing send fiat and swap amount fields request a decimal-capable keyboard, and route the send coin amount through NumberInput as well. NumberInput still renders type=number and keeps the onInput wiring internally, so desktop parsing, validation, and physical keyboard behavior should remain unchanged; Android may show a decimal-capable virtual keyboard where the WebView honors the hint.

The runtime scope is limited to account send amount fields and the market swap amount selector. Integer-only gap limit settings use raw Input type=number and are not affected.
