### PR TITLE
eth: require final outgoing tx check

### DIFF
--- a/backend/coins/eth/account.go
+++ b/backend/coins/eth/account.go
@@ -201,13 +201,21 @@ func (account *Account) Initialize() error {
 }
 
 // outgoingTransactionIsFinal checks if the transaction is final, meaning it has at least
-// NumConfirmationsComplete confirmations.
-// If the transaction is not yet included in a block, or if the tipHeight is lower than the transaction's block, it is not final.
+// NumConfirmationsComplete confirmations and has been checked at least once after reaching
+// that threshold.
+// If the transaction is not yet included in a block, or if the tipHeight is lower than the
+// transaction's block, it is not final.
 func outgoingTransactionIsFinal(tx *ethtypes.TransactionWithMetadata, tipHeight uint64) bool {
 	if tx.Height == 0 || tipHeight < tx.Height {
 		return false
 	}
-	return tipHeight-tx.Height+1 >= ethtypes.NumConfirmationsComplete
+	if tipHeight-tx.Height+1 < ethtypes.NumConfirmationsComplete {
+		return false
+	}
+	if tx.LastReceiptCheckHeight < tx.Height {
+		return false
+	}
+	return tx.LastReceiptCheckHeight-tx.Height+1 >= ethtypes.NumConfirmationsComplete
 }
 
 // updateOutgoingTransactions updates the height of the stored outgoing transactions.
@@ -258,10 +266,16 @@ func (account *Account) updateOutgoingTransactions(tipHeight uint64) {
 			continue
 		}
 		success := remoteTx.Status == types.ReceiptStatusSuccessful
-		if tx.Height == 0 || (tipHeight-remoteTx.BlockNumber) < ethtypes.NumConfirmationsComplete || tx.Success != success {
+		if tx.Height == 0 ||
+			tx.Height != remoteTx.BlockNumber ||
+			tx.GasUsed != remoteTx.GasUsed ||
+			(tipHeight-remoteTx.BlockNumber) < ethtypes.NumConfirmationsComplete ||
+			tx.Success != success ||
+			tx.LastReceiptCheckHeight != tipHeight {
 			tx.Height = remoteTx.BlockNumber
 			tx.GasUsed = remoteTx.GasUsed
 			tx.Success = success
+			tx.LastReceiptCheckHeight = tipHeight
 			if err := dbTx.PutOutgoingTransaction(tx); err != nil {
 				txLog.WithError(err).Error("could not update outgoing tx")
 				continue

--- a/backend/coins/eth/account_test.go
+++ b/backend/coins/eth/account_test.go
@@ -229,34 +229,46 @@ func outgoingTxs(t *testing.T, account *Account) []*ethtypes.TransactionWithMeta
 func TestOutgoingTransactionIsFinal(t *testing.T) {
 	tx := newTestOutgoingTx()
 	tests := []struct {
-		name      string
-		height    uint64
-		tipHeight uint64
-		expected  bool
+		name                   string
+		height                 uint64
+		tipHeight              uint64
+		lastReceiptCheckHeight uint64
+		expected               bool
 	}{
 		{
-			name:      "pending",
-			height:    0,
-			tipHeight: 100,
-			expected:  false,
+			name:                   "pending",
+			height:                 0,
+			tipHeight:              100,
+			lastReceiptCheckHeight: 100,
+			expected:               false,
 		},
 		{
-			name:      "eleven confirmations",
-			height:    90,
-			tipHeight: 100,
-			expected:  false,
+			name:                   "eleven confirmations",
+			height:                 90,
+			tipHeight:              100,
+			lastReceiptCheckHeight: 100,
+			expected:               false,
 		},
 		{
-			name:      "twelve confirmations",
-			height:    89,
-			tipHeight: 100,
-			expected:  true,
+			name:                   "twelve confirmations but not checked at finality",
+			height:                 89,
+			tipHeight:              100,
+			lastReceiptCheckHeight: 99,
+			expected:               false,
 		},
 		{
-			name:      "future height",
-			height:    101,
-			tipHeight: 100,
-			expected:  false,
+			name:                   "twelve confirmations checked at finality",
+			height:                 89,
+			tipHeight:              100,
+			lastReceiptCheckHeight: 100,
+			expected:               true,
+		},
+		{
+			name:                   "future height",
+			height:                 101,
+			tipHeight:              100,
+			lastReceiptCheckHeight: 100,
+			expected:               false,
 		},
 	}
 
@@ -264,8 +276,9 @@ func TestOutgoingTransactionIsFinal(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.expected, outgoingTransactionIsFinal(
 				&ethtypes.TransactionWithMetadata{
-					Transaction: tx,
-					Height:      test.height,
+					Transaction:            tx,
+					Height:                 test.height,
+					LastReceiptCheckHeight: test.lastReceiptCheckHeight,
 				},
 				test.tipHeight,
 			))
@@ -277,10 +290,11 @@ func TestUpdateOutgoingTransactionsSkipsFinalTransactions(t *testing.T) {
 	account := newAccountWithOptions(t, true, make(chan *Account, 1))
 	defer account.Close()
 	putOutgoingTx(t, account, &ethtypes.TransactionWithMetadata{
-		Transaction: newTestOutgoingTx(),
-		Height:      89,
-		GasUsed:     21000,
-		Success:     true,
+		Transaction:            newTestOutgoingTx(),
+		Height:                 89,
+		GasUsed:                21000,
+		Success:                true,
+		LastReceiptCheckHeight: 100,
 	})
 
 	var receiptCalls int
@@ -293,6 +307,40 @@ func TestUpdateOutgoingTransactionsSkipsFinalTransactions(t *testing.T) {
 
 	account.updateOutgoingTransactions(100)
 	require.Equal(t, 0, receiptCalls)
+}
+
+func TestUpdateOutgoingTransactionsPollsFinalTransactionUntilFinalityChecked(t *testing.T) {
+	account := newAccountWithOptions(t, true, make(chan *Account, 1))
+	defer account.Close()
+	tx := newTestOutgoingTx()
+	putOutgoingTx(t, account, &ethtypes.TransactionWithMetadata{
+		Transaction:            tx,
+		Height:                 89,
+		GasUsed:                21000,
+		Success:                true,
+		LastReceiptCheckHeight: 99,
+	})
+
+	var receiptCalls int
+	account.ETHCoin().TstSetClient(&mocks.InterfaceMock{
+		TransactionReceiptWithBlockNumberFunc: func(ctx context.Context, hash common.Hash) (*rpcclient.RPCTransactionReceipt, error) {
+			receiptCalls++
+			require.Equal(t, tx.Hash(), hash)
+			return &rpcclient.RPCTransactionReceipt{
+				Receipt: gethtypes.Receipt{
+					Status:  gethtypes.ReceiptStatusSuccessful,
+					GasUsed: 21000,
+				},
+				BlockNumber: 89,
+			}, nil
+		},
+	})
+
+	account.updateOutgoingTransactions(100)
+	require.Equal(t, 1, receiptCalls)
+	txs := outgoingTxs(t, account)
+	require.Len(t, txs, 1)
+	require.Equal(t, uint64(100), txs[0].LastReceiptCheckHeight)
 }
 
 func TestUpdateOutgoingTransactionsPollsRecentConfirmedTransactions(t *testing.T) {

--- a/backend/coins/eth/types/types.go
+++ b/backend/coins/eth/types/types.go
@@ -30,6 +30,8 @@ type TransactionWithMetadata struct {
 	// Only applies if Height > 0.
 	// false if contract execution failed, otherwise true.
 	Success bool
+	// Tip height at which the receipt was last checked successfully.
+	LastReceiptCheckHeight uint64
 	// Number of broadcast attempts.
 	BroadcastAttempts uint16
 }
@@ -66,22 +68,24 @@ func (txh *TransactionWithMetadata) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(map[string]interface{}{
-		"tx":                txSerialized,
-		"height":            txh.Height,
-		"gasUsed":           hexutil.Uint64(txh.GasUsed),
-		"success":           txh.Success,
-		"broadcastAttempts": txh.BroadcastAttempts,
+		"tx":                     txSerialized,
+		"height":                 txh.Height,
+		"gasUsed":                hexutil.Uint64(txh.GasUsed),
+		"success":                txh.Success,
+		"lastReceiptCheckHeight": txh.LastReceiptCheckHeight,
+		"broadcastAttempts":      txh.BroadcastAttempts,
 	})
 }
 
 // UnmarshalJSON implements json.Unmarshaler. Used for DB serialization.
 func (txh *TransactionWithMetadata) UnmarshalJSON(input []byte) error {
 	m := struct {
-		TransactionRLP    []byte         `json:"tx"`
-		Height            uint64         `json:"height"`
-		GasUsed           hexutil.Uint64 `json:"gasUsed"`
-		Success           bool           `json:"success"`
-		BroadcastAttempts uint16         `json:"broadcastAttempts"`
+		TransactionRLP         []byte         `json:"tx"`
+		Height                 uint64         `json:"height"`
+		GasUsed                hexutil.Uint64 `json:"gasUsed"`
+		Success                bool           `json:"success"`
+		LastReceiptCheckHeight uint64         `json:"lastReceiptCheckHeight"`
+		BroadcastAttempts      uint16         `json:"broadcastAttempts"`
 	}{}
 	if err := json.Unmarshal(input, &m); err != nil {
 		return err
@@ -93,6 +97,7 @@ func (txh *TransactionWithMetadata) UnmarshalJSON(input []byte) error {
 	txh.Height = m.Height
 	txh.GasUsed = uint64(m.GasUsed)
 	txh.Success = m.Success
+	txh.LastReceiptCheckHeight = m.LastReceiptCheckHeight
 	txh.BroadcastAttempts = m.BroadcastAttempts
 	return nil
 }


### PR DESCRIPTION
Track the tip height of the last successful outgoing transaction receipt lookup so polling is only skipped after a receipt was checked at the finality threshold.

This preserves the reorg and rebroadcast window when the account update interval jumps from a recent confirmation directly past 12 confirmations.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
