### PR TITLE
frontend: change chart default to year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Revamp Marketplace UI
 - Add the support for performing swaps between cryptocurrencies through SwapKit
 - Fullscreen region select on mobile
+- Change portfolio chart default to year
 
 ## v4.50.1
 - Fix a bug that would delay showing watch-only accounts.

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -27,7 +27,7 @@ export const AppProvider = ({ children }: TProps) => {
   const [guideExists, setGuideExists] = useState(false);
   const [hideAmounts, setHideAmounts] = useState(false);
   const [activeSidebar, setActiveSidebar] = useState(false);
-  const [chartDisplay, setChartDisplay] = useState<TChartDisplay>('all');
+  const [chartDisplay, setChartDisplay] = useState<TChartDisplay>('year');
   const [firmwareUpdateDialogOpen, setFirmwareUpdateDialogOpen] = useState(false);
   const [tmpConfig, setTmpConfig] = useState<TSessionConfig>({});
 


### PR DESCRIPTION
As the chart always tries to fit in as many datapoints as possible and adapts to different screensizes, the chart graph and the percentage difference may look different on various devices.

To have a more consistent chart and percentage differences this commit changed the default to 'Year'. With that the graph and percentage should be identical by default accross various devices.

Users that like the old behavior can still change back to 'All'.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [x] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
