### PR TITLE
backend/btc: sanity check txID

### DIFF
--- a/backend/coins/btc/electrum/client.go
+++ b/backend/coins/btc/electrum/client.go
@@ -130,6 +130,9 @@ func (c *client) TransactionGet(txHash chainhash.Hash) (*wire.MsgTx, error) {
 	if err := tx.BtcDecode(bytes.NewReader(rawTx), 0, wire.WitnessEncoding); err != nil {
 		return nil, err
 	}
+	if txHash != tx.TxHash() {
+		return nil, errp.New("Response is unexpected (transaction hash mismatch)")
+	}
 	return tx, nil
 }
 

--- a/backend/coins/btc/transactions/transactions.go
+++ b/backend/coins/btc/transactions/transactions.go
@@ -37,6 +37,17 @@ func getScriptHashHex(txOut *wire.TxOut) blockchain.ScriptHashHex {
 	return blockchain.NewScriptHashHex(txOut.PkScript)
 }
 
+func ensureTxHash(txHash chainhash.Hash, tx *wire.MsgTx) error {
+	if tx == nil {
+		return errp.Newf("missing transaction %s", txHash)
+	}
+	actualTxHash := tx.TxHash()
+	if actualTxHash != txHash {
+		return errp.Newf("transaction hash mismatch: expected %s, got %s", txHash, actualTxHash)
+	}
+	return nil
+}
+
 // Interface is the interface for the Transactions struct.
 //
 //go:generate moq -pkg mocks -out mocks/transactions.go . Interface
@@ -475,11 +486,17 @@ func (transactions *Transactions) getTransactionCached(
 	headerTimestamp := transactions.getCachedTimestampAtHeight(height, txInfo.HeaderTimestamp)
 
 	if txInfo.Tx != nil {
+		if err := ensureTxHash(txHash, txInfo.Tx); err != nil {
+			return nil, nil, err
+		}
 		return txInfo.Tx, headerTimestamp, nil
 	}
 	tx, err := transactions.blockchain.TransactionGet(txHash)
 	if err != nil {
 		return nil, nil, errp.WithMessage(err, "TransactionGet failed")
+	}
+	if err := ensureTxHash(txHash, tx); err != nil {
+		return nil, nil, err
 	}
 	return tx, headerTimestamp, nil
 }

--- a/backend/coins/btc/transactions/transactions_test.go
+++ b/backend/coins/btc/transactions/transactions_test.go
@@ -201,6 +201,20 @@ func (s *transactionsSuite) TestUpdateAddressHistorySingleTxReceive() {
 	s.Require().Equal(expectedTimestamp.UnixNano(), transactions[0].Timestamp.UnixNano())
 }
 
+func (s *transactionsSuite) TestUpdateAddressHistoryRejectsMismatchingTxHash() {
+	addresses, err := s.addressChain.EnsureAddresses()
+	s.Require().NoError(err)
+	address := addresses[0]
+	tx1 := newTx(chainhash.HashH(nil), 0, address, 123)
+	claimedTxHash := chainhash.HashH([]byte("claimed transaction"))
+	s.blockchainMock.transactions[claimedTxHash] = tx1
+
+	err = s.transactions.UpdateAddressHistory(address.PubkeyScriptHashHex(), []*blockchainpkg.TxInfo{
+		{TXHash: blockchainpkg.TXHash(claimedTxHash), Height: 0},
+	})
+	s.Require().ErrorContains(err, "transaction hash mismatch")
+}
+
 // TestSpendableOutputs checks that the utxo set is correct. Only confirmed (or unconfirmed outputs
 // we own) outputs can be spent.
 func (s *transactionsSuite) TestSpendableOutputs() {

--- a/backend/coins/btc/transactions/verification.go
+++ b/backend/coins/btc/transactions/verification.go
@@ -31,6 +31,14 @@ func (transactions *Transactions) unverifiedTransactions() (map[chainhash.Hash]i
 			if err != nil {
 				return nil, err
 			}
+			if txInfo.Tx == nil {
+				transactions.log.Warning("Transaction body missing")
+				continue
+			}
+			if txInfo.Tx.TxHash() != txHash {
+				transactions.handleTxInclusionVerificationFailed(txHash, "Transaction hash verification failed")
+				continue
+			}
 			result[txHash] = txInfo.Height
 		}
 		return result, nil
@@ -46,6 +54,10 @@ func hashMerkleRoot(merkle []blockchain.TXHash, start chainhash.Hash, pos int) c
 		}
 	}
 	return start
+}
+
+func (transactions *Transactions) handleTxInclusionVerificationFailed(txHash chainhash.Hash, reason string) {
+	transactions.log.WithField("txHash", txHash.String()).Warning(reason)
 }
 
 func (transactions *Transactions) verifyTransactions() {
@@ -86,7 +98,7 @@ func (transactions *Transactions) verifyTransaction(txHash chainhash.Hash, heigh
 	}
 	expectedMerkleRoot := hashMerkleRoot(merkle.Merkle, txHash, merkle.Pos)
 	if expectedMerkleRoot != header.MerkleRoot {
-		transactions.log.Warning("Merkle root verification failed")
+		transactions.handleTxInclusionVerificationFailed(txHash, "Merkle root verification failed")
 		return
 	}
 	transactions.log.Debugf("Merkle root verification succeeded")


### PR DESCRIPTION
Same as in `TransactionBroadcast`, sanity check the server response.
