### PR TITLE
frontend: ensure correct keystore is connected in marketplace

### DIFF
--- a/frontends/web/src/routes/market/market.tsx
+++ b/frontends/web/src/routes/market/market.tsx
@@ -115,13 +115,17 @@ export const Market = ({
   const swapDealsResponse = useLoad(selectedAccount ? () => marketAPI.getMarketDeals('swap', selectedAccount, selectedRegion) : null, [selectedAccount, selectedRegion]);
   const otcDealsResponse = useLoad(selectedAccount ? () => marketAPI.getMarketDeals('otc', selectedAccount, selectedRegion) : null, [selectedAccount, selectedRegion]);
 
-  const handleAccountChange = async (accountCode: string) => {
+  const promptConnectKeystore = async (accountCode: string): Promise<boolean> => {
     const account = supportedAccounts.find(acc => acc.code === accountCode);
     if (!account) {
-      return;
+      return false;
     }
     const connectResult = await connectKeystore(account.keystore.rootFingerprint);
-    if (connectResult.success) {
+    return connectResult.success;
+  };
+
+  const handleAccountChange = async (accountCode: string) => {
+    if (await promptConnectKeystore(accountCode)) {
       setSelectedAccount(accountCode);
     }
   };
@@ -203,7 +207,7 @@ export const Market = ({
         return;
       }
     }
-    if (!selectedAccount) {
+    if (!selectedAccount || !await promptConnectKeystore(selectedAccount)) {
       return;
     }
     navigate(`/market/${vendor}/${activeTab}/${selectedAccount}/${selectedRegion}`);


### PR DESCRIPTION
Changed to prompt to connect keystore before navigating to a deal in marketplace.

As OTC offerings are opening in external browser allow navigating without a connected keystore for OTC links.

With this canceling the connect prompt will go back to marketplace.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
