### PR TITLE
frontend: fix iOS decimal input

### DIFF
--- a/frontends/web/src/components/forms/input-number-utils.test.ts
+++ b/frontends/web/src/components/forms/input-number-utils.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { normalizeNumberInputValue, numberInputValueToString, sanitizeNumberInputValue } from './input-number-utils';
+
+describe('components/forms/input-number-utils', () => {
+  it.each([
+    [undefined, ''],
+    ['1.23', '1.23'],
+    [123, '123'],
+    [['1', '.', '2'], '1.2'],
+  ])('converts %s to %s', (value, expected) => {
+    expect(numberInputValueToString(value)).toBe(expected);
+  });
+
+  it.each([
+    ['1,23', '1,23'],
+    ['1.23', '1.23'],
+    [',99', ',99'],
+    ['.99', '.99'],
+    ['100', '100'],
+    ['100,', '100,'],
+    ['100.', '100.'],
+    ['abc', ''],
+    ['1abc', '1'],
+    ['1..2', '1.2'],
+    ['1,,2', '1,2'],
+    ['1,2.3', '1,23'],
+    ['1.2,3', '1.23'],
+    ['--1', '1'],
+    ['1-2', '12'],
+    ['1e5', '15'],
+    ['Infinity', ''],
+    ['1 000', '1000'],
+  ])('sanitizes %s to %s', (value, expected) => {
+    expect(sanitizeNumberInputValue(value)).toBe(expected);
+  });
+
+  it.each([
+    ['1,23', '1.23'],
+    ['1.23', '1.23'],
+    [',99', '.99'],
+    ['.99', '.99'],
+    ['100,', '100'],
+    ['100.', '100'],
+    [',', ''],
+    ['.', ''],
+    ['1,2.3', '1.23'],
+  ])('normalizes %s to %s', (value, expected) => {
+    expect(normalizeNumberInputValue(value)).toBe(expected);
+  });
+});

--- a/frontends/web/src/components/forms/input-number-utils.ts
+++ b/frontends/web/src/components/forms/input-number-utils.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const decimalSeparator = /[,.]/;
+const digits = /[^\d]/g;
+
+export const numberInputValueToString = (
+  value: string | number | readonly string[] | undefined
+) => {
+  if (value === undefined) {
+    return '';
+  }
+  if (Array.isArray(value)) {
+    return value.join('');
+  }
+  return String(value);
+};
+
+export const sanitizeNumberInputValue = (value: string) => {
+  const decimalIndex = value.search(decimalSeparator);
+  if (decimalIndex === -1) {
+    return value.replace(digits, '');
+  }
+
+  return [
+    value.slice(0, decimalIndex).replace(digits, ''),
+    value[decimalIndex],
+    value.slice(decimalIndex + 1).replace(digits, ''),
+  ].join('');
+};
+
+export const normalizeNumberInputValue = (value: string) => (
+  sanitizeNumberInputValue(value).replace(',', '.').replace(/[.]$/, '')
+);

--- a/frontends/web/src/components/forms/input-number.md
+++ b/frontends/web/src/components/forms/input-number.md
@@ -1,0 +1,18 @@
+# Number Input Locale Handling
+
+On iOS, `type="number"` can show a localized decimal key, such as a comma,
+but the field rejects that comma before it receives a useful value.
+
+For iOS, `NumberInput` uses `type="text"` with `inputMode="decimal"` so both
+comma and dot can be entered. The visible value can keep the user's separator,
+while `onChange` reports a canonical dot decimal value to callers.
+
+This keeps app state and backend payloads locale independent, for example:
+
+```text
+visible input: 1,23
+reported value: 1.23
+backend value: 1.23
+```
+
+Non-iOS platforms keep the existing `type="number"` behavior.

--- a/frontends/web/src/components/forms/input-number.test.tsx
+++ b/frontends/web/src/components/forms/input-number.test.tsx
@@ -1,19 +1,78 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { NumberInput } from './input-number';
+import { runningInIOS } from '@/utils/env';
+
+vi.mock('@/utils/env', () => ({
+  runningInIOS: vi.fn(() => false),
+}));
+
+const mockRunningInIOS = vi.mocked(runningInIOS);
 
 
 describe('components/forms/input-number', () => {
-  it('should preserve type attribute', () => {
+  beforeEach(() => {
+    mockRunningInIOS.mockReturnValue(false);
+  });
+
+  it('uses a number input outside iOS', () => {
     const { container } = render(<NumberInput defaultValue="" />);
     expect(container.querySelector('[type="number"')).toBeTruthy();
+  });
+
+  it('uses a text input on iOS', () => {
+    mockRunningInIOS.mockReturnValue(true);
+    const { container } = render(<NumberInput defaultValue="" />);
+    expect(container.querySelector('[type="text"')).toBeTruthy();
   });
 
   it('uses a decimal input mode by default', () => {
     render(<NumberInput id="amount" label="Amount" defaultValue="" />);
     expect(screen.getByLabelText('Amount')).toHaveAttribute('inputmode', 'decimal');
+  });
+
+  it('allows typed commas as decimal separators on iOS while reporting normalized values', () => {
+    mockRunningInIOS.mockReturnValue(true);
+    const mockCallback = vi.fn();
+    render(<NumberInput placeholder="Number input" onChange={mockCallback} />);
+    const input = screen.getByPlaceholderText('Number input');
+
+    fireEvent.input(input, { target: { value: '1,23' } });
+
+    expect(mockCallback).toHaveBeenCalledWith(expect.objectContaining({
+      target: expect.objectContaining({ value: '1.23' })
+    }));
+    expect(input).toHaveValue('1,23');
+  });
+
+  it('sanitizes typed iOS input while reporting normalized values', () => {
+    mockRunningInIOS.mockReturnValue(true);
+    const mockCallback = vi.fn();
+    render(<NumberInput placeholder="Number input" onChange={mockCallback} />);
+    const input = screen.getByPlaceholderText('Number input');
+
+    fireEvent.input(input, { target: { value: '1e2,3.4abc' } });
+
+    expect(mockCallback).toHaveBeenCalledWith(expect.objectContaining({
+      target: expect.objectContaining({ value: '12.34' })
+    }));
+    expect(input).toHaveValue('12,34');
+  });
+
+  it('keeps iOS comma display when the controlled value is normalized', () => {
+    mockRunningInIOS.mockReturnValue(true);
+    const mockCallback = vi.fn();
+    const { rerender } = render(
+      <NumberInput placeholder="Number input" value="" onChange={mockCallback} />
+    );
+    const input = screen.getByPlaceholderText('Number input');
+
+    fireEvent.input(input, { target: { value: '1,23' } });
+    rerender(<NumberInput placeholder="Number input" value="1.23" onChange={mockCallback} />);
+
+    expect(input).toHaveValue('1,23');
   });
 
   it('should have children', () => {

--- a/frontends/web/src/components/forms/input-number.tsx
+++ b/frontends/web/src/components/forms/input-number.tsx
@@ -1,15 +1,52 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback } from 'react';
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Input, TInputProps } from './input';
+import { normalizeNumberInputValue, numberInputValueToString, sanitizeNumberInputValue } from './input-number-utils';
+import { runningInIOS } from '@/utils/env';
 
 type Props = Omit<TInputProps, 'ref' | 'onInput'>;
 
-export const NumberInput = (({
+// override the change event to set
+// the value to the normalized value (decimal separator)
+const changeEventWithValue = (
+  event: React.ChangeEvent<HTMLInputElement>,
+  value: string,
+) => ({
+  ...event,
+  currentTarget: {
+    ...event.currentTarget,
+    value,
+  },
+  target: {
+    ...event.target,
+    value,
+  },
+} as React.ChangeEvent<HTMLInputElement>);
+
+export const NumberInput = forwardRef<HTMLInputElement, Props>(({
   inputMode = 'decimal',
   onChange,
+  value,
+  defaultValue,
   ...props
-}: Props) => {
+}: Props, ref) => {
+  const isIOS = runningInIOS();
+  const reportedValue = useRef(numberInputValueToString(value === undefined ? defaultValue : value));
+  const [displayValue, setDisplayValue] = useState(
+    numberInputValueToString(value === undefined ? defaultValue : value)
+  );
+
+  useEffect(() => {
+    if (value === undefined) {
+      return;
+    }
+    const nextValue = numberInputValueToString(value);
+    if (nextValue !== reportedValue.current) {
+      setDisplayValue(nextValue);
+    }
+    reportedValue.current = nextValue;
+  }, [value]);
 
   // support pasting of various different formats
   // the function tries to do some light string replacement and see if it becomes a number
@@ -66,18 +103,36 @@ export const NumberInput = (({
       console.warn(`unexpected format ${text.replace(/[\d]/g, '9')}`);
       return;
     }
+    if (isIOS) {
+      setDisplayValue(target.value);
+      reportedValue.current = target.value;
+    }
     if (onChange) {
       onChange({ ...event, target });
     }
     event.preventDefault();
+  }, [isIOS, onChange]);
+
+  const handleIOSInput = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const target = event.currentTarget;
+    const sanitizedValue = sanitizeNumberInputValue(target.value);
+    const normalizedValue = normalizeNumberInputValue(sanitizedValue);
+    setDisplayValue(sanitizedValue);
+    reportedValue.current = normalizedValue;
+    if (onChange) {
+      onChange(changeEventWithValue(event, normalizedValue));
+    }
   }, [onChange]);
 
   return (
     <Input
       {...props}
-      type="number"
+      ref={ref}
+      type={isIOS ? 'text' : 'number'}
       inputMode={inputMode}
-      onInput={onChange}
+      value={isIOS ? displayValue : value}
+      defaultValue={isIOS ? undefined : defaultValue}
+      onInput={isIOS ? handleIOSInput : onChange}
       onPaste={handlePaste}
     />
   );

--- a/frontends/web/src/routes/account/send/feetargets.test.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.test.tsx
@@ -1,19 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '../../../../__mocks__/i18n';
-import { describe, expect, it, Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 vi.mock('@/utils/request', () => ({
   apiGet: vi.fn().mockResolvedValue(''),
 }));
 vi.mock('@/i18n/i18n');
+vi.mock('@/utils/env', () => ({
+  runningInIOS: vi.fn(() => false),
+}));
 
-import { render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { FeeTargets } from './feetargets';
 import { apiGet } from '@/utils/request';
+import { runningInIOS } from '@/utils/env';
 
 import * as utilsConfig from '@/utils/config';
 const getConfig = vi.spyOn(utilsConfig, 'getConfig');
+const mockRunningInIOS = vi.mocked(runningInIOS);
 
 vi.mock('@/hooks/mediaquery', () => ({
   useMediaQuery: vi.fn().mockReturnValue(true),
@@ -21,6 +26,10 @@ vi.mock('@/hooks/mediaquery', () => ({
 }));
 
 describe('routes/account/send/feetargets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunningInIOS.mockReturnValue(false);
+  });
 
   it('should call onFeeTargetChange with default', () => new Promise<void>(async done => {
     getConfig.mockReturnValue(Promise.resolve({ frontend: { expertFee: false } }));
@@ -48,4 +57,50 @@ describe('routes/account/send/feetargets', () => {
     );
     await waitFor(() => expect(apiGetMock).toHaveBeenCalled());
   }));
+
+  it('normalizes custom fee values from iOS decimal input', async () => {
+    mockRunningInIOS.mockReturnValue(true);
+    getConfig.mockReturnValue(Promise.resolve({ frontend: { expertFee: true } }));
+    const apiGetMock = (apiGet as Mock).mockResolvedValue({
+      defaultFeeTarget: 'custom',
+      feeTargets: [],
+    });
+    const onCustomFee = vi.fn();
+
+    const props = {
+      accountCode: 'btc' as const,
+      coinCode: 'btc' as const,
+      disabled: false,
+      onCustomFee,
+      onFeeTargetChange: vi.fn(),
+    };
+    const { container, rerender } = render(
+      <FeeTargets
+        {...props}
+        customFee=""
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    let input: HTMLInputElement | null = null;
+    await waitFor(() => {
+      expect(apiGetMock).toHaveBeenCalled();
+      input = container.querySelector<HTMLInputElement>('#proposedFee');
+      expect(input).toBeTruthy();
+    });
+    if (!input) {
+      throw new Error('Custom fee input not found');
+    }
+    fireEvent.input(input, { target: { value: '1e2,3.4abc' } });
+    rerender(
+      <FeeTargets
+        {...props}
+        customFee="12.34"
+      />,
+    );
+
+    expect(onCustomFee).toHaveBeenCalledWith('12.34');
+    expect(input).toHaveValue('12,34');
+  });
 });

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -6,7 +6,7 @@ import { RatesContext } from '@/contexts/RatesContext';
 import { useLoad } from '@/hooks/api';
 import * as accountApi from '@/api/account';
 import { getConfig } from '@/utils/config';
-import { Input } from '@/components/forms';
+import { Input, NumberInput } from '@/components/forms';
 import { Message } from '@/components/message/message';
 import { customFeeUnit, getCoinCode, isEthereumBased } from '@/routes/account/utils';
 import { Dropdown, TOption as TDropdownOption } from '@/components/dropdown/dropdown';
@@ -199,8 +199,7 @@ export const FeeTargets = ({
                 options={options} />
             </div>
             <div className={style.column}>
-              <Input
-                type={disabled ? 'text' : 'number'}
+              <NumberInput
                 min="0"
                 step="any"
                 autoFocus={!preventFocus}
@@ -218,7 +217,7 @@ export const FeeTargets = ({
                   })}
                 id="proposedFee"
                 placeholder={t('send.fee.customPlaceholder')}
-                onInput={handleCustomFee}
+                onChange={handleCustomFee}
                 ref={inputRef}
                 value={customFee}
               >
@@ -227,7 +226,7 @@ export const FeeTargets = ({
                   className={style.customFeeUnit}>
                   { customFeeUnit(coinCode) }
                 </label>
-              </Input>
+              </NumberInput>
             </div>
           </div>
         )}


### PR DESCRIPTION
iOS can expose a comma decimal key while rejecting it in number inputs. Use an iOS text input path so users can enter comma or dot.