### PR TITLE
frontend: add missing i18n mock to test

### DIFF
--- a/frontends/web/src/components/guide/entry.test.tsx
+++ b/frontends/web/src/components/guide/entry.test.tsx
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import '../../../__mocks__/i18n';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Entry, TEntryProp } from './entry';
+vi.mock('@/i18n/i18n');
 
 vi.mock('@/utils/request', () => ({
   apiGet: vi.fn().mockResolvedValue(''),


### PR DESCRIPTION
Adding i18n mock to get rid of the following warning:

```
stderr | src/components/guide/entry.test.tsx > components/guide/entry > renders correct entry values > opened & has a link
react-i18next:: useTranslation: You will need to pass in an i18next instance by using initReactI18next { code: 'NO_I18NEXT_INSTANCE' }
```

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
