### PR TITLE
frontend: keep insufficient funds error for large amount

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -1892,11 +1892,12 @@ func (handlers *Handlers) postSwapSign(r *http.Request) interface{} {
 
 func (handlers *Handlers) postSwapkitQuote(r *http.Request) interface{} {
 	type result struct {
-		Success      bool                   `json:"success"`
-		ErrorCode    errp.ErrorCode         `json:"errorCode,omitempty"`
-		ErrorMessage string                 `json:"errorMessage,omitempty"`
-		ErrorData    *swapkit.APIErrorData  `json:"errorData,omitempty"`
-		Quote        *swapkit.QuoteResponse `json:"quote,omitempty"`
+		Success             bool                   `json:"success"`
+		ErrorCode           errp.ErrorCode         `json:"errorCode,omitempty"`
+		ErrorMessage        string                 `json:"errorMessage,omitempty"`
+		ErrorData           *swapkit.APIErrorData  `json:"errorData,omitempty"`
+		ValidationErrorCode errp.ErrorCode         `json:"validationErrorCode,omitempty"`
+		Quote               *swapkit.QuoteResponse `json:"quote,omitempty"`
 	}
 	errorResult := func(code errp.ErrorCode, message string, data *swapkit.APIErrorData) result {
 		return result{
@@ -1935,7 +1936,6 @@ func (handlers *Handlers) postSwapkitQuote(r *http.Request) interface{} {
 	}
 	sellAmount := request.SellAmount
 	var validationErrorCode errp.ErrorCode
-	var validationErrorMessage string
 	if request.SellAccountCode != "" {
 		account, err := handlers.backend.GetAccountFromCode(request.SellAccountCode)
 		if err != nil {
@@ -1951,7 +1951,6 @@ func (handlers *Handlers) postSwapkitQuote(r *http.Request) interface{} {
 					return errorResult(errp.ErrorCode(validationErr.Error()), validationErr.Error(), nil)
 				}
 				validationErrorCode = errp.ErrorCode(validationErr.Error())
-				validationErrorMessage = validationErr.Error()
 			} else {
 				return errorResult(swapkit.ErrInvalidRequest, err.Error(), nil)
 			}
@@ -1969,13 +1968,17 @@ func (handlers *Handlers) postSwapkitQuote(r *http.Request) interface{} {
 		sellAmount,
 	)
 	if quoteError != nil {
-		return errorResult(quoteError.ErrorCode, quoteError.Message, quoteError.Data)
+		response := errorResult(quoteError.ErrorCode, quoteError.Message, quoteError.Data)
+		if validationErrorCode != "" {
+			response.ValidationErrorCode = validationErrorCode
+		}
+		return response
 	}
 	if validationErrorCode != "" {
 		return result{
 			Success:      false,
 			ErrorCode:    validationErrorCode,
-			ErrorMessage: validationErrorMessage,
+			ErrorMessage: string(validationErrorCode),
 			Quote:        quoteResponse,
 		}
 	}

--- a/backend/market/swapkit/helpers.go
+++ b/backend/market/swapkit/helpers.go
@@ -34,7 +34,7 @@ const (
 	// ErrInvalidRequest is returned when the quote request is invalid, for example due to missing or invalid fields.
 	ErrInvalidRequest errp.ErrorCode = "invalidRequest"
 	// ErrNoRoutesFound is returned when SwapKit cannot route the selected pair.
-	ErrNoRoutesFound errp.ErrorCode = "NoRoutesFoundError"
+	ErrNoRoutesFound errp.ErrorCode = "noRoutesFound"
 )
 
 const noRoutesFoundMessage = "No routes found"

--- a/frontends/web/src/api/swap.ts
+++ b/frontends/web/src/api/swap.ts
@@ -42,6 +42,14 @@ export type TSwapQuoteRoute = {
   routeId: string;
 };
 
+export type TSwapQuoteErrorCode =
+  | 'insufficientFunds'
+  | 'invalidRequest'
+  | 'noRoutesFound'
+  | 'unexpectedError';
+
+export type TSwapQuoteValidationErrorCode = Extract<TSwapQuoteErrorCode, 'insufficientFunds'>;
+
 export type TSwapQuoteResponse = {
   success: true;
   quote: {
@@ -49,13 +57,13 @@ export type TSwapQuoteResponse = {
   };
 } | {
   success: false;
-  // Known backend values include: NoRoutesFoundError, insufficientFunds, invalidRequest, unexpectedError.
-  errorCode: string;
+  errorCode: TSwapQuoteErrorCode;
   errorData?: {
     buyCoin?: string;
     sellCoin?: string;
   };
   errorMessage: string;
+  validationErrorCode?: TSwapQuoteValidationErrorCode;
   quote?: {
     routes: TSwapQuoteRoute[];
   };

--- a/frontends/web/src/routes/market/swap/swap.test.tsx
+++ b/frontends/web/src/routes/market/swap/swap.test.tsx
@@ -268,7 +268,7 @@ describe('routes/market/swap', () => {
     });
     vi.mocked(swapApi.getSwapQuote).mockResolvedValue({
       success: false,
-      errorCode: 'NoRoutesFoundError',
+      errorCode: 'noRoutesFound',
       errorData: {
         buyCoin: 'USDC',
         sellCoin: 'ETH',
@@ -300,6 +300,46 @@ describe('routes/market/swap', () => {
     expect(await screen.findByText('No route found from ETH to USDC. Try entering a larger amount. Otherwise try again later.')).toBeInTheDocument();
     expect(screen.queryByText(/ETH\.ETH/)).not.toBeInTheDocument();
     expect(screen.queryByText(/ETH\.USDC/)).not.toBeInTheDocument();
+  });
+
+  it('shows insufficient funds warning together with no-route errors', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(swapApi.getSwapQuote).mockResolvedValue({
+      success: false,
+      errorCode: 'noRoutesFound',
+      errorData: {
+        buyCoin: 'ETH',
+        sellCoin: 'BTC',
+      },
+      errorMessage: 'No routes found',
+      validationErrorCode: 'insufficientFunds',
+    });
+
+    render(
+      <RatesContext.Provider
+        value={{
+          activeCurrencies: [],
+          addToActiveCurrencies: vi.fn(),
+          btcUnit: 'default',
+          defaultCurrency: 'USD',
+          removeFromActiveCurrencies: vi.fn(),
+          rotateBtcUnit: vi.fn(),
+          rotateDefaultCurrency: vi.fn(),
+          updateDefaultCurrency: vi.fn(),
+        }}>
+        <MemoryRouter>
+          <Swap accounts={[sellAccount, buyAccount]} />
+        </MemoryRouter>
+      </RatesContext.Provider>,
+    );
+
+    await user.click(await screen.findByTestId('agree-swap-terms'));
+    await user.type(await screen.findByLabelText('swapSendAmount'), '2');
+
+    expect(await screen.findByText('No route found from BTC to ETH. Try entering a larger amount. Otherwise try again later.')).toBeInTheDocument();
+    expect(screen.getByText(/insufficient funds/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Swap' })).toBeDisabled();
   });
 
   it('keeps quote output visible for insufficient funds', async () => {

--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -22,6 +22,7 @@ import {
   signSwap,
   type TSwapAccount,
   type TSwapAccounts,
+  type TSwapQuoteErrorCode,
   type TSwapQuoteRoute,
 } from '@/api/swap';
 import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
@@ -55,9 +56,9 @@ type Props = {
 };
 
 const QUOTE_DEBOUNCE_MS = 300;
-const INSUFFICIENT_FUNDS_ERROR = 'insufficientFunds';
-const NO_ROUTES_FOUND_ERROR = 'NoRoutesFoundError';
-const UNEXPECTED_ERROR = 'unexpectedError';
+const INSUFFICIENT_FUNDS_ERROR: TSwapQuoteErrorCode = 'insufficientFunds';
+const NO_ROUTES_FOUND_ERROR: TSwapQuoteErrorCode = 'noRoutesFound';
+const UNEXPECTED_ERROR: TSwapQuoteErrorCode = 'unexpectedError';
 
 const fetchBalance = async (code: AccountCode) => {
   const response = await getBalance(code);
@@ -127,7 +128,7 @@ export const Swap = ({
   const [routes, setRoutes] = useState<TSwapQuoteRoute[]>([]);
   const [selectedRouteId, setSelectedRouteId] = useState<string | undefined>();
   const [isFetchingRoutes, setIsFetchingRoutes] = useState<boolean>(false);
-  const [quoteErrorCode, setQuoteErrorCode] = useState<string | undefined>();
+  const [quoteErrorCode, setQuoteErrorCode] = useState<TSwapQuoteErrorCode | undefined>();
   const [routeError, setRouteError] = useState<string | undefined>();
   // Drives the button disabled/loading state for the whole confirm flow.
   const [isConfirmInFlight, setIsConfirmInFlight] = useState(false);
@@ -219,7 +220,7 @@ export const Swap = ({
     errorCode,
   }: {
     error?: string;
-    errorCode?: string;
+    errorCode?: TSwapQuoteErrorCode;
   }) => {
     clearQuoteState();
     setQuoteErrorCode(errorCode);
@@ -284,8 +285,9 @@ export const Swap = ({
           return;
         }
         const nextRoutes = response.quote?.routes ?? [];
+        const validationErrorCode = response.success ? undefined : response.validationErrorCode;
         if (nextRoutes.length > 0) {
-          setQuoteErrorCode(response.success ? undefined : response.errorCode);
+          setQuoteErrorCode(response.success ? undefined : validationErrorCode ?? response.errorCode);
           setRouteError(undefined);
           setRoutes(nextRoutes);
           const firstRouteId = nextRoutes[0]?.routeId;
@@ -314,7 +316,7 @@ export const Swap = ({
             : t('swap.noRouteFound');
           resetQuoteStateWithError({
             error: noRouteFoundMessage,
-            errorCode: response.success ? undefined : response.errorCode,
+            errorCode: response.success ? undefined : validationErrorCode ?? response.errorCode,
           });
           return;
         }
@@ -322,7 +324,7 @@ export const Swap = ({
           error: response.errorCode === UNEXPECTED_ERROR
             ? t('swap.fetchQuotesError')
             : response.errorMessage || t('swap.fetchQuotesError'),
-          errorCode: response.errorCode,
+          errorCode: validationErrorCode ?? response.errorCode,
         });
       } catch (error: unknown) {
         if (isCancelled) {


### PR DESCRIPTION
When the user enters an amount that is both too much to get a quote, and mroe than they have, instead of only showing the "no routes found" error, also show the insufficientFundsError.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
