### PR TITLE
backend: emit transaction event for tx notes

### DIFF
--- a/backend/accounts/account.go
+++ b/backend/accounts/account.go
@@ -85,7 +85,7 @@ type Interface interface {
 
 	Notes() *notes.Notes
 	TxNote(txID string) string
-	// SetTxNote sets a tx note and refreshes the account.
+	// SetTxNote sets a tx note and refreshes transactions if the note changed.
 	SetTxNote(txID string, note string) error
 
 	// ExportCSV exports the given transaction in CSV format (comma-separated).

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -230,15 +230,17 @@ func (account *BaseAccount) migrateLegacyNotes() error {
 
 // SetTxNote implements accounts.Account.
 func (account *BaseAccount) SetTxNote(txID string, note string) error {
-	if _, err := account.notes.SetTxNote(txID, note); err != nil {
+	changed, err := account.notes.SetTxNote(txID, note)
+	if err != nil {
 		return err
 	}
-	// Prompt refresh.
-	account.Notify(observable.Event{
-		Subject: string(types.EventStatusChanged),
-		Action:  action.Reload,
-		Object:  nil,
-	})
+	if changed {
+		account.Notify(observable.Event{
+			Subject: string(types.EventTransactionsChanged),
+			Action:  action.Reload,
+			Object:  nil,
+		})
+	}
 	return nil
 }
 

--- a/backend/accounts/baseaccount_test.go
+++ b/backend/accounts/baseaccount_test.go
@@ -167,7 +167,7 @@ func TestBaseAccount(t *testing.T) {
 		}
 
 		require.NoError(t, account.SetTxNote("test-tx-id", "another test note"))
-		require.Equal(t, types.EventStatusChanged, checkEvent())
+		require.Equal(t, types.EventTransactionsChanged, checkEvent())
 		require.Equal(t, "another test note", account.TxNote("test-tx-id"))
 
 		// Test notes migration from v4.27.0 to v4.28.0
@@ -178,6 +178,7 @@ func TestBaseAccount(t *testing.T) {
 		require.Equal(t, "legacy note in split account, p2wpkh-p2sh", account.TxNote("legacy-4"))
 		// Setting a note sets it in the main notes file, and wipes it out in legacy note files.
 		require.NoError(t, account.SetTxNote("legacy-1", "updated legacy note"))
+		require.Equal(t, types.EventTransactionsChanged, checkEvent())
 		require.Equal(t, "updated legacy note", account.TxNote("legacy-1"))
 	})
 

--- a/backend/accounts/types/event.go
+++ b/backend/accounts/types/event.go
@@ -13,6 +13,9 @@ const (
 	// transactions, confirmations, etc.).
 	EventSyncDone Event = "sync-done"
 
+	// EventTransactionsChanged is fired when the transaction list should be reloaded.
+	EventTransactionsChanged Event = "transactions"
+
 	// EventSyncedAddressesCount is emitted when the frontend should receives a sync progress update.
 	EventSyncedAddressesCount Event = "synced-addresses-count"
 )

--- a/frontends/web/src/api/accountsync.ts
+++ b/frontends/web/src/api/accountsync.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { TUnsubscribe } from '@/utils/transport-common';
-import type { AccountCode, TAccount, TStatus } from './account';
+import type { AccountCode, TAccount, TStatus, TTransactions } from './account';
 import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
 
 /**
@@ -49,4 +49,15 @@ export const syncdone = (
   cb: () => void,
 ): TUnsubscribe => {
   return subscribeEndpoint(`account/${code}/sync-done`, cb);
+};
+
+/**
+ * Fired when the account transaction list changed.
+ * Returns a method to unsubscribe.
+ */
+export const transactionsChanged = (
+  code: AccountCode,
+  cb: TSubscriptionCallback<TTransactions>,
+): TUnsubscribe => {
+  return subscribeEndpoint(`account/${code}/transactions`, cb);
 };

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -4,7 +4,7 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'r
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import * as accountApi from '@/api/account';
-import { statusChanged, syncAddressesCount, syncdone } from '@/api/accountsync';
+import { statusChanged, syncAddressesCount, syncdone, transactionsChanged } from '@/api/accountsync';
 import { TDevices } from '@/api/devices';
 import { getMarketVendors, MarketVendors } from '@/api/market';
 import { Balance } from '@/components/balance/balance';
@@ -149,6 +149,10 @@ const RemountAccount = ({
   useEffect(() => {
     return syncdone(code, () => onAccountChanged(status));
   }, [code, onAccountChanged, status]);
+
+  useEffect(() => {
+    return transactionsChanged(code, setTransactions);
+  }, [code]);
 
   useEffect(() => {
     onAccountChanged(status);


### PR DESCRIPTION
Stop using account status reloads for transaction note edits.

Emit and subscribe to the transactions endpoint so the frontend refreshes the list directly.

