### PR TITLE
frontend: remove swap output to be focusable

### DIFF
--- a/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
+++ b/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
@@ -9,8 +9,8 @@ import { GroupedAccountSelector } from '@/components/groupedaccountselector/grou
 import { Amount } from '@/components/amount/amount';
 import { AmountUnit } from '@/components/amount/amount-with-unit';
 import { findAccount, getDisplayedCoinUnit } from '@/routes/account/utils';
-import style from './input-with-account-selector.module.css';
 import { useMountedRef } from '@/hooks/mount';
+import style from './input-with-account-selector.module.css';
 
 type Props<T extends TAccountBase> = {
   accountCode: AccountCode;
@@ -109,7 +109,7 @@ export const InputWithAccountSelector = <T extends TAccountBase, >({
           <NumberInput
             transparent
             align="right"
-            disabled={!selectedAccount}
+            disabled={!selectedAccount || readOnlyAmount}
             id={id}
             className={style.inputComponent}
             classNameInputField={style.inputField}


### PR DESCRIPTION
An altnernative would have been to change the :focus-within css selector to take readonly input into account, but that way the input element would technically still be focusable.

Changed to disabled to the element cannot be focesd.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
