### PR TITLE
frontend: simplify onchain callback and only return value

### DIFF
--- a/frontends/web/src/components/forms/input-number.test.tsx
+++ b/frontends/web/src/components/forms/input-number.test.tsx
@@ -41,9 +41,7 @@ describe('components/forms/input-number', () => {
 
     fireEvent.input(input, { target: { value: '1,23' } });
 
-    expect(mockCallback).toHaveBeenCalledWith(expect.objectContaining({
-      target: expect.objectContaining({ value: '1.23' })
-    }));
+    expect(mockCallback).toHaveBeenCalledWith('1.23');
     expect(input).toHaveValue('1,23');
   });
 
@@ -55,9 +53,7 @@ describe('components/forms/input-number', () => {
 
     fireEvent.input(input, { target: { value: '1e2,3.4abc' } });
 
-    expect(mockCallback).toHaveBeenCalledWith(expect.objectContaining({
-      target: expect.objectContaining({ value: '12.34' })
-    }));
+    expect(mockCallback).toHaveBeenCalledWith('12.34');
     expect(input).toHaveValue('12,34');
   });
 
@@ -105,134 +101,133 @@ describe('components/forms/input-number', () => {
       }
     });
     expect(mockCallback).toHaveBeenCalledTimes(1);
-    expect(mockCallback).toHaveBeenCalledWith(expect.objectContaining({
-      target: expect.objectContaining({ value: '1000000.50' })
-    }));
+
+    expect(mockCallback).toHaveBeenCalledWith('1000000.50');
 
     fireEvent.paste(input, { clipboardData: { getData: () => '100.50' } });
     expect(mockCallback).toHaveBeenCalledTimes(2);
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[1][0].target.value).toBe('100.50');
+    expect(mockCallback.mock.calls[1][0]).toBe('100.50');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1');
+    expect(mockCallback.mock.calls[0][0]).toBe('1');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1,0' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.0');
+    expect(mockCallback.mock.calls[0][0]).toBe('1.0');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1,0' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.0');
+    expect(mockCallback.mock.calls[0][0]).toBe('1.0');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1,00' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.00');
+    expect(mockCallback.mock.calls[0][0]).toBe('1.00');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1.00' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.00');
+    expect(mockCallback.mock.calls[0][0]).toBe('1.00');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1,000' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.000');
+    expect(mockCallback.mock.calls[0][0]).toBe('1.000');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1,000.00' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.00');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000.00');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1.000,00' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.00');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000.00');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '100,50' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('100.50');
+    expect(mockCallback.mock.calls[0][0]).toBe('100.50');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '100.00' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('100.00');
+    expect(mockCallback.mock.calls[0][0]).toBe('100.00');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '100,000' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('100.000');
+    expect(mockCallback.mock.calls[0][0]).toBe('100.000');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '100.000' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('100.000');
+    expect(mockCallback.mock.calls[0][0]).toBe('100.000');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '.99' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('.99');
+    expect(mockCallback.mock.calls[0][0]).toBe('.99');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => ',99' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('.99');
+    expect(mockCallback.mock.calls[0][0]).toBe('.99');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '0.0000000000000000001' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('0.0000000000000000001');
+    expect(mockCallback.mock.calls[0][0]).toBe('0.0000000000000000001');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '0,0000000000000000001' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('0.0000000000000000001');
+    expect(mockCallback.mock.calls[0][0]).toBe('0.0000000000000000001');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1\'000\'000.50' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000000.50');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1\'000\'000,50' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000000.50');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1 000 000.50' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000000.50');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1.000.000,50' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000000.50');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1 000.50' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.50');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000.50');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1.000,50' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.50');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000.50');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1,000.50' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000.50');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000.50');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1,000,000.50' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1000000.50');
+    expect(mockCallback.mock.calls[0][0]).toBe('1000000.50');
   });
 
   it('has some unsupported number formats', async () => {
@@ -248,7 +243,7 @@ describe('components/forms/input-number', () => {
     fireEvent.paste(input, { clipboardData: { getData: () => '100,' } });
     expect(mockCallback).toHaveBeenCalledTimes(1);
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('');
+    expect(mockCallback.mock.calls[0][0]).toBe('');
 
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1,000.000,50' } });
@@ -261,7 +256,7 @@ describe('components/forms/input-number', () => {
     mockCallback.mockClear();
     fireEvent.paste(input, { clipboardData: { getData: () => '1,000' } });
     // @ts-ignore noUncheckedIndexedAccess
-    expect(mockCallback.mock.calls[0][0].target.value).toBe('1.000');
+    expect(mockCallback.mock.calls[0][0]).toBe('1.000');
 
   });
 

--- a/frontends/web/src/components/forms/input-number.tsx
+++ b/frontends/web/src/components/forms/input-number.tsx
@@ -5,24 +5,9 @@ import { Input, TInputProps } from './input';
 import { normalizeNumberInputValue, numberInputValueToString, sanitizeNumberInputValue } from './input-number-utils';
 import { runningInIOS } from '@/utils/env';
 
-type Props = Omit<TInputProps, 'ref' | 'onInput'>;
-
-// override the change event to set
-// the value to the normalized value (decimal separator)
-const changeEventWithValue = (
-  event: React.ChangeEvent<HTMLInputElement>,
-  value: string,
-) => ({
-  ...event,
-  currentTarget: {
-    ...event.currentTarget,
-    value,
-  },
-  target: {
-    ...event.target,
-    value,
-  },
-} as React.ChangeEvent<HTMLInputElement>);
+type Props = Omit<TInputProps, 'ref' | 'onInput' | 'onChange'> & {
+  onChange?: (value: string) => void;
+};
 
 export const NumberInput = forwardRef<HTMLInputElement, Props>(({
   inputMode = 'decimal',
@@ -108,7 +93,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(({
       reportedValue.current = target.value;
     }
     if (onChange) {
-      onChange({ ...event, target });
+      onChange(target.value);
     }
     event.preventDefault();
   }, [isIOS, onChange]);
@@ -120,7 +105,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(({
     setDisplayValue(sanitizedValue);
     reportedValue.current = normalizedValue;
     if (onChange) {
-      onChange(changeEventWithValue(event, normalizedValue));
+      onChange(normalizedValue);
     }
   }, [onChange]);
 
@@ -132,7 +117,9 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(({
       inputMode={inputMode}
       value={isIOS ? displayValue : value}
       defaultValue={isIOS ? undefined : defaultValue}
-      onInput={isIOS ? handleIOSInput : onChange}
+      onInput={isIOS ? handleIOSInput : (
+        onChange ? (e) => onChange(e.target.value) : undefined
+      )}
       onPaste={handlePaste}
     />
   );

--- a/frontends/web/src/components/forms/input-number.tsx
+++ b/frontends/web/src/components/forms/input-number.tsx
@@ -118,7 +118,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(({
       value={isIOS ? displayValue : value}
       defaultValue={isIOS ? undefined : defaultValue}
       onInput={isIOS ? handleIOSInput : (
-        onChange ? (e) => onChange(e.target.value) : undefined
+        onChange ? (e) => onChange(e.currentTarget.value) : undefined
       )}
       onPaste={handlePaste}
     />

--- a/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
@@ -34,7 +34,7 @@ export const CoinInput = ({
       min="0"
       label={balance ? balance.available.unit : t('send.amount.label')}
       id="amount"
-      onChange={(e: ChangeEvent<HTMLInputElement>) => onAmountChange(e.target.value)}
+      onChange={onAmountChange}
       disabled={sendAll}
       error={amountError}
       value={sendAll ? (proposedAmount ? proposedAmount.amount : '') : amount}

--- a/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConversionUnit } from '@/api/account';
 import { NumberInput } from '@/components/forms';
@@ -27,7 +26,7 @@ export const FiatInput = ({
       min="0"
       label={label}
       id="fiatAmount"
-      onChange={(event: ChangeEvent<HTMLInputElement>) => onFiatChange(event.target.value)}
+      onChange={onFiatChange}
       disabled={disabled}
       error={error}
       value={fiatAmount}

--- a/frontends/web/src/routes/account/send/feetargets.tsx
+++ b/frontends/web/src/routes/account/send/feetargets.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState, useEffect, useRef, ChangeEvent, useCallback, useContext } from 'react';
+import { useState, useEffect, useRef, useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RatesContext } from '@/contexts/RatesContext';
 import { useLoad } from '@/hooks/api';
@@ -91,10 +91,6 @@ export const FeeTargets = ({
   const handleFeeTargetChange = (value: accountApi.FeeTargetCode) => {
     setFeeTarget(value);
     onFeeTargetChange(value);
-  };
-
-  const handleCustomFee = (event: ChangeEvent<HTMLInputElement>) => {
-    onCustomFee(event.target.value);
   };
 
   const getProposeFeeText = (): string => {
@@ -217,7 +213,7 @@ export const FeeTargets = ({
                   })}
                 id="proposedFee"
                 placeholder={t('send.fee.customPlaceholder')}
-                onChange={handleCustomFee}
+                onChange={onCustomFee}
                 ref={inputRef}
                 value={customFee}
               >

--- a/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
+++ b/frontends/web/src/routes/market/swap/components/input-with-account-selector.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useContext, useEffect, useRef, useState, type ChangeEvent } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import type { AccountCode, TAccountBase } from '@/api/account';
 import { convertToCurrency } from '@/api/coins';
 import { RatesContext } from '@/contexts/RatesContext';
@@ -121,9 +121,7 @@ export const InputWithAccountSelector = <T extends TAccountBase, >({
             readOnly={readOnlyAmount}
             value={value}
             placeholder={placeholder}
-            onChange={(event: ChangeEvent<HTMLInputElement>) => {
-              onChangeValue && onChangeValue(event.target.value);
-            }}
+            onChange={onChangeValue}
           />
           <span className={style.inputUnit}>
             {displayedUnit}


### PR DESCRIPTION
The event object in onChange callback is overwritten on iOS, see
- 221c491e1dedac9878ab6982f3f2786cf24f3e68

This introduces small discrepancy as the event object on iOS, may miss name, id, disabled etc.

Fixed this by just returning the string event.target.value instead of the whole event object. This also simplifies the code in various places.

cc @shonsirsha 