### PR TITLE
frontend: show device prompt for startup settings

### DIFF
--- a/frontends/web/src/routes/settings/components/device-settings/go-to-startup-settings.tsx
+++ b/frontends/web/src/routes/settings/components/device-settings/go-to-startup-settings.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PointToBitBox02 } from '@/components/icon';
 import { gotoStartupSettings } from '@/api/bitbox02';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import { WaitDialog } from '@/components/wait-dialog/wait-dialog';
@@ -24,7 +25,9 @@ const StartupSettingsWaitDialog = ({ show }: TStartupSettingsWaitDialogProps) =>
   return (
     <WaitDialog
       title={t('bitbox02Settings.gotoStartupSettings.title')} >
-      {t('bitbox02Settings.gotoStartupSettings.description')}
+      <p>{t('bitbox02Settings.gotoStartupSettings.description')}</p>
+      <p>{t('confirm.info')}</p>
+      <PointToBitBox02 />
     </WaitDialog>
   );
 };


### PR DESCRIPTION
Add the "pointtobitbox" graphic when clicking "go to startup settings" in the app so that the user knows they need to watch the device.

<img width="525" height="498" alt="image" src="https://github.com/user-attachments/assets/44c5d8e1-52dd-43a6-aa45-c64ba2627d28" />


Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
