### PR TITLE
frontend: refactor lightning send flow

### DIFF
--- a/frontends/web/src/routes/lightning/send/components/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/confirm-step.tsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/forms';
+import { Column, Grid } from '@/components/layout';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { useLightningSendContext } from '../lightning-send-context';
+import { PaymentDetails } from './invoice-details';
+
+export const ConfirmStep = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { paymentDetails, sendPayment } = useLightningSendContext();
+
+  if (!paymentDetails) {
+    return null;
+  }
+
+  return (
+    <View fitContent minHeight="100%">
+      <ViewContent>
+        <Grid col="1">
+          <Column>
+            <PaymentDetails input={paymentDetails} />
+          </Column>
+        </Grid>
+      </ViewContent>
+      <ViewButtons>
+        <Button primary onClick={sendPayment}>
+          {t('generic.send')}
+        </Button>
+        <Button secondary onClick={() => navigate('/lightning')}>
+          {t('button.back')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/send/components/edit-invoice-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/edit-invoice-step.tsx
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ChangeEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TInputTypeVariant } from '@/api/lightning';
+import { Button, Input } from '@/components/forms';
+import { Column, Grid } from '@/components/layout';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { useLightningSendContext } from '../lightning-send-context';
+
+export const EditInvoiceStep = () => {
+  const { t } = useTranslation();
+  const {
+    customAmount,
+    paymentDetails,
+    resetPayment,
+    sendPayment,
+    setCustomAmount,
+  } = useLightningSendContext();
+
+  if (paymentDetails?.type !== TInputTypeVariant.BOLT11) {
+    return null;
+  }
+
+  return (
+    <View fitContent minHeight="100%">
+      <ViewContent>
+        <Grid col="1">
+          <Column>
+            <Input
+              type="number"
+              min="0"
+              label={t('lightning.receive.amountSats.label')}
+              placeholder={t('lightning.receive.amountSats.placeholder')}
+              id="amountSatsInput"
+              onInput={(event: ChangeEvent<HTMLInputElement>) => setCustomAmount(event.target.valueAsNumber)}
+              value={customAmount ? `${customAmount}` : ''}
+              autoFocus
+            />
+            <Input
+              type="text"
+              label={t('lightning.receive.description.label')}
+              placeholder={t('lightning.receive.description.placeholder')}
+              id="descriptionInput"
+              readOnly
+              disabled
+              value={paymentDetails.invoice.description || ''}
+            />
+          </Column>
+        </Grid>
+      </ViewContent>
+      <ViewButtons>
+        <Button
+          primary
+          onClick={sendPayment}
+          disabled={!customAmount}>
+          {t('generic.send')}
+        </Button>
+        <Button secondary onClick={resetPayment}>
+          {t('button.back')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/send/components/invoice-details.tsx
+++ b/frontends/web/src/routes/lightning/send/components/invoice-details.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TAmountWithConversions } from '@/api/account';
+import { getBtcSatsAmount } from '@/api/coins';
+import { TInputType, TInputTypeVariant, TLightningInvoice } from '@/api/lightning';
+import { Amount } from '@/components/amount/amount';
+import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import { Skeleton } from '@/components/skeleton/skeleton';
+import { useMountedRef } from '@/hooks/mount';
+import styles from '../send.module.css';
+
+type TInvoiceDetailsProps = {
+  invoice: TLightningInvoice;
+};
+
+const useInvoiceAmount = (amountSat?: number) => {
+  const [invoiceAmount, setInvoiceAmount] = useState<TAmountWithConversions>();
+  const mounted = useMountedRef();
+
+  useEffect(() => {
+    setInvoiceAmount(undefined);
+
+    if (amountSat === undefined) {
+      return;
+    }
+
+    void getBtcSatsAmount(amountSat.toString())
+      .then((response) => {
+        if (mounted.current && response.success) {
+          setInvoiceAmount(response.amount);
+        }
+      })
+      .catch(() => undefined);
+  }, [amountSat, mounted]);
+
+  return invoiceAmount;
+};
+
+const InvoiceDetails = ({ invoice }: TInvoiceDetailsProps) => {
+  const { t } = useTranslation();
+  const invoiceAmount = useInvoiceAmount(invoice.amountSat);
+
+  return (
+    <>
+      <h1 className={styles.title}>{t('lightning.send.confirm.title')}</h1>
+      <div className={styles.info}>
+        <h2 className={styles.label}>{t('lightning.send.confirm.amount')}</h2>
+        {invoiceAmount ? (
+          <>
+            <Amount amount={invoiceAmount.amount} unit={invoiceAmount.unit} />{' ' + invoiceAmount.unit}/{' '}
+            <AmountWithUnit amount={invoiceAmount} convertToFiat/>
+          </>
+        ) : <Skeleton />}
+      </div>
+      {invoice.description && (
+        <div className={styles.info}>
+          <h2 className={styles.label}>{t('lightning.send.confirm.memo')}</h2>
+          {invoice.description}
+        </div>
+      )}
+    </>
+  );
+};
+
+type TPaymentDetailsProps = {
+  input: TInputType;
+};
+
+export const PaymentDetails = ({ input }: TPaymentDetailsProps) => {
+  switch (input.type) {
+  case TInputTypeVariant.BOLT11:
+    return <InvoiceDetails invoice={input.invoice} />;
+  }
+};

--- a/frontends/web/src/routes/lightning/send/components/select-invoice-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/select-invoice-step.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ChangeEvent, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { Button, Input } from '@/components/forms';
+import { Column, Grid } from '@/components/layout';
+import { Status } from '@/components/status/status';
+import { View, ViewButtons, ViewContent, ViewHeader } from '@/components/view/view';
+import { ScanQRVideo } from '@/routes/account/send/components/inputs/scan-qr-video';
+import { runningInAndroid, runningInIOS } from '@/utils/env';
+import { useLightningSendContext } from '../lightning-send-context';
+import styles from '../send.module.css';
+
+export const SelectInvoiceStep = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { inputError, parsePaymentInput } = useLightningSendContext();
+  const [invoiceInput, setInvoiceInput] = useState('');
+
+  const scanQRVideo = useMemo(() => (
+    <ScanQRVideo onResult={parsePaymentInput} />
+  ), [parsePaymentInput]);
+
+  const submitInvoiceInput = async () => {
+    const success = await parsePaymentInput(invoiceInput);
+    if (success) {
+      setInvoiceInput('');
+    }
+  };
+
+  return (
+    <View textCenter width="660px">
+      <ViewHeader title={t('lightning.send.qrCode.label')} />
+      <ViewContent textAlign="center">
+        <Grid col="1">
+          <Column className={styles.camera}>
+            <div className={styles.error}>
+              {inputError && <Status dismissible="" type="warning">{inputError}</Status>}
+            </div>
+            {scanQRVideo}
+            <Input
+              placeholder={t('lightning.send.invoice.input')}
+              onInput={(event: ChangeEvent<HTMLInputElement>) => setInvoiceInput(event.target.value)}
+              value={invoiceInput}
+              autoFocus={!runningInAndroid() && !runningInIOS()}
+            />
+          </Column>
+        </Grid>
+      </ViewContent>
+      <ViewButtons>
+        <Button disabled={!invoiceInput} primary onClick={submitInvoiceInput}>
+          {t('generic.send')}
+        </Button>
+        <Button secondary onClick={() => navigate('/lightning')}>
+          {t('button.back')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/send/components/sending-spinner.tsx
+++ b/frontends/web/src/routes/lightning/send/components/sending-spinner.tsx
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Spinner } from '@/components/spinner/Spinner';
+
+export const SendingSpinner = () => {
+  const { t } = useTranslation();
+  const [message, setMessage] = useState<string>(t('lightning.send.sending.connecting'));
+
+  useEffect(() => {
+    setMessage(t('lightning.send.sending.connecting'));
+    const timeout = window.setTimeout(() => {
+      setMessage(t('lightning.send.sending.message'));
+    }, 1000);
+
+    return () => window.clearTimeout(timeout);
+  }, [t]);
+
+  return <Spinner text={message} />;
+};

--- a/frontends/web/src/routes/lightning/send/components/success-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/success-step.tsx
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import { View, ViewContent } from '@/components/view/view';
+import { SimpleMarkup } from '@/utils/markup';
+import styles from '../send.module.css';
+
+export const SuccessStep = () => {
+  const { t } = useTranslation();
+
+  return (
+    <View fitContent textCenter verticallyCentered>
+      <ViewContent withIcon="success">
+        <SimpleMarkup className={styles.successMessage} markup={t('lightning.send.success.message')} tagName="p" />
+      </ViewContent>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/send/index.ts
+++ b/frontends/web/src/routes/lightning/send/index.ts
@@ -1,3 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-
-export { Send } from './send';

--- a/frontends/web/src/routes/lightning/send/lightning-send-context.tsx
+++ b/frontends/web/src/routes/lightning/send/lightning-send-context.tsx
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ReactNode, createContext, useCallback, useContext, useState } from 'react';
+import {
+  TInputType,
+  TInputTypeVariant,
+  TSdkError,
+  getParsePaymentInput,
+  postSendPayment,
+} from '@/api/lightning';
+
+type TSendStep = 'select-invoice' | 'edit-invoice' | 'confirm' | 'sending' | 'success';
+
+type TLightningSendContext = {
+  customAmount?: number;
+  inputError?: string;
+  paymentDetails?: TInputType;
+  resetPayment: () => void;
+  sendError?: string;
+  sendPayment: () => Promise<void>;
+  setCustomAmount: (amount?: number) => void;
+  step: TSendStep;
+  parsePaymentInput: (rawInput: string) => Promise<boolean>;
+};
+
+const errorMessage = (error: unknown): string => {
+  if (error instanceof TSdkError) {
+    return error.message;
+  }
+  return String(error);
+};
+
+const isValidCustomAmount = (amount?: number): amount is number => (
+  typeof amount === 'number' && Number.isFinite(amount) && Number.isInteger(amount) && amount > 0
+);
+
+const LightningSendContext = createContext<TLightningSendContext | null>(null);
+
+type TProps = {
+  children: ReactNode;
+};
+
+export const LightningSendProvider = ({ children }: TProps) => {
+  const [step, setStep] = useState<TSendStep>('select-invoice');
+  const [paymentDetails, setPaymentDetails] = useState<TInputType>();
+  const [customAmount, setCustomAmount] = useState<number>();
+  const [inputError, setInputError] = useState<string>();
+  const [sendError, setSendError] = useState<string>();
+
+  const resetPayment = useCallback(() => {
+    setStep('select-invoice');
+    setPaymentDetails(undefined);
+    setCustomAmount(undefined);
+    setInputError(undefined);
+    setSendError(undefined);
+  }, []);
+
+  const parsePaymentInput = useCallback(async (rawInput: string) => {
+    setInputError(undefined);
+    setSendError(undefined);
+
+    try {
+      const result = await getParsePaymentInput({ s: rawInput });
+      setPaymentDetails(result);
+
+      if (result.type === TInputTypeVariant.BOLT11 && !result.invoice.amountSat) {
+        setCustomAmount(0);
+        setStep('edit-invoice');
+        return true;
+      }
+
+      setCustomAmount(undefined);
+      setStep('confirm');
+      return true;
+    } catch (error) {
+      setInputError(errorMessage(error));
+      return false;
+    }
+  }, []);
+
+  const sendPayment = useCallback(async () => {
+    if (paymentDetails?.type !== TInputTypeVariant.BOLT11) {
+      return;
+    }
+
+    if (!paymentDetails.invoice.amountSat && !isValidCustomAmount(customAmount)) {
+      setSendError('Please enter a valid whole number amount greater than 0.');
+      return;
+    }
+
+    setStep('sending');
+    setSendError(undefined);
+
+    try {
+      await postSendPayment({
+        bolt11: paymentDetails.invoice.bolt11,
+        amountSat: paymentDetails.invoice.amountSat ? undefined : customAmount,
+      });
+      setStep('success');
+    } catch (error) {
+      setStep('select-invoice');
+      setSendError(errorMessage(error));
+    }
+  }, [customAmount, paymentDetails]);
+
+  return (
+    <LightningSendContext.Provider value={{
+      customAmount,
+      inputError,
+      paymentDetails,
+      resetPayment,
+      sendError,
+      sendPayment,
+      setCustomAmount,
+      step,
+      parsePaymentInput,
+    }}>
+      {children}
+    </LightningSendContext.Provider>
+  );
+};
+
+export const useLightningSendContext = () => {
+  const context = useContext(LightningSendContext);
+  if (context === null) {
+    throw new Error('useLightningSendContext must be used within LightningSendProvider');
+  }
+  return context;
+};

--- a/frontends/web/src/routes/lightning/send/send.tsx
+++ b/frontends/web/src/routes/lightning/send/send.tsx
@@ -1,333 +1,52 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import * as accountApi from '../../../api/account';
-import { Column, Grid, GuideWrapper, GuidedContent, Header, Main } from '../../../components/layout';
-import { View, ViewButtons, ViewContent, ViewHeader } from '../../../components/view/view';
-import { Button, Input } from '../../../components/forms';
-import { TInputType, TInputTypeVariant, TLightningInvoice, TSdkError, getParsePaymentInput, postSendPayment } from '../../../api/lightning';
-import { SimpleMarkup } from '../../../utils/markup';
-import { Amount } from '../../../components/amount/amount';
-import { Status } from '../../../components/status/status';
-import { ScanQRVideo } from '../../account/send/components/inputs/scan-qr-video';
-import { Spinner } from '../../../components/spinner/Spinner';
-import { getBtcSatsAmount } from '../../../api/coins';
-import { Skeleton } from '../../../components/skeleton/skeleton';
-import { runningInAndroid, runningInIOS } from '@/utils/env';
-import { AmountWithUnit } from '@/components/amount/amount-with-unit';
-import styles from './send.module.css';
 import { useNavigate } from 'react-router-dom';
+import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
+import { Status } from '@/components/status/status';
+import { ConfirmStep } from './components/confirm-step';
+import { EditInvoiceStep } from './components/edit-invoice-step';
+import { SelectInvoiceStep } from './components/select-invoice-step';
+import { SendingSpinner } from './components/sending-spinner';
+import { SuccessStep } from './components/success-step';
+import { LightningSendProvider, useLightningSendContext } from './lightning-send-context';
 
-type TStep = 'select-invoice' | 'edit-invoice' | 'confirm' | 'sending' | 'success';
-
-const SendingSpinner = () => {
-  const { t } = useTranslation();
-  // Show dummy connecting-to-server message first
-  const [message, setStep] = useState<string>(t('lightning.send.sending.connecting'));
-
-  setTimeout(() => {
-    setStep(t('lightning.send.sending.message'));
-  }, 1000);
-
-  return <Spinner text={message} />;
-};
-
-type InvoiceInputProps = {
-  invoice: TLightningInvoice;
-};
-
-const InvoiceInput = ({ invoice }: InvoiceInputProps) => {
-  const { t } = useTranslation();
-  const [invoiceAmount, setInvoiceAmount] = useState<accountApi.TAmountWithConversions>();
-
-  useEffect(() => {
-    getBtcSatsAmount((invoice.amountSat || 0).toString()).then((response) => {
-      if (response.success) {
-        setInvoiceAmount(response.amount);
-      }
-    });
-  }, [invoice]);
-  return (
-    <>
-      <h1 className={styles.title}>{t('lightning.send.confirm.title')}</h1>
-      <div className={styles.info}>
-        <h2 className={styles.label}>{t('lightning.send.confirm.amount')}</h2>
-        {invoiceAmount ? (
-          <>
-            <Amount amount={invoiceAmount.amount} unit={invoiceAmount.unit} />{' ' + invoiceAmount.unit}/{' '}
-            <AmountWithUnit amount={invoiceAmount} convertToFiat/>
-          </>
-        ) : <Skeleton />};
-      </div>
-      {invoice.description && (
-        <div className={styles.info}>
-          <h2 className={styles.label}>{t('lightning.send.confirm.memo')}</h2>
-          {invoice.description}
-        </div>
-      )}
-    </>);
-};
-
-type PaymentInputProps = {
-  input: TInputType;
-};
-
-const PaymentInput = ({ input }: PaymentInputProps) => {
-  switch (input.type) {
-  case TInputTypeVariant.BOLT11:
-    return (
-      <InvoiceInput invoice={input.invoice} />
-    );
-  }
-};
-
-type SendWorkflowProps = {
-  onBack: () => void;
-  onInvoiceInput: (input: string) => void;
-  onCustomAmount: (input: number) => void;
-  onSend: () => void;
-  parsedInput?: TInputType;
-  inputError?: string;
-  customAmount?: number;
-  step: TStep;
-};
-
-const SendWorkflow = ({
-  onBack,
-  onInvoiceInput,
-  onCustomAmount,
-  onSend,
-  parsedInput,
-  inputError,
-  customAmount,
-  step,
-}: SendWorkflowProps) => {
-  const { t } = useTranslation();
-  const [lnInvoice, setLnInvoice] = useState('');
-
-  // Memoize the ScanQRVideo component to prevent unnecessary re-renders due to state updates.
-  const memoizedScanQRVideo = useMemo(() => (
-    <ScanQRVideo onResult={onInvoiceInput} />
-  ), [onInvoiceInput]);
-
-  switch (step) {
-  case 'select-invoice':
-    return (
-      <View textCenter width="660px" >
-        <ViewHeader title="Scan lightning invoice" />
-        <ViewContent textAlign="center">
-          <Grid col="1">
-            <Column className={styles.camera}>
-              { /* we need a cointainer for the error with a fixed height to avoid
-                layout shifts, that would cause the yellow target on the video
-                component to become misaligned due to the fact that it is memoized
-                and so it doesn't re-render when inputError changes.*/ }
-              <div className={styles.error}>
-                {inputError && <Status dismissible="" type="warning">{inputError}</Status>}
-              </div>
-              {memoizedScanQRVideo}
-              <Input
-                placeholder={t('lightning.send.invoice.input')}
-                onInput={(e: ChangeEvent<HTMLInputElement>) => setLnInvoice(e.target.value)}
-                value={lnInvoice}
-                // to prevent the virtual Android/iOS keyboard to be displayed by default.
-                autoFocus={!runningInAndroid() && !runningInIOS()}/>
-            </Column>
-          </Grid>
-        </ViewContent>
-        <ViewButtons>
-          <Button disabled={!lnInvoice} primary onClick={() => {
-            onInvoiceInput(lnInvoice);
-            setLnInvoice('');
-          }}>
-            {t('generic.send')}
-          </Button>
-          <Button secondary onClick={onBack}>
-            {t('button.back')}
-          </Button>
-        </ViewButtons>
-      </View>
-    );
-  case 'edit-invoice':
-    if (parsedInput?.type !== TInputTypeVariant.BOLT11) {
-      return (
-        <View fitContent minHeight="100%">
-          Invoices without amount are currently only supported for BOLT11 type invoices
-        </View>
-      );
-    }
-    return (
-      <View fitContent minHeight="100%">
-        <ViewContent>
-          <Grid col="1">
-            <Column>
-              <Input
-                type="number"
-                min="0"
-                label={t('lightning.receive.amountSats.label')}
-                placeholder={t('lightning.receive.amountSats.placeholder')}
-                id="amountSatsInput"
-                onInput={e => onCustomAmount(e.target.valueAsNumber)}
-                value={customAmount ? `${customAmount}` : ''}
-                autoFocus
-              />
-              <Input
-                type="text"
-                label={t('lightning.receive.description.label')}
-                placeholder="This invoice has no description"
-                id="descriptionInput"
-                readOnly
-                disabled
-                value={parsedInput.invoice.description}
-              />
-            </Column>
-          </Grid>
-        </ViewContent>
-        <ViewButtons>
-          <Button
-            primary
-            onClick={onSend}
-            disabled={!customAmount}>
-            {t('generic.send')}
-          </Button>
-          <Button secondary onClick={onBack}>
-            {t('button.back')}
-          </Button>
-        </ViewButtons>
-      </View>
-    );
-  case 'confirm':
-    if (!parsedInput) {
-      return 'no invoice found';
-    }
-    return (
-      <View fitContent minHeight="100%">
-        <ViewContent>
-          <Grid col="1">
-            <Column>
-              <PaymentInput input={parsedInput} />
-            </Column>
-          </Grid>
-        </ViewContent>
-        <ViewButtons>
-          <Button primary onClick={onSend}>
-            {t('generic.send')}
-          </Button>
-          <Button secondary onClick={onBack}>
-            {t('button.back')}
-          </Button>
-        </ViewButtons>
-      </View>
-    );
-  case 'sending':
-    return <SendingSpinner />;
-  case 'success':
-    return (
-      <View fitContent textCenter verticallyCentered>
-        <ViewContent withIcon="success">
-          <SimpleMarkup className={styles.successMessage} markup={t('lightning.send.success.message')} tagName="p" />
-        </ViewContent>
-      </View>
-    );
-  }
-};
-
-export const Send = () => {
+const SendContent = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [step, setStep] = useState<TStep>('select-invoice');
-  const [paymentDetails, setPaymentDetails] = useState<TInputType>();
-  const [customAmount, setCustomAmount] = useState<number>();
-  const [rawInputError, setRawInputError] = useState<string>();
-  const [sendError, setSendError] = useState<string>();
+  const { sendError, step } = useLightningSendContext();
 
-  const back = () => {
-    switch (step) {
-    case 'select-invoice':
-    case 'confirm':
-      navigate('/lightning');
-      break;
-    case 'edit-invoice':
-    case 'success':
-      setStep('select-invoice');
-      setSendError(undefined);
-      setPaymentDetails(undefined);
-      break;
+  useEffect(() => {
+    if (step !== 'success') {
+      return;
     }
-  };
 
-  const parsePaymentInput = useCallback(async (rawInput: string) => {
-    setRawInputError(undefined);
-    try {
-      const result = await getParsePaymentInput({ s: rawInput });
-      switch (result.type) {
-      case TInputTypeVariant.BOLT11:
-        setPaymentDetails(result);
-        // if invoice has 0 amount or no amount given
-        if (!result.invoice.amountSat) {
-          setCustomAmount(0);
-          setStep('edit-invoice');
-          break;
-        }
-        setStep('confirm');
-        break;
-      default:
-        setRawInputError('Invalid input');
-      }
-    } catch (e) {
-      if (e instanceof TSdkError) {
-        setRawInputError(e.message);
-      } else {
-        setRawInputError(String(e));
-      }
-    }
-  }, []);
-
-  const sendPayment = async () => {
-    setStep('sending');
-    setSendError(undefined);
-    try {
-      switch (paymentDetails?.type) {
-      case TInputTypeVariant.BOLT11:
-        await postSendPayment({
-          bolt11: paymentDetails.invoice.bolt11,
-          amountSat: customAmount || undefined
-        });
-        setStep('success');
-        setTimeout(() => navigate('/lightning'), 1000);
-        break;
-      }
-    } catch (e) {
-      setStep('select-invoice');
-      if (e instanceof TSdkError) {
-        setSendError(e.message);
-      } else {
-        setSendError(String(e));
-      }
-    }
-  };
+    const timeout = window.setTimeout(() => navigate('/lightning'), 1000);
+    return () => window.clearTimeout(timeout);
+  }, [navigate, step]);
 
   return (
     <GuideWrapper>
       <GuidedContent>
         <Main>
+          <Header title={<h2>{t('lightning.send.title')}</h2>} />
           <Status dismissible="" type="warning" hidden={!sendError}>
             {sendError}
           </Status>
-          <Header title={<h2>{t('lightning.send.title')}</h2>} />
-          <SendWorkflow
-            onBack={back}
-            onInvoiceInput={parsePaymentInput}
-            onCustomAmount={setCustomAmount}
-            onSend={sendPayment}
-            parsedInput={paymentDetails}
-            inputError={rawInputError}
-            customAmount={customAmount}
-            step={step}
-          />
+          {step === 'select-invoice' && <SelectInvoiceStep />}
+          {step === 'edit-invoice' && <EditInvoiceStep />}
+          {step === 'confirm' && <ConfirmStep />}
+          {step === 'sending' && <SendingSpinner />}
+          {step === 'success' && <SuccessStep />}
         </Main>
       </GuidedContent>
     </GuideWrapper>
   );
 };
+
+export const Send = () => (
+  <LightningSendProvider>
+    <SendContent />
+  </LightningSendProvider>
+);


### PR DESCRIPTION
The current frontend send flow is long and complicated, hard to read and to maintain. This refactors it, making it more modular and introducing a dedicated context/provider that allows keeping track of the flow status while splitting the differents parts.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
