### PR TITLE
frontend: re-fetch btcdirectinfo in case account is not synced

### DIFF
--- a/frontends/web/src/routes/market/btcdirect.tsx
+++ b/frontends/web/src/routes/market/btcdirect.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useContext, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { getBTCDirectInfo, TMarketAction } from '@/api/market';
+import { getBTCDirectInfo, TBTCDirectInfoResponse, TMarketAction } from '@/api/market';
+import { syncdone } from '@/api/accountsync';
 import { parseExternalBtcAmount } from '@/api/coins';
 import { AppContext } from '@/contexts/AppContext';
 import { AccountCode, TAccount, proposeTx, sendTx, TTxInput } from '@/api/account';
@@ -48,7 +49,15 @@ export const BTCDirect = ({
   const { isDarkMode } = useDarkmode();
   const navigate = useNavigate();
 
-  const btcdirectInfo = useLoad(() => getBTCDirectInfo(action, code));
+  const [btcdirectInfo, setBtcdirectInfo] = useState<TBTCDirectInfoResponse>();
+  const fetchBTCDirectInfo = useCallback(async () => {
+    setBtcdirectInfo(await getBTCDirectInfo(action, code));
+  }, [action, code]);
+  // re-fetch btcdirectInfo in case account is not fully synced
+  useEffect(() => {
+    fetchBTCDirectInfo();
+    return syncdone(code, fetchBTCDirectInfo);
+  }, [code, fetchBTCDirectInfo]);
 
   const [blocking, setBlocking] = useState(false);
 


### PR DESCRIPTION
Fixed BTCDirect loading forever if the account is not fully synced.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
