### PR TITLE
frontend: hide balances for empty wallets and accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add external block explorer links to used addresses
 - Settings search
 - Support macOS "Number Format" system setting
+- Hide balances for empty wallets and accounts 
 
 ## v4.51.1
 - iOS: fix App Store submission by packaging Inter as TTF fonts

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -193,11 +193,10 @@ const RemountAccount = ({
 
   const exchangeSupported = supportedVendors && supportedVendors.vendors.length > 0;
 
-  const isAccountEmpty = balance
+  const isAccountEmpty = !!balance
     && !balance.hasAvailable
     && !balance.hasIncoming
-    && transactions
-    && transactions.success
+    && transactions?.success === true
     && transactions.list.length === 0;
 
 
@@ -255,15 +254,17 @@ const RemountAccount = ({
             <HeadersSync coinCode={account.coinCode} />
           )}
           <View>
-            <ViewHeader>
-              <div className={style.balanceHeader}>
-                <Balance balance={balance} />
-                {!isAccountEmpty && <ActionButtons {...actionButtonsProps} />}
-              </div>
-            </ViewHeader>
+            {!isAccountEmpty && (
+              <ViewHeader>
+                <div className={style.balanceHeader}>
+                  <Balance balance={balance} />
+                  <ActionButtons {...actionButtonsProps} />
+                </div>
+              </ViewHeader>
+            )}
             <ViewContent>
               <div className={style.accountHeader}>
-                {isAccountEmpty && (
+                {isAccountEmpty && balance && (
                   <BuyReceiveCTA
                     account={account}
                     code={code}

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -58,6 +58,14 @@ export const AccountsSummary = ({
   const [accountsBalanceSummary, setAccountsBalanceSummary] = useState<accountApi.TAccountsBalanceSummary>();
   const [balances, setBalances] = useState<Balances>();
   const [offlineError, setOfflineError] = useState<string | null>(null);
+  const balancesLoaded = accounts.length > 0
+    && accounts.every(account => balances?.[account.code] !== undefined);
+  const balanceList = accounts
+    .map(account => balances?.[account.code])
+    .filter((balance): balance is accountApi.TBalance => !!balance);
+  const isPortfolioEmpty = balancesLoaded
+    && balanceList.every(balance => !balance.hasAvailable && !balance.hasIncoming);
+  const hideChartSummaryOnNoData = !balancesLoaded || isPortfolioEmpty;
 
   const getChartData = useCallback(async () => {
     // replace previous timer if present
@@ -188,8 +196,9 @@ export const AccountsSummary = ({
             <Chart
               hideAmounts={hideAmounts}
               data={chartData}
+              hideSummaryOnNoData={hideChartSummaryOnNoData}
               noDataPlaceholder={
-                (accounts.length && accounts.length <= Object.keys(balances || {}).length) ? (
+                balancesLoaded ? (
                   <AddBuyReceiveOnEmptyBalances accounts={accounts} balances={balances} />
                 ) : undefined
               } />

--- a/frontends/web/src/routes/account/summary/chart.tsx
+++ b/frontends/web/src/routes/account/summary/chart.tsx
@@ -22,6 +22,7 @@ type TProps = {
   data?: TChartData;
   noDataPlaceholder?: JSX.Element;
   hideAmounts?: boolean;
+  hideSummaryOnNoData?: boolean;
 };
 
 const defaultData: Readonly<TChartData> = {
@@ -162,7 +163,8 @@ const autoScaleProvider: AutoscaleInfoProvider = (original) => {
 export const Chart = ({
   data = defaultData,
   noDataPlaceholder,
-  hideAmounts = false
+  hideAmounts = false,
+  hideSummaryOnNoData = false,
 }: TProps) => {
   const height: number = 300;
   const mobileHeight: number = 150;
@@ -618,6 +620,8 @@ export const Chart = ({
   const hasDifference = difference && Number.isFinite(difference);
   const disableFilters = !hasData || chartDataMissing;
   const disableWeeklyFilters = !hasHourlyData || chartDataMissing;
+  const showNoDataPlaceholder = !chartDataMissing && !hasData;
+  const hideSummary = hideSummaryOnNoData && showNoDataPlaceholder;
   const showMobileTotalValue = toolTipVisible && !!toolTipValue && isMobile;
   const chartFiltersProps = {
     display: chartDisplay,
@@ -633,37 +637,41 @@ export const Chart = ({
 
   return (
     <section className={styles.chart}>
-      <header>
-        <div className={styles.summary}>
-          <div className={styles.totalValue}>
-            {formattedChartTotal !== null ? (
-              // remove trailing zeroes for BTC fiat total
-              <Amount
-                amount={!showMobileTotalValue ? formattedChartTotal : toolTipValue}
-                unit={chartFiat}
-                onMobileClick={rotateDefaultCurrency}
-              />
-            ) : (
-              <Skeleton minWidth="220px" />
-            )}
-            <span className={styles.totalUnit}>
-              {chartTotal !== null && <AmountUnit unit={chartFiat} rotateUnit={rotateDefaultCurrency}/>}
-            </span>
-          </div>
-          {!showMobileTotalValue ? (
-            <PercentageDiff
-              hasDifference={!!hasDifference}
-              difference={difference}
-              title={diffSince}
-            />
-          ) : (
-            <span className={styles.diffValue}>
-              {renderDate(toolTipTime * 1000, i18n.language, source)}
-            </span>
+      {(!hideSummary || !isMobile) && (
+        <header>
+          {!hideSummary && (
+            <div className={styles.summary}>
+              <div className={styles.totalValue}>
+                {formattedChartTotal !== null ? (
+                  // remove trailing zeroes for BTC fiat total
+                  <Amount
+                    amount={!showMobileTotalValue ? formattedChartTotal : toolTipValue}
+                    unit={chartFiat}
+                    onMobileClick={rotateDefaultCurrency}
+                  />
+                ) : (
+                  <Skeleton minWidth="220px" />
+                )}
+                <span className={styles.totalUnit}>
+                  {chartTotal !== null && <AmountUnit unit={chartFiat} rotateUnit={rotateDefaultCurrency}/>}
+                </span>
+              </div>
+              {!showMobileTotalValue ? (
+                <PercentageDiff
+                  hasDifference={!!hasDifference}
+                  difference={difference}
+                  title={diffSince}
+                />
+              ) : (
+                <span className={styles.diffValue}>
+                  {renderDate(toolTipTime * 1000, i18n.language, source)}
+                </span>
+              )}
+            </div>
           )}
-        </div>
-        {!isMobile && <Filters {...chartFiltersProps} />}
-      </header>
+          {!isMobile && <Filters {...chartFiltersProps} />}
+        </header>
+      )}
       {!chartDataMissing && hasChartAnimationParam && (
         <div
           style={{ minHeight: chartHeight }}


### PR DESCRIPTION
Hide the balance header on empty account pages and hide the My Portfolio 
chart summary when loaded balances show no available or incoming funds.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
