### PR TITLE
backend: add btc-only software test keystore

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -970,9 +970,17 @@ func (backend *Backend) CheckElectrumServer(serverInfo *config.ServerInfo) error
 
 // RegisterTestKeystore adds a keystore derived deterministically from a PIN, for convenience in
 // devmode.
-func (backend *Backend) RegisterTestKeystore(pin string) {
-	softwareBasedKeystore := software.NewKeystoreFromPIN(pin)
+func (backend *Backend) RegisterTestKeystore(pin string, edition software.Edition) error {
+	switch edition {
+	case "":
+		edition = software.EditionMulti
+	case software.EditionMulti, software.EditionBTCOnly:
+	default:
+		return errp.Newf("Unsupported test keystore edition: %s", edition)
+	}
+	softwareBasedKeystore := software.NewKeystoreFromPINWithEdition(pin, edition)
 	backend.registerKeystore(softwareBasedKeystore)
+	return nil
 }
 
 // NotifyUser creates a desktop notification.

--- a/backend/coins/coin/codes.go
+++ b/backend/coins/coin/codes.go
@@ -42,3 +42,13 @@ var TestnetCoins = map[Code]struct{}{
 	CodeSEPETH: {},
 	CodeRBTC:   {},
 }
+
+// IsBitcoinOnly returns true for Bitcoin mainnet, testnet, or regtest coin codes.
+func IsBitcoinOnly(code Code) bool {
+	switch code {
+	case CodeBTC, CodeTBTC, CodeRBTC:
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -37,6 +37,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/bluetooth"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/device"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore/software"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/market"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/market/swapkit"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
@@ -86,7 +87,7 @@ type Backend interface {
 	CoinFiatPrices(coinpkg.Coin) *coinpkg.FormattedAmountWithConversions
 	DownloadCert(string) (string, error)
 	CheckElectrumServer(*config.ServerInfo) error
-	RegisterTestKeystore(string)
+	RegisterTestKeystore(string, software.Edition) error
 	NotifyUser(string)
 	SystemOpen(string) error
 	ReinitializeAccounts()
@@ -990,12 +991,15 @@ func (handlers *Handlers) postRegisterTestKeystore(r *http.Request) (interface{}
 		return nil, errp.New("Test keystore not available")
 	}
 	var jsonBody struct {
-		PIN string `json:"pin"`
+		PIN     string           `json:"pin"`
+		Edition software.Edition `json:"edition"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&jsonBody); err != nil {
 		return nil, errp.WithStack(err)
 	}
-	handlers.backend.RegisterTestKeystore(jsonBody.PIN)
+	if err := handlers.backend.RegisterTestKeystore(jsonBody.PIN, jsonBody.Edition); err != nil {
+		return nil, err
+	}
 	return nil, nil
 }
 

--- a/backend/keystore/software/software.go
+++ b/backend/keystore/software/software.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/types"
-	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth"
 	keystorePkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/keystore"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
@@ -40,30 +40,53 @@ type Keystore struct {
 	// The master extended private key from which all keys are derived.
 	master     *hdkeychain.ExtendedKey
 	identifier string
+	edition    Edition
 	log        *logrus.Entry
 }
+
+// Edition models the coin set supported by the software keystore.
+type Edition string
+
+const (
+	// EditionMulti supports all coins that the software keystore can sign for.
+	EditionMulti Edition = "multi"
+	// EditionBTCOnly only supports Bitcoin accounts.
+	EditionBTCOnly Edition = "btc-only"
+)
 
 // NewKeystore creates a new keystore with the given configuration, index and key.
 func NewKeystore(
 	master *hdkeychain.ExtendedKey,
 ) *Keystore {
+	return NewKeystoreWithEdition(master, EditionMulti)
+}
+
+// NewKeystoreWithEdition creates a new keystore with the given edition.
+func NewKeystoreWithEdition(
+	master *hdkeychain.ExtendedKey,
+	edition Edition,
+) *Keystore {
+	if edition == "" {
+		edition = EditionMulti
+	}
 	publicKey, _ := master.ECPubKey()
 	hash := sha256.Sum256(publicKey.SerializeCompressed())
 	return &Keystore{
 		master:     master,
 		identifier: hex.EncodeToString(hash[:]),
+		edition:    edition,
 		log:        logging.Get().WithGroup("software"),
 	}
 }
 
-// NewKeystoreFromPIN creates a new unique keystore derived from the PIN.
-func NewKeystoreFromPIN(pin string) *Keystore {
+// NewKeystoreFromPINWithEdition creates a new unique keystore derived from the PIN.
+func NewKeystoreFromPINWithEdition(pin string, edition Edition) *Keystore {
 	seed := pbkdf2.Key([]byte(pin), []byte("BitBox"), 64, hdkeychain.RecommendedSeedLen, sha256.New)
 	master, err := hdkeychain.NewMaster(seed, &chaincfg.TestNet3Params)
 	if err != nil {
 		panic(errp.WithStack(err))
 	}
-	return NewKeystore(master)
+	return NewKeystoreWithEdition(master, edition)
 }
 
 // Type implements keystore.Keystore.
@@ -103,7 +126,10 @@ func (keystore *Keystore) Configuration() *signing.Configuration {
 }
 
 // SupportsCoin implements keystore.Keystore.
-func (keystore *Keystore) SupportsCoin(coin coin.Coin) bool {
+func (keystore *Keystore) SupportsCoin(coin coinpkg.Coin) bool {
+	if keystore.edition == EditionBTCOnly && (coin == nil || !coinpkg.IsBitcoinOnly(coin.Code())) {
+		return false
+	}
 	switch coin.(type) {
 	case *btc.Coin, *eth.Coin:
 		return true
@@ -113,7 +139,7 @@ func (keystore *Keystore) SupportsCoin(coin coin.Coin) bool {
 }
 
 // SupportsAccount implements keystore.Keystore.
-func (keystore *Keystore) SupportsAccount(coin coin.Coin, meta interface{}) bool {
+func (keystore *Keystore) SupportsAccount(coin coinpkg.Coin, meta interface{}) bool {
 	if !keystore.SupportsCoin(coin) {
 		return false
 	}
@@ -142,17 +168,17 @@ func (keystore *Keystore) Identifier() (string, error) {
 }
 
 // CanVerifyAddress implements keystore.Keystore.
-func (keystore *Keystore) CanVerifyAddress(coin.Coin) (bool, bool, error) {
+func (keystore *Keystore) CanVerifyAddress(coinpkg.Coin) (bool, bool, error) {
 	return false, false, nil
 }
 
 // VerifyAddressBTC implements keystore.Keystore.
-func (keystore *Keystore) VerifyAddressBTC(*signing.Configuration, types.Derivation, coin.Coin) error {
+func (keystore *Keystore) VerifyAddressBTC(*signing.Configuration, types.Derivation, coinpkg.Coin) error {
 	return errp.New("The software-based keystore has no secure output to display the address.")
 }
 
 // VerifyAddressETH implements keystore.Keystore.
-func (keystore *Keystore) VerifyAddressETH(*signing.Configuration, coin.Coin) error {
+func (keystore *Keystore) VerifyAddressETH(*signing.Configuration, coinpkg.Coin) error {
 	return errp.New("The software-based keystore has no secure output to display the address.")
 }
 
@@ -162,13 +188,13 @@ func (keystore *Keystore) CanVerifyExtendedPublicKey() bool {
 }
 
 // VerifyExtendedPublicKey implements keystore.Keystore.
-func (keystore *Keystore) VerifyExtendedPublicKey(coin coin.Coin, configuration *signing.Configuration) error {
+func (keystore *Keystore) VerifyExtendedPublicKey(coin coinpkg.Coin, configuration *signing.Configuration) error {
 	return errp.New("The software-based keystore has no secure output to display the public key.")
 }
 
 // ExtendedPublicKey implements keystore.Keystore.
 func (keystore *Keystore) ExtendedPublicKey(
-	coin coin.Coin, absoluteKeypath signing.AbsoluteKeypath,
+	coin coinpkg.Coin, absoluteKeypath signing.AbsoluteKeypath,
 ) (*hdkeychain.ExtendedKey, error) {
 	extendedPrivateKey, err := absoluteKeypath.Derive(keystore.master)
 	if err != nil {
@@ -179,7 +205,7 @@ func (keystore *Keystore) ExtendedPublicKey(
 
 // BTCXPubs implements keystore.Keystore.
 func (keystore *Keystore) BTCXPubs(
-	coin coin.Coin, keypaths []signing.AbsoluteKeypath) ([]*hdkeychain.ExtendedKey, error) {
+	coin coinpkg.Coin, keypaths []signing.AbsoluteKeypath) ([]*hdkeychain.ExtendedKey, error) {
 	xpubs := make([]*hdkeychain.ExtendedKey, len(keypaths))
 	for i, keypath := range keypaths {
 		xpub, err := keystore.ExtendedPublicKey(coin, keypath)
@@ -292,8 +318,15 @@ func (keystore *Keystore) SignTransaction(
 ) error {
 	switch specificProposedTx := proposedTransaction.(type) {
 	case *btc.ProposedTransaction:
+		if keystore.edition == EditionBTCOnly &&
+			!coinpkg.IsBitcoinOnly(specificProposedTx.TXProposal.Coin.Code()) {
+			return errp.Newf("coin not supported: %s", specificProposedTx.TXProposal.Coin.Code())
+		}
 		return keystore.signBTCTransaction(specificProposedTx)
 	case *eth.TxProposal:
+		if keystore.edition == EditionBTCOnly {
+			return errp.Newf("coin not supported: %s", specificProposedTx.Coin.Code())
+		}
 		return keystore.signETHTransaction(specificProposedTx)
 	default:
 		panic("unknown proposal type")
@@ -301,12 +334,12 @@ func (keystore *Keystore) SignTransaction(
 }
 
 // CanSignMessage implements keystore.Keystore.
-func (keystore *Keystore) CanSignMessage(code coin.Code) bool {
-	return code == coin.CodeBTC ||
-		code == coin.CodeTBTC ||
-		code == coin.CodeRBTC ||
-		code == coin.CodeETH ||
-		code == coin.CodeSEPETH
+func (keystore *Keystore) CanSignMessage(code coinpkg.Code) bool {
+	if coinpkg.IsBitcoinOnly(code) {
+		return true
+	}
+	return keystore.edition == EditionMulti &&
+		(code == coinpkg.CodeETH || code == coinpkg.CodeSEPETH)
 }
 
 func btcMessageHash(message []byte) ([]byte, error) {
@@ -321,11 +354,11 @@ func btcMessageHash(message []byte) ([]byte, error) {
 }
 
 // SignBTCMessage implements keystore.Keystore.
-func (keystore *Keystore) SignBTCMessage(message []byte, keypath signing.AbsoluteKeypath, scriptType signing.ScriptType, coinCode coin.Code) ([]byte, error) {
+func (keystore *Keystore) SignBTCMessage(message []byte, keypath signing.AbsoluteKeypath, scriptType signing.ScriptType, coinCode coinpkg.Code) ([]byte, error) {
 	if scriptType == signing.ScriptTypeP2TR {
 		return nil, errp.New("taproot not supported")
 	}
-	if coinCode != coin.CodeBTC && coinCode != coin.CodeTBTC && coinCode != coin.CodeRBTC {
+	if !coinpkg.IsBitcoinOnly(coinCode) {
 		return nil, errp.Newf("coin not supported: %s", coinCode)
 	}
 	xprv, err := keypath.Derive(keystore.master)
@@ -346,6 +379,9 @@ func (keystore *Keystore) SignBTCMessage(message []byte, keypath signing.Absolut
 // SignETHMessage implements keystore.Keystore.
 func (keystore *Keystore) SignETHMessage(chainID uint64, message []byte, keypath signing.AbsoluteKeypath) ([]byte, error) {
 	_ = chainID
+	if keystore.edition == EditionBTCOnly {
+		return nil, errp.New("coin not supported: eth")
+	}
 	xprv, err := keypath.Derive(keystore.master)
 	if err != nil {
 		return nil, err

--- a/backend/keystore/software/software_test.go
+++ b/backend/keystore/software/software_test.go
@@ -5,22 +5,35 @@ package software
 import (
 	"testing"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/maketx"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/eth"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/socksproxy"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
-func makeKeystore(t *testing.T) *Keystore {
+func makeRootXprv(t *testing.T) *hdkeychain.ExtendedKey {
 	t.Helper()
 	// Xprv derived from BIP39 mnemonic (no passphrase):
 	// awkward squirrel wait rubber biology escape toe daring still pause fitness vendor
 	rootXprv, err := hdkeychain.NewKeyFromString("xprv9s21ZrQH143K3uDh9hiNXB3a9GVzcCujEmCwmZA9g8m4i5nUDVdLHJjsLMPzV26vj8Q7ceGrUhX119Y3XzGhJqq5K6LWP1h6gjv2cbkMEH1")
 	require.NoError(t, err)
+	return rootXprv
+}
+
+func makeKeystore(t *testing.T) *Keystore {
+	t.Helper()
+	rootXprv := makeRootXprv(t)
 	return NewKeystore(rootXprv)
 }
 
@@ -41,6 +54,32 @@ func TestCanSignMessage(t *testing.T) {
 	require.True(t, keystore.CanSignMessage(coin.CodeETH))
 	require.True(t, keystore.CanSignMessage(coin.CodeSEPETH))
 	require.False(t, keystore.CanSignMessage(coin.CodeLTC))
+}
+
+func TestEditionSupport(t *testing.T) {
+	btcCoin := btc.NewCoin(coin.CodeTBTC, "Bitcoin Testnet", "TBTC", coin.BtcUnitDefault, &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "", socksproxy.NewSocksProxy(false, ""))
+	ltcCoin := btc.NewCoin(coin.CodeTLTC, "Litecoin Testnet", "TLTC", coin.BtcUnitDefault, &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "", socksproxy.NewSocksProxy(false, ""))
+	ethCoin := eth.NewCoin(nil, coin.CodeSEPETH, "Sepolia", "ETH", "ETH", params.SepoliaChainConfig, "", nil, nil)
+
+	multi := NewKeystoreWithEdition(makeRootXprv(t), EditionMulti)
+	require.True(t, multi.SupportsCoin(btcCoin))
+	require.True(t, multi.SupportsCoin(ltcCoin))
+	require.True(t, multi.SupportsCoin(ethCoin))
+	require.True(t, multi.CanSignMessage(coin.CodeSEPETH))
+
+	btcOnly := NewKeystoreWithEdition(makeRootXprv(t), EditionBTCOnly)
+	require.True(t, btcOnly.SupportsCoin(btcCoin))
+	require.True(t, btcOnly.SupportsAccount(btcCoin, signing.ScriptTypeP2WPKH))
+	require.False(t, btcOnly.SupportsCoin(ltcCoin))
+	require.False(t, btcOnly.SupportsCoin(ethCoin))
+	require.False(t, btcOnly.SupportsAccount(ethCoin, nil))
+	require.True(t, btcOnly.CanSignMessage(coin.CodeTBTC))
+	require.False(t, btcOnly.CanSignMessage(coin.CodeSEPETH))
+
+	keypath, err := signing.NewAbsoluteKeypath("m/44'/60'/0'/0/0")
+	require.NoError(t, err)
+	_, err = btcOnly.SignETHMessage(11155111, []byte("hello eth"), keypath)
+	require.EqualError(t, err, "coin not supported: eth")
 }
 
 func TestSignBTCMessage(t *testing.T) {
@@ -74,6 +113,19 @@ func TestSignBTCMessageUnsupported(t *testing.T) {
 
 	_, err = keystore.SignBTCMessage([]byte("hello"), keypath, signing.ScriptTypeP2WPKH, coin.CodeLTC)
 	require.EqualError(t, err, "coin not supported: ltc")
+}
+
+func TestSignTransactionBTCOnlyRejectsLitecoin(t *testing.T) {
+	keystore := NewKeystoreWithEdition(makeRootXprv(t), EditionBTCOnly)
+	ltcCoin := btc.NewCoin(coin.CodeTLTC, "Litecoin Testnet", "TLTC", coin.BtcUnitDefault, &chaincfg.TestNet3Params, ".", []*config.ServerInfo{}, "", socksproxy.NewSocksProxy(false, ""))
+
+	err := keystore.SignTransaction(&btc.ProposedTransaction{
+		TXProposal: &maketx.TxProposal{
+			Coin: ltcCoin,
+		},
+	})
+
+	require.EqualError(t, err, "coin not supported: tltc")
 }
 
 func TestSignETHMessage(t *testing.T) {

--- a/frontends/web/src/api/keystores.ts
+++ b/frontends/web/src/api/keystores.ts
@@ -28,8 +28,10 @@ export const getKeystores = (): Promise<TKeystores> => {
   return apiGet('keystores');
 };
 
-export const registerTest = (pin: string): Promise<null> => {
-  return apiPost('test/register', { pin });
+export type TTestKeystoreEdition = 'btc-only' | 'multi';
+
+export const registerTest = (pin: string, edition: TTestKeystoreEdition): Promise<null> => {
+  return apiPost('test/register', { pin, edition });
 };
 
 export const deregisterTest = (): Promise<null> => {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1013,6 +1013,7 @@
     "title": "Custom gap limit settings"
   },
   "generic": {
+    "bitcoinOnly": "Bitcoin-only",
     "buy": "Buy {{coinCode}}",
     "buySell": "Marketplace",
     "buy_bitcoin": "Buy Bitcoin",

--- a/frontends/web/src/routes/device/components/skipfortesting.tsx
+++ b/frontends/web/src/routes/device/components/skipfortesting.tsx
@@ -3,8 +3,8 @@
 import React, { ReactNode, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppContext } from '@/contexts/AppContext';
-import { registerTest } from '@/api/keystores';
-import { Button } from '@/components/forms';
+import { registerTest, type TTestKeystoreEdition } from '@/api/keystores';
+import { Button, Checkbox } from '@/components/forms';
 import { PasswordSingleInput } from '@/components/password';
 import { Dialog, DialogButtons } from '@/components/dialog/dialog';
 
@@ -21,9 +21,11 @@ export const SkipForTesting = ({
   const { isTesting } = useContext(AppContext);
   const [dialog, setDialog] = useState(false);
   const [testPIN, setTestPIN] = useState('');
+  const [btcOnly, setBTCOnly] = useState(false);
   const registerTestingDevice = async (e: React.SyntheticEvent) => {
     e.preventDefault();
-    await registerTest(testPIN);
+    const edition: TTestKeystoreEdition = btcOnly ? 'btc-only' : 'multi';
+    await registerTest(testPIN, edition);
     setDialog(false);
   };
 
@@ -48,6 +50,12 @@ export const SkipForTesting = ({
             autoFocus
             label={t('testWallet.prompt.passwordLabel')}
             onValidPassword={(pw) => setTestPIN(pw ? pw : '')}/>
+          <Checkbox
+            id="test-wallet-btc-only"
+            checked={btcOnly}
+            onChange={e => setBTCOnly((e.target as HTMLInputElement).checked)}
+            label={t('generic.bitcoinOnly')}
+          />
           <DialogButtons>
             <Button primary type="submit">
               {t('testWallet.prompt.button')}


### PR DESCRIPTION
Allow the software test keystore to be started as either Multi or BTC-only.

The test wallet unlock dialog now exposes a BTC-only checkbox and sends the selected edition to the backend. The software keystore defaults to Multi for existing callers, while BTC-only mode only supports BTC/TBTC/RBTC and rejects ETH signing paths.

This is useful for testing BTC-only features without having to on on mainnet or starting regtest.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
