### PR TITLE
frontend: settings search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Bitcoin: show account details for the persisted receive address type by default
 - Add external block explorer links to used addresses
+- Settings search
 
 ## v4.51.1
 - iOS: fix App Store submission by packaging Inter as TTF fonts

--- a/frontends/web/src/components/forms/search-input.module.css
+++ b/frontends/web/src/components/forms/search-input.module.css
@@ -6,3 +6,23 @@
   pointer-events: none;
   width: 20px;
 }
+
+.clearButton {
+  align-items: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex: none;
+  height: 24px;
+  justify-content: center;
+  margin: auto 0;
+  padding: 0;
+  width: 24px;
+}
+
+.clearButton img,
+.clearButton svg {
+  height: 20px;
+  width: 20px;
+}

--- a/frontends/web/src/components/forms/search-input.tsx
+++ b/frontends/web/src/components/forms/search-input.tsx
@@ -1,13 +1,61 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { forwardRef } from 'react';
-import { Loupe } from '@/components/icon';
+import { useTranslation } from 'react-i18next';
+import { CloseXDark, CloseXWhite, Loupe } from '@/components/icon';
 import { Input } from './input';
 import type { TInputProps } from './input';
 import styles from './search-input.module.css';
 
-export const SearchInput = forwardRef<HTMLInputElement, TInputProps>((props, ref) => (
-  <Input ref={ref} type="text" {...props}>
-    <Loupe className={styles.searchIcon} />
-  </Input>
-));
+type TBaseProps = Omit<TInputProps, 'children' | 'type'>;
+
+type TClearProps = TBaseProps & {
+  onClear: () => void;
+  variant: 'clear';
+};
+
+type TSearchProps = TBaseProps & {
+  onClear?: never;
+  variant?: 'search';
+};
+
+type TProps = TClearProps | TSearchProps;
+
+export const SearchInput = forwardRef<HTMLInputElement, TProps>((props, ref) => {
+  const { t } = useTranslation();
+
+  if (props.variant === 'clear') {
+    const {
+      onClear,
+      variant: _variant,
+      ...inputProps
+    } = props;
+
+    return (
+      <Input ref={ref} type="text" {...inputProps}>
+        {String(inputProps.value ?? '').trim().length > 0 ? (
+          <button
+            aria-label={t('generic.close')}
+            className={styles.clearButton}
+            onClick={onClear}
+            type="button"
+          >
+            <CloseXDark className="show-in-lightmode" />
+            <CloseXWhite className="show-in-darkmode" />
+          </button>
+        ) : null}
+      </Input>
+    );
+  }
+
+  const {
+    variant: _variant,
+    ...inputProps
+  } = props;
+
+  return (
+    <Input ref={ref} type="text" {...inputProps}>
+      <Loupe className={styles.searchIcon} />
+    </Input>
+  );
+});

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -53,6 +53,7 @@
     "name": "Account name",
     "noAccount": "There are no accounts to show.",
     "portfolio": "Portfolio",
+    "searchPlaceholder": "Search transactions...",
     "title": "My portfolio",
     "total": "Total",
     "totalAssets": "Total assets",
@@ -1988,6 +1989,9 @@
       "title": "Manage notes"
     },
     "restart": "Please re-start the BitBoxApp for the changes to take effect.",
+    "search": {
+      "noResults": "No settings found"
+    },
     "services": {
       "title": "Services"
     },

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -313,7 +313,7 @@ const RemountAccount = ({
                     `}>
                       <SearchInput
                         ref={searchInputRef}
-                        placeholder="Search transactions..."
+                        placeholder={t('accountSummary.searchPlaceholder')}
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.currentTarget.value)}
                       />

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -87,6 +87,16 @@ export const AppRouter = ({ devices, devicesKey, accounts, activeAccounts }: TAp
     </InjectParams>
   );
 
+  const NoAccounts = (
+    <InjectParams>
+      <NoDeviceConnected
+        key="no-accounts"
+        devices={devices}
+        hasAccounts={hasAccounts}
+      />
+    </InjectParams>
+  );
+
   const Acc = (<InjectParams>
     <Account
       code={'' /* dummy to satisfy TS */}
@@ -324,7 +334,7 @@ export const AppRouter = ({ devices, devicesKey, accounts, activeAccounts }: TAp
           <Route path="about" element={AboutEl} />
           <Route path="device-settings/:deviceID" element={Device} />
           <Route path="no-device-connected" element={NoDevice} />
-          <Route path="no-accounts" element={NoDevice} />
+          <Route path="no-accounts" element={NoAccounts} />
           <Route path="device-settings/passphrase/:deviceID" element={PassphraseEl} />
           <Route path="device-settings/recovery-words/:deviceID" element={RecoveryWordsEl} />
           <Route path="device-settings/bip85/:deviceID" element={Bip85El} />

--- a/frontends/web/src/routes/settings/about.tsx
+++ b/frontends/web/src/routes/settings/about.tsx
@@ -13,6 +13,7 @@ import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
 import { FeedbackLink } from './components/about/feedback-link-setting';
 import { SupportLink } from './components/about/support-link-setting';
+import { SettingsContent, type TSettingsContentSection } from './components/settings-content';
 
 export const About = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
@@ -34,9 +35,7 @@ export const About = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
           <View fullscreen={false}>
             <ViewContent>
               <WithSettingsTabs devices={devices} hideMobileMenu hasAccounts={hasAccounts}>
-                <AppVersion />
-                <FeedbackLink />
-                <SupportLink />
+                <AboutSettingsContent />
               </WithSettingsTabs>
             </ViewContent>
           </View>
@@ -47,6 +46,20 @@ export const About = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
   );
 };
 
+export const AboutSettingsContent = () => {
+  const sections: TSettingsContentSection[] = [
+    {
+      id: 'about',
+      items: [
+        { id: 'app-version', content: <AppVersion /> },
+        { id: 'feedback', content: <FeedbackLink /> },
+        { id: 'support', content: <SupportLink /> },
+      ],
+    },
+  ];
+
+  return <SettingsContent sections={sections} />;
+};
 
 const AboutGuide = () => {
   const { t } = useTranslation();

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Main, Header, GuideWrapper, GuidedContent } from '@/components/layout';
 import { View, ViewContent } from '@/components/view/view';
@@ -19,12 +20,20 @@ import { Entry } from '@/components/guide/entry';
 import { EnableAuthSetting } from './components/advanced-settings/enable-auth-setting';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
+import { SettingsContent, type TSettingsContentSection } from './components/settings-content';
+import { AppContext } from '@/contexts/AppContext';
+import {
+  isExportLogsSettingVisible,
+  isScreenLockSettingVisible,
+  isTestWalletSettingVisible,
+} from './settings-availability';
+
+type TProps = {
+  devices: TPagePropsWithSettingsTabs['devices'];
+};
 
 export const AdvancedSettings = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
-
-  const deviceIDs = Object.keys(devices);
-
   return (
     <GuideWrapper>
       <GuidedContent>
@@ -47,15 +56,7 @@ export const AdvancedSettings = ({ devices, hasAccounts }: TPagePropsWithSetting
                 hideMobileMenu
                 hasAccounts={hasAccounts}
               >
-                <EnableCustomFeesToggleSetting />
-                <EnableCoinControlSetting />
-                <EnableAuthSetting />
-                <EnableTorProxySetting />
-                <RestartInTestnetSetting />
-                <CustomGapLimitSettings />
-                <UnlockSoftwareKeystore deviceIDs={deviceIDs}/>
-                <ConnectFullNodeSetting />
-                <ExportLogSetting />
+                <AdvancedSettingsContent devices={devices} />
               </WithSettingsTabs>
             </ViewContent>
           </View>
@@ -67,6 +68,40 @@ export const AdvancedSettings = ({ devices, hasAccounts }: TPagePropsWithSetting
   );
 };
 
+export const AdvancedSettingsContent = ({
+  devices,
+}: TProps) => {
+  const { isTesting } = useContext(AppContext);
+
+  const deviceIDs = Object.keys(devices);
+  const sections: TSettingsContentSection[] = [
+    {
+      id: 'advanced-settings',
+      items: [
+        { id: 'custom-fees', content: <EnableCustomFeesToggleSetting /> },
+        { id: 'coin-control', content: <EnableCoinControlSetting /> },
+        ...(isScreenLockSettingVisible() ? [{
+          id: 'screen-lock',
+          content: <EnableAuthSetting />,
+        }] : []),
+        { id: 'tor-proxy', content: <EnableTorProxySetting /> },
+        { id: 'testnet-mode', content: <RestartInTestnetSetting /> },
+        { id: 'gap-limit', content: <CustomGapLimitSettings /> },
+        ...(isTestWalletSettingVisible({ deviceIDs, isTesting }) ? [{
+          id: 'test-wallet',
+          content: <UnlockSoftwareKeystore />,
+        }] : []),
+        { id: 'full-node', content: <ConnectFullNodeSetting /> },
+        ...(isExportLogsSettingVisible() ? [{
+          id: 'export-logs',
+          content: <ExportLogSetting />,
+        }] : []),
+      ],
+    },
+  ];
+
+  return <SettingsContent sections={sections} />;
+};
 
 const AdvancedSettingsGuide = () => {
   const { t } = useTranslation();

--- a/frontends/web/src/routes/settings/bb02-settings.module.css
+++ b/frontends/web/src/routes/settings/bb02-settings.module.css
@@ -1,11 +1,3 @@
-.section {
-    margin-bottom: var(--space-default)
-}
-
-.section h3 {
-    margin-bottom: var(--space-half)
-}
-
 .skeletonWrapper {
     margin-bottom: var(--space-half);
 }
@@ -14,9 +6,5 @@
 @media (max-width: 768px) {
     .skeletonWrapper {
          margin-bottom: 2px;
-    }
-
-    .withMobilePadding {
-        padding: 0 var(--space-half);
     }
 }

--- a/frontends/web/src/routes/settings/bb02-settings.tsx
+++ b/frontends/web/src/routes/settings/bb02-settings.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import { useLoad } from '@/hooks/api';
 import { useTranslation } from 'react-i18next';
-import { runningInIOS } from '@/utils/env';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
 import { ViewContent, View } from '@/components/view/view';
 import { WithSettingsTabs } from './components/tabs';
@@ -29,14 +28,21 @@ import { ManageDeviceGuide } from '@/routes/device/bitbox02/settings-guide';
 import { MobileHeader } from './components/mobile-header';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
+import { SettingsContent, type TSettingsContentSection } from './components/settings-content';
 import { SubTitle } from '@/components/title';
+import {
+  isBluetoothToggleSettingVisible,
+  isDeviceBluetoothSupported,
+} from './settings-availability';
 import styles from './bb02-settings.module.css';
 
-type TProps = {
+type TCommonProps = {
   deviceID: string;
 };
 
-type TWrapperProps = TProps & TPagePropsWithSettingsTabs;
+type TWrapperProps = TCommonProps & TPagePropsWithSettingsTabs;
+
+type TProps = TCommonProps;
 
 export const StyledSkeleton = () => {
   return (
@@ -70,7 +76,7 @@ const BB02Settings = ({ deviceID, devices, hasAccounts }: TWrapperProps) => {
                 hideMobileMenu
                 hasAccounts={hasAccounts}
               >
-                <Content deviceID={deviceID} />
+                <ManageDeviceSettingsContent deviceID={deviceID} />
               </WithSettingsTabs>
             </ViewContent>
           </View>
@@ -81,7 +87,9 @@ const BB02Settings = ({ deviceID, devices, hasAccounts }: TWrapperProps) => {
   );
 };
 
-const Content = ({ deviceID }: TProps) => {
+export const ManageDeviceSettingsContent = ({
+  deviceID,
+}: TProps) => {
   const { t } = useTranslation();
 
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo>();
@@ -100,104 +108,118 @@ const Content = ({ deviceID }: TProps) => {
       .catch(console.error);
   }, [deviceID, t]);
 
-  return (
-    <>
-      {/*"Backups" section*/}
-      <div className={styles.section}>
-        <SubTitle className={styles.withMobilePadding}>{t('deviceSettings.backups.title')}</SubTitle>
-        <ManageBackupSetting deviceID={deviceID} />
-        <ShowRecoveryWordsSetting deviceID={deviceID} />
-      </div>
-
-      {/*"Device settings" section*/}
-      <div className={styles.section}>
-        <SubTitle className={styles.withMobilePadding}>{t('deviceSettings.deviceSettings.title')}</SubTitle>
-        {deviceInfo ? (
-          <DeviceNameSetting
-            deviceName={deviceInfo.name}
-            deviceID={deviceID}
-          />
-        ) :
-          <StyledSkeleton />
-        }
-        { deviceInfo && deviceInfo.bluetooth && !runningInIOS()
-          ? <BluetoothToggleEnabledSetting deviceID={deviceID} />
-          : null
-        }
+  const sections: TSettingsContentSection[] = [
+    {
+      id: 'backups',
+      items: [
+        { id: 'manage-backups', content: <ManageBackupSetting deviceID={deviceID} /> },
+        { id: 'show-recovery-words', content: <ShowRecoveryWordsSetting deviceID={deviceID} /> },
+      ],
+      title: <SubTitle className="m-top-default">{t('deviceSettings.backups.title')}</SubTitle>,
+    },
+    {
+      id: 'device-settings',
+      items: [
         {
-          versionInfo ? (
+          id: 'device-name',
+          content: deviceInfo ? (
+            <DeviceNameSetting
+              deviceName={deviceInfo.name}
+              deviceID={deviceID}
+            />
+          ) : (
+            <StyledSkeleton />
+          ),
+        },
+        ...(isBluetoothToggleSettingVisible(deviceInfo) ? [{
+          id: 'bluetooth',
+          content: <BluetoothToggleEnabledSetting deviceID={deviceID} />,
+        }] : []),
+        {
+          id: 'device-password',
+          content: versionInfo ? (
             <ChangeDevicePasswordSetting
               deviceID={deviceID}
               canChangePassword={versionInfo.canChangePassword}
             />
           ) : (
             <StyledSkeleton />
-          )
-        }
-      </div>
-
-      {/*"Device information" section*/}
-      <div className={styles.section}>
-        <SubTitle className={styles.withMobilePadding}>{t('deviceSettings.deviceInformation.title')}</SubTitle>
+          ),
+        },
+      ],
+      title: <SubTitle className="m-top-default">{t('deviceSettings.deviceSettings.title')}</SubTitle>,
+    },
+    {
+      id: 'device-information',
+      items: [
         {
-          versionInfo ? (
+          id: 'firmware',
+          content: versionInfo ? (
             <FirmwareSetting
               deviceID={deviceID}
               versionInfo={versionInfo}
             />
-          ) :
+          ) : (
             <StyledSkeleton />
-        }
-        {
-          deviceInfo && deviceInfo.bluetooth ? (
+          ),
+        },
+        ...(isDeviceBluetoothSupported(deviceInfo) ? [{
+          id: 'bluetooth-firmware',
+          content: (
             <BluetoothFirmwareSetting
               firmwareVersion={deviceInfo.bluetooth.firmwareVersion}
             />
-          ) : null
-        }
-        <AttestationCheckSetting deviceID={deviceID} />
+          ),
+        }] : []),
+        { id: 'authenticity-check', content: <AttestationCheckSetting deviceID={deviceID} /> },
         {
-          rootFingerprintResult && rootFingerprintResult.success ?
-            <RootFingerprintSetting rootFingerprint={rootFingerprintResult.rootFingerprint} />
-            :
-            <StyledSkeleton />
-        }
+          id: 'root-fingerprint',
+          content: rootFingerprintResult && rootFingerprintResult.success
+            ? <RootFingerprintSetting rootFingerprint={rootFingerprintResult.rootFingerprint} />
+            : <StyledSkeleton />,
+        },
         {
-          deviceInfo && deviceInfo.securechipModel !== '' ?
-            <SecureChipSetting secureChipModel={deviceInfo.securechipModel} />
-            :
-            <StyledSkeleton />
-        }
-      </div>
-
-      {/*"Expert settings" section*/}
-      <div className={styles.section}>
-        <SubTitle className={styles.withMobilePadding}>{t('settings.expert.title')}</SubTitle>
+          id: 'secure-chip',
+          content: deviceInfo && deviceInfo.securechipModel !== ''
+            ? <SecureChipSetting secureChipModel={deviceInfo.securechipModel} />
+            : <StyledSkeleton />,
+        },
+      ],
+      title: <SubTitle className="m-top-default">{t('deviceSettings.deviceInformation.title')}</SubTitle>,
+    },
+    {
+      id: 'expert-settings',
+      items: [
         {
-          deviceInfo ? (
+          id: 'passphrase',
+          content: deviceInfo ? (
             <PassphraseSetting
               passphraseEnabled={deviceInfo.mnemonicPassphraseEnabled}
               deviceID={deviceID}
             />
           ) : (
             <StyledSkeleton />
-          )
-        }
+          ),
+        },
         {
-          versionInfo ? (
+          id: 'bip85',
+          content: versionInfo ? (
             <Bip85Setting
               canBIP85={versionInfo.canBIP85}
               deviceID={deviceID}
             />
           ) : (
             <StyledSkeleton />
-          )
-        }
-        <GoToStartupSettings deviceID={deviceID} />
-        <FactoryResetSetting deviceID={deviceID} />
-      </div>
-    </>
-  );
+          ),
+        },
+        { id: 'startup-settings', content: <GoToStartupSettings deviceID={deviceID} /> },
+        { id: 'factory-reset', content: <FactoryResetSetting deviceID={deviceID} /> },
+      ],
+      title: <SubTitle className="m-top-default">{t('settings.expert.title')}</SubTitle>,
+    },
+  ];
+
+  return <SettingsContent sections={sections} />;
 };
 
 export { BB02Settings };

--- a/frontends/web/src/routes/settings/components/advanced-settings/enable-auth-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/enable-auth-setting.tsx
@@ -6,7 +6,6 @@ import { Toggle } from '@/components/toggle/toggle';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import { useConfig } from '@/contexts/ConfigProvider';
 import { onAuthSettingChanged, TAuthEventObject, subscribeAuth, forceAuth } from '@/api/backend';
-import { runningInAndroid, runningInIOS } from '@/utils/env';
 
 export const EnableAuthSetting = () => {
   const { t } = useTranslation();
@@ -38,10 +37,6 @@ export const EnableAuthSetting = () => {
     });
     onAuthSettingChanged();
   };
-
-  if (!runningInAndroid() && !runningInIOS()) {
-    return null;
-  }
 
   return (
     <SettingsItem

--- a/frontends/web/src/routes/settings/components/advanced-settings/export-log-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/export-log-setting.tsx
@@ -2,13 +2,12 @@
 
 import { useTranslation } from 'react-i18next';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
-import { debug } from '@/utils/env';
 import { alertUser } from '@/components/alert/Alert';
 import { exportLogs } from '@/api/backend';
 
 export const ExportLogSetting = () => {
   const { t } = useTranslation();
-  return debug === true ? null : (
+  return (
     <SettingsItem
       settingName={t('settings.expert.exportLogs.title')}
       onClick={async () => {

--- a/frontends/web/src/routes/settings/components/advanced-settings/unlock-software-keystore.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/unlock-software-keystore.tsx
@@ -1,30 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useTranslation } from 'react-i18next';
-import { useDefault } from '@/hooks/default';
-import { useLoad } from '@/hooks/api';
 import { useKeystores } from '@/hooks/backend';
-import { getTesting } from '@/api/backend';
 import { deregisterTest } from '@/api/keystores';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import { SkipForTesting } from '@/routes/device/components/skipfortesting';
 import { ChevronRightDark, Eject } from '@/components/icon';
 import styles from './unlock-software-keystore.module.css';
 
-type TProps = {
-  deviceIDs: string[];
-};
-
-export const UnlockSoftwareKeystore = ({
-  deviceIDs,
-}: TProps) => {
+export const UnlockSoftwareKeystore = () => {
   const { t } = useTranslation();
-  const isTesting = useDefault(useLoad(getTesting), false);
   const keystores = useKeystores();
 
-  if (!isTesting || deviceIDs.length) {
-    return null;
-  }
   if (keystores?.some(({ type }) => type === 'software')) {
     return (
       <SettingsItem

--- a/frontends/web/src/routes/settings/components/settings-content.module.css
+++ b/frontends/web/src/routes/settings/components/settings-content.module.css
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.highlightedItem {
+  animation: settings-highlight-pulse 800ms ease-in-out 3;
+  border-radius: var(--radius-xl);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+@keyframes settings-highlight-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--color-blue-rgb), 0);
+    outline-color: transparent;
+  }
+
+  50% {
+    box-shadow: 0 0 0 4px rgba(var(--color-blue-rgb), 0.18);
+    outline-color: var(--color-primary);
+  }
+}

--- a/frontends/web/src/routes/settings/components/settings-content.tsx
+++ b/frontends/web/src/routes/settings/components/settings-content.tsx
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Fragment, ReactNode, useEffect, useRef } from 'react';
+import { useSettingsHighlight } from '../use-settings-highlight';
+import styles from './settings-content.module.css';
+
+export type TSettingsContentItem = {
+  content: ReactNode;
+  id: string;
+};
+
+export type TSettingsContentSection = {
+  id: string;
+  items: TSettingsContentItem[];
+  title?: ReactNode;
+};
+
+type TProps = {
+  sections: TSettingsContentSection[];
+};
+
+export const SettingsContent = ({
+  sections,
+}: TProps) => {
+  const highlightedItemID = useSettingsHighlight();
+  const highlightedItemRef = useRef<HTMLDivElement | null>(null);
+  const scrolledItemID = useRef<string>();
+
+  useEffect(() => {
+    if (!highlightedItemID) {
+      scrolledItemID.current = undefined;
+      return;
+    }
+
+    if (!highlightedItemRef.current || scrolledItemID.current === highlightedItemID) {
+      return;
+    }
+
+    const scrollToHighlightedItem = () => {
+      highlightedItemRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    };
+
+    // waits for the page layout to settle
+    // after navigation before centering the item.
+    window.setTimeout(scrollToHighlightedItem, 150);
+    scrolledItemID.current = highlightedItemID;
+  });
+
+  return (
+    sections.map(section => {
+      if (section.items.length === 0) {
+        return null;
+      }
+
+      return (
+        <Fragment key={section.id}>
+          {section.title ? section.title : null}
+          {section.items.map(settingItem => {
+            const isHighlighted = settingItem.id === highlightedItemID;
+
+            return (
+              <div
+                className={isHighlighted ? styles.highlightedItem : undefined}
+                key={settingItem.id}
+                ref={isHighlighted ? highlightedItemRef : undefined}
+              >
+                {settingItem.content}
+              </div>
+            );
+          })}
+        </Fragment>
+      );
+    })
+  );
+};

--- a/frontends/web/src/routes/settings/components/settings-search-content.module.css
+++ b/frontends/web/src/routes/settings/components/settings-search-content.module.css
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.container {
+  margin-bottom: var(--space-default);
+}
+
+.empty {
+  color: var(--color-secondary);
+  margin: 0 0 var(--space-default);
+}
+
+.pageGroup {
+  margin-bottom: var(--space-default);
+}
+
+.pageTitle {
+  margin-top: var(--space-default);
+}

--- a/frontends/web/src/routes/settings/components/settings-search-content.tsx
+++ b/frontends/web/src/routes/settings/components/settings-search-content.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import type { TDevices } from '@/api/devices';
+import { SubTitle } from '@/components/title';
+import {
+  SETTINGS_HIGHLIGHT_QUERY_PARAM,
+  SETTINGS_SEARCH_PAGE_ORDER,
+  groupSearchResultsByPage,
+  type TSettingsSearchItem,
+  type TSettingsSearchPage,
+} from '../settings-search';
+import { SettingsItem } from './settingsItem/settingsItem';
+import styles from './settings-search-content.module.css';
+
+type TProps = {
+  devices: TDevices;
+  searchResults: TSettingsSearchItem[];
+};
+
+const getSettingsSearchResultURL = (
+  searchResult: TSettingsSearchItem,
+  firstDeviceID?: string,
+) => {
+  const searchParams = new URLSearchParams({
+    [SETTINGS_HIGHLIGHT_QUERY_PARAM]: searchResult.id,
+  });
+
+  if (searchResult.page === 'device') {
+    return firstDeviceID ? `/settings/device-settings/${firstDeviceID}?${searchParams}` : undefined;
+  }
+
+  const pageURLs: Record<Exclude<TSettingsSearchPage, 'device'>, string> = {
+    about: '/settings/about',
+    advanced: '/settings/advanced-settings',
+    general: '/settings/general',
+  };
+
+  return `${pageURLs[searchResult.page]}?${searchParams}`;
+};
+
+export const SettingsSearchContent = ({
+  devices,
+  searchResults,
+}: TProps) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const firstDeviceID = Object.keys(devices)[0];
+
+  const pageTitles: Record<TSettingsSearchPage, string> = {
+    about: t('settings.about'),
+    advanced: t('settings.advancedSettings'),
+    device: t('sidebar.device'),
+    general: t('settings.general'),
+  };
+
+  const searchResultsByPage = groupSearchResultsByPage(searchResults);
+
+  return (
+    <div className={styles.container}>
+      {searchResults.length === 0 ? (
+        <p className={styles.empty}>
+          {t('settings.search.noResults')}
+        </p>
+      ) : (
+        SETTINGS_SEARCH_PAGE_ORDER.map(page => {
+          const pageSearchResults = searchResultsByPage[page];
+          const navigableResults = pageSearchResults
+            .map(searchResult => ({
+              searchResult,
+              url: getSettingsSearchResultURL(searchResult, firstDeviceID),
+            }))
+            .filter(
+              (item): item is { searchResult: TSettingsSearchItem; url: string } => item.url !== undefined,
+            );
+
+          if (navigableResults.length === 0) {
+            return null;
+          }
+
+          return (
+            <div className={styles.pageGroup} key={page}>
+              <SubTitle className={styles.pageTitle}>{pageTitles[page]}</SubTitle>
+              {navigableResults.map(({ searchResult, url }) => {
+                return (
+                  <SettingsItem
+                    key={searchResult.id}
+                    onClick={() => navigate(url)}
+                    settingName={searchResult.title}
+                  />
+                );
+              })}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+};

--- a/frontends/web/src/routes/settings/components/tabs.module.css
+++ b/frontends/web/src/routes/settings/components/tabs.module.css
@@ -4,6 +4,43 @@
     word-break: keep-all;
 }
 
+.searchContainer {
+    margin-bottom: var(--space-default);
+}
+
+.desktopTabsRow {
+    align-items: flex-start;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: var(--space-default);
+    width: 100%;
+}
+
+.desktopTabsRow .container {
+    margin-bottom: 0;
+}
+
+.searchToggleContainer {
+    display: flex;
+    flex-shrink: 0;
+    justify-content: flex-end;
+    margin-left: var(--space-default);
+}
+
+.searchButton {
+    align-items: start;
+    display: flex;
+    gap: var(--space-eight);
+    justify-content: flex-end;
+    padding: 0;
+    text-align: right;
+    white-space: nowrap;
+}
+
+.loupe {
+    width: var(--size-default);
+}
+
 .container a {
     margin-right: var(--space-default);
     font-size: var(--size-subheader);

--- a/frontends/web/src/routes/settings/components/tabs.tsx
+++ b/frontends/web/src/routes/settings/components/tabs.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useNavigate } from 'react-router-dom';
 import type { TDevices, TPlatformName } from '@/api/devices';
@@ -8,6 +8,9 @@ import { useLoad } from '@/hooks/api';
 import { getVersion } from '@/api/bitbox02';
 import { useDarkmode } from '@/hooks/darkmode';
 import { SettingsItem } from './settingsItem/settingsItem';
+import { SettingsSearchContent } from './settings-search-content';
+import { Button, SearchInput } from '@/components/forms';
+import { useSettingsSearch } from '../use-settings-search';
 import {
   AdvancedSettingsIcon,
   AdvancedSettingsIconDark,
@@ -20,6 +23,7 @@ import {
   InfoIconDark,
   USBLight,
   USBDark,
+  LoupeBlue,
 } from '@/components/icon';
 import { useMediaQuery } from '@/hooks/mediaquery';
 import styles from './tabs.module.css';
@@ -29,6 +33,7 @@ type TWithSettingsTabsProps = {
   devices: TDevices;
   hasAccounts: boolean;
   hideMobileMenu?: boolean;
+  renderDefaultTabs?: boolean;
 };
 
 type TTab = {
@@ -50,17 +55,85 @@ export const WithSettingsTabs = ({
   devices,
   hideMobileMenu,
   hasAccounts,
+  renderDefaultTabs = true,
 }: TWithSettingsTabsProps) => {
+  const { t } = useTranslation();
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const [showSearchBar, setShowSearchBar] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const {
+    searchResults,
+    searchTerm,
+    showSearchResults,
+    updateSearchTerm,
+  } = useSettingsSearch({
+    devices,
+    hasAccounts,
+  });
+  const showDesktopSearchBar = showSearchBar || searchTerm.trim().length > 0;
+  const showSearchBarInput = isMobile || showDesktopSearchBar;
+
+  useEffect(() => {
+    if (!isMobile && showSearchBarInput) {
+      searchInputRef.current?.focus();
+    }
+  }, [isMobile, showSearchBarInput]);
+
   return (
     <>
-      <div className="hide-on-small">
-        <Tabs
-          hideMobileMenu={hideMobileMenu}
+      {showSearchBarInput ? (
+        <div className={styles.searchContainer}>
+          <SearchInput
+            autoFocus={!isMobile}
+            onChange={event => updateSearchTerm(event.currentTarget.value)}
+            onClear={() => updateSearchTerm('')}
+            placeholder={t('generic.search')}
+            ref={searchInputRef}
+            value={searchTerm}
+            variant="clear"
+          />
+        </div>
+      ) : null}
+      {renderDefaultTabs ? (
+        <div className="hide-on-small">
+          <div className={styles.desktopTabsRow}>
+            <Tabs
+              hideMobileMenu={hideMobileMenu}
+              devices={devices}
+              hasAccounts={hasAccounts}
+            />
+            <div className={styles.searchToggleContainer}>
+              <Button
+                className={styles.searchButton}
+                onClick={() => {
+                  if (showDesktopSearchBar) {
+                    setShowSearchBar(false);
+                    updateSearchTerm('');
+                  } else {
+                    setShowSearchBar(true);
+                  }
+                }}
+                transparent
+              >
+                {showDesktopSearchBar ? (
+                  <>✕ {t('generic.close')}</>
+                ) : (
+                  <>
+                    <LoupeBlue className={styles.loupe} />
+                    {t('generic.searchButton')}
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+      {showSearchResults ? (
+        <SettingsSearchContent
           devices={devices}
-          hasAccounts={hasAccounts}
+          searchResults={searchResults}
         />
-      </div>
-      {children}
+      ) : children}
     </>
   );
 };

--- a/frontends/web/src/routes/settings/general.module.css
+++ b/frontends/web/src/routes/settings/general.module.css
@@ -1,5 +1,0 @@
-@media (max-width: 768px) {
-    .subtitleWithMobilePadding {
-        padding: 0 var(--space-half);
-    }
-}

--- a/frontends/web/src/routes/settings/general.tsx
+++ b/frontends/web/src/routes/settings/general.tsx
@@ -13,11 +13,16 @@ import { WithSettingsTabs } from './components/tabs';
 import { MobileHeader } from './components/mobile-header';
 import { Guide } from '@/components/guide/guide';
 import { Entry } from '@/components/guide/entry';
+import { SettingsContent, type TSettingsContentSection } from './components/settings-content';
 import { SubTitle } from '@/components/title';
 import { TPagePropsWithSettingsTabs } from './types';
 import { GlobalBanners } from '@/components/banners';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
-import style from './general.module.css';
+import { isNotesSettingsVisible } from './settings-availability';
+
+type TProps = {
+  hasAccounts: boolean;
+};
 
 export const General = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
@@ -39,22 +44,7 @@ export const General = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) =>
           <View fullscreen={false}>
             <ViewContent>
               <WithSettingsTabs hasAccounts={hasAccounts} hideMobileMenu devices={devices}>
-                <SubTitle className={style.subtitleWithMobilePadding}>
-                  {t('settings.appearance')}
-                </SubTitle>
-                <LanguageDropdownSetting />
-                <DefaultCurrencyDropdownSetting />
-                <ActiveCurrenciesDropdownSetting />
-                <DarkmodeToggleSetting />
-                { hasAccounts ? (
-                  <>
-                    <SubTitle className={`m-top-default ${style.subtitleWithMobilePadding || ''}`}>
-                      {t('settings.notes.title')}
-                    </SubTitle>
-                    <NotesExport />
-                    <NotesImport />
-                  </>
-                ) : null }
+                <GeneralSettingsContent hasAccounts={hasAccounts} />
               </WithSettingsTabs>
             </ViewContent>
           </View>
@@ -63,6 +53,37 @@ export const General = ({ devices, hasAccounts }: TPagePropsWithSettingsTabs) =>
       <GeneralGuide />
     </GuideWrapper>
 
+  );
+};
+
+export const GeneralSettingsContent = ({
+  hasAccounts,
+}: TProps) => {
+  const { t } = useTranslation();
+
+  const sections: TSettingsContentSection[] = [
+    {
+      id: 'appearance',
+      items: [
+        { id: 'language', content: <LanguageDropdownSetting /> },
+        { id: 'default-currency', content: <DefaultCurrencyDropdownSetting /> },
+        { id: 'active-currencies', content: <ActiveCurrenciesDropdownSetting /> },
+        { id: 'dark-mode', content: <DarkmodeToggleSetting /> },
+      ],
+      title: <SubTitle>{t('settings.appearance')}</SubTitle>,
+    },
+    ...(isNotesSettingsVisible(hasAccounts) ? [{
+      id: 'notes',
+      items: [
+        { id: 'export-notes', content: <NotesExport /> },
+        { id: 'import-notes', content: <NotesImport /> },
+      ],
+      title: <SubTitle className="m-top-default">{t('settings.notes.title')}</SubTitle>,
+    }] : []),
+  ];
+
+  return (
+    <SettingsContent sections={sections} />
   );
 };
 

--- a/frontends/web/src/routes/settings/mobile-settings.tsx
+++ b/frontends/web/src/routes/settings/mobile-settings.tsx
@@ -3,7 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import { View, ViewContent } from '@/components/view/view';
 import { Header, Main } from '@/components/layout';
-import { Tabs } from './components/tabs';
+import { Tabs, WithSettingsTabs } from './components/tabs';
 import { TPagePropsWithSettingsTabs } from './types';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
@@ -41,7 +41,9 @@ export const MobileSettings = ({ devices, hasAccounts }: TPagePropsWithSettingsT
         } />
       <View fullscreen={false}>
         <ViewContent>
-          <Tabs devices={devices} hasAccounts={hasAccounts} />
+          <WithSettingsTabs devices={devices} hasAccounts={hasAccounts} renderDefaultTabs={false}>
+            <Tabs devices={devices} hasAccounts={hasAccounts} />
+          </WithSettingsTabs>
         </ViewContent>
       </View>
     </Main>

--- a/frontends/web/src/routes/settings/settings-availability.ts
+++ b/frontends/web/src/routes/settings/settings-availability.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { DeviceInfo } from '@/api/bitbox02';
+import type { TDevices } from '@/api/devices';
+import { debug, runningInAndroid, runningInIOS } from '@/utils/env';
+
+type TTestWalletVisibilityArgs = {
+  deviceIDs: string[];
+  isTesting: boolean;
+};
+
+type TDeviceInfoWithBluetooth = DeviceInfo & {
+  bluetooth: NonNullable<DeviceInfo['bluetooth']>;
+};
+
+export const isNotesSettingsVisible = (hasAccounts: boolean) => hasAccounts;
+
+export const isDeviceSettingsVisible = (devices: TDevices) => Object.keys(devices).length > 0;
+
+export const isDeviceBluetoothSupported = (
+  deviceInfo?: DeviceInfo,
+): deviceInfo is TDeviceInfoWithBluetooth => !!deviceInfo?.bluetooth;
+
+export const isBluetoothToggleSettingVisible = (deviceInfo?: DeviceInfo) => (
+  isDeviceBluetoothSupported(deviceInfo) && !runningInIOS()
+);
+
+export const isScreenLockSettingVisible = () => runningInAndroid() || runningInIOS();
+
+export const isExportLogsSettingVisible = () => !debug;
+
+export const isTestWalletSettingVisible = ({
+  deviceIDs,
+  isTesting,
+}: TTestWalletVisibilityArgs) => isTesting && deviceIDs.length === 0;

--- a/frontends/web/src/routes/settings/settings-search.test.ts
+++ b/frontends/web/src/routes/settings/settings-search.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TFunction } from 'i18next';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  filterSettingsSearchItems,
+  getSettingsSearchItems,
+} from './settings-search';
+
+vi.mock('@/utils/env', () => ({
+  debug: false,
+  runningInAndroid: () => false,
+  runningInIOS: () => false,
+}));
+
+const translations: Record<string, string> = {
+  'testWallet.connect.title': 'Test wallet',
+  'testWallet.disconnect.title': 'Disconnect test wallet',
+};
+
+const t = ((key: string) => translations[key] || key) as TFunction;
+
+const getItems = (hasSoftwareKeystore: boolean) => getSettingsSearchItems({
+  devices: {},
+  hasAccounts: true,
+  hasSoftwareKeystore,
+  isTesting: true,
+  t,
+});
+
+describe('settings search', () => {
+  it('uses the connect title for the test wallet setting when no software wallet exists', () => {
+    const results = filterSettingsSearchItems(getItems(false), 'test wallet');
+
+    expect(results).toContainEqual({
+      id: 'test-wallet',
+      page: 'advanced',
+      title: 'Test wallet',
+    });
+    expect(filterSettingsSearchItems(getItems(false), 'disconnect')).toEqual([]);
+  });
+
+  it('uses the disconnect title for the test wallet setting when a software wallet exists', () => {
+    const results = filterSettingsSearchItems(getItems(true), 'disconnect');
+
+    expect(results).toEqual([{
+      id: 'test-wallet',
+      page: 'advanced',
+      title: 'Disconnect test wallet',
+    }]);
+  });
+});

--- a/frontends/web/src/routes/settings/settings-search.ts
+++ b/frontends/web/src/routes/settings/settings-search.ts
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TFunction } from 'i18next';
+import type { DeviceInfo } from '@/api/bitbox02';
+import type { TDevices } from '@/api/devices';
+import {
+  isBluetoothToggleSettingVisible,
+  isDeviceBluetoothSupported,
+  isDeviceSettingsVisible,
+  isExportLogsSettingVisible,
+  isNotesSettingsVisible,
+  isScreenLockSettingVisible,
+  isTestWalletSettingVisible,
+} from './settings-availability';
+
+export type TSettingsSearchItem = {
+  id: string;
+  title: string;
+  page: TSettingsSearchPage;
+};
+
+type TGetSettingsSearchItemsArgs = {
+  deviceInfo?: DeviceInfo;
+  devices: TDevices;
+  hasAccounts: boolean;
+  hasSoftwareKeystore: boolean;
+  isTesting: boolean;
+  t: TFunction;
+};
+
+export type TSettingsSearchPage = 'general' | 'device' | 'advanced' | 'about';
+
+export const SETTINGS_SEARCH_PAGE_ORDER: TSettingsSearchPage[] = ['general', 'device', 'advanced', 'about'];
+export const SETTINGS_HIGHLIGHT_QUERY_PARAM = 'settingsHighlight';
+
+type TSettingsSearchContext = TGetSettingsSearchItemsArgs & {
+  deviceIDs: string[];
+};
+
+type TSettingsSearchDescriptor = {
+  id: string;
+  page: TSettingsSearchPage;
+  getTitle: (context: TSettingsSearchContext) => string;
+  isAvailable?: (context: TSettingsSearchContext) => boolean;
+};
+
+const SETTINGS_SEARCH_DESCRIPTORS: TSettingsSearchDescriptor[] = [
+  {
+    id: 'language',
+    getTitle: ({ t }) => t('newSettings.appearance.language.title'),
+    page: 'general',
+  },
+  {
+    id: 'default-currency',
+    getTitle: ({ t }) => t('newSettings.appearance.defaultCurrency.title'),
+    page: 'general',
+  },
+  {
+    id: 'active-currencies',
+    getTitle: ({ t }) => t('newSettings.appearance.activeCurrencies.title'),
+    page: 'general',
+  },
+  {
+    id: 'dark-mode',
+    getTitle: ({ t }) => t('darkmode.toggle'),
+    page: 'general',
+  },
+  {
+    id: 'custom-fees',
+    getTitle: ({ t }) => t('settings.expert.fee'),
+    page: 'advanced',
+  },
+  {
+    id: 'coin-control',
+    getTitle: ({ t }) => t('settings.expert.coinControl'),
+    page: 'advanced',
+  },
+  {
+    id: 'screen-lock',
+    isAvailable: isScreenLockSettingVisible,
+    getTitle: ({ t }) => t('newSettings.advancedSettings.authentication.title'),
+    page: 'advanced',
+  },
+  {
+    id: 'tor-proxy',
+    getTitle: ({ t }) => t('settings.expert.useProxy'),
+    page: 'advanced',
+  },
+  {
+    id: 'testnet-mode',
+    getTitle: ({ isTesting, t }) => isTesting ? t('testnet.deactivate.title') : t('testnet.activate.title'),
+    page: 'advanced',
+  },
+  {
+    id: 'gap-limit',
+    getTitle: ({ t }) => t('gapLimit.title'),
+    page: 'advanced',
+  },
+  {
+    id: 'full-node',
+    getTitle: ({ t }) => t('settings.expert.electrum.title'),
+    page: 'advanced',
+  },
+  {
+    id: 'export-logs',
+    isAvailable: isExportLogsSettingVisible,
+    getTitle: ({ t }) => t('settings.expert.exportLogs.title'),
+    page: 'advanced',
+  },
+  {
+    id: 'app-version',
+    getTitle: ({ t }) => t('newSettings.about.appVersion.title'),
+    page: 'about',
+  },
+  {
+    id: 'feedback',
+    getTitle: ({ t }) => t('newSettings.about.feedbackLink.title'),
+    page: 'about',
+  },
+  {
+    id: 'support',
+    getTitle: ({ t }) => t('newSettings.about.supportLink.title'),
+    page: 'about',
+  },
+  {
+    id: 'export-notes',
+    isAvailable: ({ hasAccounts }) => isNotesSettingsVisible(hasAccounts),
+    getTitle: ({ t }) => t('settings.notes.export.title'),
+    page: 'general',
+  },
+  {
+    id: 'import-notes',
+    isAvailable: ({ hasAccounts }) => isNotesSettingsVisible(hasAccounts),
+    getTitle: ({ t }) => t('settings.notes.import.title'),
+    page: 'general',
+  },
+  {
+    id: 'test-wallet',
+    isAvailable: ({ deviceIDs, isTesting }) => isTestWalletSettingVisible({ deviceIDs, isTesting }),
+    getTitle: ({ hasSoftwareKeystore, t }) => t(
+      hasSoftwareKeystore
+        ? 'testWallet.disconnect.title'
+        : 'testWallet.connect.title'
+    ),
+    page: 'advanced',
+  },
+  {
+    id: 'manage-backups',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('backup.title'),
+    page: 'device',
+  },
+  {
+    id: 'show-recovery-words',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('backup.showMnemonic.title'),
+    page: 'device',
+  },
+  {
+    id: 'device-name',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('bitbox02Settings.deviceName.input'),
+    page: 'device',
+  },
+  {
+    id: 'bluetooth',
+    isAvailable: ({ deviceInfo }) => isBluetoothToggleSettingVisible(deviceInfo),
+    getTitle: ({ t }) => t('bitbox02Settings.bluetoothToggleEnabled.titleEnabled'),
+    page: 'device',
+  },
+  {
+    id: 'device-password',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('bitbox02Settings.changePassword.title'),
+    page: 'device',
+  },
+  {
+    id: 'firmware',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('deviceSettings.firmware.title'),
+    page: 'device',
+  },
+  {
+    id: 'bluetooth-firmware',
+    isAvailable: ({ deviceInfo }) => isDeviceBluetoothSupported(deviceInfo),
+    getTitle: ({ t }) => t('deviceSettings.bluetoothFirmware.title'),
+    page: 'device',
+  },
+  {
+    id: 'authenticity-check',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('deviceSettings.hardware.attestation.label'),
+    page: 'device',
+  },
+  {
+    id: 'root-fingerprint',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: () => 'Root fingerprint',
+    page: 'device',
+  },
+  {
+    id: 'secure-chip',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('deviceSettings.hardware.securechip'),
+    page: 'device',
+  },
+  {
+    id: 'passphrase',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('deviceSettings.expert.passphrase.title'),
+    page: 'device',
+  },
+  {
+    id: 'bip85',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('deviceSettings.expert.bip85.title'),
+    page: 'device',
+  },
+  {
+    id: 'startup-settings',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('bitbox02Settings.gotoStartupSettings.title'),
+    page: 'device',
+  },
+  {
+    id: 'factory-reset',
+    isAvailable: ({ devices }) => isDeviceSettingsVisible(devices),
+    getTitle: ({ t }) => t('deviceSettings.expert.factoryReset.title'),
+    page: 'device',
+  },
+];
+
+export const getSettingsSearchItems = ({
+  deviceInfo,
+  devices,
+  hasAccounts,
+  hasSoftwareKeystore,
+  isTesting,
+  t,
+}: TGetSettingsSearchItemsArgs): TSettingsSearchItem[] => {
+  const context = {
+    deviceInfo,
+    devices,
+    deviceIDs: Object.keys(devices),
+    hasAccounts,
+    hasSoftwareKeystore,
+    isTesting,
+    t,
+  };
+
+  return SETTINGS_SEARCH_DESCRIPTORS
+    .filter(descriptor => descriptor.isAvailable ? descriptor.isAvailable(context) : true)
+    .map(descriptor => ({
+      id: descriptor.id,
+      title: descriptor.getTitle(context),
+      page: descriptor.page,
+    }));
+};
+
+
+export const filterSettingsSearchItems = (
+  searchItems: TSettingsSearchItem[],
+  searchTerm: string,
+): TSettingsSearchItem[] => {
+  const normalizedSearchTerm = searchTerm.trim().toLowerCase();
+  if (!normalizedSearchTerm) {
+    return [];
+  }
+  return searchItems.filter(searchItem => (
+    searchItem.title.trim().toLowerCase().includes(normalizedSearchTerm)
+  ));
+};
+
+export const groupSearchResultsByPage = (searchResults: TSettingsSearchItem[]) => {
+  const searchResultsByPage: Record<TSettingsSearchPage, TSettingsSearchItem[]> = {
+    about: [],
+    advanced: [],
+    device: [],
+    general: [],
+  };
+
+  searchResults.forEach(searchResult => {
+    searchResultsByPage[searchResult.page].push(searchResult);
+  });
+
+  return searchResultsByPage;
+};
+
+export const SETTINGS_SEARCH_QUERY_PARAM = 'settingsSearch';

--- a/frontends/web/src/routes/settings/use-settings-highlight.ts
+++ b/frontends/web/src/routes/settings/use-settings-highlight.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { SETTINGS_HIGHLIGHT_QUERY_PARAM } from './settings-search';
+
+const HIGHLIGHT_DURATION_MS = 2700;
+
+export const useSettingsHighlight = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const highlightedItemIDFromParams = searchParams.get(SETTINGS_HIGHLIGHT_QUERY_PARAM) || '';
+  const [highlightedItemID, setHighlightedItemID] = useState(highlightedItemIDFromParams);
+
+  useEffect(() => {
+    if (!highlightedItemIDFromParams) {
+      return;
+    }
+
+    setHighlightedItemID(highlightedItemIDFromParams);
+
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.delete(SETTINGS_HIGHLIGHT_QUERY_PARAM);
+    setSearchParams(nextSearchParams, { replace: true });
+  }, [highlightedItemIDFromParams, searchParams, setSearchParams]);
+
+  useEffect(() => {
+    if (!highlightedItemID) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setHighlightedItemID('');
+    }, HIGHLIGHT_DURATION_MS);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [highlightedItemID]);
+
+  return highlightedItemID;
+};

--- a/frontends/web/src/routes/settings/use-settings-search.ts
+++ b/frontends/web/src/routes/settings/use-settings-search.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useContext, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
+import { getDeviceInfo } from '@/api/bitbox02';
+import type { TDevices } from '@/api/devices';
+import { AppContext } from '@/contexts/AppContext';
+import { useLoad } from '@/hooks/api';
+import { useKeystores } from '@/hooks/backend';
+import {
+  SETTINGS_SEARCH_QUERY_PARAM,
+  filterSettingsSearchItems,
+  getSettingsSearchItems,
+} from './settings-search';
+
+type TUseSettingsSearchArgs = {
+  devices: TDevices;
+  hasAccounts: boolean;
+};
+
+export const useSettingsSearch = ({
+  devices,
+  hasAccounts,
+}: TUseSettingsSearchArgs) => {
+  const { t } = useTranslation();
+  const { isTesting } = useContext(AppContext);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchTerm = searchParams.get(SETTINGS_SEARCH_QUERY_PARAM) || '';
+  const keystores = useKeystores();
+  const hasSoftwareKeystore = keystores?.some(({ type }) => type === 'software') ?? false;
+  const deviceId = Object.keys(devices)[0];
+  const device = deviceId ? devices[deviceId] : undefined;
+  const bb02DeviceId = device === 'bitbox02' ? deviceId : undefined;
+  const deviceInfoResult = useLoad(
+    bb02DeviceId ? () => getDeviceInfo(bb02DeviceId) : null,
+    [bb02DeviceId],
+  );
+  const deviceInfo = deviceInfoResult?.success ? deviceInfoResult.deviceInfo : undefined;
+  const searchItems = useMemo(() => getSettingsSearchItems({
+    deviceInfo,
+    devices,
+    hasAccounts,
+    hasSoftwareKeystore,
+    isTesting,
+    t,
+  }), [deviceInfo, devices, hasAccounts, hasSoftwareKeystore, isTesting, t]);
+  const searchResults = useMemo(
+    () => filterSettingsSearchItems(searchItems, searchTerm),
+    [searchItems, searchTerm],
+  );
+  const showSearchResults = !!searchTerm.trim();
+
+  const updateSearchTerm = (value: string) => {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    const nextSearchTerm = value.trim();
+    const hasCurrentSearchTerm = searchParams.has(SETTINGS_SEARCH_QUERY_PARAM);
+
+    if (nextSearchTerm) {
+      nextSearchParams.set(SETTINGS_SEARCH_QUERY_PARAM, value);
+    } else {
+      nextSearchParams.delete(SETTINGS_SEARCH_QUERY_PARAM);
+    }
+    setSearchParams(nextSearchParams, {
+      replace: !nextSearchTerm || hasCurrentSearchTerm,
+    });
+  };
+
+  return {
+    searchResults,
+    searchTerm,
+    showSearchResults,
+    updateSearchTerm,
+  };
+};


### PR DESCRIPTION
Adds search to the settings area so users can find settings without manually scanning each tab.

Behaviour:
- Typing in the settings search field filters matches across General, Manage device, Advanced settings, and About.
- Results are grouped by destination page and navigate directly to the matching settings page with the item highlighted (border flashes 3x).
- Device-only settings are shown only when a device is available. Same with bluetooth, their entries are also gated by device Bluetooth support.

Technical notes:
- Introduces shared settings search descriptors, grouping/filtering helpers, and unit coverage for matching and availability rules.
- Adds the reusable clearable SearchInput variant and keeps the search term in the URL query params.