### PR TITLE
frontend/backend: use macos number format system settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Bitcoin: show account details for the persisted receive address type by default
 - Add external block explorer links to used addresses
 - Settings search
+- Support macOS "Number Format" system setting
 
 ## v4.51.1
 - iOS: fix App Store submission by packaging Inter as TTF fonts

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -164,6 +164,12 @@ type authEventObject struct {
 	Result *AuthResultType `json:"result,omitempty"`
 }
 
+// NumberFormat can contain different decimal and group separators specified by the user to format numbers can be empty in case the user did not overwrite.
+type NumberFormat struct {
+	DecimalSeparator string `json:"decimal"`
+	GroupSeparator   string `json:"group"`
+}
+
 // Environment represents functionality where the implementation depends on the environment the app
 // runs in, e.g. Qt5/Mobile/webdev.
 type Environment interface {
@@ -186,6 +192,7 @@ type Environment interface {
 	// to return empty string or unsupported value, in which case the app will use
 	// English by default.
 	NativeLocale() string
+	NumberFormat() *NumberFormat
 	// Invoke a file picker dialog for the user to select a destination to store a file.
 	// `suggestedFilename` is the proposed/default destination.
 	// The function should return the empty string if the user aborted the process.

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -226,6 +226,10 @@ func (e environment) NativeLocale() string {
 	return ""
 }
 
+func (e environment) NumberFormat() *NumberFormat {
+	return nil
+}
+
 func (e environment) GetSaveFilename(string) string {
 	return ""
 }

--- a/backend/bridgecommon/bridgecommon.go
+++ b/backend/bridgecommon/bridgecommon.go
@@ -181,6 +181,7 @@ type BackendEnvironment struct {
 	// NativeLocaleFunc is used by the backend to query native app layer for user
 	// preferred UI language.
 	NativeLocaleFunc         func() string
+	NumberFormatFunc         func() *backend.NumberFormat
 	GetSaveFilenameFunc      func(string) string
 	SetDarkThemeFunc         func(bool)
 	DetectDarkThemeFunc      func() bool
@@ -226,6 +227,14 @@ func (env *BackendEnvironment) NativeLocale() string {
 		return env.NativeLocaleFunc()
 	}
 	return ""
+}
+
+// NumberFormat implements backend.Environment.
+func (env *BackendEnvironment) NumberFormat() *backend.NumberFormat {
+	if env.NumberFormatFunc != nil {
+		return env.NumberFormatFunc()
+	}
+	return nil
 }
 
 // GetSaveFilename implements backend.Environment.

--- a/backend/bridgecommon/bridgecommon_test.go
+++ b/backend/bridgecommon/bridgecommon_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/bridgecommon"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/usb"
 	"github.com/stretchr/testify/require"
@@ -43,6 +44,10 @@ func (e environment) UsingMobileData() bool {
 
 func (e environment) NativeLocale() string {
 	return ""
+}
+
+func (e environment) NumberFormat() *backend.NumberFormat {
+	return nil
 }
 
 func (e environment) GetSaveFilename(string) string {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -205,6 +205,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/config/default", handlers.getDefaultConfig).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/config", handlers.postAppConfig).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/native-locale", handlers.getNativeLocale).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/number-format", handlers.getNumberFormat).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/notify-user", handlers.postNotify).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/open", handlers.postOpen).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/update", handlers.getUpdate).Methods("GET")
@@ -567,6 +568,10 @@ func (handlers *Handlers) postAppConfig(r *http.Request) interface{} {
 // The response value may be invalid or unsupported by the app.
 func (handlers *Handlers) getNativeLocale(*http.Request) interface{} {
 	return handlers.backend.Environment().NativeLocale()
+}
+
+func (handlers *Handlers) getNumberFormat(*http.Request) interface{} {
+	return handlers.backend.Environment().NumberFormat()
 }
 
 func (handlers *Handlers) postNotify(r *http.Request) interface{} {

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -38,17 +38,18 @@ type backendEnv struct {
 	Locale string // returned by NativeLocale
 }
 
-func (e *backendEnv) NotifyUser(string)             {}
-func (e *backendEnv) SystemOpen(string) error       { return nil }
-func (e *backendEnv) DeviceInfos() []usb.DeviceInfo { return nil }
-func (e *backendEnv) UsingMobileData() bool         { return false }
-func (e *backendEnv) NativeLocale() string          { return e.Locale }
-func (e *backendEnv) GetSaveFilename(string) string { return "" }
-func (e *backendEnv) SetDarkTheme(bool)             {}
-func (e *backendEnv) DetectDarkTheme() bool         { return false }
-func (e *backendEnv) Auth()                         {}
-func (e *backendEnv) OnAuthSettingChanged(bool)     {}
-func (e *backendEnv) BluetoothConnect(string)       {}
+func (e *backendEnv) NotifyUser(string)                   {}
+func (e *backendEnv) SystemOpen(string) error             { return nil }
+func (e *backendEnv) DeviceInfos() []usb.DeviceInfo       { return nil }
+func (e *backendEnv) UsingMobileData() bool               { return false }
+func (e *backendEnv) NativeLocale() string                { return e.Locale }
+func (e *backendEnv) NumberFormat() *backend.NumberFormat { return nil }
+func (e *backendEnv) GetSaveFilename(string) string       { return "" }
+func (e *backendEnv) SetDarkTheme(bool)                   {}
+func (e *backendEnv) DetectDarkTheme() bool               { return false }
+func (e *backendEnv) Auth()                               {}
+func (e *backendEnv) OnAuthSettingChanged(bool)           {}
+func (e *backendEnv) BluetoothConnect(string)             {}
 
 func TestGetNativeLocale(t *testing.T) {
 	const ptLocale = "pt"

--- a/backend/mobileserver/mobileserver.go
+++ b/backend/mobileserver/mobileserver.go
@@ -185,9 +185,12 @@ func Serve(dataDir string, testnet bool, environment GoEnvironmentInterface, goA
 				}
 				return []usb.DeviceInfo{deviceInfo{i}}
 			},
-			SystemOpenFunc:           environment.SystemOpen,
-			UsingMobileDataFunc:      environment.UsingMobileData,
-			NativeLocaleFunc:         environment.NativeLocale,
+			SystemOpenFunc:      environment.SystemOpen,
+			UsingMobileDataFunc: environment.UsingMobileData,
+			NativeLocaleFunc:    environment.NativeLocale,
+			NumberFormatFunc: func() *backend.NumberFormat {
+				return nil
+			},
 			GetSaveFilenameFunc:      environment.GetSaveFilename,
 			SetDarkThemeFunc:         environment.SetDarkTheme,
 			DetectDarkThemeFunc:      environment.DetectDarkTheme,

--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -118,6 +119,49 @@ func (webdevEnvironment) NativeLocale() string {
 	// used in the frontend and breaks UI in unexpected ways.
 	// We are always UTF-8 anyway.
 	return strings.Split(v, ".")[0]
+}
+
+func normalizeAppleSeparator(s string) string {
+	// macOS defaults encodes narrow no-break space as \U202f
+	return strings.ReplaceAll(s, `\\U202f`, "\u202f")
+}
+
+func parseAppleICUNumberSymbols(out []byte) *backendPkg.NumberFormat {
+	result := &backendPkg.NumberFormat{}
+
+	re := regexp.MustCompile(`(\d+)\s*=\s*"([^"]*)"`)
+	for _, m := range re.FindAllStringSubmatch(string(out), -1) {
+		switch m[1] {
+		case "0":
+			result.DecimalSeparator = normalizeAppleSeparator(m[2])
+		case "1":
+			result.GroupSeparator = normalizeAppleSeparator(m[2])
+		}
+	}
+
+	if result.DecimalSeparator == "" &&
+		result.GroupSeparator == "" {
+		return nil
+	}
+
+	return result
+}
+
+// NumberFormatting in webdev
+func (webdevEnvironment) NumberFormat() *backendPkg.NumberFormat {
+	log := logging.Get().WithGroup("servewallet")
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+
+	out, err := exec.Command("defaults", "read", "-g", "AppleICUNumberSymbols").Output()
+
+	if err != nil {
+		log.Warnf("failed to read AppleICUNumberSymbols via defaults: %v", err)
+		return nil
+	}
+
+	return parseAppleICUNumberSymbols(out)
 }
 
 // GetSaveFilename implements backend.Environment.

--- a/frontends/qt/libserver.h
+++ b/frontends/qt/libserver.h
@@ -48,7 +48,7 @@ extern "C" {
 extern void backendCall(int queryID, cchar_t* s);
 extern void setOnline(bool online);
 extern void handleURI(cchar_t* uri);
-extern void serve(cppHeapFree cppHeapFreeFn, pushNotificationsCallback pushNotificationsFn, responseCallback responseFn, notifyUserCallback notifyUserFn, cchar_t* preferredLocale, getSaveFilenameCallback getSaveFilenameFn);
+extern void serve(cppHeapFree cppHeapFreeFn, pushNotificationsCallback pushNotificationsFn, responseCallback responseFn, notifyUserCallback notifyUserFn, cchar_t* preferredDecimalSeparator, cchar_t* preferredGroupSeparator, cchar_t* preferredLocale, getSaveFilenameCallback getSaveFilenameFn);
 extern void systemOpen(cchar_t* url);
 extern void goLog(cchar_t* msg);
 extern void backendShutdown();

--- a/frontends/qt/main.cpp
+++ b/frontends/qt/main.cpp
@@ -353,10 +353,18 @@ int main(int argc, char *argv[])
     QResource::registerResource(QCoreApplication::applicationDirPath() + "/assets.rcc");
 
     QString preferredLocale = "";
-    QStringList uiLangs = QLocale::system().uiLanguages();
+    QLocale locale = QLocale::system();
+
+    QStringList uiLangs = locale.uiLanguages();
     if (!uiLangs.isEmpty()) {
         preferredLocale = uiLangs.first();
     }
+
+    QString decimalSeparator(locale.decimalPoint());
+    QString groupSeparator(locale.groupSeparator());
+
+    std::string decimalSeparatorStr = decimalSeparator.toUtf8().toStdString();
+    std::string groupSeparatorStr = groupSeparator.toUtf8().toStdString();
 
     webClass = new WebClass();
 
@@ -391,6 +399,8 @@ int main(int argc, char *argv[])
                                       Q_ARG(QString, APPNAME),
                                       Q_ARG(QString, msg));
         },
+        decimalSeparatorStr.c_str(),
+        groupSeparatorStr.c_str(),
         // user preferred UI language
         preferredLocale.toStdString().c_str(),
         // getSaveFilenameCallback

--- a/frontends/qt/server/server.go
+++ b/frontends/qt/server/server.go
@@ -54,6 +54,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/bridgecommon"
 	btctypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/types"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/bitbox02/simulator"
@@ -112,6 +113,8 @@ func serve(
 	pushNotificationsFn C.pushNotificationsCallback,
 	responseFn C.responseCallback,
 	notifyUserFn C.notifyUserCallback,
+	preferredDecimalSeparator *C.cchar_t,
+	preferredGroupSeparator *C.cchar_t,
 	preferredLocale *C.cchar_t,
 	getSaveFilenameFn C.getSaveFilenameCallback,
 ) {
@@ -153,6 +156,18 @@ func serve(
 	// from the stack.
 	nativeLocale := C.GoString(preferredLocale)
 
+	decimalSeparator := C.GoString(preferredDecimalSeparator)
+	groupSeparator := C.GoString(preferredGroupSeparator)
+
+	var numberFormat *backend.NumberFormat
+
+	if decimalSeparator != "" && groupSeparator != "" {
+		numberFormat = &backend.NumberFormat{
+			DecimalSeparator: decimalSeparator,
+			GroupSeparator:   groupSeparator,
+		}
+	}
+
 	bridgecommon.Serve(
 		*testnet,
 		*useSimulator,
@@ -179,6 +194,7 @@ func serve(
 			SystemOpenFunc:      system.Open,
 			UsingMobileDataFunc: func() bool { return false },
 			NativeLocaleFunc:    func() string { return nativeLocale },
+			NumberFormatFunc:    func() *backend.NumberFormat { return numberFormat },
 			GetSaveFilenameFunc: func(suggestedFilename string) string {
 				cSuggestedFilename := C.CString(suggestedFilename)
 				defer C.free(unsafe.Pointer(cSuggestedFilename))

--- a/frontends/web/src/api/nativelocale.ts
+++ b/frontends/web/src/api/nativelocale.ts
@@ -5,3 +5,12 @@ import { apiGet } from '@/utils/request';
 export const getNativeLocale = (): Promise<string> => {
   return apiGet('native-locale');
 };
+
+export type TNumberFormat = {
+  decimal: string;
+  group: string;
+} | null;
+
+export const getNumberFormat = (): Promise<TNumberFormat> => {
+  return apiGet('number-format');
+};

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -103,4 +103,3 @@ export const AppProvider = ({ children }: TProps) => {
     </AppContext.Provider>
   );
 };
-

--- a/frontends/web/src/contexts/localization-context.ts
+++ b/frontends/web/src/contexts/localization-context.ts
@@ -8,4 +8,4 @@ type LocalizationContextProps = {
 };
 
 
-export const LocalizationContext = createContext<LocalizationContextProps>({}as LocalizationContextProps);
+export const LocalizationContext = createContext<LocalizationContextProps>({} as LocalizationContextProps);

--- a/frontends/web/src/contexts/localization-provider.tsx
+++ b/frontends/web/src/contexts/localization-provider.tsx
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ReactNode, useContext } from 'react';
+import { useLoad } from '@/hooks/api';
+import { useDefault } from '@/hooks/default';
+import { getNumberFormat } from '@/api/nativelocale';
 import { useLocalizedPunctuation } from '@/hooks/localized';
 import { LocalizationContext } from './localization-context';
 import { AppContext } from './AppContext';
@@ -11,7 +14,16 @@ type TProps = {
 
 export const LocalizationProvider = ({ children }: TProps) => {
   const { nativeLocale } = useContext(AppContext);
-  const { decimal, group } = useLocalizedPunctuation(nativeLocale);
+  const {
+    decimal: decimalFromLocale,
+    group: groupFromLocale,
+  } = useLocalizedPunctuation(nativeLocale);
+
+  const systemNumberFormat = useDefault(useLoad(getNumberFormat), null);
+
+  const decimal = systemNumberFormat?.decimal ?? decimalFromLocale;
+
+  const group = systemNumberFormat?.group ?? groupFromLocale;
 
   return (
     <LocalizationContext.Provider value={{ decimal, group }}>

--- a/frontends/web/src/routes/account/summary/percentage-diff.tsx
+++ b/frontends/web/src/routes/account/summary/percentage-diff.tsx
@@ -5,6 +5,7 @@ import { AppContext } from '@/contexts/AppContext';
 import { localizePercentage } from '@/utils/localize';
 import { ArrowDownRed, ArrowUpGreen } from '@/components/icon';
 import styles from './percentage-diff.module.css';
+import { LocalizationContext } from '@/contexts/localization-context';
 
 type TPercentageDiff = {
   hasDifference: boolean;
@@ -18,10 +19,12 @@ export const PercentageDiff = ({
   title,
 }: TPercentageDiff) => {
   const { hideAmounts, nativeLocale } = useContext(AppContext);
+  const { decimal, group } = useContext(LocalizationContext);
   const positive = difference && difference > 0;
   const style = difference && positive ? 'up' : 'down';
   const className = hasDifference ? styles[style] : '';
-  const formattedDifference = difference && localizePercentage(difference, nativeLocale);
+  const formattedDifference = difference && localizePercentage(difference, nativeLocale, { decimal, group });
+
   return (
     <span className={className} title={title}>
       {hasDifference ? (

--- a/frontends/web/src/utils/localize.test.ts
+++ b/frontends/web/src/utils/localize.test.ts
@@ -5,8 +5,13 @@ import { localizePercentage } from './localize';
 
 describe('rates utils', () => {
   describe('localizePercentage', () => {
+
     it('formats positive number without thousand separator', () => {
       expect(localizePercentage(5.3212, 'es-419')).toBe('532.12');
+    });
+
+    it('falls back to default locale when locale is invalid', () => {
+      expect(localizePercentage(105.3212, 'c')).toMatch(/^10['’]532\.12$/);
     });
 
     it('formats positive number with thousand separator', () => {
@@ -43,6 +48,67 @@ describe('rates utils', () => {
 
     it('formats large negative number with separators, rounds to 2 digits', () => {
       expect(localizePercentage(-1234.56789, 'en-US')).toBe('-123,456.79');
+    });
+
+    it('overrides decimal and group separators when both are provided', () => {
+      expect(
+        localizePercentage(
+          12345.6789,
+          'en-US',
+          {
+            decimal: ',',
+            group: '.',
+          },
+        ),
+      ).toBe('1.234.567,89');
+    });
+
+    it('preserves locale grouping rules while overriding separators', () => {
+      expect(
+        localizePercentage(
+          15.3212,
+          'de-CH',
+          {
+            decimal: ',',
+            group: '.',
+          },
+        ),
+      ).toBe('1.532,12');
+    });
+
+    it('ignores custom format when only decimal or group separator is provided', () => {
+      expect(
+        localizePercentage(
+          12345.6789,
+          'en-US',
+          {
+            decimal: ',',
+          } as any,
+        ),
+      ).toBe('1,234,567.89');
+
+      expect(
+        localizePercentage(
+          12345.6789,
+          'en-US',
+          {
+            group: '.',
+          } as any,
+        ),
+      ).toBe('1,234,567.89');
+    });
+
+    it('applies custom separators when locale falls back', () => {
+      expect(
+        localizePercentage(
+          12345.6789,
+          'c',
+          {
+            decimal: ',',
+            group: '.',
+          },
+        ),
+      ).toBe('1.234.567,89');
     });
 
   });

--- a/frontends/web/src/utils/localize.ts
+++ b/frontends/web/src/utils/localize.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import type { TNumberFormat } from '@/api/nativelocale';
+
 /**
  * Formats a decimal value as a localized percentage string without the percent symbol.
  *
@@ -15,21 +17,35 @@
  *
  * The percent sign produced by Intl is removed from the final result.
  *
- * If the provided locale is invalid or Intl.NumberFormat fails,
- * the function falls back to a simple non-localized percentage format:
+ * If a customFormat object with both decimal and group separators is provided,
+ * the function overrides the locale's decimal and grouping separators while
+ * preserving all other locale-specific formatting behavior.
+ *
+ * If the provided locale is invalid or Intl.NumberFormat initialization fails,
+ * the function falls back to a `de-CH` percent formatter with two fraction digits.
+ * Custom decimal and grouping separator overrides are still applied when provided.
+ *
+ * If no formatter can be created, the function falls back to:
  *
  *   (amount * 100).toFixed(2)
  *
  * @param amount - Decimal percentage value (e.g. 0.1532 for 15.32%)
  * @param locale - BCP 47 locale string used for number formatting
+ * @param customFormat - Optional custom decimal and grouping separators.
+ * Both separators must be provided for the override to be applied.
+ * Overrides only the locale's decimal and group symbols while preserving all
+ * other locale-specific formatting behavior.
  * @returns Localized percentage string without the percent symbol
  */
 export const localizePercentage = (
   amount: number,
   locale: string,
+  customFormat?: TNumberFormat,
 ): string => {
 
-  let formatter;
+  const decimalSeparator = customFormat?.decimal;
+  const groupSeparator = customFormat?.group;
+  let formatter: Intl.NumberFormat | undefined;
 
   try {
     formatter = new Intl.NumberFormat(locale, {
@@ -38,14 +54,35 @@ export const localizePercentage = (
       signDisplay: 'auto',
       style: 'percent',
     });
-  } catch (error) {
+  } catch {
+    try {
+      // in case invalid locale / Intl formatting failures and fall back below
+      formatter = Intl.NumberFormat('de-CH', {
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2,
+        signDisplay: 'auto',
+        style: 'percent',
+      });
+    } catch {}
   }
 
   if (formatter) {
     return (
       formatter
-        .format(amount)
-        .replace('%', '')
+        .formatToParts(amount)
+        .filter(part => part.type !== 'percentSign')
+        .map(part => {
+          if (decimalSeparator !== undefined && groupSeparator !== undefined) {
+            if (part.type === 'decimal') {
+              return decimalSeparator;
+            }
+            if (part.type === 'group') {
+              return groupSeparator;
+            }
+          }
+          return part.value;
+        })
+        .join('')
         .trim()
     );
   }


### PR DESCRIPTION
In case the user configured a custom 'Number format' in macOS system settings, prefer this over formatting by locale.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [x] updating the Changelog
- [x] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [x] testing on multiple environments (Qt, Android, ...)
- [x] having an AI review your changes
