### PR TITLE
transactions: show fee rate in details

### DIFF
--- a/backend/coins/btc/feetarget.go
+++ b/backend/coins/btc/feetarget.go
@@ -29,10 +29,15 @@ func (feeTarget *FeeTarget) Code() accounts.FeeTargetCode {
 
 // FormattedFeeRate returns a string showing the fee rate.
 func (feeTarget *FeeTarget) FormattedFeeRate() string {
-	if feeTarget.feeRatePerKb == nil {
+	return FormatFeeRate(feeTarget.feeRatePerKb)
+}
+
+// FormatFeeRate returns a string showing the fee rate.
+func FormatFeeRate(feeRatePerKb *btcutil.Amount) string {
+	if feeRatePerKb == nil {
 		return ""
 	}
-	feePerByte := fmt.Sprintf("%.03f", float64(*feeTarget.feeRatePerKb)/1000.0)
+	feePerByte := fmt.Sprintf("%.03f", float64(*feeRatePerKb)/1000.0)
 	// Truncate trailing zeroes, and final '.' if the number has no decimal places.
 	feePerByte = strings.TrimRight(strings.TrimRight(feePerByte, "0"), ".")
 	return feePerByte + " sat/vB"

--- a/backend/coins/btc/feetarget_test.go
+++ b/backend/coins/btc/feetarget_test.go
@@ -43,6 +43,25 @@ func TestFeeTarget(t *testing.T) {
 	)
 }
 
+func TestFormatFeeRate(t *testing.T) {
+	require.Equal(t,
+		"",
+		FormatFeeRate(nil),
+	)
+	require.Equal(t,
+		"0.123 sat/vB",
+		FormatFeeRate(amt(123)),
+	)
+	require.Equal(t,
+		"123.456 sat/vB",
+		FormatFeeRate(amt(123456)),
+	)
+	require.Equal(t,
+		"1 sat/vB",
+		FormatFeeRate(amt(1000)),
+	)
+}
+
 func TestFeeTargets(t *testing.T) {
 	// empty slice
 	var feeTargets FeeTargets

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -103,10 +103,10 @@ type Transaction struct {
 	Note                     string                              `json:"note"`
 
 	// BTC specific fields.
-	VSize        int64                               `json:"vsize"`
-	Size         int64                               `json:"size"`
-	Weight       int64                               `json:"weight"`
-	FeeRatePerKb coin.FormattedAmountWithConversions `json:"feeRatePerKb"`
+	VSize       int64  `json:"vsize"`
+	Size        int64  `json:"size"`
+	Weight      int64  `json:"weight"`
+	FeeRateInfo string `json:"feeRateInfo"`
 
 	// ETH specific fields
 	Gas   uint64  `json:"gas"`
@@ -172,10 +172,7 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 			txInfoJSON.VSize = txInfo.VSize
 			txInfoJSON.Size = txInfo.Size
 			txInfoJSON.Weight = txInfo.Weight
-			feeRatePerKb := txInfo.FeeRatePerKb
-			if feeRatePerKb != nil {
-				txInfoJSON.FeeRatePerKb = coin.ConvertBTCAmount(handlers.account.Coin(), *feeRatePerKb, true, accountConfig.RateUpdater)
-			}
+			txInfoJSON.FeeRateInfo = btc.FormatFeeRate(txInfo.FeeRatePerKb)
 		case *eth.Coin:
 			txInfoJSON.Gas = txInfo.Gas
 			txInfoJSON.Nonce = txInfo.Nonce

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -231,7 +231,7 @@ export type TTransaction = {
   amount: TAmountWithConversions;
   amountAtTime: TAmountWithConversions;
   fee: TAmountWithConversions;
-  feeRatePerKb: TAmountWithConversions;
+  feeRateInfo: string;
   deductedAmountAtTime: TAmountWithConversions;
   gas: number;
   nonce: number | null;

--- a/frontends/web/src/components/transactions/components/tx-detail-dialog/advanced-tx-detail.tsx
+++ b/frontends/web/src/components/transactions/components/tx-detail-dialog/advanced-tx-detail.tsx
@@ -44,6 +44,12 @@ export const AdvancedTxDetail = ({ transactionInfo }: Props) => {
             <span>{transactionInfo.numConfirmations}</span>
           </TxDetailRow>
         ) }
+        {!!transactionInfo.feeRateInfo && (
+          <TxDetailRow>
+            <p className={styles.label}>{t('transaction.feeRate')}</p>
+            <span>{transactionInfo.feeRateInfo}</span>
+          </TxDetailRow>
+        ) }
         {!!transactionInfo.weight && (
           <TxDetailRow>
             <p className={styles.label}>{t('transaction.weight')}</p>

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -2094,6 +2094,7 @@
     "explorer": "Transaction ID",
     "explorerTitle": "Open in external block explorer",
     "fee": "Fee",
+    "feeRate": "Fee rate",
     "fiatHistorical": "Historical",
     "gas": "Gas",
     "no-results": "No transactions found matching \"{{searchTerm}}\"",

--- a/frontends/web/tests/send.test.ts
+++ b/frontends/web/tests/send.test.ts
@@ -208,6 +208,10 @@ test('Send BTC', async ({ page, host, frontendPort, servewalletPort, browserName
     await expect(txDetails).toBeVisible();
     const amount = await txDetails.getByTestId('amountBlocks').nth(0).textContent();
     const fee = await txDetails.getByTestId('amountBlocks').nth(1).textContent();
+    await expect(txDetails.getByText(/sat\/vB/)).toHaveCount(0);
+    await txDetails.getByRole('button', { name: 'Advanced' }).click();
+    await expect(txDetails.getByText('Fee rate', { exact: true })).toBeVisible();
+    await expect(txDetails.getByText(/^[0-9.]+ sat\/vB$/)).toBeVisible();
 
     await page.getByTestId('close-button').click();
 


### PR DESCRIPTION
Expose a backend-formatted BTC/LTC fee rate string on transaction details. Show it in the advanced transaction details section and cover the behavior in the existing send Playwright test.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
