### PR TITLE
servewallet: normalize ICU space escapes

### DIFF
--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -122,8 +122,14 @@ func (webdevEnvironment) NativeLocale() string {
 }
 
 func normalizeAppleSeparator(s string) string {
-	// macOS defaults encodes narrow no-break space as \U202f
-	return strings.ReplaceAll(s, `\\U202f`, "\u202f")
+	// macOS defaults may encode narrow no-break space as \U202f.
+	replacer := strings.NewReplacer(
+		`\\U202f`, "\u202f",
+		`\\U202F`, "\u202f",
+		`\U202f`, "\u202f",
+		`\U202F`, "\u202f",
+	)
+	return replacer.Replace(s)
 }
 
 func parseAppleICUNumberSymbols(out []byte) *backendPkg.NumberFormat {

--- a/cmd/servewallet/main_test.go
+++ b/cmd/servewallet/main_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "testing"
+
+func TestNormalizeAppleSeparator(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "double backslash lowercase",
+			in:   `\\U202f`,
+		},
+		{
+			name: "double backslash uppercase",
+			in:   `\\U202F`,
+		},
+		{
+			name: "single backslash lowercase",
+			in:   `\U202f`,
+		},
+		{
+			name: "single backslash uppercase",
+			in:   `\U202F`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeAppleSeparator(tc.in); got != "\u202f" {
+				t.Fatalf("got %q, want %q", got, "\u202f")
+			}
+		})
+	}
+}


### PR DESCRIPTION
macOS defaults may return the ICU narrow no-break space escape with one or two leading backslashes, and with either lowercase or uppercase hex digits.

Normalize all of those forms before exposing the number format to the frontend so custom group separators are interpreted consistently in webdev.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
