### PR TITLE
frontend: add lightning balance to my portfolio

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -293,6 +293,29 @@ type coinFormattedAmount struct {
 	FormattedAmount coinpkg.FormattedAmountWithConversions `json:"formattedAmount"`
 }
 
+func (backend *Backend) formattedCoinBalance(
+	coinCode coinpkg.Code,
+	coinName string,
+	coin coinpkg.Coin,
+	amount *big.Int,
+) coinFormattedAmount {
+	coinAmount := coinpkg.NewAmount(amount)
+	return coinFormattedAmount{
+		CoinCode: coinCode,
+		CoinName: coinName,
+		FormattedAmount: coinpkg.FormattedAmountWithConversions{
+			Amount: coin.FormatAmount(coinAmount, false),
+			Unit:   coin.GetFormatUnit(false),
+			Conversions: coinpkg.Conversions(
+				coinAmount,
+				coin,
+				false,
+				backend.RatesUpdater(),
+			),
+		},
+	}
+}
+
 // getCoinsTotalBalance returns the total balances grouped by coins.
 func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
 	coinFormattedAmounts := []coinFormattedAmount{}
@@ -325,19 +348,9 @@ func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
 		}
 	}
 
-	// Add lightning balance to BTC totals when lightning is enabled.
-	if backend.lightning.Account() != nil {
-		lightningBalance, err := backend.lightning.Balance()
-		if err != nil {
-			return nil, err
-		}
-		availableBalance := lightningBalance.Available().BigInt()
-		if bitcoinBalance, exists := totalCoinsBalances[coinpkg.CodeBTC]; exists {
-			bitcoinBalance.Add(bitcoinBalance, availableBalance)
-		} else {
-			totalCoinsBalances[coinpkg.CodeBTC] = availableBalance
-			sortedCoins = append([]coinpkg.Code{coinpkg.CodeBTC}, sortedCoins...)
-		}
+	lightningBalance, err := backend.lightningFormattedBalance()
+	if err != nil {
+		return nil, err
 	}
 
 	for _, coinCode := range sortedCoins {
@@ -345,23 +358,14 @@ func (backend *Backend) coinsTotalBalance() ([]coinFormattedAmount, error) {
 		if err != nil {
 			return nil, err
 		}
-		coinAmount := coinpkg.NewAmount(totalCoinsBalances[coinCode])
-		coinFormattedAmounts = append(coinFormattedAmounts, coinFormattedAmount{
-			CoinCode: coinCode,
-			CoinName: coin.Name(),
-			FormattedAmount: coinpkg.FormattedAmountWithConversions{
-				Amount: coin.FormatAmount(coinAmount, false),
-				Unit:   coin.GetFormatUnit(false),
-				Conversions: coinpkg.Conversions(
-					coinAmount,
-					coin,
-					false,
-					backend.RatesUpdater(),
-				),
-			},
-		})
+		coinFormattedAmounts = append(coinFormattedAmounts, backend.formattedCoinBalance(
+			coinCode,
+			coin.Name(),
+			coin,
+			totalCoinsBalances[coinCode],
+		))
 	}
-	return coinFormattedAmounts, nil
+	return insertLightningFormattedBalance(coinFormattedAmounts, lightningBalance), nil
 }
 
 // AmountsByCoin maps the total amount of each coin.
@@ -429,28 +433,6 @@ func (backend *Backend) keystoresBalance() (map[string]KeystoreBalance, error) {
 		keystoreTotalBalance, keystoreCoinsBalance, err := backend.AccountsFiatAndCoinBalance(accountList, fiatUnit)
 		if err != nil {
 			return nil, err
-		}
-
-		// Add lightning balance to the matching keystore totals when lightning is enabled.
-		if lightningAccount := backend.lightning.Account(); lightningAccount != nil {
-			lightningConfigRootFingerprint := hex.EncodeToString(lightningAccount.RootFingerprint)
-			if lightningConfigRootFingerprint == rootFingerprint {
-				lightningBalance, err := backend.lightning.Balance()
-				if err != nil {
-					return nil, err
-				}
-				lightningBalanceFiat, err := backend.convertBtcAmountToFiat(lightningBalance.Available(), fiatUnit)
-				if err != nil {
-					return nil, err
-				}
-				keystoreTotalBalance.Add(keystoreTotalBalance, lightningBalanceFiat)
-				lightningBalanceInt := lightningBalance.Available().BigInt()
-				if btcBalance, exists := keystoreCoinsBalance[coinpkg.CodeBTC]; exists {
-					btcBalance.Add(btcBalance, lightningBalanceInt)
-				} else {
-					keystoreCoinsBalance[coinpkg.CodeBTC] = lightningBalanceInt
-				}
-			}
 		}
 
 		keystoreCoinsAmount := AmountsByCoin{}

--- a/backend/lightning.go
+++ b/backend/lightning.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+
+// coinCodeLightning is a portfolio-only pseudo coin code. Use BTC for formatting and conversions;
+// backend.Coin(coinCodeLightning) does not resolve.
+const coinCodeLightning coinpkg.Code = "lightning"
+
+func (backend *Backend) lightningFormattedBalance() (*coinFormattedAmount, error) {
+	if backend.lightning.Account() == nil {
+		return nil, nil
+	}
+	lightningBalance, err := backend.lightning.Balance()
+	if err != nil {
+		return nil, err
+	}
+	btcCoin, err := backend.Coin(coinpkg.CodeBTC)
+	if err != nil {
+		return nil, err
+	}
+	formattedBalance := backend.formattedCoinBalance(
+		coinCodeLightning,
+		"Lightning",
+		btcCoin,
+		lightningBalance.Available().BigInt(),
+	)
+	return &formattedBalance, nil
+}
+
+func insertLightningFormattedBalance(
+	balances []coinFormattedAmount,
+	lightningBalance *coinFormattedAmount,
+) []coinFormattedAmount {
+	if lightningBalance == nil {
+		return balances
+	}
+	for index, balance := range balances {
+		if balance.CoinCode == coinpkg.CodeBTC {
+			result := make([]coinFormattedAmount, 0, len(balances)+1)
+			result = append(result, balances[:index+1]...)
+			result = append(result, *lightningBalance)
+			result = append(result, balances[index+1:]...)
+			return result
+		}
+	}
+	return append([]coinFormattedAmount{*lightningBalance}, balances...)
+}

--- a/backend/lightning_test.go
+++ b/backend/lightning_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"math/big"
+	"testing"
+
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormattedLightningBalance(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	b.ratesUpdater = rates.MockRateUpdater()
+	defer b.ratesUpdater.Stop()
+
+	btcCoin, err := b.Coin(coinpkg.CodeBTC)
+	require.NoError(t, err)
+
+	balance := b.formattedCoinBalance(
+		coinCodeLightning,
+		"Lightning",
+		btcCoin,
+		big.NewInt(1e8),
+	)
+
+	require.Equal(t, coinCodeLightning, balance.CoinCode)
+	require.Equal(t, "Lightning", balance.CoinName)
+	require.Equal(t, "1.00000000", balance.FormattedAmount.Amount)
+	require.Equal(t, "BTC", balance.FormattedAmount.Unit)
+	require.Equal(t, "21.00", balance.FormattedAmount.Conversions["USD"])
+}
+
+func TestLightningFormattedBalanceWithoutAccount(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	balance, err := b.lightningFormattedBalance()
+
+	require.NoError(t, err)
+	require.Nil(t, balance)
+}
+
+func TestInsertLightningFormattedBalance(t *testing.T) {
+	lightningBalance := coinFormattedAmount{CoinCode: coinCodeLightning}
+
+	tests := []struct {
+		name     string
+		balances []coinFormattedAmount
+		expected []coinpkg.Code
+	}{
+		{
+			name: "after bitcoin",
+			balances: []coinFormattedAmount{
+				{CoinCode: coinpkg.CodeBTC},
+				{CoinCode: coinpkg.CodeETH},
+			},
+			expected: []coinpkg.Code{
+				coinpkg.CodeBTC,
+				coinCodeLightning,
+				coinpkg.CodeETH,
+			},
+		},
+		{
+			name: "first when bitcoin is missing",
+			balances: []coinFormattedAmount{
+				{CoinCode: coinpkg.CodeETH},
+			},
+			expected: []coinpkg.Code{
+				coinCodeLightning,
+				coinpkg.CodeETH,
+			},
+		},
+		{
+			name:     "only row",
+			balances: []coinFormattedAmount{},
+			expected: []coinpkg.Code{coinCodeLightning},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := insertLightningFormattedBalance(tt.balances, &lightningBalance)
+			resultCodes := make([]coinpkg.Code, 0, len(result))
+			for _, balance := range result {
+				resultCodes = append(resultCodes, balance.CoinCode)
+			}
+			require.Equal(t, tt.expected, resultCodes)
+		})
+	}
+
+	require.Equal(t,
+		[]coinFormattedAmount{{CoinCode: coinpkg.CodeBTC}},
+		insertLightningFormattedBalance([]coinFormattedAmount{{CoinCode: coinpkg.CodeBTC}}, nil),
+	)
+}

--- a/frontends/web/src/hooks/coin-unit-price.test.ts
+++ b/frontends/web/src/hooks/coin-unit-price.test.ts
@@ -1,20 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { CoinCode } from '@/api/account';
 import { useCoinUnitPrice } from './coin-unit-price';
 
 vi.mock('@/api/coins', () => ({
   getCoinFiatPrices: vi.fn(),
-  subscribeCoinFiatPrices: vi.fn(() => () => () => {}),
+  subscribeCoinFiatPrices: vi.fn(() => () => {}),
 }));
 
-import { getCoinFiatPrices } from '@/api/coins';
+import { getCoinFiatPrices, subscribeCoinFiatPrices } from '@/api/coins';
 
 const mockGetCoinFiatPrices = vi.mocked(getCoinFiatPrices);
+const mockSubscribeCoinFiatPrices = vi.mocked(subscribeCoinFiatPrices);
 
 describe('useCoinUnitPrice', () => {
+  beforeEach(() => {
+    mockGetCoinFiatPrices.mockReset();
+    mockSubscribeCoinFiatPrices.mockClear();
+  });
+
   it('returns undefined while loading', () => {
     mockGetCoinFiatPrices.mockReturnValue(new Promise(() => {}));
     const { result } = renderHook(
@@ -40,5 +46,25 @@ describe('useCoinUnitPrice', () => {
       estimated: false,
     }));
     expect(mockGetCoinFiatPrices).toHaveBeenCalledWith('btc');
+  });
+
+  it('uses bitcoin prices for lightning', async () => {
+    mockGetCoinFiatPrices.mockResolvedValue({
+      amount: '1',
+      unit: 'BTC',
+      conversions: { USD: '60000.00' } as Record<string, string>,
+      estimated: false,
+    });
+    const { result } = renderHook(
+      () => useCoinUnitPrice('lightning', 'BTC'),
+    );
+    await waitFor(() => expect(result.current).toEqual({
+      amount: '1',
+      unit: 'BTC',
+      conversions: { USD: '60000.00' },
+      estimated: false,
+    }));
+    expect(mockGetCoinFiatPrices).toHaveBeenCalledWith('btc');
+    expect(mockSubscribeCoinFiatPrices).toHaveBeenCalledWith('btc');
   });
 });

--- a/frontends/web/src/hooks/coin-unit-price.ts
+++ b/frontends/web/src/hooks/coin-unit-price.ts
@@ -13,9 +13,10 @@ export const useCoinUnitPrice = (
   coinCode: CoinCode,
   unit?: CoinUnit,
 ): TAmountWithConversions | undefined => {
+  const unitPriceCoinCode = coinCode === 'lightning' ? 'btc' : coinCode;
   const result = useSync(
-    () => getCoinFiatPrices(coinCode),
-    subscribeCoinFiatPrices(coinCode),
+    () => getCoinFiatPrices(unitPriceCoinCode),
+    subscribeCoinFiatPrices(unitPriceCoinCode),
   );
   if (!result || !unit) {
     return undefined;

--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -139,6 +139,13 @@
     width: 100%;
 }
 
+.assetBalanceLogo {
+    width: 32px;
+    height: 32px;
+    flex: 0 0 32px;
+    object-fit: contain;
+}
+
 .assetBalanceDetailsRow {
     display: flex;
     flex-direction: row;

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -5,9 +5,11 @@ import { useTranslation } from 'react-i18next';
 import * as accountApi from '@/api/account';
 import { TDevices } from '@/api/devices';
 import { statusChanged, syncdone } from '@/api/accountsync';
+import { subscribeListPayments } from '@/api/lightning';
 import { unsubscribe } from '@/utils/subscriptions';
 import { TUnsubscribe } from '@/utils/transport-common';
 import { useMountedRef } from '@/hooks/mount';
+import { useLightning } from '@/hooks/lightning';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
 import { View } from '@/components/view/view';
 import { Chart } from './chart';
@@ -44,6 +46,7 @@ export const AccountsSummary = ({
   const mounted = useMountedRef();
   const { hideAmounts } = useContext(AppContext);
   const { defaultCurrency } = useContext(RatesContext);
+  const { lightningAccount } = useLightning();
 
   const accountsByKeystore = getAccountsByKeystore(accounts);
 
@@ -51,7 +54,8 @@ export const AccountsSummary = ({
   const hasMultipleAccountsPerCoin = Object.values(accountsPerCoin).some(
     coinAccounts => coinAccounts !== undefined && coinAccounts.length > 1
   );
-  const showTotalBalance = accountsByKeystore.length > 1
+  const showTotalBalance = lightningAccount !== null
+    || accountsByKeystore.length > 1
     || (accountsByKeystore.length > 0 && hasMultipleAccountsPerCoin);
 
   const [chartData, setChartData] = useState<accountApi.TChartData>();
@@ -124,7 +128,7 @@ export const AccountsSummary = ({
 
   useEffect(() => {
     // for subscriptions and unsubscriptions
-    // runs only on component mount and unmount.
+    // re-subscribes when accounts or lightning account state changes.
     const subscriptions: TUnsubscribe[] = [];
     accounts.forEach(account => {
       const currentCode = account.code;
@@ -136,8 +140,16 @@ export const AccountsSummary = ({
       }
       ));
     });
+    if (lightningAccount !== null) {
+      subscriptions.push(subscribeListPayments(() => {
+        if (mounted.current) {
+          getChartData();
+          getAccountsBalanceSummary();
+        }
+      }));
+    }
     return () => unsubscribe(subscriptions);
-  }, [update, accounts]);
+  }, [accounts, getAccountsBalanceSummary, getChartData, lightningAccount, mounted, update]);
 
 
   useEffect(() => {
@@ -145,7 +157,7 @@ export const AccountsSummary = ({
     // & whenever any of the dependencies change.
     getChartData();
     getAccountsBalanceSummary();
-  }, [getChartData, getAccountsBalanceSummary, defaultCurrency]);
+  }, [getChartData, getAccountsBalanceSummary, defaultCurrency, lightningAccount]);
 
   useEffect(() => {
     return () => {

--- a/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.test.tsx
+++ b/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.test.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TAmountWithConversions } from '@/api/account';
+import { useCoinUnitPrice } from '@/hooks/coin-unit-price';
+import { AssetBalanceWithUnitPrice } from './asset-balance-with-unit-price';
+
+vi.mock('@/hooks/coin-unit-price', () => ({
+  useCoinUnitPrice: vi.fn(),
+}));
+
+vi.mock('@/components/amount/amount-with-unit', () => ({
+  AmountWithUnit: ({ amount }: { amount?: TAmountWithConversions }) => (
+    <span>{amount?.amount}</span>
+  ),
+}));
+
+vi.mock('@/components/icon/logo', () => ({
+  Logo: ({ className, coinCode }: { className?: string; coinCode: string }) => (
+    <span className={className} data-testid="asset-logo">{coinCode}</span>
+  ),
+}));
+
+const mockUseCoinUnitPrice = vi.mocked(useCoinUnitPrice);
+
+const amount: TAmountWithConversions = {
+  amount: '0.00010000',
+  conversions: { USD: '10.00' },
+  estimated: false,
+  unit: 'BTC',
+};
+
+const ethAmount: TAmountWithConversions = {
+  amount: '1',
+  conversions: { USD: '100.00' },
+  estimated: false,
+  unit: 'ETH',
+};
+
+describe('AssetBalanceWithUnitPrice', () => {
+  beforeEach(() => {
+    mockUseCoinUnitPrice.mockReset();
+    mockUseCoinUnitPrice.mockReturnValue(undefined);
+  });
+
+  it('passes the asset coin code to the unit price hook', () => {
+    const { getByTestId } = render(
+      <AssetBalanceWithUnitPrice
+        amount={amount}
+        coinCode="lightning"
+        coinName="Lightning"
+      />
+    );
+
+    expect(mockUseCoinUnitPrice).toHaveBeenCalledWith('lightning', 'BTC');
+    expect(getByTestId('asset-logo').className).toContain('assetBalanceLogo');
+  });
+
+  it('uses the asset unit price for regular coins', () => {
+    render(
+      <AssetBalanceWithUnitPrice
+        amount={ethAmount}
+        coinCode="eth"
+        coinName="Ethereum"
+      />
+    );
+
+    expect(mockUseCoinUnitPrice).toHaveBeenCalledWith('eth', 'ETH');
+  });
+});

--- a/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
+++ b/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
@@ -20,7 +20,7 @@ export const AssetBalanceWithUnitPrice = ({ amount, coinCode, coinName, dataTest
   return (
     <div className={style.assetBalanceRow}>
       <div className={style.assetBalanceInfoFull}>
-        <Logo coinCode={coinCode} active={true} alt={coinCode} />
+        <Logo className={style.assetBalanceLogo} coinCode={coinCode} active={true} alt={coinCode} />
         <div className={style.assetBalanceDetailsRow}>
           <div className={style.assetBalanceDetailsCol}>
             <span


### PR DESCRIPTION
Show the Lightning balance as its own row in the portfolio total instead of adding it to the Bitcoin or keystore balances.

Use Bitcoin formatting and fiat conversions for the Lightning row, and refresh the account summary when Lightning payments change.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
