### PR TITLE
ios: serialize WidgetAppGroupSync.sync()

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp/WidgetAppGroupSync.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/WidgetAppGroupSync.swift
@@ -20,10 +20,18 @@ struct WidgetAppGroupSync {
         let accounts: [Account]
     }
 
+    private static let serialQueue = DispatchQueue(label: "swiss.bitbox.WidgetAppGroupSync")
+
     func sync() {
-        #if TARGET_TESTNET
-        return
-        #else
+        #if !TARGET_TESTNET
+        Self.serialQueue.sync {
+            performSync()
+        }
+        #endif
+    }
+
+    #if !TARGET_TESTNET
+    private func performSync() {
         let appSupportDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         guard let defaults = UserDefaults(suiteName: WidgetShared.appGroupID) else {
             return
@@ -73,6 +81,6 @@ struct WidgetAppGroupSync {
         if changed {
             WidgetCenter.shared.reloadAllTimelines()
         }
-        #endif
     }
+    #endif
 }


### PR DESCRIPTION
sync() can fire from three lifecycle events at once. Run it through a private serial queue so only one runs at a time and the widget isn't asked to reload twice.



This resolves the following CodeRabbit comment:

_⚠️ Potential issue_ | _🔴 Critical_ | _⚡ Quick win_

<details>
<summary>🧩 Analysis chain</summary>

🏁 Script executed:

```shell
#!/bin/bash
fd -t f WidgetAppGroupSync.swift --exec cat {}
```

Repository: BitBoxSwiss/bitbox-wallet-app

Length of output: 2835

---



</details>

**Ensure `WidgetAppGroupSync.sync()` handles concurrent invocation safely.**

The current implementation is **not reentrant**. It reads previous state from `UserDefaults` (e.g., line 43: `defaults.stringArray(forKey: WidgetShared.Keys.sharedCoins)`) and then later writes new state with multiple separate `set()` calls. If two `sync()` calls overlap—e.g., both read the old `previous` value, both compute changes, and both write—you will get:
- Redundant `WidgetCenter.reloadAllTimelines()` calls (lines 50 and 57)
- Non-atomic read-modify-write sequences on `UserDefaults`

Add a serial `DispatchQueue` or use an `actor` to serialize `sync()` invocations.

<details>
<summary>🤖 Prompt for AI Agents</summary>

```
Verify each finding against current code. Fix only still-valid issues, skip the
rest with a brief reason, keep changes minimal, and validate.

In `@frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift` around lines 199 - 230,
WidgetAppGroupSync.sync() is not reentrant: concurrent calls can read the same
previous state from UserDefaults (e.g., WidgetShared.Keys.sharedCoins) and then
perform non-atomic set() writes and duplicate WidgetCenter.reloadAllTimelines()
calls; serialize sync() invocations by introducing a private serial
DispatchQueue or converting WidgetAppGroupSync into an actor and ensure all
reads/writes to UserDefaults and any calls to WidgetCenter.reloadAllTimelines()
happen inside that serialized context so only one sync() runs at a time and the
read-modify-write is atomic.
```

</details>

<!-- b3e5f241 -->

<!-- This is an auto-generated reply by CodeRabbit -->