### PR TITLE
frontend: show whole BTC and LTC amounts without decimal places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add external block explorer links to used addresses
 - Settings search
 - Support macOS "Number Format" system setting
+- Show whole BTC and LTC amounts without decimal places
 
 ## v4.51.1
 - iOS: fix App Store submission by packaging Inter as TTF fonts

--- a/frontends/web/src/components/amount/amount.test.tsx
+++ b/frontends/web/src/components/amount/amount.test.tsx
@@ -129,14 +129,24 @@ describe('Amount formatting', () => {
   });
 
   describe('BTC/LTC coins amounts', () => {
-    let coins: NativeCoinUnit[] = ['BTC', 'TBTC', 'LTC', 'TLTC'];
+    let coins: NativeCoinUnit[] = ['BTC', 'TBTC', 'RBTC', 'LTC', 'TLTC'];
     coins.forEach(coin => {
 
-      it('10.00000000 ' + coin + ' gets spaced', () => {
-        const { getByTestId } = render(<Amount amount="10.00000000" unit={coin}/>);
+      it('10.00000000 ' + coin + ' becomes 10', () => {
+        const { container } = render(<Amount amount="10.00000000" unit={coin}/>);
+        expect(container.textContent).toBe('10');
+      });
+
+      it('0.00000000 ' + coin + ' becomes 0', () => {
+        const { container } = render(<Amount amount="0.00000000" unit={coin}/>);
+        expect(container.textContent).toBe('0');
+      });
+
+      it('0.03000000 ' + coin + ' gets spaced', () => {
+        const { getByTestId } = render(<Amount amount="0.03000000" unit={coin}/>);
         const blocks = getByTestId('amountBlocks');
         const values = [
-          '10.00',
+          '0.03',
           '000',
           '000'
         ];

--- a/frontends/web/src/components/amount/amount.tsx
+++ b/frontends/web/src/components/amount/amount.tsx
@@ -76,6 +76,10 @@ const formatBtc = (
   if (dot === -1) {
     return formatLocalizedAmount(amount, group, decimal);
   }
+  const fractionalPart = amount.slice(dot + 1);
+  if (/^0+$/.test(fractionalPart)) {
+    return formatLocalizedAmount(stripTrailingZeros(amount), group, decimal);
+  }
   // localize the first part, everything up to the second decimal place, the rest is grouped by spaces
   const formattedPart = formatLocalizedAmount(amount.slice(0, dot + 3), group, decimal);
   return (


### PR DESCRIPTION
Keep the existing grouped decimal formatting for fractional amounts such as 0.03 000 000 BTC.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
