### PR TITLE
frontend: fix orientation change on all-accounts

### DIFF
--- a/frontends/web/src/routes/accounts/all-accounts.tsx
+++ b/frontends/web/src/routes/accounts/all-accounts.tsx
@@ -73,7 +73,7 @@ const AccountItem = ({ account }: TAccountItemProp) => {
 export const AllAccounts = ({ accounts = [] }: AllAccountsProps) => {
   const { t } = useTranslation();
   const accountsByKeystore = getAccountsByKeystore(accounts);
-  useOnlyVisitableOnMobile('/settings/manage-accounts');
+  useOnlyVisitableOnMobile('/account-summary');
 
   return (
     <Main>


### PR DESCRIPTION
The app currently redirects to settings/manage-accounts when a orientation change happens on all-accounts. Ideally the view does not change, but all-accounts is not available on large screens.

This fixes by changing the view to account-summary.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
