### PR TITLE
swap: show error message if providers offline

### DIFF
--- a/backend/market/swapkit/client.go
+++ b/backend/market/swapkit/client.go
@@ -23,7 +23,7 @@ type Client struct {
 // NewClient creates a new SwapKit API client.
 func NewClient(httpClient *http.Client) *Client {
 	return &Client{
-		baseURL:    "https://swapkit.shiftcrypto.io/v3",
+		baseURL:    "https://swapkit.shiftcrypto.io",
 		httpClient: httpClient,
 		log:        logging.Get().WithGroup("swapkit"),
 	}
@@ -45,6 +45,22 @@ func (c *Client) post(ctx context.Context, path string, body any, out any) error
 
 	req.Header.Set("Content-Type", "application/json")
 
+	return c.do(req, out)
+}
+
+func (c *Client) get(ctx context.Context, path string, out any) error {
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return errp.Wrap(err, "create request")
+	}
+
+	return c.do(req, out)
+}
+
+func (c *Client) do(req *http.Request, out any) error {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return errp.Wrap(err, "http error")

--- a/backend/market/swapkit/helpers.go
+++ b/backend/market/swapkit/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
@@ -30,19 +31,43 @@ var swapkitAssetByCoinCode = map[string]string{
 	"eth-erc20-dai0x6b17": "ETH.DAI-0x6b175474e89094c44da98b954eedeac495271d0f",
 }
 
+var swapkitChainIDByCoinCode = map[string]string{
+	"btc":    "bitcoin",
+	"tbtc":   "bitcoin",
+	"rbtc":   "bitcoin",
+	"ltc":    "litecoin",
+	"tltc":   "litecoin",
+	"eth":    "1",
+	"sepeth": "1",
+}
+
 const (
 	// ErrInvalidRequest is returned when the quote request is invalid, for example due to missing or invalid fields.
 	ErrInvalidRequest errp.ErrorCode = "invalidRequest"
 	// ErrNoRoutesFound is returned when SwapKit cannot route the selected pair.
 	ErrNoRoutesFound errp.ErrorCode = "NoRoutesFoundError"
+	// ErrProvidersUnavailable is returned when SwapKit supports a requested pair, but no route is available while all relevant providers are unavailable.
+	ErrProvidersUnavailable errp.ErrorCode = "ProvidersUnavailableError"
 )
 
-const noRoutesFoundMessage = "No routes found"
+const (
+	noRoutesFoundMessage        = "No routes found"
+	providersUnavailableMessage = "Providers unavailable"
+)
 
 // assetFromCoinCode translates an internal coin code into a SwapKit asset identifier.
 func assetFromCoinCode(coinCode string) (string, bool) {
 	asset, ok := swapkitAssetByCoinCode[strings.ToLower(strings.TrimSpace(coinCode))]
 	return asset, ok
+}
+
+func chainIDFromCoinCode(coinCode string) (string, bool) {
+	normalizedCoinCode := strings.ToLower(strings.TrimSpace(coinCode))
+	if strings.HasPrefix(normalizedCoinCode, "eth-erc20-") {
+		return "1", true
+	}
+	chainID, ok := swapkitChainIDByCoinCode[normalizedCoinCode]
+	return chainID, ok
 }
 
 // FormatAmount converts a user-entered amount from the coin's display unit into the decimal string
@@ -147,6 +172,70 @@ func newSwapRequestFromCoinCodes(
 	}, nil
 }
 
+func noRoutesQuoteError(ctx context.Context, client *Client, sellCoin, buyCoin coinpkg.Coin, data *APIErrorData) *APIError {
+	providers, err := client.Providers(ctx)
+	if err == nil && allRelevantProvidersUnavailable(providers, quoteChainIDs(sellCoin, buyCoin)) {
+		return &APIError{
+			ErrorCode: ErrProvidersUnavailable,
+			Message:   providersUnavailableMessage,
+			Data:      data,
+		}
+	}
+	return &APIError{
+		ErrorCode: ErrNoRoutesFound,
+		Message:   noRoutesFoundMessage,
+		Data:      data,
+	}
+}
+
+func quoteChainIDs(sellCoin, buyCoin coinpkg.Coin) []string {
+	seenChainIDs := map[string]bool{}
+	var chainIDs []string
+	for _, coin := range []coinpkg.Coin{sellCoin, buyCoin} {
+		chainID, ok := chainIDFromCoinCode(string(coin.Code()))
+		if !ok || seenChainIDs[chainID] {
+			continue
+		}
+		seenChainIDs[chainID] = true
+		chainIDs = append(chainIDs, chainID)
+	}
+	return chainIDs
+}
+
+func allRelevantProvidersUnavailable(providers []Provider, chainIDs []string) bool {
+	if len(chainIDs) == 0 {
+		return false
+	}
+	relevantProviders := 0
+	for _, provider := range providers {
+		if !slices.Contains(provider.SupportedActions, "swap") {
+			continue
+		}
+		supportsPair := true
+		for _, chainID := range chainIDs {
+			if !slices.Contains(provider.SupportedChainIDs, chainID) {
+				supportsPair = false
+				break
+			}
+		}
+		if !supportsPair {
+			continue
+		}
+		relevantProviders++
+		enabledForPair := true
+		for _, chainID := range chainIDs {
+			if !slices.Contains(provider.EnabledChainIDs, chainID) {
+				enabledForPair = false
+				break
+			}
+		}
+		if enabledForPair {
+			return false
+		}
+	}
+	return relevantProviders > 0
+}
+
 // NewQuoteFromCoinCode validates the provided coins, fetches a quote, and maps structured API errors.
 func NewQuoteFromCoinCode(ctx context.Context, httpClient *http.Client, sellCoin, buyCoin coinpkg.Coin, sellAmount string) (*QuoteResponse, *APIError) {
 	quoteErrorData := &APIErrorData{
@@ -162,15 +251,12 @@ func NewQuoteFromCoinCode(ctx context.Context, httpClient *http.Client, sellCoin
 		return nil, apiError
 	}
 
-	quoteResponse, err := NewClient(httpClient).Quote(ctx, quoteRequest)
+	client := NewClient(httpClient)
+	quoteResponse, err := client.Quote(ctx, quoteRequest)
 	if err != nil {
 		if apiError, ok := apiErrorFromError(err); ok {
 			if strings.Contains(apiError.Message, noRoutesFoundMessage) {
-				return nil, &APIError{
-					ErrorCode: ErrNoRoutesFound,
-					Message:   noRoutesFoundMessage,
-					Data:      quoteErrorData,
-				}
+				return nil, noRoutesQuoteError(ctx, client, sellCoin, buyCoin, quoteErrorData)
 			}
 			return nil, apiError
 		}
@@ -180,11 +266,7 @@ func NewQuoteFromCoinCode(ctx context.Context, httpClient *http.Client, sellCoin
 		}
 	}
 	if len(quoteResponse.Routes) == 0 {
-		return nil, &APIError{
-			ErrorCode: ErrNoRoutesFound,
-			Message:   noRoutesFoundMessage,
-			Data:      quoteErrorData,
-		}
+		return nil, noRoutesQuoteError(ctx, client, sellCoin, buyCoin, quoteErrorData)
 	}
 	return quoteResponse, nil
 }

--- a/backend/market/swapkit/helpers_test.go
+++ b/backend/market/swapkit/helpers_test.go
@@ -28,6 +28,11 @@ import (
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
+const (
+	providersPath = "/providers"
+	quotePath     = "/v3/quote"
+)
+
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
@@ -163,22 +168,73 @@ func TestNewQuoteFromCoinCodeUsesInjectedHTTPClient(t *testing.T) {
 	require.Equal(t, []string{"provider-a"}, response.Routes[0].Providers)
 }
 
+func TestNewQuoteFromCoinCodeDoesNotFetchProvidersWhenRoutesFound(t *testing.T) {
+	var requestPaths []string
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requestPaths = append(requestPaths, req.URL.Path)
+
+			switch req.URL.Path {
+			case quotePath:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"routes":[{"providers":["provider-a"],"sellAsset":"BTC.BTC","buyAsset":"ETH.ETH","expectedBuyAmount":"1.23"}]}`,
+					)),
+					Header: make(http.Header),
+				}, nil
+			case providersPath:
+				require.FailNow(t, "providers should only be fetched when no routes are found")
+				return nil, nil
+			default:
+				require.FailNow(t, "unexpected path", req.URL.Path)
+				return nil, nil
+			}
+		}),
+	}
+
+	response, apiError := NewQuoteFromCoinCode(
+		context.Background(),
+		httpClient,
+		newQuoteCoin(coinpkg.CodeBTC, "BTC"),
+		newQuoteCoin(coinpkg.CodeETH, "ETH"),
+		"1.23456789",
+	)
+	require.Nil(t, apiError)
+	require.NotNil(t, response)
+	require.Equal(t, []string{quotePath}, requestPaths)
+}
+
 func TestNewQuoteFromCoinCodeMapsEmptyRoutesToNoRoutesFound(t *testing.T) {
 	httpClient := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			bodyBytes, err := io.ReadAll(req.Body)
-			require.NoError(t, err)
+			switch req.URL.Path {
+			case quotePath:
+				bodyBytes, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
 
-			var body QuoteRequest
-			require.NoError(t, json.Unmarshal(bodyBytes, &body))
-			require.Equal(t, "LTC.LTC", body.SellAsset)
-			require.Equal(t, "BTC.BTC", body.BuyAsset)
+				var body QuoteRequest
+				require.NoError(t, json.Unmarshal(bodyBytes, &body))
+				require.Equal(t, "LTC.LTC", body.SellAsset)
+				require.Equal(t, "BTC.BTC", body.BuyAsset)
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(`{"routes":[]}`)),
-				Header:     make(http.Header),
-			}, nil
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"routes":[]}`)),
+					Header:     make(http.Header),
+				}, nil
+			case providersPath:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`[{"name":"THORCHAIN","enabledChainIds":["bitcoin","litecoin"],"supportedActions":["swap"],"supportedChainIds":["bitcoin","litecoin"]}]`,
+					)),
+					Header: make(http.Header),
+				}, nil
+			default:
+				require.FailNow(t, "unexpected path", req.URL.Path)
+				return nil, nil
+			}
 		}),
 	}
 
@@ -202,21 +258,35 @@ func TestNewQuoteFromCoinCodeMapsEmptyRoutesToNoRoutesFound(t *testing.T) {
 func TestNewQuoteFromCoinCodeMapsNoRouteAPIErrorToNoRoutesFound(t *testing.T) {
 	httpClient := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			bodyBytes, err := io.ReadAll(req.Body)
-			require.NoError(t, err)
+			switch req.URL.Path {
+			case quotePath:
+				bodyBytes, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
 
-			var body QuoteRequest
-			require.NoError(t, json.Unmarshal(bodyBytes, &body))
-			require.Equal(t, "ETH.ETH", body.SellAsset)
-			require.Equal(t, "BTC.BTC", body.BuyAsset)
+				var body QuoteRequest
+				require.NoError(t, json.Unmarshal(bodyBytes, &body))
+				require.Equal(t, "ETH.ETH", body.SellAsset)
+				require.Equal(t, "BTC.BTC", body.BuyAsset)
 
-			return &http.Response{
-				StatusCode: http.StatusBadRequest,
-				Body: io.NopCloser(strings.NewReader(
-					`{"error":"No route found","message":"No routes found for ETH.ETH to BTC.BTC"}`,
-				)),
-				Header: make(http.Header),
-			}, nil
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Body: io.NopCloser(strings.NewReader(
+						`{"error":"No route found","message":"No routes found for ETH.ETH to BTC.BTC"}`,
+					)),
+					Header: make(http.Header),
+				}, nil
+			case providersPath:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`[{"name":"THORCHAIN","enabledChainIds":["1","bitcoin"],"supportedActions":["swap"],"supportedChainIds":["1","bitcoin"]}]`,
+					)),
+					Header: make(http.Header),
+				}, nil
+			default:
+				require.FailNow(t, "unexpected path", req.URL.Path)
+				return nil, nil
+			}
 		}),
 	}
 
@@ -234,6 +304,98 @@ func TestNewQuoteFromCoinCodeMapsNoRouteAPIErrorToNoRoutesFound(t *testing.T) {
 	require.Equal(t, &APIErrorData{
 		SellCoin: "SEPETH",
 		BuyCoin:  "BTC",
+	}, apiError.Data)
+}
+
+func TestNewQuoteFromCoinCodeMapsUnavailableProvidersToProvidersUnavailable(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case quotePath:
+				bodyBytes, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+
+				var body QuoteRequest
+				require.NoError(t, json.Unmarshal(bodyBytes, &body))
+				require.Equal(t, "ETH.ETH", body.SellAsset)
+				require.Equal(t, "ETH.USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", body.BuyAsset)
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"routes":[]}`)),
+					Header:     make(http.Header),
+				}, nil
+			case providersPath:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`[{"name":"UNISWAP_V2","enabledChainIds":["42161"],"supportedActions":["swap"],"supportedChainIds":["1","42161"]},{"name":"ONEINCH","enabledChainIds":["42161"],"supportedActions":["swap"],"supportedChainIds":["1","42161"]}]`,
+					)),
+					Header: make(http.Header),
+				}, nil
+			default:
+				require.FailNow(t, "unexpected path", req.URL.Path)
+				return nil, nil
+			}
+		}),
+	}
+
+	response, apiError := NewQuoteFromCoinCode(
+		context.Background(),
+		httpClient,
+		newQuoteCoin(coinpkg.CodeETH, "ETH"),
+		newQuoteCoin(coinpkg.Code("eth-erc20-usdc"), "USDC"),
+		"1.23456789",
+	)
+	require.Nil(t, response)
+	require.NotNil(t, apiError)
+	require.Equal(t, ErrProvidersUnavailable, apiError.ErrorCode)
+	require.Equal(t, providersUnavailableMessage, apiError.Message)
+	require.Equal(t, &APIErrorData{
+		SellCoin: "ETH",
+		BuyCoin:  "USDC",
+	}, apiError.Data)
+}
+
+func TestNewQuoteFromCoinCodeMapsMixedProviderAvailabilityToNoRoutesFound(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case quotePath:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"routes":[]}`)),
+					Header:     make(http.Header),
+				}, nil
+			case providersPath:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`[{"name":"UNISWAP_V2","enabledChainIds":["42161"],"supportedActions":["swap"],"supportedChainIds":["1","42161"]},{"name":"ONEINCH","enabledChainIds":["1"],"supportedActions":["swap"],"supportedChainIds":["1"]}]`,
+					)),
+					Header: make(http.Header),
+				}, nil
+			default:
+				require.FailNow(t, "unexpected path", req.URL.Path)
+				return nil, nil
+			}
+		}),
+	}
+
+	response, apiError := NewQuoteFromCoinCode(
+		context.Background(),
+		httpClient,
+		newQuoteCoin(coinpkg.CodeETH, "ETH"),
+		newQuoteCoin(coinpkg.Code("eth-erc20-usdc"), "USDC"),
+		"1.23456789",
+	)
+	require.Nil(t, response)
+	require.NotNil(t, apiError)
+	require.Equal(t, ErrNoRoutesFound, apiError.ErrorCode)
+	require.Equal(t, noRoutesFoundMessage, apiError.Message)
+	require.Equal(t, &APIErrorData{
+		SellCoin: "ETH",
+		BuyCoin:  "USDC",
 	}, apiError.Data)
 }
 
@@ -346,7 +508,7 @@ func TestNewQuoteFromCoinCodePreservesRoutesWithAnyProviderCount(t *testing.T) {
 
 func TestClientPostAppliesRequestTimeout(t *testing.T) {
 	client := &Client{
-		baseURL: "https://swapkit.shiftcrypto.io/v3",
+		baseURL: "https://swapkit.shiftcrypto.io",
 		httpClient: &http.Client{
 			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 				deadline, ok := req.Context().Deadline()
@@ -363,5 +525,5 @@ func TestClientPostAppliesRequestTimeout(t *testing.T) {
 	}
 
 	var out QuoteResponse
-	require.NoError(t, client.post(context.Background(), "/quote", &QuoteRequest{}, &out))
+	require.NoError(t, client.post(context.Background(), quotePath, &QuoteRequest{}, &out))
 }

--- a/backend/market/swapkit/methods.go
+++ b/backend/market/swapkit/methods.go
@@ -7,16 +7,25 @@ import (
 // Quote performs a SwapKit V3 quote request.
 func (c *Client) Quote(ctx context.Context, req *QuoteRequest) (*QuoteResponse, error) {
 	var resp QuoteResponse
-	if err := c.post(ctx, "/quote", req, &resp); err != nil {
+	if err := c.post(ctx, "/v3/quote", req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
+// Providers fetches SwapKit provider metadata.
+func (c *Client) Providers(ctx context.Context) ([]Provider, error) {
+	var resp []Provider
+	if err := c.get(ctx, "/providers", &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // Swap performs a SwapKit V3 swap request.
 func (c *Client) Swap(ctx context.Context, req *SwapRequest) (*SwapResponse, error) {
 	var resp SwapResponse
-	if err := c.post(ctx, "/swap", req, &resp); err != nil {
+	if err := c.post(ctx, "/v3/swap", req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/backend/market/swapkit/types.go
+++ b/backend/market/swapkit/types.go
@@ -74,6 +74,16 @@ type QuoteRoute struct {
 	NextActions []NextAction `json:"nextActions,omitempty"`
 }
 
+// Provider represents the subset of SwapKit provider metadata needed for quote error handling.
+type Provider struct {
+	Name              string   `json:"name"`
+	Provider          string   `json:"provider"`
+	DisplayName       string   `json:"displayName"`
+	EnabledChainIDs   []string `json:"enabledChainIds"`
+	SupportedActions  []string `json:"supportedActions"`
+	SupportedChainIDs []string `json:"supportedChainIds"`
+}
+
 // Fee represents a fee associated with a quote route returned by the SwapKit API.
 // See https://docs.swapkit.dev/swapkit-api/v3-quote-request-a-swap-quote and
 // https://docs.swapkit.dev/swapkit-api/v3-swap-obtain-swap-transaction-details

--- a/frontends/web/src/api/swap.ts
+++ b/frontends/web/src/api/swap.ts
@@ -49,7 +49,7 @@ export type TSwapQuoteResponse = {
   };
 } | {
   success: false;
-  // Known backend values include: NoRoutesFoundError, insufficientFunds, invalidRequest, unexpectedError.
+  // Known backend values include: NoRoutesFoundError, ProvidersUnavailableError, insufficientFunds, invalidRequest, unexpectedError.
   errorCode: string;
   errorData?: {
     buyCoin?: string;

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -2118,6 +2118,8 @@
     "noRouteFound": "No route found",
     "noRouteFoundForPair": "No route found from {{sellCoin}} to {{buyCoin}}. Try entering a larger amount. Otherwise try again later.",
     "oneRouteAvailable": "One route available",
+    "providersUnavailable": "SwapKit providers for this chain are currently unavailable. Try again later.",
+    "providersUnavailableForPair": "SwapKit providers for {{sellCoin}} to {{buyCoin}} are currently unavailable. Try again later.",
     "recommended": "Recommended",
     "route": "Swap route",
     "routesPlaceholder": "Routes will appear here after entering an amount",

--- a/frontends/web/src/routes/market/swap/swap.test.tsx
+++ b/frontends/web/src/routes/market/swap/swap.test.tsx
@@ -345,6 +345,52 @@ describe('routes/market/swap', () => {
     expect(screen.getByRole('button', { name: 'Swap' })).toBeDisabled();
   });
 
+  it('shows providers-unavailable quote errors with display units', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(swapApi.getSwapAccounts).mockResolvedValue({
+      success: true,
+      sellAccounts: [swapBuyAccount],
+      buyAccounts: [swapBuyTokenAccount],
+      defaultSellAccountCode: swapBuyAccount.code,
+      defaultBuyAccountCode: swapBuyTokenAccount.code,
+    });
+    vi.mocked(swapApi.getSwapQuote).mockResolvedValue({
+      success: false,
+      errorCode: 'ProvidersUnavailableError',
+      errorData: {
+        buyCoin: 'USDC',
+        sellCoin: 'ETH',
+      },
+      errorMessage: 'Providers unavailable',
+    });
+
+    render(
+      <RatesContext.Provider
+        value={{
+          activeCurrencies: [],
+          addToActiveCurrencies: vi.fn(),
+          btcUnit: 'default',
+          defaultCurrency: 'USD',
+          removeFromActiveCurrencies: vi.fn(),
+          rotateBtcUnit: vi.fn(),
+          rotateDefaultCurrency: vi.fn(),
+          updateDefaultCurrency: vi.fn(),
+        }}>
+        <MemoryRouter>
+          <Swap accounts={[buyAccount]} />
+        </MemoryRouter>
+      </RatesContext.Provider>,
+    );
+
+    await user.click(await screen.findByTestId('agree-swap-terms'));
+    await user.type(await screen.findByLabelText('swapSendAmount'), '1');
+
+    expect(await screen.findByText('SwapKit providers for ETH to USDC are currently unavailable. Try again later.')).toBeInTheDocument();
+    expect(screen.queryByText(/ETH\.ETH/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ETH\.USDC/)).not.toBeInTheDocument();
+  });
+
   it('disables swap button immediately when sell amount changes', async () => {
     const user = userEvent.setup();
 

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -57,6 +57,7 @@ type Props = {
 const QUOTE_DEBOUNCE_MS = 300;
 const INSUFFICIENT_FUNDS_ERROR = 'insufficientFunds';
 const NO_ROUTES_FOUND_ERROR = 'NoRoutesFoundError';
+const PROVIDERS_UNAVAILABLE_ERROR = 'ProvidersUnavailableError';
 const UNEXPECTED_ERROR = 'unexpectedError';
 
 const fetchBalance = async (code: AccountCode) => {
@@ -298,6 +299,19 @@ export const Swap = ({
         }
         if (!response.success && response.errorCode === INSUFFICIENT_FUNDS_ERROR) {
           resetQuoteStateWithError({ errorCode: response.errorCode });
+          return;
+        }
+        if (!response.success && response.errorCode === PROVIDERS_UNAVAILABLE_ERROR) {
+          const providersUnavailableMessage = response.errorData?.sellCoin && response.errorData?.buyCoin
+            ? t('swap.providersUnavailableForPair', {
+              buyCoin: response.errorData.buyCoin,
+              sellCoin: response.errorData.sellCoin,
+            })
+            : t('swap.providersUnavailable');
+          resetQuoteStateWithError({
+            error: providersUnavailableMessage,
+            errorCode: response.errorCode,
+          });
           return;
         }
         if (


### PR DESCRIPTION
Use the `providers` endpoint to determine whether quoting on a specific provider for the current chain is halted. If it is for all providers, we show a specifcic error.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
