### PR TITLE
frontend: keep mobile nav for lightning wallet

### DIFF
--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -29,6 +29,7 @@ func NewHandlers(
 	lightning *Lightning,
 ) {
 	handleNoError("/account", lightning.GetAccount).Methods("GET")
+	handleNoError("/ready", lightning.GetReady).Methods("GET")
 	handleNoError("/activate", lightning.PostActivate).Methods("POST")
 	handleNoError("/deactivate", lightning.PostDeactivate).Methods("POST")
 	handleNoError("/balance", lightning.GetBalance).Methods("GET")
@@ -64,6 +65,11 @@ func (lightning *Lightning) GetAccount(_ *http.Request) interface{} {
 		Code:            account.Code,
 		Number:          account.Number,
 	}
+}
+
+// GetReady handles the GET request to retrieve whether the lightning SDK is ready.
+func (lightning *Lightning) GetReady(_ *http.Request) interface{} {
+	return responseDto{Success: true, Data: lightning.Ready()}
 }
 
 // PostActivate handles the POST request to activate lightning.

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -160,6 +160,7 @@ func (lightning *Lightning) Disconnect() {
 		lightning.sdkService.Destroy()
 		lightning.sdkService = nil
 		lightning.synced = false
+		lightning.notifyReady()
 	}
 }
 
@@ -196,6 +197,19 @@ func (lightning *Lightning) CheckActive() error {
 		return errp.New("Lightning not initialized")
 	}
 	return nil
+}
+
+// Ready returns true if the lightning account is configured and the SDK is connected.
+func (lightning *Lightning) Ready() bool {
+	return lightning.Account() != nil && lightning.sdkService != nil
+}
+
+func (lightning *Lightning) notifyReady() {
+	lightning.Notify(observable.Event{
+		Subject: "lightning/ready",
+		Action:  action.Replace,
+		Object:  lightning.Ready(),
+	})
 }
 
 // Balance returns the balance of the lightning account.
@@ -331,6 +345,7 @@ func (lightning *Lightning) connect(_ bool) error {
 		}
 
 		lightning.sdkService = sdk
+		lightning.notifyReady()
 	}
 	return nil
 }
@@ -471,6 +486,7 @@ func (lightning *Lightning) SetAccount(account *config.LightningAccountConfig) e
 		Subject: "lightning/account",
 		Action:  action.Reload,
 	})
+	lightning.notifyReady()
 
 	return nil
 }

--- a/backend/lightning/lightning_test.go
+++ b/backend/lightning/lightning_test.go
@@ -124,6 +124,25 @@ func TestSetAccount(t *testing.T) {
 	require.Empty(t, lightning.backendConfig.LightningConfig().Accounts)
 }
 
+func TestReady(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	require.False(t, lightning.Ready())
+
+	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{
+		Seed:            "test mnemonic",
+		RootFingerprint: []byte{0xde, 0xad, 0xbe, 0xef},
+		Code:            "v0-deadbeef-ln-0",
+		Number:          0,
+	}))
+	require.False(t, lightning.Ready())
+
+	lightning.sdkService = &breez_sdk_spark.BreezSdk{}
+	require.True(t, lightning.Ready())
+
+	require.NoError(t, lightning.SetAccount(nil))
+	require.False(t, lightning.Ready())
+}
+
 func TestServiceStatus(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -133,6 +133,10 @@ export const getLightningAccount = async (): Promise<TLightningAccount | null> =
   return apiGet('lightning/account');
 };
 
+export const getLightningReady = async (): Promise<boolean> => {
+  return getApiResponse<boolean>('lightning/ready', 'Error calling getLightningReady');
+};
+
 export const postActivate = async (): Promise<void> => {
   return postApiResponse<void, undefined>('lightning/activate', undefined, 'Error calling postActivate');
 };
@@ -179,6 +183,10 @@ export const getReceivePayment = async (params: TReceivePaymentRequest): Promise
 
 export const subscribeLightningAccount = (cb: TSubscriptionCallback<TLightningAccount | null>): TUnsubscribe => {
   return subscribeEndpoint('lightning/account', cb);
+};
+
+export const subscribeLightningReady = (cb: TSubscriptionCallback<boolean>): TUnsubscribe => {
+  return subscribeEndpoint('lightning/ready', cb);
 };
 
 export const subscribeListPayments = (cb: TSubscriptionCallback<TLightningPayment[]>) => {

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -15,6 +15,7 @@ import { getAccounts } from './api/account';
 import { syncAccountsList } from './api/accountsync';
 import { getDeviceList } from './api/devices';
 import { syncDeviceList } from './api/devicessync';
+import { getLightningAccount, subscribeLightningAccount } from './api/lightning';
 import { syncNewTxs } from './api/transactions';
 import { notifyUser } from './api/system';
 import { ConnectedApp } from './connected';
@@ -42,10 +43,12 @@ export const App = () => {
 
   const accounts = useDefault(useSync(getAccounts, syncAccountsList), []);
   const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});
+  const lightningAccount = useSync(getLightningAccount, subscribeLightningAccount);
   const prevDevices = usePrevious(devices);
 
   const deviceIDs = Object.keys(devices);
   const firstDevice = deviceIDs[0];
+  const hasLightningAccount = lightningAccount !== undefined && lightningAccount !== null;
 
   useEffect(() => {
     return syncNewTxs((meta) => {
@@ -68,15 +71,17 @@ export const App = () => {
       return;
     }
     // if no accounts are registered on specified views route to /
-    if (accounts.length === 0 && (
+    const canNavigateWithLightningAccount = currentURL === '/settings/more' || currentURL === '/accounts/all';
+    const requiresRegularAccount =
       currentURL.startsWith('/account-summary')
       || currentURL.startsWith('/add-account')
       || currentURL.startsWith('/settings/manage-accounts')
       || currentURL.startsWith('/accounts/')
-      // Workaround on mobile where the bottom menu is not shown when there are no devices/accounts.
-      // If one is on "More" and the bottom menu disappears, one is stuck.
-      || currentURL === '/settings/more'
-    )) {
+      || currentURL === '/settings/more';
+    const shouldRedirectNoRegularAccount =
+      !canNavigateWithLightningAccount
+      || lightningAccount === null;
+    if (accounts.length === 0 && requiresRegularAccount && shouldRedirectNoRegularAccount) {
       navigate('/');
       return;
     }
@@ -127,7 +132,7 @@ export const App = () => {
       return;
     }
 
-  }, [accounts, deviceIDs, firstDevice, navigate]);
+  }, [accounts, deviceIDs, firstDevice, lightningAccount, navigate]);
 
   useEffect(() => {
     const oldDeviceIDList = Object.keys(prevDevices || {});
@@ -165,60 +170,67 @@ export const App = () => {
   const activeAccounts = useMemo(() => accounts.filter(acct => acct.active), [accounts]);
   const tabKey = useMemo(() => getBottomNavKey(pathname), [pathname]);
 
-  const isBitboxBootloader = firstDevice && devices[firstDevice] === 'bitbox02-bootloader';
-  const showBottomNavigation = (deviceIDs.length > 0 || activeAccounts.length > 0) && !isBitboxBootloader;
+  const isBitboxBootloader = Boolean(firstDevice && devices[firstDevice] === 'bitbox02-bootloader');
+  const showBottomNavigation = (
+    deviceIDs.length > 0
+    || activeAccounts.length > 0
+    || hasLightningAccount
+  ) && !isBitboxBootloader;
 
 
   return (
     <ConnectedApp>
       <Providers>
-        <Darkmode />
-        <div className="app">
-          <AuthRequired/>
-          <Sidebar
-            accounts={activeAccounts}
-            devices={devices}
-          />
-          <div className={`
-            ${styles.appContent || ''}
-            ${showBottomNavigation && styles.hasBottomNavigation || ''}
-          `}>
-            <WCSigningRequest />
-            <Aopp />
-            <KeystoreConnectPrompt />
-            {
-              Object.entries(devices).map(([deviceID, platformName]) => {
-                if (platformName === 'bitbox02') {
-                  return (
-                    <Fragment key={deviceID}>
-                      <BitBox02Wizard
-                        deviceID={deviceID}
-                      />
-                    </Fragment>
-                  );
-                }
-                return null;
-              })
-            }
-            <div key={tabKey} className={styles.tabTransition}>
-              <AppRouter
-                accounts={accounts}
-                activeAccounts={activeAccounts}
-                devices={devices}
-                devicesKey={devicesKey}
-              />
-            </div>
-            <RouterWatcher />
-          </div>
-          {showBottomNavigation && (
-            <BottomNavigation
+        <>
+          <Darkmode />
+          <div className="app">
+            <AuthRequired/>
+            <Sidebar
+              accounts={activeAccounts}
               devices={devices}
-              activeAccounts={activeAccounts}
             />
-          )}
-          <Alert />
-          <Confirm />
-        </div>
+            <div className={`
+              ${styles.appContent || ''}
+              ${showBottomNavigation && styles.hasBottomNavigation || ''}
+            `}>
+              <WCSigningRequest />
+              <Aopp />
+              <KeystoreConnectPrompt />
+              {
+                Object.entries(devices).map(([deviceID, platformName]) => {
+                  if (platformName === 'bitbox02') {
+                    return (
+                      <Fragment key={deviceID}>
+                        <BitBox02Wizard
+                          deviceID={deviceID}
+                        />
+                      </Fragment>
+                    );
+                  }
+                  return null;
+                })
+              }
+              <div key={tabKey} className={styles.tabTransition}>
+                <AppRouter
+                  accounts={accounts}
+                  activeAccounts={activeAccounts}
+                  devices={devices}
+                  devicesKey={devicesKey}
+                />
+              </div>
+              <RouterWatcher />
+            </div>
+            {showBottomNavigation && (
+              <BottomNavigation
+                devices={devices}
+                activeAccounts={activeAccounts}
+                hasLightningAccount={hasLightningAccount}
+              />
+            )}
+            <Alert />
+            <Confirm />
+          </div>
+        </>
       </Providers>
     </ConnectedApp>
   );

--- a/frontends/web/src/components/bottom-navigation/bottom-navigation.tsx
+++ b/frontends/web/src/components/bottom-navigation/bottom-navigation.tsx
@@ -11,15 +11,17 @@ import { RedDot } from '@/components/icon';
 import { NewBadge } from '@/components/new-badge/new-badge';
 import styles from './bottom-navigation.module.css';
 
-type Props = {
+type TProps = {
   activeAccounts: TAccount[];
   devices: TDevices;
+  hasLightningAccount: boolean;
 };
 
 export const BottomNavigation = ({
   activeAccounts,
   devices,
-}: Props) => {
+  hasLightningAccount,
+}: TProps) => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
   const deviceID = Object.keys(devices)[0];
@@ -27,8 +29,15 @@ export const BottomNavigation = ({
   const versionInfo = useLoad(isBitBox02 ? () => getVersion(deviceID) : null, [deviceID, isBitBox02]);
   const canUpgrade = versionInfo ? versionInfo.canUpgrade : false;
 
-  const onlyHasOneAccount = activeAccounts.length === 1;
+  const accountCount = activeAccounts.length + (hasLightningAccount ? 1 : 0);
+  const onlyHasOneAccount = accountCount === 1;
   const accountCode = activeAccounts[0]?.code || '';
+  const accountTabURL = onlyHasOneAccount && accountCode
+    ? `/account/${accountCode}`
+    : onlyHasOneAccount && hasLightningAccount
+      ? '/lightning'
+      : '/accounts/all';
+  const onlyHasLightningAccount = hasLightningAccount && activeAccounts.length === 0;
 
   return (
     <div className={styles.container}>
@@ -45,36 +54,34 @@ export const BottomNavigation = ({
       <Link
         className={`
           ${styles.link || ''}
-          ${pathname.startsWith('/account/') || pathname.startsWith('/accounts/') ? (styles.active || '') : ''}
+          ${pathname.startsWith('/account/') || pathname.startsWith('/accounts/') || pathname.startsWith('/lightning') ? (styles.active || '') : ''}
         `}
-        to={
-          onlyHasOneAccount && accountCode ?
-            `/account/${accountCode}` :
-            '/accounts/all'
-        }
+        to={accountTabURL}
       >
         <AccountIconSVG />
         {onlyHasOneAccount ? t('account.account') : t('account.accounts')}
       </Link>
-      <Link
-        className={`
-          ${styles.link || ''}
-          ${pathname.startsWith('/market/') && styles.active || ''}
-        `}
-        to="/market/select"
-      >
-        <MarketIconSVG />
-        <span className={styles.marketplaceLabel}>
-          {t('generic.buySell')}
-          <NewBadge
-            className={styles.marketplaceNudgeDot}
-            configKey="hasSeenMarketplaceNudge"
-            hideOnPathPrefix="/market/"
-            pathname={pathname}
-            type="dot"
-          />
-        </span>
-      </Link>
+      {!onlyHasLightningAccount && (
+        <Link
+          className={`
+            ${styles.link || ''}
+            ${pathname.startsWith('/market/') && styles.active || ''}
+          `}
+          to="/market/select"
+        >
+          <MarketIconSVG />
+          <span className={styles.marketplaceLabel}>
+            {t('generic.buySell')}
+            <NewBadge
+              className={styles.marketplaceNudgeDot}
+              configKey="hasSeenMarketplaceNudge"
+              hideOnPathPrefix="/market/"
+              pathname={pathname}
+              type="dot"
+            />
+          </span>
+        </Link>
+      )}
       <Link
         className={`
           ${styles.link || ''}

--- a/frontends/web/src/components/bottom-navigation/utils.ts
+++ b/frontends/web/src/components/bottom-navigation/utils.ts
@@ -8,7 +8,7 @@ export const getBottomNavKey = (pathname: string): string => {
   if (pathname.startsWith('/account-summary')) {
     return 'portfolio';
   }
-  if (pathname.startsWith('/account/') || pathname.startsWith('/accounts/')) {
+  if (pathname.startsWith('/account/') || pathname.startsWith('/accounts/') || pathname.startsWith('/lightning')) {
     return 'accounts';
   }
   if (pathname.startsWith('/market/')) {

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -148,7 +148,7 @@ const Sidebar = ({
           </div>
         ) : null }
 
-        {lightningAccount !== null && (
+        {lightningAccount && (
           <GetLightningLink key="lightning" handleSidebarItemClick={handleSidebarItemClick} />
         )}
 

--- a/frontends/web/src/contexts/LightningContext.tsx
+++ b/frontends/web/src/contexts/LightningContext.tsx
@@ -4,7 +4,8 @@ import { createContext } from 'react';
 import { TLightningAccount } from '@/api/lightning';
 
 type Props = {
-  lightningAccount: TLightningAccount | null;
+  isLightningReady: boolean | undefined;
+  lightningAccount: TLightningAccount | null | undefined;
 };
 
 export const LightningContext = createContext<Props>({} as Props);

--- a/frontends/web/src/contexts/LightningProvider.tsx
+++ b/frontends/web/src/contexts/LightningProvider.tsx
@@ -2,23 +2,21 @@
 
 import { ReactNode } from 'react';
 import { LightningContext } from './LightningContext';
-import { getLightningAccount, subscribeLightningAccount } from '../api/lightning';
+import { getLightningAccount, getLightningReady, subscribeLightningAccount, subscribeLightningReady } from '../api/lightning';
 import { useSync } from '../hooks/api';
-import { useDefault } from '../hooks/default';
 
 type TProps = {
   children: ReactNode;
 };
 
 export const LightningProvider = ({ children }: TProps) => {
-  const lightningAccount = useDefault(
-    useSync(getLightningAccount, subscribeLightningAccount),
-    null,
-  );
+  const lightningAccount = useSync(getLightningAccount, subscribeLightningAccount);
+  const isLightningReady = useSync(getLightningReady, subscribeLightningReady);
 
   return (
     <LightningContext.Provider
       value={{
+        isLightningReady,
         lightningAccount
       }}>
       {children}

--- a/frontends/web/src/hooks/lightning.ts
+++ b/frontends/web/src/hooks/lightning.ts
@@ -4,6 +4,6 @@ import { useContext } from 'react';
 import { LightningContext } from '../contexts/LightningContext';
 
 export const useLightning = () => {
-  const { lightningAccount } = useContext(LightningContext);
-  return { lightningAccount };
+  const { isLightningReady, lightningAccount } = useContext(LightningContext);
+  return { isLightningReady, lightningAccount };
 };

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1593,6 +1593,7 @@
         "title": "Disabling lightning wallet..."
       }
     },
+    "initializing": "Lightning account initializing...",
     "payments": {
       "header": {
         "amount": "Amount",

--- a/frontends/web/src/routes/accounts/all-accounts.tsx
+++ b/frontends/web/src/routes/accounts/all-accounts.tsx
@@ -87,10 +87,15 @@ const AccountItem = ({ account }: TAccountItemProp) => {
 
 const LightningItem = () => {
   const { t } = useTranslation();
+  const { isLightningReady } = useLightning();
   const [balance, setBalance] = useState<accountApi.TAmountWithConversions>();
   const mounted = useMountedRef();
 
   useEffect(() => {
+    if (!isLightningReady) {
+      return;
+    }
+
     const fetchBalance = async () => {
       try {
         const response = await getLightningBalance();
@@ -104,7 +109,7 @@ const LightningItem = () => {
     };
 
     fetchBalance();
-  }, [mounted]);
+  }, [isLightningReady, mounted]);
 
   return (
     <AccountRow
@@ -133,7 +138,7 @@ export const AllAccounts = ({ accounts = [] }: AllAccountsProps) => {
       <View width="768px" fullscreen={false}>
         <ViewContent>
           <div className={styles.container} data-testid="all-accounts-keystores">
-            {lightningAccount !== null && (
+            {lightningAccount && (
               <div className={styles.accountsList}>
                 <LightningItem />
               </div>

--- a/frontends/web/src/routes/lightning/activate.tsx
+++ b/frontends/web/src/routes/lightning/activate.tsx
@@ -80,7 +80,7 @@ export const LightningActivate = () => {
   }, [activateLightning, activationStarted, step]);
 
   useEffect(() => {
-    if (step === 'confirm' && activationStarted && lightningAccount !== null) {
+    if (step === 'confirm' && activationStarted && lightningAccount) {
       setStep('activating');
     }
   }, [activationStarted, lightningAccount, step]);

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -20,7 +20,6 @@ import { GuideWrapper, GuidedContent, Header, Main } from '../../components/layo
 import { Spinner } from '../../components/spinner/Spinner';
 import { ActionButtons } from './components/action-buttons';
 import { LightningGuide } from './guide';
-import { unsubscribe } from '../../utils/subscriptions';
 import { GlobalBanners } from '@/components/banners';
 import { Status } from '../../components/status/status';
 import { HideAmountsButton } from '../../components/hideamountsbutton/hideamountsbutton';
@@ -30,39 +29,56 @@ import styles from './lightning.module.css';
 import { RatesContext } from '@/contexts/RatesContext';
 import { useLoad } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
+import { useLightning } from '@/hooks/lightning';
 
 const sparkStatusPollInterval = 60 * 1000;
 
 export const Lightning = () => {
   const { t } = useTranslation();
   const { btcUnit } = useContext(RatesContext);
+  const { isLightningReady, lightningAccount } = useLightning();
   const [balance, setBalance] = useState<accountApi.TBalance>();
   const [syncedAddressesCount] = useState<number>();
   const [payments, setPayments] = useState<TLightningPayment[]>();
+  const [boardingAddress, setBoardingAddress] = useState<string>();
   const [sparkStatus, setSparkStatus] = useState<TSparkStatus>();
   const [error, setError] = useState<string>();
   const [detailID, setDetailID] = useState<TLightningPayment['id'] | null>(null);
   const mounted = useMountedRef();
   const devices = useLoad(getDeviceList);
-  const boardingAddress = useLoad(getBoardingAddress);
 
   const onStateChange = useCallback(async () => {
     try {
       setError(undefined);
-      setBalance(await getLightningBalance());
-      setPayments(await getListPayments());
+      const [balance, payments, boardingAddress] = await Promise.all([
+        getLightningBalance(),
+        getListPayments(),
+        getBoardingAddress(),
+      ]);
+      if (!mounted.current) {
+        return;
+      }
+      setBalance(balance);
+      setPayments(payments);
+      setBoardingAddress(boardingAddress);
     } catch (err: any) {
-      const errorMessage = err?.errorMessage || err;
+      if (!mounted.current) {
+        return;
+      }
+      const errorMessage = err?.errorMessage || err?.message || String(err);
       setError(errorMessage);
     }
-  }, []);
+  }, [mounted]);
 
   useEffect(() => {
+    if (!lightningAccount || !isLightningReady) {
+      return;
+    }
+
     onStateChange();
 
-    const subscriptions = [subscribeListPayments(onStateChange)];
-    return () => unsubscribe(subscriptions);
-  }, [onStateChange, btcUnit]);
+    return subscribeListPayments(onStateChange);
+  }, [btcUnit, isLightningReady, lightningAccount, onStateChange]);
 
   const loadSparkStatus = useCallback(async () => {
     try {
@@ -121,6 +137,14 @@ export const Lightning = () => {
         <LightningGuide />
       </GuideWrapper>
     );
+  }
+
+  if (
+    lightningAccount === undefined
+    || isLightningReady === undefined
+    || (lightningAccount && !isLightningReady)
+  ) {
+    return <Spinner text={t('lightning.initializing')} />;
   }
 
   const canSend = balance && balance.hasAvailable;

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -82,10 +82,10 @@ export const AdvancedSettingsContent = ({
     {
       id: 'advanced-settings',
       items: [
-        {
+        ...(lightningAccount !== undefined ? [{
           id: 'lightning-wallet',
           content: lightningAccount === null ? <EnableLightning /> : <DisableLightning />,
-        },
+        }] : []),
         { id: 'custom-fees', content: <EnableCustomFeesToggleSetting /> },
         { id: 'coin-control', content: <EnableCoinControlSetting /> },
         ...(isScreenLockSettingVisible() ? [{


### PR DESCRIPTION
Show the bottom navigation when a Lightning wallet is remembered, even without a connected keystore or regular active accounts.

Treat Lightning routes as account-tab destinations so mobile users can navigate back to Settings after disconnecting the keystore.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
