### PR TITLE
frontend: fix hidden send-all amounts

### DIFF
--- a/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
+++ b/frontends/web/src/routes/account/send/components/confirm/confirm.tsx
@@ -79,158 +79,161 @@ export const ConfirmSend = ({
       <UseDisableBackButton />
       <ViewHeader title={<div className={style.title}>{t('send.confirm.title')}</div>} />
       <ViewContent>
-        <Message type="info">
-          {t('send.confirm.infoMessage')}
-        </Message>
+        <div data-testid="send-confirm">
+          <Message type="info">
+            {t('send.confirm.infoMessage')}
+          </Message>
 
-        <Grid col="2">
+          <Grid col="2">
 
-          <Column col="2">
-            <div className={style.bitBoxContainer}>
-              <PointToBitBox02 />
-            </div>
-          </Column>
-
-          {/* Send amount */}
-          <Column col="2">
-            <span className={style.label}>
-              {t('generic.send')}
-            </span>
-          </Column>
-          <Column className={style.confirmItem}>
-            <span className={style.valueOriginalLarge}>
-              <AmountWithUnit
-                amount={proposedAmount}
-                enableRotateUnit
-                unitClassName={style.unit}
-              />
-            </span>
-          </Column>
-          <Column className={style.confirmItem}>
-            <FiatValue
-              amount={proposedAmount}
-              className={style.valueOriginalLarge}
-              enableRotateUnit
-            />
-          </Column>
-
-          {/* To (recipient address) */}
-          <Column col="2">
-            <span className={style.label}>
-              {t('send.confirm.to')}
-            </span>
-          </Column>
-          <Column col="2" className={style.confirmItem}>
-            <span>
-              {selectedReceiverAccountName
-                ? selectedReceiverAccountName
-                : recipientDisplayAddress
-              }
-              {' '}
-              {selectedReceiverAccountNumber !== undefined && (
-                <span className={style.address}>
-                  (Account #{selectedReceiverAccountNumber})
-                </span>
-              )}
-            </span>
-            {selectedReceiverAccountName && (
-              <span className={style.address}>
-                {recipientDisplayAddress}
-              </span>
-            )}
-          </Column>
-
-          {/* Note */}
-          {note ? (
-            <Column col="2" className={style.confirmItem}>
-              <span className={style.label}>
-                {t('note.title')}
-              </span>
-              <span>
-                {note}
-              </span>
-            </Column>
-          ) : null}
-
-          {/* Selected UTXOs grouped by address */}
-          { hasSelectedUTXOs && (
-            <Column col="2" className={style.confirmItem}>
-              <span className={style.label}>
-                {t('send.confirm.selected-coins')}
-              </span>
-              <div>
-                { Object.entries(groupUTXOsByAddress(selectedUTXOs)).map(([address, outpoints]) => (
-                  <div key={address} className={style.addressGroup}>
-                    <div className={style.address}>
-                      {address}
-                    </div>
-                    <ul>
-                      {outpoints.map((outpoint) => (
-                        <li key={outpoint} className={style.valueOriginal}>
-                          {outpoint}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )) }
+            <Column col="2">
+              <div className={style.bitBoxContainer}>
+                <PointToBitBox02 />
               </div>
             </Column>
-          )}
 
-          {/* Fee */}
-          <Column col="2">
-            <span className={style.label}>
-              {t('send.fee.label')}
-              {feeTarget ? ' (' + t(`send.feeTarget.label.${feeTarget}`) + ')' : ''}
-            </span>
-          </Column>
-          <Column className={style.confirmItem}>
-            <span>
-              <AmountWithUnit
+            {/* Send amount */}
+            <Column col="2">
+              <span className={style.label}>
+                {t('generic.send')}
+              </span>
+            </Column>
+            <Column className={style.confirmItem}>
+              <span className={style.valueOriginalLarge}>
+                <AmountWithUnit
+                  amount={proposedAmount}
+                  alwaysShowAmounts
+                  enableRotateUnit
+                  unitClassName={style.unit}
+                />
+              </span>
+            </Column>
+            <Column className={style.confirmItem}>
+              <FiatValue
+                amount={proposedAmount}
+                className={style.valueOriginalLarge}
+                enableRotateUnit
+              />
+            </Column>
+
+            {/* To (recipient address) */}
+            <Column col="2">
+              <span className={style.label}>
+                {t('send.confirm.to')}
+              </span>
+            </Column>
+            <Column col="2" className={style.confirmItem}>
+              <span>
+                {selectedReceiverAccountName
+                  ? selectedReceiverAccountName
+                  : recipientDisplayAddress
+                }
+                {' '}
+                {selectedReceiverAccountNumber !== undefined && (
+                  <span className={style.address}>
+                    (Account #{selectedReceiverAccountNumber})
+                  </span>
+                )}
+              </span>
+              {selectedReceiverAccountName && (
+                <span className={style.address}>
+                  {recipientDisplayAddress}
+                </span>
+              )}
+            </Column>
+
+            {/* Note */}
+            {note ? (
+              <Column col="2" className={style.confirmItem}>
+                <span className={style.label}>
+                  {t('note.title')}
+                </span>
+                <span>
+                  {note}
+                </span>
+              </Column>
+            ) : null}
+
+            {/* Selected UTXOs grouped by address */}
+            { hasSelectedUTXOs && (
+              <Column col="2" className={style.confirmItem}>
+                <span className={style.label}>
+                  {t('send.confirm.selected-coins')}
+                </span>
+                <div>
+                  { Object.entries(groupUTXOsByAddress(selectedUTXOs)).map(([address, outpoints]) => (
+                    <div key={address} className={style.addressGroup}>
+                      <div className={style.address}>
+                        {address}
+                      </div>
+                      <ul>
+                        {outpoints.map((outpoint) => (
+                          <li key={outpoint} className={style.valueOriginal}>
+                            {outpoint}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )) }
+                </div>
+              </Column>
+            )}
+
+            {/* Fee */}
+            <Column col="2">
+              <span className={style.label}>
+                {t('send.fee.label')}
+                {feeTarget ? ' (' + t(`send.feeTarget.label.${feeTarget}`) + ')' : ''}
+              </span>
+            </Column>
+            <Column className={style.confirmItem}>
+              <span>
+                <AmountWithUnit
+                  amount={proposedFee}
+                  alwaysShowAmounts
+                  enableRotateUnit
+                  unitClassName={style.unit}
+                />
+                {' '}
+                {customFee ? (
+                  <small>
+                    <br />
+                    ({customFee} {customFeeUnit(coinCode)})
+                  </small>
+                ) : null}
+              </span>
+            </Column>
+            <Column className={style.confirmItem}>
+              <FiatValue
                 amount={proposedFee}
+                enableRotateUnit
+              />
+            </Column>
+
+            {/* Total */}
+            <Column col="2">
+              <span className={style.label}>
+                {t('send.confirm.total')}
+              </span>
+            </Column>
+            <Column className={style.valueOriginalLarge}>
+              <AmountWithUnit
+                amount={proposedTotal}
                 alwaysShowAmounts
                 enableRotateUnit
                 unitClassName={style.unit}
               />
-              {' '}
-              {customFee ? (
-                <small>
-                  <br />
-                  ({customFee} {customFeeUnit(coinCode)})
-                </small>
-              ) : null}
-            </span>
-          </Column>
-          <Column className={style.confirmItem}>
-            <FiatValue
-              amount={proposedFee}
-              enableRotateUnit
-            />
-          </Column>
+            </Column>
+            <Column className={style.valueOriginalLarge}>
+              <FiatValue
+                className={style.totalFiatValue}
+                amount={proposedTotal}
+                enableRotateUnit
+              />
+            </Column>
 
-          {/* Total */}
-          <Column col="2">
-            <span className={style.label}>
-              {t('send.confirm.total')}
-            </span>
-          </Column>
-          <Column className={style.valueOriginalLarge}>
-            <AmountWithUnit
-              amount={proposedTotal}
-              alwaysShowAmounts
-              enableRotateUnit
-              unitClassName={style.unit}
-            />
-          </Column>
-          <Column className={style.valueOriginalLarge}>
-            <FiatValue
-              className={style.totalFiatValue}
-              amount={proposedTotal}
-              enableRotateUnit
-            />
-          </Column>
-
-        </Grid>
+          </Grid>
+        </div>
       </ViewContent>
     </View>
   );

--- a/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/coin-input.tsx
@@ -26,8 +26,9 @@ export const CoinInput = ({
   proposedAmount,
   amount,
   hasSelectedUTXOs
-}: TProps) => {
+}: TProps): JSX.Element => {
   const { t } = useTranslation();
+
   return (
     <NumberInput
       step="any"

--- a/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
+++ b/frontends/web/src/routes/account/send/components/inputs/fiat-input.tsx
@@ -18,7 +18,7 @@ export const FiatInput = ({
   disabled,
   error,
   fiatAmount,
-}: TProps) => {
+}: TProps): JSX.Element => {
   const { t } = useTranslation();
   return (
     <NumberInput

--- a/frontends/web/tests/send.test.ts
+++ b/frontends/web/tests/send.test.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect } from '@playwright/test';
+import { expect, type Route } from '@playwright/test';
 import { test } from './helpers/fixtures';
 import { ServeWallet } from './helpers/servewallet';
 import { launchRegtest, setupRegtestWallet, sendCoins, mineBlocks, cleanupRegtest } from './helpers/regtest';
 import { ChildProcess } from 'child_process';
-import { deleteAccountsFile } from './helpers/fs';
+import { deleteAccountsFile, deleteConfigFile } from './helpers/fs';
 import { getAccountCodeFromUrl, getReceiveAddressData, waitForAccountTransactions } from './helpers/account';
 
 let servewallet: ServeWallet | undefined;
@@ -114,19 +114,45 @@ test('Send BTC', async ({ page, host, frontendPort, servewalletPort, browserName
     const availableBalance = page.getByTestId('availableBalance');
     await availableBalance.getByTestId(`amount-unit-${currentFiat}`).click();
     await expect(fiatLabel).not.toHaveText(currentFiat);
+    await page.getByRole('button', { name: /Hide amounts/i }).click();
+    await expect(availableBalance).toContainText('***');
 
     await page.fill('#recipientAddress', recvAdd);
     await page.click('#sendAll');
     const reviewButton = page.getByRole('button', { name: 'Review' });
     await expect(reviewButton).toBeEnabled();
+    await expect(page.locator('#amount')).not.toHaveValue('');
+    await expect(page.locator('#amount')).not.toHaveAttribute('placeholder', '***');
+    await expect(page.locator('#fiatAmount')).not.toHaveValue('');
+    await expect(page.locator('#fiatAmount')).not.toHaveAttribute('placeholder', '***');
+    let releaseSendTxRequest: () => void = () => {};
+    const sendTxRequestGate = new Promise<void>((resolve) => {
+      releaseSendTxRequest = resolve;
+    });
+    const sendTxRouteHandler = async (route: Route) => {
+      await sendTxRequestGate;
+      await route.continue();
+    };
+    await page.route('**/sendtx', sendTxRouteHandler);
     const sendTxResponse = page.waitForResponse((response) =>
       response.url().includes('/sendtx') && response.request().method() === 'POST'
     );
     await reviewButton.click();
+    const sendConfirm = page.getByTestId('send-confirm');
+    try {
+      await expect(sendConfirm).toContainText('Send');
+      await expect(sendConfirm).toContainText('Network fee');
+      await expect(sendConfirm).toContainText('Total');
+      await expect(sendConfirm).not.toContainText('***');
+    } finally {
+      releaseSendTxRequest();
+    }
     await sendTxResponse;
+    await page.unroute('**/sendtx', sendTxRouteHandler);
     const doneButton = page.getByRole('button', { name: 'Done' });
     await expect(doneButton).toBeVisible();
     await doneButton.click();
+    await page.getByRole('button', { name: /Show amounts/i }).click();
     await mineBlocks(12);
     await Promise.all([
       waitForAccountTransactions(page, host, servewalletPort, firstAccountCode, 2),
@@ -225,9 +251,11 @@ test('Send BTC', async ({ page, host, frontendPort, servewalletPort, browserName
 
 test.beforeEach(async () => {
   deleteAccountsFile();
+  deleteConfigFile();
 });
 
 test.afterAll(async () => {
   await servewallet?.stop();
   await cleanupRegtest(regtest);
+  deleteConfigFile();
 });


### PR DESCRIPTION
Keep the send-all amount fields blank when hide amounts is enabled while leaving review transaction details visible, and add Playwright coverage for the send flow regression.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
