### PR TITLE
frontend: remove back button in swap on mobile add headerback

### DIFF
--- a/frontends/web/src/routes/market/swap/swap.tsx
+++ b/frontends/web/src/routes/market/swap/swap.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/api/swap';
 import { FirmwareUpgradeRequiredDialog } from '@/components/dialog/firmware-upgrade-required-dialog';
 import { GuideWrapper, GuidedContent, Main, Header } from '@/components/layout';
+import { MobileHeader } from '@/routes/settings/components/mobile-header';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
@@ -566,9 +567,10 @@ export const Swap = ({
           <Header
             hideSidebarToggler
             title={
-              <h2>
-                {t('generic.swap')}
-              </h2>
+              <>
+                <h2 className="hide-on-small">{t('generic.swap')}</h2>
+                <MobileHeader withGuide title={t('generic.swap')} />
+              </>
             }
           />
           <View
@@ -685,7 +687,7 @@ export const Swap = ({
                   {isConfirmInFlight ? t('loading') : t('generic.swap')}
                 </span>
               </Button>
-              <BackButton>
+              <BackButton className="hide-on-small">
                 {t('button.back')}
               </BackButton>
             </ViewButtons>


### PR DESCRIPTION
To be more consisitent with the rest of the app back buttons on mobile should be in the header.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
