### PR TITLE
backend: encode empty balances as array

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -310,7 +310,7 @@ type coinFormattedAmount struct {
 
 // getCoinsTotalBalance returns the total balances grouped by coins.
 func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
-	var coinFormattedAmounts []coinFormattedAmount
+	coinFormattedAmounts := []coinFormattedAmount{}
 	var sortedCoins []coinpkg.Code
 	totalCoinsBalances := make(map[coinpkg.Code]*big.Int)
 


### PR DESCRIPTION
Unplugging a BitBox can briefly leave the frontend with the previous account list while /accounts/balance-summary is computed after account teardown.

A nil Go slice encoded coinsTotalBalance as null, but the frontend treats it as an array and dereferences .length, blanking the screen.

Initialize the slice so the JSON response is [] during that empty-account race window.

