### PR TITLE
swap: prevent account refresh flicker

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1689,11 +1689,13 @@ func (backend *Backend) checkAccountUsed(account accounts.Interface) {
 		}
 	}
 	log.Info("marking account as used")
+	var emitUpdate bool
 	err := backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
 		acct := accountsConfig.Lookup(account.Config().Config.Code)
 		if acct == nil {
 			return errp.Newf("could not find account")
 		}
+		emitUpdate = !acct.Used || acct.HiddenBecauseUnused
 		acct.Used = true
 		acct.HiddenBecauseUnused = false
 
@@ -1703,7 +1705,9 @@ func (backend *Backend) checkAccountUsed(account accounts.Interface) {
 		log.WithError(err).Error("checkAccountUsed")
 		return
 	}
-	backend.emitAccountsStatusChanged()
+	if emitUpdate {
+		backend.emitAccountsStatusChanged()
+	}
 	backend.maybeAddHiddenUnusedAccounts()
 }
 

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -21,6 +21,7 @@ import {
   getSwapQuote,
   signSwap,
   type TSwapAccount,
+  type TSwapAccounts,
   type TSwapQuoteRoute,
 } from '@/api/swap';
 import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
@@ -91,7 +92,14 @@ export const Swap = ({
   const navigate = useNavigate();
   const { activeCurrencies, btcUnit } = useContext(RatesContext);
   // accounts is added as a dependency, to reload swap accounts when the account list changes.
-  const swapAccounts = useLoad(getSwapAccounts, [accounts]);
+  const loadedSwapAccounts = useLoad(getSwapAccounts, [accounts]);
+  const [retainedSwapAccounts, setRetainedSwapAccounts] = useState<TSwapAccounts>();
+  useEffect(() => {
+    if (loadedSwapAccounts !== undefined) {
+      setRetainedSwapAccounts(loadedSwapAccounts);
+    }
+  }, [loadedSwapAccounts]);
+  const swapAccounts = loadedSwapAccounts ?? retainedSwapAccounts;
   const sellAccounts = swapAccounts?.success ? swapAccounts.sellAccounts : undefined;
   const buyAccounts = swapAccounts?.success ? swapAccounts.buyAccounts : undefined;
 


### PR DESCRIPTION
Keep the last successful swap accounts response while a dependency-triggered reload is pending, so the swap selectors do not briefly render skeletons.

Also skip no-op account-used updates for already visible used accounts. This avoids emitting redundant accounts reload events after regular sync-done notifications.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
