### PR TITLE
ipados: fix tap highlight on hamburger (menu) btn

### DIFF
--- a/frontends/web/src/components/layout/header.module.css
+++ b/frontends/web/src/components/layout/header.module.css
@@ -64,10 +64,17 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
 }
 
 .sidebarToggler img {
     width: 20px;
+    transition: opacity 0.15s ease;
+}
+
+.sidebarToggler:active img {
+    opacity: 0.5;
 }
 
 .title {

--- a/frontends/web/src/components/spinner/Spinner.module.css
+++ b/frontends/web/src/components/spinner/Spinner.module.css
@@ -86,10 +86,17 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
 }
 
 .toggler img {
     width: 20px;
+    transition: opacity 0.15s ease;
+}
+
+.toggler:active img {
+    opacity: 0.5;
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
On some iPads like the 11 inch ones, the sidebar are collapsed and user can toggle it using the hamburger menu button.
However, its tap highlight color looks rather crooked. In this commit, we remove the tap highlight color, make the icon react to it instead.