### PR TITLE
eth: skip finalized outgoing tx polling

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -200,6 +200,16 @@ func (account *Account) Initialize() error {
 	return account.BaseAccount.Initialize(accountIdentifier)
 }
 
+// outgoingTransactionIsFinal checks if the transaction is final, meaning it has at least
+// NumConfirmationsComplete confirmations.
+// If the transaction is not yet included in a block, or if the tipHeight is lower than the transaction's block, it is not final.
+func outgoingTransactionIsFinal(tx *ethtypes.TransactionWithMetadata, tipHeight uint64) bool {
+	if tx.Height == 0 || tipHeight < tx.Height {
+		return false
+	}
+	return tipHeight-tx.Height+1 >= ethtypes.NumConfirmationsComplete
+}
+
 // updateOutgoingTransactions updates the height of the stored outgoing transactions.
 // We update heights for tx with up to 12 confirmations, so re-orgs are taken into account.
 // tipHeight is the current blockchain height.
@@ -222,6 +232,9 @@ func (account *Account) updateOutgoingTransactions(tipHeight uint64) {
 
 	// Update the stored txs' metadata if up to 12 confirmations.
 	for idx, tx := range outgoingTransactions {
+		if outgoingTransactionIsFinal(tx, tipHeight) {
+			continue
+		}
 		txLog := account.log.WithField("idx", idx)
 		remoteTx, err := account.coin.client.TransactionReceiptWithBlockNumber(context.TODO(), tx.Transaction.Hash())
 		if remoteTx == nil || err != nil {

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/rpcclient"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/rpcclient/mocks"
+	ethtypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth/types"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
 	keystoremock "github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore/mocks"
@@ -25,6 +27,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -191,6 +194,174 @@ func TestTxProposal(t *testing.T) {
 		})
 		require.Equal(t, errors.ErrInvalidAddress, errp.Cause(err))
 	})
+}
+
+func newTestOutgoingTx() *gethtypes.Transaction {
+	to := common.HexToAddress("0xa29163852021BF4C139D03Dff59ae763AC73e84e")
+	return gethtypes.NewTx(&gethtypes.LegacyTx{
+		Nonce:    0,
+		GasPrice: big.NewInt(1),
+		Gas:      21000,
+		To:       &to,
+		Value:    big.NewInt(1),
+	})
+}
+
+func putOutgoingTx(t *testing.T, account *Account, tx *ethtypes.TransactionWithMetadata) {
+	t.Helper()
+	dbTx, err := account.db.Begin()
+	require.NoError(t, err)
+	defer dbTx.Rollback()
+	require.NoError(t, dbTx.PutOutgoingTransaction(tx))
+	require.NoError(t, dbTx.Commit())
+}
+
+func outgoingTxs(t *testing.T, account *Account) []*ethtypes.TransactionWithMetadata {
+	t.Helper()
+	dbTx, err := account.db.Begin()
+	require.NoError(t, err)
+	defer dbTx.Rollback()
+	txs, err := dbTx.OutgoingTransactions()
+	require.NoError(t, err)
+	return txs
+}
+
+func TestOutgoingTransactionIsFinal(t *testing.T) {
+	tx := newTestOutgoingTx()
+	tests := []struct {
+		name      string
+		height    uint64
+		tipHeight uint64
+		expected  bool
+	}{
+		{
+			name:      "pending",
+			height:    0,
+			tipHeight: 100,
+			expected:  false,
+		},
+		{
+			name:      "eleven confirmations",
+			height:    90,
+			tipHeight: 100,
+			expected:  false,
+		},
+		{
+			name:      "twelve confirmations",
+			height:    89,
+			tipHeight: 100,
+			expected:  true,
+		},
+		{
+			name:      "future height",
+			height:    101,
+			tipHeight: 100,
+			expected:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, outgoingTransactionIsFinal(
+				&ethtypes.TransactionWithMetadata{
+					Transaction: tx,
+					Height:      test.height,
+				},
+				test.tipHeight,
+			))
+		})
+	}
+}
+
+func TestUpdateOutgoingTransactionsSkipsFinalTransactions(t *testing.T) {
+	account := newAccountWithOptions(t, true, make(chan *Account, 1))
+	defer account.Close()
+	putOutgoingTx(t, account, &ethtypes.TransactionWithMetadata{
+		Transaction: newTestOutgoingTx(),
+		Height:      89,
+		GasUsed:     21000,
+		Success:     true,
+	})
+
+	var receiptCalls int
+	account.ETHCoin().TstSetClient(&mocks.InterfaceMock{
+		TransactionReceiptWithBlockNumberFunc: func(ctx context.Context, hash common.Hash) (*rpcclient.RPCTransactionReceipt, error) {
+			receiptCalls++
+			return nil, errp.New("receipt should not be fetched")
+		},
+	})
+
+	account.updateOutgoingTransactions(100)
+	require.Equal(t, 0, receiptCalls)
+}
+
+func TestUpdateOutgoingTransactionsPollsRecentConfirmedTransactions(t *testing.T) {
+	account := newAccountWithOptions(t, true, make(chan *Account, 1))
+	defer account.Close()
+	tx := newTestOutgoingTx()
+	putOutgoingTx(t, account, &ethtypes.TransactionWithMetadata{
+		Transaction: tx,
+		Height:      90,
+		GasUsed:     21000,
+		Success:     false,
+	})
+
+	var receiptCalls int
+	account.ETHCoin().TstSetClient(&mocks.InterfaceMock{
+		TransactionReceiptWithBlockNumberFunc: func(ctx context.Context, hash common.Hash) (*rpcclient.RPCTransactionReceipt, error) {
+			receiptCalls++
+			require.Equal(t, tx.Hash(), hash)
+			return &rpcclient.RPCTransactionReceipt{
+				Receipt: gethtypes.Receipt{
+					Status:  gethtypes.ReceiptStatusSuccessful,
+					GasUsed: 42000,
+				},
+				BlockNumber: 90,
+			}, nil
+		},
+	})
+
+	account.updateOutgoingTransactions(100)
+	require.Equal(t, 1, receiptCalls)
+	txs := outgoingTxs(t, account)
+	require.Len(t, txs, 1)
+	require.True(t, txs[0].Success)
+	require.Equal(t, uint64(42000), txs[0].GasUsed)
+}
+
+func TestUpdateOutgoingTransactionsStillChecksPendingTransactions(t *testing.T) {
+	account := newAccountWithOptions(t, true, make(chan *Account, 1))
+	defer account.Close()
+	tx := newTestOutgoingTx()
+	putOutgoingTx(t, account, &ethtypes.TransactionWithMetadata{
+		Transaction: tx,
+		Height:      0,
+	})
+
+	var receiptCalls int
+	var transactionByHashCalls int
+	var sendCalls int
+	account.ETHCoin().TstSetClient(&mocks.InterfaceMock{
+		TransactionReceiptWithBlockNumberFunc: func(ctx context.Context, hash common.Hash) (*rpcclient.RPCTransactionReceipt, error) {
+			receiptCalls++
+			require.Equal(t, tx.Hash(), hash)
+			return nil, errp.New("not found")
+		},
+		TransactionByHashFunc: func(ctx context.Context, hash common.Hash) (*gethtypes.Transaction, bool, error) {
+			transactionByHashCalls++
+			require.Equal(t, tx.Hash(), hash)
+			return tx, true, nil
+		},
+		SendTransactionFunc: func(ctx context.Context, tx *gethtypes.Transaction) error {
+			sendCalls++
+			return nil
+		},
+	})
+
+	account.updateOutgoingTransactions(100)
+	require.Equal(t, 1, receiptCalls)
+	require.Equal(t, 1, transactionByHashCalls)
+	require.Equal(t, 0, sendCalls)
 }
 
 func TestMatchesAddress(t *testing.T) {


### PR DESCRIPTION
Skip Etherscan receipt lookups for locally stored outgoing ETH/ERC20 transactions once they have reached the existing finality threshold.

Pending transactions and recently confirmed transactions are still polled so rebroadcast and reorg-sensitive metadata updates keep working.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
