### PR TITLE
frontend: remove password change warning icon.

### DIFF
--- a/frontends/web/src/routes/settings/components/device-settings/change-password-setting.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/change-password-setting.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PointToBitBox02, WarningOLD } from '@/components/icon';
+import { PointToBitBox02 } from '@/components/icon';
 import { changeDevicePassword, errUserAbort } from '@/api/bitbox02';
 import { alertUser } from '@/components/alert/Alert';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
@@ -51,7 +51,6 @@ export const ChangeDevicePasswordSetting = ({ deviceID, canChangePassword }: TCh
       <SettingsItem
         settingName={t('bitbox02Settings.changePassword.title')}
         secondaryText={t('bitbox02Settings.changePassword.description')}
-        extraComponent={<WarningOLD width={20} height={20} />}
         displayedValue={t('bitbox02Wizard.advanced.outOfDate')}
       />
     );


### PR DESCRIPTION
Remove red warning triangle when displaying the "firmware required" message near the "change password" feature.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
