### PR TITLE
frontend: fix visual space between minus sign and amount

### DIFF
--- a/frontends/web/src/components/amount/amount-with-unit.module.css
+++ b/frontends/web/src/components/amount/amount-with-unit.module.css
@@ -6,14 +6,15 @@
 }
 
 .unit {
-  font-weight: 400;
+  color: var(--color-secondary);
+  cursor: default;
   flex-grow: 0;
   flex-shrink: 0;
-  color: var(--color-secondary);
-  font-variant: normal;
-  position: relative;
-  cursor: default;
   font-size: var(--size-smaller);
+  font-variant: normal;
+  font-weight: 400;
+  margin-left: .4ch;
+  position: relative;
 }
 
 .availableFiatAmount {
@@ -21,7 +22,6 @@
   display: inline-flex;
   flex-grow: 0;
   justify-content: flex-start;
-  gap: 0.4ch;
   text-align: right;
 }
 

--- a/frontends/web/src/components/amount/conversion-amount.module.css
+++ b/frontends/web/src/components/amount/conversion-amount.module.css
@@ -8,7 +8,14 @@
   display: flex;
   font-variant-numeric: tabular-nums;
   margin-left: auto;
-  gap: 3px;
+}
+
+.txPrefix {
+  margin-right: .4ch;
+}
+
+.txUnit {
+  margin-left: .4ch;
 }
 
 .txPrefix,

--- a/frontends/web/src/components/transactions/transaction.module.css
+++ b/frontends/web/src/components/transactions/transaction.module.css
@@ -97,7 +97,6 @@
   align-items: baseline;
   font-size: var(--size-default);
   font-variant-numeric: tabular-nums;
-  gap: 3px;
   justify-content: flex-end;
   line-height: 1.25;
   display: flex;

--- a/frontends/web/src/routes/account/summary/chart.module.css
+++ b/frontends/web/src/routes/account/summary/chart.module.css
@@ -125,7 +125,6 @@
   display: inline-block;
   font-size: var(--size-header);
   margin-bottom: 3px;
-  padding: 0 4px;
 }
 
 .chartCanvas {

--- a/frontends/web/src/routes/market/components/vendor-deals.module.css
+++ b/frontends/web/src/routes/market/components/vendor-deals.module.css
@@ -23,7 +23,6 @@
     display: inline-flex;
     font-size: var(--size-default);
     font-weight: normal;
-    gap: .4ch;
     line-height: 1.6;
     margin: 0;
     word-break: keep-all;

--- a/frontends/web/src/routes/market/swap/components/input-with-account-selector.module.css
+++ b/frontends/web/src/routes/market/swap/components/input-with-account-selector.module.css
@@ -81,7 +81,6 @@
   color: var(--color-gray);
   display: flex;
   font-size: var(--size-small);
-  gap: .4ch;
   min-height: 2rem;
   padding-right: var(--space-half);
 }

--- a/frontends/web/src/routes/market/swap/swap.module.css
+++ b/frontends/web/src/routes/market/swap/swap.module.css
@@ -12,12 +12,17 @@
 }
 
 .max {
-    color: var(--color-gray);
-    display: flex;
-    font-size: var(--size-small);
-    gap: 0.4ch;
-    min-height: auto;
-    padding: 0;
+  align-items: baseline;
+  color: var(--color-gray);
+  display: flex;
+  font-size: var(--size-small);
+  gap: .4ch;
+  min-height: auto;
+  padding: 0;
+}
+
+.nomargin {
+  margin-left: 0;
 }
 
 .sellWarning {

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -569,7 +569,6 @@ export const Swap = ({
                 {maxSellAmount && (
                   <span className={style.max}>
                     {t('generic.max')}
-                    {' '}
                     <AmountWithUnit
                       maxDecimals={9}
                       amount={maxSellAmount.available} />
@@ -623,6 +622,7 @@ export const Swap = ({
                     />
                     <AmountUnit
                       unit={expectedOutputUnit || buyAccount.coinUnit}
+                      className={style.nomargin}
                     />
                   </span>
                 )}


### PR DESCRIPTION
In the transaction list there was a visual space between the minus and plus sign and the amount.

Fixed styling to have visual space between estimate sign, amount and unit, but no space between plus/minus sign and amount.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
