### PR TITLE
frontend: add BitBox screen when checking backup

### DIFF
--- a/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/checkbackup.tsx
@@ -7,6 +7,7 @@ import { Backup } from '@/api/backup';
 import { alertUser } from '@/components/alert/Alert';
 import { Dialog, DialogButtons } from '@/components/dialog/dialog';
 import { Button } from '@/components/forms';
+import { PointToBitBox02 } from '@/components/icon';
 import { useTranslation } from 'react-i18next';
 
 type TProps = {
@@ -55,6 +56,8 @@ export const Check = ({ deviceID, backups, disabled }: TProps) => {
     }
   };
 
+  const isWaitingForDevice = foundBackup !== undefined && !userVerified && message === '';
+
   return (
     <>
       <Button
@@ -78,6 +81,12 @@ export const Check = ({ deviceID, backups, disabled }: TProps) => {
             <BackupsListItem
               backup={foundBackup}
               radio={false} />
+          )}
+          {isWaitingForDevice && (
+            <>
+              <p className="text-center">{t('confirm.info')}</p>
+              <PointToBitBox02 />
+            </>
           )}
           <DialogButtons>
             {userVerified && (

--- a/frontends/web/src/routes/device/bitbox02/createbackup.tsx
+++ b/frontends/web/src/routes/device/bitbox02/createbackup.tsx
@@ -5,6 +5,7 @@ import { checkBackup, createBackup as createBackupAPI } from '@/api/bitbox02';
 import { alertUser } from '@/components/alert/Alert';
 import { confirmation } from '@/components/confirm/Confirm';
 import { Button } from '@/components/forms';
+import { PointToBitBox02 } from '@/components/icon';
 import { WaitDialog } from '@/components/wait-dialog/wait-dialog';
 import { useTranslation } from 'react-i18next';
 
@@ -60,7 +61,8 @@ export const Create = ({ deviceID }: TProps) => {
       </Button>
       { creatingBackup && (
         <WaitDialog title={t('backup.create.title')}>
-          {t('bitbox02Interact.followInstructions')}
+          <p className="text-center">{t('bitbox02Interact.followInstructions')}</p>
+          <PointToBitBox02 />
         </WaitDialog>
       )}
     </>


### PR DESCRIPTION
When checking the validity of a backup, add the graphics that points the user towards checking the BitBox screen so they know something is happening on the device.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
