### PR TITLE
ios: refresh widget prices more often

### DIFF
--- a/frontends/ios/BitBoxApp/BitBoxApp/WidgetShared.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/WidgetShared.swift
@@ -18,7 +18,7 @@ enum WidgetShared {
 
     enum Cache {
         static let priceDataPrefix = "cachedPriceData"
-        static let priceTTL: TimeInterval = 3600
+        static let priceTTL: TimeInterval = 10 * 60
     }
 
     static func normalizeCoinCode(_ code: String) -> String {

--- a/frontends/ios/BitBoxApp/BitBoxAppWidget/WidgetTimelineProvider.swift
+++ b/frontends/ios/BitBoxApp/BitBoxAppWidget/WidgetTimelineProvider.swift
@@ -2,6 +2,9 @@ import Foundation
 import WidgetKit
 
 struct Provider: TimelineProvider {
+    private static let refreshInterval: TimeInterval = 10 * 60
+    private static let retryInterval: TimeInterval = 60
+
     private let dataService = WidgetDataService()
 
     func placeholder(in context: Context) -> SimpleEntry {
@@ -48,15 +51,14 @@ struct Provider: TimelineProvider {
 
         if let exactCacheHit {
             let entry = resolvedEntry(for: coinCode, currency: currency, data: exactCacheHit)
-            let nextUpdate = Date().addingTimeInterval(15 * 60)
+            let nextUpdate = Date().addingTimeInterval(Self.refreshInterval)
             completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
         } else {
             Task {
                 let fetched = await dataService.fetchChartData(coinCode: coinCode, currency: currency)
                 let data = fetched ?? dataService.cachedFallback(for: coinCode, currency: currency)
                 let entry = resolvedEntry(for: coinCode, currency: currency, data: data)
-                let retryMinutes = fetched == nil ? 1 : 15
-                let nextUpdate = Date().addingTimeInterval(TimeInterval(retryMinutes * 60))
+                let nextUpdate = Date().addingTimeInterval(fetched == nil ? Self.retryInterval : Self.refreshInterval)
                 completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
             }
         }

--- a/frontends/ios/WIDGET.md
+++ b/frontends/ios/WIDGET.md
@@ -73,7 +73,7 @@ Every successful API response is saved to `UserDefaults` as a `CachedPriceRecord
 
 **Cache key format:** `cachedPriceData_btc_USD` (one entry per coin+currency pair).
 
-**Cache TTL:** 1 hour. After that, the cached entry is considered stale and ignored.
+**Cache TTL:** 10 minutes. After that, the cached entry is considered stale and ignored.
 
 ### Cache-first strategy
 
@@ -81,7 +81,7 @@ When the widget refreshes, it follows this order:
 
 1. **Check cache** for the selected coin + currency.
 2. **If exact match found** (same coin AND same currency, not expired):
-   - Show the cached data immediately (no waiting). The next iOS-scheduled timeline reload will refresh it inline.
+   - Show the cached data immediately (no waiting). The next iOS-scheduled timeline reload will check again.
 3. **If no match** (cache miss, wrong currency, or expired):
    - Fetch from the network (blocking - the widget waits for the response).
    - If the network fails, try the cache as a last resort (even a different currency).
@@ -100,7 +100,9 @@ If the network fetch fails:
 
 ## 5. Refresh schedule
 
-- iOS calls the widget's timeline roughly **every 15 minutes**. This is not exact - iOS controls the actual timing based on widget budget, battery, and usage patterns.
+- The widget asks iOS for another timeline after **10 minutes**.
+- This is not exact - iOS controls the actual timing based on widget budget, battery, and usage patterns.
+- With the 10-minute cache TTL, each iOS-granted timeline reload should either use recent cached data or fetch fresh data.
 - If a network fetch fails, the widget asks iOS to retry in **1 minute**.
 - If the user changes their currency or accounts in the app, a refresh is triggered immediately.
 


### PR DESCRIPTION
The widget now asks iOS to refresh about every 10 minutes.

When iOS grants a refresh, the widget reuses cached price data only if it is less than 10 minutes old, instead of the previous 1 hour.