### PR TITLE
frontend: unlock view should cover mobilefullscreen selector

### DIFF
--- a/frontends/web/src/components/dropdown/mobile-fullscreen-selector.module.css
+++ b/frontends/web/src/components/dropdown/mobile-fullscreen-selector.module.css
@@ -33,7 +33,7 @@
     position: fixed;
     right: 0;
     top: 0;
-    z-index: 9999;
+    z-index: 2; /* needs to be higher than 1 to cover feetargets in send view */
 }
 
 .fullscreenContent {


### PR DESCRIPTION
In the rare case where a user opens account or region selector on mobile so it goes into fullscreen AND connects a device to unlock, the unlock view was hidden by the fullscreen selector.

Reduced the mobile fullscreen selector to 1 so it is just one higher than the rest which should be sufficient.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
