### PR TITLE
lightning: refactor lightning payments and add conversions

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -338,6 +338,12 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	backend.ratesUpdater.Observe(func(event observable.Event) {
 		backend.Notify(event)
 		backend.notifyCoinFiatPrices()
+		if backend.lightning != nil && backend.lightning.Account() != nil {
+			backend.Notify(observable.Event{
+				Subject: "lightning/list-payments",
+				Action:  action.Reload,
+			})
+		}
 	})
 
 	backend.banners = banners.NewBanners(backend.DevServers())
@@ -354,6 +360,13 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 		btcCoin)
 
 	backend.lightning.Observe(backend.Notify)
+	backend.lightning.Observe(func(event observable.Event) {
+		if event.Subject != "lightning/account" {
+			return
+		}
+		defer backend.accountsAndKeystoreLock.Lock()()
+		backend.configureHistoryExchangeRates()
+	})
 
 	backend.bluetooth = bluetooth.New(log)
 	backend.bluetooth.Observe(backend.Notify)
@@ -369,6 +382,9 @@ func (backend *Backend) configureHistoryExchangeRates() {
 	var coins []string
 	for _, acct := range backend.accounts {
 		coins = append(coins, string(acct.Coin().Code()))
+	}
+	if backend.lightning != nil && backend.lightning.Account() != nil {
+		coins = append(coins, string(coinpkg.CodeBTC))
 	}
 	fiats := backend.config.AppConfig().Backend.FiatList
 	backend.ratesUpdater.ReconfigureHistory(coins, fiats)

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -5,8 +5,10 @@ package lightning
 import (
 	"math/big"
 	"strconv"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 )
@@ -25,16 +27,16 @@ type parsePaymentInputResponse struct {
 }
 
 type lightningPayment struct {
-	ID              string            `json:"id"`
-	Type            accounts.TxType   `json:"type"`
-	Status          accounts.TxStatus `json:"status"`
-	AmountSat       uint64            `json:"amountSat"`
-	FeesSat         uint64            `json:"feesSat"`
-	Timestamp       uint64            `json:"timestamp"`
-	Description     string            `json:"description,omitempty"`
-	PaymentHash     string            `json:"paymentHash,omitempty"`
-	PaymentPreimage string            `json:"paymentPreimage,omitempty"`
-	Invoice         string            `json:"invoice,omitempty"`
+	ID                   string                              `json:"id"`
+	Type                 accounts.TxType                     `json:"type"`
+	Status               accounts.TxStatus                   `json:"status"`
+	Time                 *string                             `json:"time"`
+	Description          string                              `json:"description,omitempty"`
+	Amount               coin.FormattedAmountWithConversions `json:"amount"`
+	AmountAtTime         coin.FormattedAmountWithConversions `json:"amountAtTime"`
+	DeductedAmountAtTime coin.FormattedAmountWithConversions `json:"deductedAmountAtTime"`
+	Fee                  coin.FormattedAmountWithConversions `json:"fee"`
+	Invoice              string                              `json:"invoice,omitempty"`
 }
 
 type receivePaymentResponse struct {
@@ -149,14 +151,33 @@ func toLightningPaymentStatus(status breez_sdk_spark.PaymentStatus) accounts.TxS
 	}
 }
 
-func toLightningPayment(payment breez_sdk_spark.Payment) lightningPayment {
+func (lightning *Lightning) toLightningPayment(payment breez_sdk_spark.Payment) lightningPayment {
+	paymentType := toLightningPaymentType(payment.PaymentType)
+	amount := coin.NewAmountFromInt64(int64(parseLightningUint(payment.Amount)))
+	fee := coin.NewAmountFromInt64(int64(parseLightningUint(payment.Fees)))
+	deductedAmount := coin.NewAmountFromInt64(0)
+	if paymentType == accounts.TxTypeSend {
+		deductedAmount = coin.SumAmounts(amount, fee)
+	}
+
+	var timestamp *time.Time
+	var formattedTime *string
+	if payment.Timestamp > 0 {
+		t := time.Unix(int64(payment.Timestamp), 0).UTC()
+		timestamp = &t
+		formatted := t.Format(time.RFC3339)
+		formattedTime = &formatted
+	}
+
 	result := lightningPayment{
-		ID:        payment.Id,
-		Type:      toLightningPaymentType(payment.PaymentType),
-		Status:    toLightningPaymentStatus(payment.Status),
-		AmountSat: parseLightningUint(payment.Amount),
-		FeesSat:   parseLightningUint(payment.Fees),
-		Timestamp: payment.Timestamp,
+		ID:                   payment.Id,
+		Type:                 paymentType,
+		Status:               toLightningPaymentStatus(payment.Status),
+		Time:                 formattedTime,
+		Amount:               amount.FormatWithConversions(lightning.btcCoin, false, lightning.ratesUpdater),
+		AmountAtTime:         amount.FormatWithConversionsAtTime(lightning.btcCoin, timestamp, lightning.ratesUpdater),
+		DeductedAmountAtTime: deductedAmount.FormatWithConversionsAtTime(lightning.btcCoin, timestamp, lightning.ratesUpdater),
+		Fee:                  fee.FormatWithConversions(lightning.btcCoin, true, lightning.ratesUpdater),
 	}
 
 	if payment.Details == nil {
@@ -169,22 +190,12 @@ func toLightningPayment(payment breez_sdk_spark.Payment) lightningPayment {
 			result.Description = *details.Description
 		}
 		result.Invoice = details.Invoice
-		result.PaymentHash = details.HtlcDetails.PaymentHash
-		if details.HtlcDetails.Preimage != nil {
-			result.PaymentPreimage = *details.HtlcDetails.Preimage
-		}
 	case breez_sdk_spark.PaymentDetailsSpark:
 		if details.InvoiceDetails != nil {
 			if details.InvoiceDetails.Description != nil {
 				result.Description = *details.InvoiceDetails.Description
 			}
 			result.Invoice = details.InvoiceDetails.Invoice
-		}
-		if details.HtlcDetails != nil {
-			result.PaymentHash = details.HtlcDetails.PaymentHash
-			if details.HtlcDetails.Preimage != nil {
-				result.PaymentPreimage = *details.HtlcDetails.Preimage
-			}
 		}
 	}
 
@@ -349,7 +360,7 @@ func (lightning *Lightning) ListPayments() ([]lightningPayment, error) {
 
 	payments := make([]lightningPayment, 0, len(response.Payments))
 	for _, payment := range response.Payments {
-		payments = append(payments, toLightningPayment(payment))
+		payments = append(payments, lightning.toLightningPayment(payment))
 	}
 	return payments, nil
 }

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -7,26 +7,45 @@ import (
 	"testing"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
+	btccoin "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/socksproxy"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/stretchr/testify/require"
 )
 
+func makeTestLightning() *Lightning {
+	return &Lightning{
+		btcCoin: btccoin.NewCoin(
+			coin.CodeBTC,
+			"Bitcoin",
+			"BTC",
+			coin.BtcUnitDefault,
+			&chaincfg.MainNetParams,
+			".",
+			[]*config.ServerInfo{},
+			"",
+			socksproxy.NewSocksProxy(false, ""),
+		),
+		ratesUpdater: rates.NewRateUpdater(nil, "/dev/null"),
+	}
+}
+
 func TestToLightningPayment(t *testing.T) {
+	lightning := makeTestLightning()
 	description := "invoice description"
-	preimage := "preimage"
 	details := breez_sdk_spark.PaymentDetailsLightning{
 		Description:       &description,
 		Invoice:           "lnbc1invoice",
 		DestinationPubkey: "destination",
-		HtlcDetails: breez_sdk_spark.SparkHtlcDetails{
-			PaymentHash: "hash",
-			Preimage:    &preimage,
-		},
 	}
 	var paymentDetails breez_sdk_spark.PaymentDetails = details
 
-	payment := toLightningPayment(breez_sdk_spark.Payment{
+	payment := lightning.toLightningPayment(breez_sdk_spark.Payment{
 		Id:          "payment-id",
 		PaymentType: breez_sdk_spark.PaymentTypeReceive,
 		Status:      breez_sdk_spark.PaymentStatusCompleted,
@@ -37,17 +56,116 @@ func TestToLightningPayment(t *testing.T) {
 	})
 
 	require.Equal(t, lightningPayment{
-		ID:              "payment-id",
-		Type:            accounts.TxTypeReceive,
-		Status:          accounts.TxStatusComplete,
-		AmountSat:       123,
-		FeesSat:         4,
-		Timestamp:       42,
-		Description:     "invoice description",
-		PaymentHash:     "hash",
-		PaymentPreimage: "preimage",
-		Invoice:         "lnbc1invoice",
+		ID:          "payment-id",
+		Type:        accounts.TxTypeReceive,
+		Status:      accounts.TxStatusComplete,
+		Time:        stringPointer("1970-01-01T00:00:42Z"),
+		Description: "invoice description",
+		Amount: coinAmountWithConversions(
+			"0.00000123",
+		),
+		AmountAtTime: coinAmountWithConversions(
+			"0.00000123",
+		),
+		DeductedAmountAtTime: coinAmountWithConversions(
+			"0.00000000",
+		),
+		Fee: coinAmountWithConversions(
+			"0.00000004",
+		),
+		Invoice: "lnbc1invoice",
 	}, payment)
+}
+
+func TestToLightningPaymentSparkInvoiceDetails(t *testing.T) {
+	lightning := makeTestLightning()
+	description := "spark description"
+	details := breez_sdk_spark.PaymentDetailsSpark{
+		InvoiceDetails: &breez_sdk_spark.SparkInvoicePaymentDetails{
+			Invoice:     "lnsb1invoice",
+			Description: &description,
+		},
+	}
+	var paymentDetails breez_sdk_spark.PaymentDetails = details
+
+	payment := lightning.toLightningPayment(breez_sdk_spark.Payment{
+		Id:          "spark-payment-id",
+		PaymentType: breez_sdk_spark.PaymentTypeReceive,
+		Status:      breez_sdk_spark.PaymentStatusCompleted,
+		Amount:      big.NewInt(123),
+		Fees:        big.NewInt(4),
+		Timestamp:   42,
+		Details:     &paymentDetails,
+	})
+
+	require.Equal(t, lightningPayment{
+		ID:          "spark-payment-id",
+		Type:        accounts.TxTypeReceive,
+		Status:      accounts.TxStatusComplete,
+		Time:        stringPointer("1970-01-01T00:00:42Z"),
+		Description: "spark description",
+		Amount: coinAmountWithConversions(
+			"0.00000123",
+		),
+		AmountAtTime: coinAmountWithConversions(
+			"0.00000123",
+		),
+		DeductedAmountAtTime: coinAmountWithConversions(
+			"0.00000000",
+		),
+		Fee: coinAmountWithConversions(
+			"0.00000004",
+		),
+		Invoice: "lnsb1invoice",
+	}, payment)
+}
+
+func TestToLightningPaymentSparkNilInvoiceDetails(t *testing.T) {
+	lightning := makeTestLightning()
+	details := breez_sdk_spark.PaymentDetailsSpark{}
+	var paymentDetails breez_sdk_spark.PaymentDetails = details
+
+	require.NotPanics(t, func() {
+		payment := lightning.toLightningPayment(breez_sdk_spark.Payment{
+			Id:          "spark-nil-invoice-details",
+			PaymentType: breez_sdk_spark.PaymentTypeReceive,
+			Status:      breez_sdk_spark.PaymentStatusCompleted,
+			Amount:      big.NewInt(123),
+			Fees:        big.NewInt(4),
+			Timestamp:   42,
+			Details:     &paymentDetails,
+		})
+
+		require.Equal(t, "", payment.Invoice)
+		require.Equal(t, "", payment.Description)
+		require.Equal(t, "spark-nil-invoice-details", payment.ID)
+		require.Equal(t, accounts.TxTypeReceive, payment.Type)
+		require.Equal(t, accounts.TxStatusComplete, payment.Status)
+		require.Equal(t, stringPointer("1970-01-01T00:00:42Z"), payment.Time)
+		require.Equal(t, coinAmountWithConversions("0.00000123"), payment.Amount)
+		require.Equal(t, coinAmountWithConversions("0.00000004"), payment.Fee)
+	})
+}
+
+func TestToLightningPaymentSendWithMissingTimestamp(t *testing.T) {
+	lightning := makeTestLightning()
+
+	payment := lightning.toLightningPayment(breez_sdk_spark.Payment{
+		Id:          "send-id",
+		PaymentType: breez_sdk_spark.PaymentTypeSend,
+		Status:      breez_sdk_spark.PaymentStatusPending,
+		Amount:      big.NewInt(100),
+		Fees:        big.NewInt(5),
+	})
+
+	require.Nil(t, payment.Time)
+	require.Equal(t, accounts.TxTypeSend, payment.Type)
+	require.Equal(t, accounts.TxStatusPending, payment.Status)
+	require.Equal(t, "0.00000100", payment.Amount.Amount)
+	require.Equal(t, "0.00000105", payment.DeductedAmountAtTime.Amount)
+	require.Equal(t, "0.00000005", payment.Fee.Amount)
+	require.True(t, payment.AmountAtTime.Estimated)
+	require.True(t, payment.DeductedAmountAtTime.Estimated)
 }
 
 func TestParseLightningUint(t *testing.T) {
@@ -151,4 +269,17 @@ func TestValidateApprovedLightningFee(t *testing.T) {
 	err := checkApprovedPaymentFee(10, 9)
 	require.Error(t, err)
 	require.Equal(t, errPaymentApprovalRequired, errp.Cause(err))
+}
+
+func coinAmountWithConversions(amount string) coin.FormattedAmountWithConversions {
+	return coin.FormattedAmountWithConversions{
+		Amount:      amount,
+		Unit:        "BTC",
+		Conversions: coin.ConversionsMap{},
+		Estimated:   false,
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
 }

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { apiGet, apiPost } from '../utils/request';
-import { AccountCode, TBalance, TTransactionStatus } from './account';
+import { AccountCode, TAmountWithConversions, TBalance, TTransactionStatus } from './account';
 import { TSubscriptionCallback, TUnsubscribe, subscribeEndpoint } from './subscribe';
 
 export type TLightningResponse<T> =
@@ -31,12 +31,12 @@ export type TLightningPayment = {
   id: string;
   type: 'send' | 'receive';
   status: TTransactionStatus;
-  amountSat: number;
-  feesSat: number;
-  timestamp: number;
+  time: string | null;
   description?: string;
-  paymentHash?: string;
-  paymentPreimage?: string;
+  amount: TAmountWithConversions;
+  amountAtTime: TAmountWithConversions;
+  deductedAmountAtTime: TAmountWithConversions;
+  fee: TAmountWithConversions;
   invoice?: string;
 };
 

--- a/frontends/web/src/routes/lightning/components/lightning-payment.tsx
+++ b/frontends/web/src/routes/lightning/components/lightning-payment.tsx
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import type { TLightningPayment } from '@/api/lightning';
+import { useMediaQuery } from '@/hooks/mediaquery';
+import { Loupe } from '@/components/icon/icon';
+import { parseTimeLong, parseTimeShort } from '@/utils/date';
+import { ProgressRing } from '@/components/progressRing/progressRing';
+import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import { ConversionAmount } from '@/components/amount/conversion-amount';
+import { Arrow } from '@/components/transactions/components/arrows';
+import { getTxSign } from '@/utils/transaction';
+import styles from '@/components/transactions/transaction.module.css';
+
+type TProps = TLightningPayment & {
+  onShowDetail: (id: TLightningPayment['id']) => void;
+};
+
+export const LightningPayment = ({
+  amountAtTime,
+  deductedAmountAtTime,
+  description,
+  id,
+  onShowDetail,
+  status,
+  time,
+  type,
+}: TProps) => {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+
+  return (
+    <section
+      className={styles.tx}
+      onClick={() => {
+        if (isMobile) {
+          onShowDetail(id);
+        }
+      }}>
+      <div className={styles.txContent} data-testid="transaction" data-tx-type={type}>
+        <span className={styles.txIcon}>
+          <Arrow status={status} type={type} />
+        </span>
+        <PaymentStatus
+          description={description}
+          status={status}
+          time={time}
+          type={type}
+        />
+        <PaymentAmounts
+          amount={amountAtTime}
+          deductedAmount={deductedAmountAtTime}
+          type={type}
+        />
+        <button
+          className={styles.txShowDetailBtn}
+          onClick={() => !isMobile && onShowDetail(id)}
+          type="button"
+          data-testid="tx-details-button">
+          <Loupe className={styles.iconLoupe} data-testid="tx-details" />
+        </button>
+      </div>
+    </section>
+  );
+};
+
+type TPaymentStatusProps = Pick<TLightningPayment, 'description' | 'status' | 'time' | 'type'>;
+
+const PaymentStatus = ({
+  description,
+  status,
+  time,
+  type,
+}: TPaymentStatusProps) => {
+  const showDate = status === 'complete' && !!time;
+
+  return (
+    <span className={styles.txInfoColumn}>
+      <span className={styles.txNote}>
+        <span className={description ? styles.txNoteText : styles.txType}>
+          {description || <FallbackLabel type={type} />}
+        </span>
+      </span>
+      {showDate ? (
+        <PaymentDate time={time} />
+      ) : status === 'pending' ? (
+        <PaymentProgress status={status} type={type} />
+      ) : (
+        <PaymentStatusText status={status} type={type} />
+      )}
+    </span>
+  );
+};
+
+type TPaymentProgressProps = Pick<TLightningPayment, 'status' | 'type'>;
+
+const PaymentProgress = ({ status, type }: TPaymentProgressProps) => {
+  const { t } = useTranslation();
+  const isComplete = status === 'complete';
+
+  return (
+    <span className={styles.txProgress}>
+      <span className={styles.txProgressTextLong}>
+        {t(`transaction.status.${status}`, { context: type })}
+      </span>
+      <span className={styles.txProgressTextShort}>
+        {t(`transaction.statusShort.${status}`, { context: type })}
+      </span>
+      <ProgressRing
+        className={styles.iconProgress}
+        width={18}
+        value={isComplete ? 100 : 50}
+        isComplete={isComplete}
+      />
+    </span>
+  );
+};
+
+const PaymentStatusText = ({ status, type }: TPaymentProgressProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <span className={styles.txDate}>
+      {t(`transaction.status.${status}`, { context: type })}
+    </span>
+  );
+};
+
+type TPaymentAmountsProps = {
+  amount: TLightningPayment['amountAtTime'];
+  deductedAmount: TLightningPayment['deductedAmountAtTime'];
+  type: TLightningPayment['type'];
+};
+
+const PaymentAmounts = ({
+  amount,
+  deductedAmount,
+  type,
+}: TPaymentAmountsProps) => {
+  const txTypeClass = `txAmount-${type}`;
+  const displayAmount = type === 'receive' ? amount : deductedAmount;
+
+  return (
+    <span
+      className={`
+        ${styles.txAmountsColumn || ''}
+        ${styles[txTypeClass] || ''}
+      `}
+      data-testid="tx-amounts">
+      <span className={styles.txAmount}>
+        {displayAmount.amount !== '0' && getTxSign(type)}
+        <AmountWithUnit
+          amount={displayAmount}
+          maxDecimals={9}
+          unitClassName={styles.txUnit}
+        />
+      </span>
+      <ConversionAmount amount={amount} deductedAmount={deductedAmount} type={type} />
+    </span>
+  );
+};
+
+type TPaymentDateProps = {
+  time: string;
+};
+
+const PaymentDate = ({ time }: TPaymentDateProps) => {
+  const { i18n } = useTranslation();
+
+  return (
+    <span className={styles.txDate}>
+      <span className={styles.txDateShort}>
+        {parseTimeShort(time, i18n.language)}
+      </span>
+      <span className={styles.txDateLong}>
+        {parseTimeLong(time, i18n.language)}
+      </span>
+    </span>
+  );
+};
+
+type TFallbackLabelProps = Pick<TLightningPayment, 'type'>;
+
+const FallbackLabel = ({ type }: TFallbackLabelProps) => {
+  const { t } = useTranslation();
+  return type === 'receive' ? t('generic.received') : t('generic.sent');
+};

--- a/frontends/web/src/routes/lightning/components/payment-details.tsx
+++ b/frontends/web/src/routes/lightning/components/payment-details.tsx
@@ -4,26 +4,27 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TLightningPayment } from '@/api/lightning';
 import { Dialog } from '@/components/dialog/dialog';
-import { getTxSign } from '@/utils/transaction';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { TxDetailRow } from '@/components/transactions/components/tx-detail-dialog/tx-detail-row';
-import { AddressOrTxId } from '@/components/transactions/components/tx-detail-dialog/address-or-tx-id';
+import { parseTimeLongWithYear } from '@/utils/date';
+import { getTxSign } from '@/utils/transaction';
 import styles from '@/components/transactions/components/tx-detail-dialog/tx-detail-dialog.module.css';
 
 type TTxDetailsDialog = {
   open: boolean;
   onClose: () => void;
   payment: TLightningPayment;
-  sign: string;
 };
 
 export const PaymentDetailsDialog = ({
   open,
   onClose,
   payment,
-  sign,
 }: TTxDetailsDialog) => {
-  const { t } = useTranslation();
+  const { i18n, t } = useTranslation();
+
+  const typeText = payment.type === 'receive' ? t('generic.received') : t('generic.sent');
+  const sign = payment.amount.amount === '0' ? '' : getTxSign(payment.type);
 
   return (
     <Dialog
@@ -35,55 +36,65 @@ export const PaymentDetailsDialog = ({
       {payment && (
         <div className={styles.container}>
           <TxDetailRow>
-            <p className={styles.label}>Memo</p>
+            <p className={styles.label}>{t('lightning.send.confirm.memo')}</p>
             <span>{payment.description || '-'}</span>
           </TxDetailRow>
           <TxDetailRow>
             <p className={styles.label}>{t('transaction.details.date')}</p>
-            <span>{payment.timestamp ? new Date(payment.timestamp * 1000).toString() : '-'}</span>
+            <span>{payment.time ? parseTimeLongWithYear(payment.time, i18n.language) : '-'}</span>
           </TxDetailRow>
           <TxDetailRow>
-            <p className={styles.label}>Amount</p>
-            <span>{payment.amountSat} sat</span>
-          </TxDetailRow>
-          <TxDetailRow>
-            <p className={styles.label}>{t('transaction.details.fiat')}</p>
+            <p className={styles.label}>{t('transaction.details.amount')}</p>
             <span>
               <AmountWithUnit
-                amount={{
-                  amount: `${payment.amountSat}`,
-                  unit: 'sat',
-                  estimated: false
-                }}
-                sign={sign}
+                amount={payment.amount}
+                unitClassName={styles.rowUnit}
+              />
+            </span>
+          </TxDetailRow>
+          {payment.type === 'send' && (
+            <TxDetailRow>
+              <p className={styles.label}>{t('transaction.fee')}</p>
+              <span>
+                <AmountWithUnit
+                  amount={payment.fee}
+                  unitClassName={styles.rowUnit}
+                />
+              </span>
+            </TxDetailRow>
+          )}
+          {!payment.amountAtTime.estimated && (
+            <TxDetailRow>
+              <p className={styles.label}>{t('transaction.details.historicalValue')}</p>
+              <span>
+                <AmountWithUnit
+                  amount={payment.amountAtTime}
+                  convertToFiat
+                  sign={sign}
+                  unitClassName={styles.rowUnit}
+                />
+              </span>
+            </TxDetailRow>
+          )}
+          <TxDetailRow>
+            <p className={styles.label}>{t('transaction.details.currentValue')}</p>
+            <span>
+              <AmountWithUnit
+                amount={payment.amount}
                 convertToFiat
+                sign={sign}
+                unitClassName={styles.rowUnit}
               />
             </span>
           </TxDetailRow>
           <TxDetailRow>
-            <p className={styles.label}>Fee</p>
-            <span>{payment.feesSat} sat</span>
+            <p className={styles.label}>{t('transaction.details.type')}</p>
+            <span>{typeText}</span>
           </TxDetailRow>
           <TxDetailRow>
-            <p className={styles.label}>Type</p>
-            <span>{payment.type}</span>
+            <p className={styles.label}>{t('transaction.details.status')}</p>
+            <span>{t(`transaction.status.${payment.status}`, { context: payment.type })}</span>
           </TxDetailRow>
-          <TxDetailRow>
-            <p className={styles.label}>Status</p>
-            <span>{payment.status}</span>
-          </TxDetailRow>
-          {payment.paymentPreimage && (
-            <TxDetailRow>
-              <p className={styles.label}>Preimage</p>
-              <AddressOrTxId values={[payment.paymentPreimage]} />
-            </TxDetailRow>
-          )}
-          {payment.paymentHash && (
-            <TxDetailRow>
-              <p className={styles.label}>Payment Hash</p>
-              <AddressOrTxId values={[payment.paymentHash]} />
-            </TxDetailRow>
-          )}
         </div>
       )}
     </Dialog>
@@ -121,7 +132,6 @@ export const PaymentDetails = ({
         onClose();
       }}
       payment={payment}
-      sign={getTxSign(payment.type)}
     />
   );
 };

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -22,8 +22,8 @@ import { unsubscribe } from '../../utils/subscriptions';
 import { GlobalBanners } from '@/components/banners';
 import { Status } from '../../components/status/status';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
-import { Transaction } from '@/components/transactions/transaction';
 import { PaymentDetails } from './components/payment-details';
+import { LightningPayment } from './components/lightning-payment';
 import styles from './lightning.module.css';
 import { RatesContext } from '@/contexts/RatesContext';
 import { useLoad } from '@/hooks/api';
@@ -35,7 +35,7 @@ export const Lightning = () => {
   const [syncedAddressesCount] = useState<number>();
   const [payments, setPayments] = useState<TLightningPayment[]>();
   const [error, setError] = useState<string>();
-  const [detailID, setDetailID] = useState<accountApi.TTransaction['internalID'] | null>(null);
+  const [detailID, setDetailID] = useState<TLightningPayment['id'] | null>(null);
   const devices = useLoad(getDeviceList);
   const boardingAddress = useLoad(getBoardingAddress);
 
@@ -119,55 +119,11 @@ export const Lightning = () => {
               ) : (
                 payments && payments.length > 0 ? (
                   payments
-                    .map(payment => ({ // TODO: giant hack start
-                      internalID: payment.id,
-                      addresses: [],
-                      amountAtTime: {
-                        amount: payment.amountSat.toString(),
-                        conversions: {}, // TODO: add conversions
-                        unit: 'sat' as accountApi.NativeCoinUnit,
-                        estimated: false
-                      },
-                      deductedAmountAtTime: {
-                        amount: payment.type === 'send' ? (payment.amountSat + payment.feesSat).toString() : '',
-                        conversions: {}, // TODO: add conversions
-                        unit: 'sat' as accountApi.NativeCoinUnit,
-                        estimated: false
-                      },
-                      amount: {
-                        amount: payment.amountSat.toString(),
-                        unit: 'sat' as accountApi.NativeCoinUnit,
-                        estimated: false
-                      },
-                      fee: {
-                        amount: payment.feesSat.toString(),
-                        unit: 'sat' as accountApi.NativeCoinUnit,
-                        estimated: false
-                      },
-                      feeRatePerKb: {
-                        amount: '',
-                        unit: 'sat' as accountApi.NativeCoinUnit,
-                        estimated: false
-                      },
-                      type: payment.type,
-                      txID: payment.id,
-                      note: payment.description || '',
-                      status: payment.status,
-                      time: payment.timestamp ? new Date(payment.timestamp * 1000).toString() : null, // TODO: remove hack?
-                      // most of these are not for lightning
-                      gas: 0,
-                      nonce: null,
-                      numConfirmationsComplete: payment.status === 'pending' ? 1 : 0,
-                      size: 0,
-                      numConfirmations: 0,
-                      vsize: 0,
-                      weight: 0
-                    })) // TODO: giant hack end
                     .map((payment) => (
-                      <Transaction
-                        key={payment.internalID}
-                        onShowDetail={(internalID: string) => {
-                          setDetailID(internalID);
+                      <LightningPayment
+                        key={payment.id}
+                        onShowDetail={(id: string) => {
+                          setDetailID(id);
                         }}
                         {...payment}
                       />


### PR DESCRIPTION
Lightning payments were just drafted in the frontend: the backend was providing a DTO object that wasn't matching the frontend representation and was lacking the amounts' fiat conversions. This fixes it by creating a dedicated lightning payment component in the frontend and adapting the data returned by the backend.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
