### PR TITLE
frontend: add optional onion block explorer URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add optional .onion block explorer links for BTC/TBTC in advanced settings
 - Bitcoin: show account details for the persisted receive address type by default
 - Add external block explorer links to used addresses
 - Settings search

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -74,6 +74,10 @@ var fixedURLWhitelist = []string{
 	"https://mempool.space/address/",
 	"https://mempool.space/testnet/tx/",
 	"https://mempool.space/testnet/address/",
+	"http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/tx/",
+	"http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/address/",
+	"http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/tx/",
+	"http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/address/",
 	"https://sochain.com/tx/LTCTEST/",
 	"https://sochain.com/address/LTCTEST/",
 	"https://blockchair.com/litecoin/transaction/",
@@ -1032,8 +1036,7 @@ func isWhitelistedSystemOpenURL(rawURL string) bool {
 		if !strings.EqualFold(parsedURL.Hostname(), parsedWhitelisted.Hostname()) {
 			continue
 		}
-		port := parsedURL.Port()
-		if port != "" && port != "443" {
+		if effectivePort(parsedURL) != effectivePort(parsedWhitelisted) {
 			continue
 		}
 		requestedPath := parsedURL.Path
@@ -1052,6 +1055,22 @@ func isWhitelistedSystemOpenURL(rawURL string) bool {
 		}
 	}
 	return false
+}
+
+// effectivePort returns the URL's port, falling back to the scheme's default
+// port (80 for http, 443 for https) when none is explicitly specified.
+func effectivePort(parsedURL *url.URL) string {
+	if port := parsedURL.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(parsedURL.Scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
 }
 
 // SystemOpen opens the given URL using backend.environment.

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -247,7 +247,32 @@ func TestIsWhitelistedSystemOpenURL(t *testing.T) {
 			allowed: true,
 		},
 		{
-			name:    "blocks host prefix bypass",
+			name:    "allows mempool onion tx URL",
+			url:     "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/tx/abc123",
+			allowed: true,
+		},
+		{
+			name:    "allows mempool onion tx URL with default http port",
+			url:     "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion:80/tx/abc123",
+			allowed: true,
+		},
+		{
+			name:    "blocks mempool onion tx URL with https default port",
+			url:     "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion:443/tx/abc123",
+			allowed: false,
+		},
+		{
+			name:    "allows mempool onion testnet address URL",
+			url:     "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/address/bc1qexample",
+			allowed: true,
+		},
+		{
+			name:    "blocks mempool onion path prefix bypass",
+			url:     "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/txevil/123",
+			allowed: false,
+		},
+		{
+			name:    "blocks wrong host prefix bypass",
 			url:     "https://support.bitbox.swiss.evil.example/de_DE/",
 			allowed: false,
 		},

--- a/frontends/web/src/api/config.ts
+++ b/frontends/web/src/api/config.ts
@@ -57,6 +57,7 @@ export type TConfigFrontend = Readonly<{
   darkmode?: boolean;
   expertFee?: boolean;
   coinControl?: boolean;
+  useOnionExplorerUrls?: boolean;
   selectedExchangeRegion?: string;
   hideEnableRememberWalletDialog?: boolean;
   hasUsedWalletConnect?: boolean;

--- a/frontends/web/src/components/block-explorer-link/block-explorer-link.test.tsx
+++ b/frontends/web/src/components/block-explorer-link/block-explorer-link.test.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { BlockExplorerLink } from './block-explorer-link';
+import { open } from '@/api/system';
+import type { TConfig } from '@/api/config';
+
+vi.mock('@/i18n/i18n', () => ({
+  default: {
+    t: (key: string) => key,
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/api/system', () => ({
+  open: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('@/contexts/ConfigProvider', () => ({
+  useConfig: vi.fn(() => ({
+    config: { frontend: { useOnionExplorerUrls: false }, backend: {} } as TConfig,
+    setConfig: vi.fn(),
+  })),
+}));
+
+import { useConfig } from '@/contexts/ConfigProvider';
+
+describe('BlockExplorerLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useConfig).mockReturnValue({
+      config: { frontend: { useOnionExplorerUrls: false }, backend: {} } as TConfig,
+      setConfig: vi.fn(),
+    });
+  });
+
+  it('opens clearnet URL when onion explorer URLs are disabled', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BlockExplorerLink
+        prefix="https://mempool.space/tx/"
+        explorerId="abc123">
+        Open explorer
+      </BlockExplorerLink>,
+    );
+
+    await user.click(screen.getByText('Open explorer'));
+
+    expect(open).toHaveBeenCalledWith('https://mempool.space/tx/abc123');
+  });
+
+  it('opens onion URL when onion explorer URLs are enabled', async () => {
+    vi.mocked(useConfig).mockReturnValue({
+      config: { frontend: { useOnionExplorerUrls: true }, backend: {} } as TConfig,
+      setConfig: vi.fn(),
+    });
+    const user = userEvent.setup();
+
+    render(
+      <BlockExplorerLink
+        prefix="https://mempool.space/tx/"
+        explorerId="abc123">
+        Open explorer
+      </BlockExplorerLink>,
+    );
+
+    await user.click(screen.getByText('Open explorer'));
+
+    expect(open).toHaveBeenCalledWith(
+      'http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/tx/abc123',
+    );
+  });
+});

--- a/frontends/web/src/components/block-explorer-link/block-explorer-link.tsx
+++ b/frontends/web/src/components/block-explorer-link/block-explorer-link.tsx
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { A } from '@/components/anchor/anchor';
+import { useConfig } from '@/contexts/ConfigProvider';
+import { getMempoolExplorerUrl } from '@/utils/explorer-url';
+
+type TProps = {
+  children: ReactNode;
+  className?: string;
+  explorerId: string;
+  prefix: string;
+  title?: string;
+};
+
+export const BlockExplorerLink = ({
+  children,
+  className,
+  explorerId,
+  prefix,
+  title,
+}: TProps) => {
+  const { t } = useTranslation();
+  const { config } = useConfig();
+  const useOnion = config?.frontend.useOnionExplorerUrls ?? false;
+  const href = getMempoolExplorerUrl(prefix, explorerId, useOnion);
+  const linkTitle = title ?? `${t('transaction.explorerTitle')}\n${href}`;
+
+  return (
+    <A className={className} href={href} title={linkTitle}>
+      {children}
+    </A>
+  );
+};

--- a/frontends/web/src/components/transactions/components/tx-detail-dialog/tx-detail-dialog.tsx
+++ b/frontends/web/src/components/transactions/components/tx-detail-dialog/tx-detail-dialog.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TTransaction, TAmountWithConversions, getTransaction, TTransactionStatus, TTransactionType } from '@/api/account';
-import { A } from '@/components/anchor/anchor';
+import { BlockExplorerLink } from '@/components/block-explorer-link/block-explorer-link';
 import { Dialog } from '@/components/dialog/dialog';
 import { Note } from './note';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
@@ -154,14 +154,14 @@ export const TxDetailsDialog = ({
 
           {/* explorer link */}
           <div className={styles.explorerLinkContainer}>
-            <A
+            <BlockExplorerLink
               className={styles.explorerLink}
-              href={explorerURL + transactionInfo.txID}
-              title={`${t('transaction.explorerTitle')}\n${explorerURL}${transactionInfo.txID}`}>
+              prefix={explorerURL}
+              explorerId={transactionInfo.txID}>
               <ExternalLink />
               {' '}
               {t('transaction.explorerTitle')}
-            </A>
+            </BlockExplorerLink>
           </div>
         </div>
 

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1582,6 +1582,9 @@
       "customFees": {
         "description": "Lets you enter your own fee when sending."
       },
+      "onionExplorer": {
+        "description": "Use mempool's .onion address for BTC block explorer links. Requires a Tor-capable browser."
+      },
       "restartInTestnet": {
         "description": "Explore and test features by using testnet."
       },
@@ -1952,6 +1955,7 @@
         "title": "Export logs"
       },
       "fee": "Enable custom fees",
+      "onionExplorer": "Use .onion URLs for BTC explorer links",
       "restartInTestnet": "Testnet mode",
       "setProxyAddress": "Set proxy address",
       "title": "Expert settings",

--- a/frontends/web/src/routes/account/addresses/address-actions.tsx
+++ b/frontends/web/src/routes/account/addresses/address-actions.tsx
@@ -3,7 +3,7 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { AccountCode, TUsedAddress } from '@/api/account';
-import { A } from '@/components/anchor/anchor';
+import { BlockExplorerLink } from '@/components/block-explorer-link/block-explorer-link';
 import { Button } from '@/components/forms';
 import { Copy, ExternalLink, OutlinedFileProtectPrimary } from '@/components/icon';
 import style from './addresses.module.css';
@@ -35,15 +35,15 @@ export const AddressActions = ({ code, address, blockExplorerAddressPrefix, onCo
         </Button>
       )}
       {blockExplorerAddressPrefix && (
-        <A
+        <BlockExplorerLink
           className={style.linkAction}
-          href={`${blockExplorerAddressPrefix}${address.address}`}
-          title={`${t('transaction.explorerTitle')}\n${blockExplorerAddressPrefix}${address.address}`}>
+          prefix={blockExplorerAddressPrefix}
+          explorerId={address.address}>
           <span className={style.linkActionLabel}>
             <ExternalLink className={style.linkActionIcon} />
             {t('transaction.explorerTitle')}
           </span>
-        </A>
+        </BlockExplorerLink>
       )}
     </div>
   );

--- a/frontends/web/src/routes/account/addresses/addresses.test.tsx
+++ b/frontends/web/src/routes/account/addresses/addresses.test.tsx
@@ -25,6 +25,12 @@ vi.mock('@/components/banners', () => ({
 vi.mock('@/api/system', () => ({
   open: vi.fn().mockResolvedValue({ success: true }),
 }));
+vi.mock('@/contexts/ConfigProvider', () => ({
+  useConfig: vi.fn(() => ({
+    config: { frontend: { useOnionExplorerUrls: false } },
+    setConfig: vi.fn(),
+  })),
+}));
 
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { act, render, screen, waitFor } from '@testing-library/react';

--- a/frontends/web/src/routes/account/send/utxos.tsx
+++ b/frontends/web/src/routes/account/send/utxos.tsx
@@ -10,7 +10,7 @@ import {
   TUTXO,
 } from '@/api/account';
 import { syncdone } from '@/api/accountsync';
-import { A } from '@/components/anchor/anchor';
+import { BlockExplorerLink } from '@/components/block-explorer-link/block-explorer-link';
 import { Dialog, DialogButtons, DialogScrollContent } from '@/components/dialog/dialog';
 import { Button, Checkbox } from '@/components/forms';
 import { ExternalLink } from '@/components/icon';
@@ -165,12 +165,13 @@ export const UTXOs = ({
                       </span>:<span className={style.tabularNums}>{utxo.txOutput}</span>
                     </div>
                   </div>
-                  <A
+                  <BlockExplorerLink
                     className={style.utxoExplorer}
-                    href={explorerURL + utxo.txId}
+                    prefix={explorerURL}
+                    explorerId={utxo.txId}
                     title={t('transaction.explorerTitle')}>
                     <ExternalLink />
-                  </A>
+                  </BlockExplorerLink>
                 </div>
               </Checkbox>
             </li>

--- a/frontends/web/src/routes/settings/advanced-settings.tsx
+++ b/frontends/web/src/routes/settings/advanced-settings.tsx
@@ -9,6 +9,7 @@ import { TPagePropsWithSettingsTabs } from './types';
 import { EnableCustomFeesToggleSetting } from './components/advanced-settings/enable-custom-fees-toggle-setting';
 import { EnableCoinControlSetting } from './components/advanced-settings/enable-coin-control-setting';
 import { ConnectFullNodeSetting } from './components/advanced-settings/connect-full-node-setting';
+import { EnableOnionExplorerSetting } from './components/advanced-settings/enable-onion-explorer-setting';
 import { EnableTorProxySetting } from './components/advanced-settings/enable-tor-proxy-setting';
 import { UnlockSoftwareKeystore } from './components/advanced-settings/unlock-software-keystore';
 import { RestartInTestnetSetting } from './components/advanced-settings/restart-in-testnet-setting';
@@ -85,6 +86,7 @@ export const AdvancedSettingsContent = ({
           content: <EnableAuthSetting />,
         }] : []),
         { id: 'tor-proxy', content: <EnableTorProxySetting /> },
+        { id: 'onion-explorer', content: <EnableOnionExplorerSetting /> },
         { id: 'testnet-mode', content: <RestartInTestnetSetting /> },
         { id: 'gap-limit', content: <CustomGapLimitSettings /> },
         ...(isTestWalletSettingVisible({ deviceIDs, isTesting }) ? [{

--- a/frontends/web/src/routes/settings/components/advanced-settings/enable-onion-explorer-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/enable-onion-explorer-setting.tsx
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ChangeEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Toggle } from '@/components/toggle/toggle';
+import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
+import { useConfig } from '@/contexts/ConfigProvider';
+
+export const EnableOnionExplorerSetting = () => {
+  const { t } = useTranslation();
+  const { config, setConfig } = useConfig();
+
+  const handleToggle = async (e: ChangeEvent<HTMLInputElement>) => {
+    await setConfig({
+      frontend: {
+        useOnionExplorerUrls: e.target.checked,
+      },
+    });
+  };
+
+  return (
+    <SettingsItem
+      settingName={t('settings.expert.onionExplorer')}
+      secondaryText={t('newSettings.advancedSettings.onionExplorer.description')}
+      extraComponent={
+        config ? (
+          <Toggle
+            checked={config.frontend.useOnionExplorerUrls || false}
+            onChange={handleToggle}
+          />
+        ) : null
+      }
+    />
+  );
+};

--- a/frontends/web/src/routes/settings/settings-search.test.ts
+++ b/frontends/web/src/routes/settings/settings-search.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/utils/env', () => ({
 }));
 
 const translations: Record<string, string> = {
+  'settings.expert.onionExplorer': 'Use .onion URLs for explorer links',
   'testWallet.connect.title': 'Test wallet',
   'testWallet.disconnect.title': 'Disconnect test wallet',
 };
@@ -48,5 +49,15 @@ describe('settings search', () => {
       page: 'advanced',
       title: 'Disconnect test wallet',
     }]);
+  });
+
+  it('includes the onion explorer setting', () => {
+    const results = filterSettingsSearchItems(getItems(false), 'onion');
+
+    expect(results).toContainEqual({
+      id: 'onion-explorer',
+      page: 'advanced',
+      title: 'Use .onion URLs for explorer links',
+    });
   });
 });

--- a/frontends/web/src/routes/settings/settings-search.ts
+++ b/frontends/web/src/routes/settings/settings-search.ts
@@ -87,6 +87,11 @@ const SETTINGS_SEARCH_DESCRIPTORS: TSettingsSearchDescriptor[] = [
     page: 'advanced',
   },
   {
+    id: 'onion-explorer',
+    getTitle: ({ t }) => t('settings.expert.onionExplorer'),
+    page: 'advanced',
+  },
+  {
     id: 'testnet-mode',
     getTitle: ({ isTesting, t }) => isTesting ? t('testnet.deactivate.title') : t('testnet.activate.title'),
     page: 'advanced',

--- a/frontends/web/src/utils/explorer-url.test.ts
+++ b/frontends/web/src/utils/explorer-url.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { getMempoolExplorerUrl } from './explorer-url';
+
+const TX_ID = 'abc123';
+const ADDRESS = 'bc1qexample';
+
+describe('getMempoolExplorerUrl', () => {
+  it('returns the clearnet URL when onion mode is disabled', () => {
+    expect(getMempoolExplorerUrl('https://mempool.space/tx/', TX_ID, false)).toBe(
+      `https://mempool.space/tx/${TX_ID}`,
+    );
+  });
+
+  it('maps mainnet tx prefix to onion', () => {
+    expect(getMempoolExplorerUrl('https://mempool.space/tx/', TX_ID, true)).toBe(
+      `http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/tx/${TX_ID}`,
+    );
+  });
+
+  it('maps mainnet address prefix to onion', () => {
+    expect(getMempoolExplorerUrl('https://mempool.space/address/', ADDRESS, true)).toBe(
+      `http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/address/${ADDRESS}`,
+    );
+  });
+
+  it('maps testnet tx prefix to onion', () => {
+    expect(getMempoolExplorerUrl('https://mempool.space/testnet/tx/', TX_ID, true)).toBe(
+      `http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/tx/${TX_ID}`,
+    );
+  });
+
+  it('maps testnet address prefix to onion', () => {
+    expect(getMempoolExplorerUrl('https://mempool.space/testnet/address/', ADDRESS, true)).toBe(
+      `http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/testnet/address/${ADDRESS}`,
+    );
+  });
+
+  it('returns the clearnet URL for unknown explorer prefixes', () => {
+    const prefix = 'https://etherscan.io/tx/';
+    expect(getMempoolExplorerUrl(prefix, TX_ID, true)).toBe(`${prefix}${TX_ID}`);
+  });
+});

--- a/frontends/web/src/utils/explorer-url.ts
+++ b/frontends/web/src/utils/explorer-url.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const MEMPOOL_ONION_HOST = 'mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion';
+
+// The onion targets below must stay whitelisted in `fixedURLWhitelist` in
+// backend/backend.go, otherwise SystemOpen will block them. The keys must match
+// the clearnet prefixes the backend reports (BlockExplorer{Transaction,Address}URLPrefix);
+// unknown prefixes fall back to clearnet, so keep this map in sync with the backend.
+const CLEARNET_TO_ONION_PREFIX: Readonly<Record<string, string>> = {
+  'https://mempool.space/tx/': `http://${MEMPOOL_ONION_HOST}/tx/`,
+  'https://mempool.space/address/': `http://${MEMPOOL_ONION_HOST}/address/`,
+  'https://mempool.space/testnet/tx/': `http://${MEMPOOL_ONION_HOST}/testnet/tx/`,
+  'https://mempool.space/testnet/address/': `http://${MEMPOOL_ONION_HOST}/testnet/address/`,
+};
+
+export const getMempoolExplorerUrl = (
+  clearnetPrefix: string,
+  id: string,
+  useOnion: boolean,
+): string => {
+  if (!useOnion) {
+    return `${clearnetPrefix}${id}`;
+  }
+  const onionPrefix = CLEARNET_TO_ONION_PREFIX[clearnetPrefix];
+  if (!onionPrefix) {
+    return `${clearnetPrefix}${id}`;
+  }
+  return `${onionPrefix}${id}`;
+};


### PR DESCRIPTION
Add an expert setting to use mempool's .onion address for BTC/TBTC explorer links, whitelist the URLs in SystemOpen, and route existing explorer link call sites through a shared BlockExplorerLink component.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [x] updating the Changelog
- [x] writing unit tests
- [x] checking if your changes affect other coins or tokens in unintended ways
- [x] testing on multiple environments (Qt, Android, ...)
- [x] having an AI review your changes
