### PR TITLE
backend: fix amount/unit in CoinFiatPrices

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -934,8 +934,8 @@ func (backend *Backend) CoinFiatPrices(coin coinpkg.Coin) *coinpkg.FormattedAmou
 	const isFee = false
 	coinAmount := coin.SetAmount(big.NewRat(1, 1), isFee)
 	return &coinpkg.FormattedAmountWithConversions{
-		Amount: coin.Unit(isFee),
-		Unit:   coin.GetFormatUnit(isFee),
+		Amount: "1",
+		Unit:   coin.Unit(isFee),
 		Conversions: coinpkg.Conversions(
 			coinAmount,
 			coin,


### PR DESCRIPTION
Amount was not an amount, but should be.

Unit in sats mode was "sat", even though the conversions are for BTC.

Neither amount nor unit is needed, it is dead code. We keep the shape for now anyway to avoid a larger refactor in the frontend.
