### PR TITLE
frontend: use mobile viewport bugfix on width <=768px

### DIFF
--- a/frontends/web/src/app.module.css
+++ b/frontends/web/src/app.module.css
@@ -4,8 +4,6 @@
     flex-direction: column;
     height: 100dvh;
     min-width: 0;
-    /* mobile viewport bug fix */
-    max-height: -webkit-fill-available;
     /* iOS safe area handling */
     padding-top: env(safe-area-inset-top, 0);
     padding-left: env(safe-area-inset-left, 0);
@@ -27,6 +25,11 @@
 }
 
 @media (max-width: 768px) {
+    .appContent {
+        /* mobile viewport bug fix */
+        max-height: -webkit-fill-available;
+    }
+
     .appContent.hasBottomNavigation {
        height: calc(100dvh - var(--bottom-navigation-height));
     }


### PR DESCRIPTION
When used on all sizes, this breaks ipadOS

Before (see whitespace on the bottom):

<img width="2752" height="2064" alt="image" src="https://github.com/user-attachments/assets/7b46f117-7706-47d6-8b8b-917816944cb2" />


After:

https://github.com/user-attachments/assets/60a36cd0-ec02-4d53-bcfa-67ad9891a1d6

