### PR TITLE
config: remove unused files

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,3 +1,0 @@
-<context>: <title> (column size: <= 60 chars)
-
-<summary> (column size: <= 80 chars)

--- a/config/logging/log.yaml
+++ b/config/logging/log.yaml
@@ -1,2 +1,0 @@
-output: "log/output.log"
-base-threshold: DEBUG


### PR DESCRIPTION
Remove the unused logging YAML config and Git commit-message template. The logging file has been orphaned since aff986738 switched logging configuration away from config/logging/log.yaml in 2018. The commit template conflicts with CONTRIBUTING.md guidance.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
