### PR TITLE
frontend: fix missing visual space in 1 column grid-as-card

### DIFF
--- a/frontends/web/src/components/layout/grid.module.css
+++ b/frontends/web/src/components/layout/grid.module.css
@@ -33,6 +33,10 @@
     padding: var(--space-default);
 }
 
+.grid.grid-columns-1 .columnAsCard + .columnAsCard {
+    margin-top: var(--space-default);
+}
+
 @media (max-width: 768px) {
     .grid.responsive {
         display: block;


### PR DESCRIPTION
Space between keystores in manage-account was missing.

Regression introduced in:
- 27e3b4aea09eb423ef89b8646588327503bde1c9

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
