### PR TITLE
frontend: preselect account from connected keystore in market

### DIFF
--- a/frontends/web/src/routes/market/market.tsx
+++ b/frontends/web/src/routes/market/market.tsx
@@ -73,7 +73,8 @@ export const Market = ({
   useEffect(() => {
     setSupportedAccounts(accounts);
     if (!selectedAccount || !accounts.some(account => account.code === selectedAccount)) {
-      setSelectedAccount(accounts[0]?.code || '');
+      const accountOfConnectedKeystore = accounts.find(account => account.keystore.connected);
+      setSelectedAccount(accountOfConnectedKeystore?.code || accounts[0]?.code || '');
     }
   }, [accounts, selectedAccount]);
 


### PR DESCRIPTION
In marketplace and when there is a connected wallet, the pre-filled account should be the first account in the connected wallet, not the first account listed in the app.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
