### PR TITLE
backend: fix duplicate transaction panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Bitcoin: show account details for the persisted receive address type by default
+- Electrum: prevent panic on transaction that is confirmed and still in mempool
 
 ## v4.51.1
 - iOS: fix App Store submission by packaging Inter as TTF fonts

--- a/backend/coins/btc/transactions/transactions.go
+++ b/backend/coins/btc/transactions/transactions.go
@@ -363,13 +363,48 @@ func (transactions *Transactions) UpdateAddressHistory(scriptHashHex blockchain.
 		return
 	}
 	err := DBUpdate(transactions.db, func(dbTx DBTxInterface) error {
-		txsSet := map[chainhash.Hash]struct{}{}
+		txsSet := map[chainhash.Hash]int{}
 		for _, txInfo := range txs {
-			txsSet[txInfo.TXHash.Hash()] = struct{}{}
+			hash := txInfo.TXHash.Hash()
+			haveHeight, haveTX := txsSet[hash]
+
+			// Electrum returns both confirmed transactions and
+			// mempool transactions. But if the server is still
+			// purging a recently mined transaction from the mempool
+			// exactly at the time of the call, it might appear
+			// twice, once with a valid height and once with no
+			// height. In that case we don't want to error out but
+			// instead just keep the confirmed TX.
+			switch {
+			// Two transactions both with a non-zero height, this is
+			// definitely wrong.
+			case haveTX && haveHeight > 0 && txInfo.Height > 0:
+				return errp.New("duplicate tx ids in address " +
+					"history returned by server")
+
+			// Two transactions both with a (below) zero height,
+			// this is also wrong.
+			case haveTX && haveHeight <= 0 && txInfo.Height <= 0:
+				return errp.New("duplicate tx ids in address " +
+					"history returned by server")
+
+			// We already had a mempool TX but now found a confirmed
+			// one, so we keep the confirmed.
+			case haveTX && haveHeight <= 0 && txInfo.Height > 0:
+				txsSet[txInfo.TXHash.Hash()] = txInfo.Height
+
+			// We already had a confirmed TX but now found a mempool
+			// one, which we just ignore.
+			case haveTX && haveHeight > 0 && txInfo.Height <= 0:
+				continue
+
+			// The default case means we don't have the TX yet, in
+			// which case we add it to the set.
+			default:
+				txsSet[txInfo.TXHash.Hash()] = txInfo.Height
+			}
 		}
-		if len(txsSet) != len(txs) {
-			return errp.New("duplicate tx ids in address history returned by server")
-		}
+
 		previousHistory, err := dbTx.AddressHistory(scriptHashHex)
 		if err != nil {
 			return err
@@ -384,10 +419,25 @@ func (transactions *Transactions) UpdateAddressHistory(scriptHashHex blockchain.
 			transactions.removeTxForAddress(dbTx, scriptHashHex, entry.TXHash.Hash())
 		}
 
-		if err := dbTx.PutAddressHistory(scriptHashHex, txs); err != nil {
+		// We want to deduplicate the list of transactions but in the
+		// same order as we received them. This is why we do it slightly
+		// more complicated than just turning the map into a slice
+		// again.
+		dedupTXs := make([]*blockchain.TxInfo, 0, len(txs))
+		for _, txInfo := range txs {
+			// If this isn't the exact value in the dedup map, we
+			// skip it, as it's a duplicate.
+			existingHeight, existing := txsSet[txInfo.TXHash.Hash()]
+			if !existing || existingHeight != txInfo.Height {
+				continue
+			}
+
+			dedupTXs = append(dedupTXs, txInfo)
+		}
+		if err := dbTx.PutAddressHistory(scriptHashHex, dedupTXs); err != nil {
 			return err
 		}
-		for _, txInfo := range txs {
+		for _, txInfo := range dedupTXs {
 			txHash := txInfo.TXHash.Hash()
 			height := txInfo.Height
 			tx, headerTimestamp := transactions.getTransactionCached(dbTx, txHash, height)

--- a/backend/coins/btc/transactions/transactions_test.go
+++ b/backend/coins/btc/transactions/transactions_test.go
@@ -332,6 +332,202 @@ func (s *transactionsSuite) TestBalance() {
 	s.Require().Equal(newBalance(expectedAmount2, 0), balance)
 }
 
+// TestUpdateAddressHistoryDuplicateTxs exercises every branch of the switch
+// inside UpdateAddressHistory that handles a tx hash appearing twice in the
+// server-returned history, plus the downstream dedup that decides what
+// actually gets persisted. The switch has four arms:
+//
+//  1. Both copies confirmed (Height > 0):                error / logrus.Panic
+//  2. Mempool first (Height <= 0), then confirmed:       upgrade to confirmed
+//  3. Confirmed first, then mempool (Height <= 0):       ignore the mempool copy
+//  4. Default (no prior entry, only add):                store the entry
+//
+// For non-error cases the test additionally pins down the *observable* outcome:
+// after the call, Transactions() must return exactly one entry with the
+// expected Height, and Balance() must classify that entry as Available (for
+// confirmed) or Incoming (for mempool / unconfirmed-parent). This guards the
+// downstream-loop dedup contract: case 3 in particular previously appeared
+// correct from the switch's perspective while the unfiltered txs slice was
+// still being persisted, silently overwriting the confirmed entry with the
+// mempool one.
+func (s *transactionsSuite) TestUpdateAddressHistoryDuplicateTxs() {
+	cases := []struct {
+		name string
+		// heights is the sequence of Height values returned by the
+		// (mock) server for one address — all sharing the same tx hash
+		// in the duplicate cases.
+		heights []int
+		// wantHeight is the Height the test expects to find indexed
+		// after UpdateAddressHistory returns. Unused when wantPanic.
+		wantHeight int
+		wantPanic  bool
+	}{
+		{
+			// Default branch: single new mempool tx, no duplicate.
+			name:       "default branch (single mempool tx)",
+			heights:    []int{0},
+			wantHeight: 0,
+		},
+		{
+			// Default branch: single new confirmed tx, no duplicate.
+			name:       "default branch (single confirmed tx)",
+			heights:    []int{10},
+			wantHeight: 10,
+		},
+		{
+			// Case 2: dedup must upgrade the mempool entry to
+			// confirmed.
+			name:       "mempool then confirmed",
+			heights:    []int{0, 10},
+			wantHeight: 10,
+		},
+		{
+			// Case 3: dedup must keep the confirmed entry and
+			// discard the mempool one. Before the slice-level
+			// dedup, the downstream processTxForAddress loop
+			// silently overwrote the confirmed Height with 0.
+			name:       "confirmed then mempool",
+			heights:    []int{10, 0},
+			wantHeight: 10,
+		},
+		{
+			// Case 2 variant: Electrum can return Height == -1 for
+			// "unconfirmed with unconfirmed parents". The switch
+			// treats Height <= 0 as mempool so the confirmed entry
+			// must still win.
+			name:       "unconfirmed-parent then confirmed",
+			heights:    []int{-1, 10},
+			wantHeight: 10,
+		},
+		{
+			// Case 3 variant: same as above with order reversed.
+			name:       "confirmed then unconfirmed-parent",
+			heights:    []int{10, -1},
+			wantHeight: 10,
+		},
+		{
+			// Case 1: two confirmed entries with the same hash is
+			// a real server bug; the switch returns an error from
+			// DBUpdate, which UpdateAddressHistory turns into a
+			// logrus.Panic.
+			name:      "two confirmed duplicates panics",
+			heights:   []int{10, 11},
+			wantPanic: true,
+		},
+		{
+			// Case 1b: same-hash, same-height mempool entries are
+			// also rejected. The switch arm that catches this is
+			// the "both <= 0" arm, distinct from the "both > 0"
+			// arm above.
+			name:      "two identical mempool entries panic",
+			heights:   []int{0, 0},
+			wantPanic: true,
+		},
+		{
+			// Case 1b variant: an unconfirmed-with-parent pair is
+			// also a server bug (a tx can't simultaneously be
+			// "in mempool, parents confirmed" and "in mempool,
+			// parents unconfirmed").
+			name:      "mempool then unconfirmed-parent panics",
+			heights:   []int{0, -1},
+			wantPanic: true,
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			// Reset the suite's DB / mocks / transactions instance
+			// so each case runs against a clean slate.
+			s.SetupTest()
+
+			addressList, err := s.addressChain.EnsureAddresses()
+			s.Require().NoError(err)
+			address := addressList[0]
+
+			const amount = btcutil.Amount(1000)
+			tx := newTx(chainhash.HashH(nil), 0, address, amount)
+			s.blockchainMock.RegisterTxs(tx)
+
+			entries := make([]*blockchainpkg.TxInfo, len(tc.heights))
+			for i, h := range tc.heights {
+				entries[i] = &blockchainpkg.TxInfo{
+					TXHash: blockchainpkg.TXHash(tx.TxHash()),
+					Height: h,
+				}
+			}
+
+			// After dedup, processTxForAddress is called once with
+			// wantHeight (or once per element in the panic case,
+			// but the panic happens first so nothing fires).
+			// Register one VerifiedHeaderByHeight return per
+			// confirmed entry the dedup might still process; .Once
+			// expectations that aren't consumed don't fail the
+			// test.
+			for _, h := range tc.heights {
+				if h > 0 {
+					s.headersMock.
+						On("VerifiedHeaderByHeight", h).
+						Return(nil, nil).Once()
+				}
+			}
+
+			if tc.wantPanic {
+				// In the panic case, DBUpdate returns the
+				// "duplicate tx ids" error before reaching the
+				// notifier.Put loop, so we bypass the helper
+				// (which would register Put expectations that
+				// never fire) and call the API directly.
+				s.Require().Panics(func() {
+					s.transactions.UpdateAddressHistory(
+						address.PubkeyScriptHashHex(), entries,
+					)
+				})
+				return
+			}
+
+			// All non-error branches must complete without panicking.
+			s.updateAddressHistory(address, entries)
+
+			// Exactly one indexed tx, at the height the dedup chose.
+			indexed, err := s.transactions.Transactions(
+				func(blockchainpkg.ScriptHashHex) bool { return false },
+			)
+			s.Require().NoError(err)
+			s.Require().Len(indexed, 1)
+			s.Require().Equal(tc.wantHeight, indexed[0].Height,
+				"final stored height after dedup")
+
+			// notifier.Put fires once per processTxForAddress call;
+			// the dedup must collapse all occurrences of a single
+			// hash into one downstream call. Counting Put calls
+			// catches dedup bugs that the per-hash-keyed PutTx
+			// happens to hide.
+			putCalls := 0
+			for _, c := range s.notifierMock.Calls {
+				if c.Method == "Put" {
+					putCalls++
+				}
+			}
+			s.Require().Equalf(1, putCalls,
+				"expected one notifier.Put per unique tx hash, got %d", putCalls)
+
+			// Balance reflects the chosen height. A positive height
+			// means the tx is confirmed and its output spendable;
+			// any other height (0 or -1) classifies the output as
+			// incoming because the tx's inputs aren't ours either.
+			balance, err := s.transactions.Balance()
+			s.Require().NoError(err)
+			if tc.wantHeight > 0 {
+				s.Require().Equal(newBalance(amount, 0), balance,
+					"confirmed tx must contribute to available balance")
+			} else {
+				s.Require().Equal(newBalance(0, amount), balance,
+					"unconfirmed tx must contribute to incoming balance")
+			}
+		})
+	}
+}
+
 func (s *transactionsSuite) TestRemoveTransaction() {
 	addresses, err := s.addressChain.EnsureAddresses()
 	s.Require().NoError(err)


### PR DESCRIPTION
Due to a race condition in electrs (and possibly in other Electrum server implementation), it's possible that a transaction appears both in the list of confirmed and mempool transactions (which in case of electrs is just concatenated and returned). That is not really a bug but just an inconvenience, so we change the code to only return an error if two confirmed transactions appear.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [x] updating the Changelog
- [x] writing unit tests
- [x] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [x] having an AI review your changes
