### PR TITLE
frontend: build frontend with npm ci --ignore-scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd frontends/web
-          npm install
+          npm ci --ignore-scripts
 
       - name: Build frontend
         run: |
@@ -164,7 +164,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontends/mobiletests
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Enable KVM group perms
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Run `make buildweb` before the first `make webdev` to install npm dependencies. 
   `make servewallet-simulator`, `make servewallet-prodservers`.
 - The Go backend does **not** hot-reload — restart it after code changes. The Vite frontend
   hot-reloads automatically.
-- `make buildweb` performs a clean web build (`npm ci && npm run build`) used by desktop packages.
+- `make buildweb` performs a clean web build (`npm ci --ignore-scripts && npm run build`) used by desktop packages.
 - `make webtest` and `make webtestwatch` run Vitest unit tests (one-shot and watch mode).
 - `make webe2etest` runs Playwright E2E tests. `make weblint` runs ESLint + type-check.
   `make webfix` auto-fixes lint issues.

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ buildweb:
 	node --version
 	npm --version
 	rm -rf ${WEBROOT}/build
-	cd ${WEBROOT} && npm ci
+	cd ${WEBROOT} && npm ci --ignore-scripts
 	cd ${WEBROOT} && npm run build
 webdev:
 	cd ${WEBROOT} && $(MAKE) dev

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -18,7 +18,7 @@ golangci-lint --version
 golangci-lint config verify
 golangci-lint run
 
-npm --prefix=frontends/web install # needed to install dev dependencies.
+npm --prefix=frontends/web ci --ignore-scripts # needed to install dev dependencies.
 make weblint
 npm --prefix=frontends/web test -- --no-color --no-watch
 


### PR DESCRIPTION
The web fronternd and all its dependencies should work without postintall hook, this may reduce some evil scripts in npm deps from executing malicious code at install time.

Most important make tasks such as webdev, webbuild, weblint and webtest all seem to work and not require running any postinstall npm hooks.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
