### PR TITLE
frontend: fix partly visible cursor in swap send

### DIFF
--- a/frontends/web/src/routes/market/swap/components/input-with-account-selector.module.css
+++ b/frontends/web/src/routes/market/swap/components/input-with-account-selector.module.css
@@ -72,7 +72,9 @@
   text-overflow: ellipsis;
 }
 
-.inputField {
+.inputField,
+.inputField input[type="number"],
+.inputField input[type="text"] {
   border-radius: 0;
 }
 


### PR DESCRIPTION
The cursor was only partly visible in case input field was empty, it was cut-off by border-radius.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
