### PR TITLE
frontend: fix strip trailing zeros also in cased of tbtc rbtc ltc

### DIFF
--- a/frontends/web/src/components/amount/amount-with-unit.tsx
+++ b/frontends/web/src/components/amount/amount-with-unit.tsx
@@ -4,7 +4,7 @@ import { useContext } from 'react';
 import type { CoinUnit, ConversionUnit, TAmountWithConversions } from '@/api/account';
 import { RatesContext } from '@/contexts/RatesContext';
 import { Amount } from '@/components/amount/amount';
-import { isBitcoinCoin } from '@/routes/account/utils';
+import { isBitcoinCoin, isBitcoinCoinBased } from '@/routes/account/utils';
 import style from './amount-with-unit.module.css';
 
 type TAmountWithUnitProps = {
@@ -53,7 +53,7 @@ export const AmountWithUnit = ({
   }
 
   const enableClick = enableRotateUnit && (convertToFiat || isBitcoinCoin(amount.unit));
-  const stripTrailingZeros = removeTrailingZeros && displayedUnit === 'BTC';
+  const stripTrailingZeros = removeTrailingZeros && isBitcoinCoinBased(amount.unit);
 
   return (
     <span className={`

--- a/frontends/web/src/routes/account/utils.ts
+++ b/frontends/web/src/routes/account/utils.ts
@@ -58,6 +58,21 @@ export const isBitcoinBased = (coinCode: CoinCode): boolean => {
   }
 };
 
+export const isBitcoinCoinBased = (coinCode: CoinUnit): boolean => {
+  switch (coinCode) {
+  case 'BTC':
+  case 'TBTC':
+  case 'RBTC':
+  case 'sat':
+  case 'tsat':
+  case 'LTC':
+  case 'TLTC':
+    return true;
+  default:
+    return false;
+  }
+};
+
 export const isEthereumBased = (coinCode: CoinCode): boolean => {
   return coinCode === 'eth' || coinCode === 'sepeth' || coinCode.startsWith('eth-erc20-');
 };


### PR DESCRIPTION
The removeTrailingZeros prop only had an effect if the unit was 'BTC' but not in case of tbtc, ltc etc.

'sat' is also bitcoin based but is handled correclty by internal amount component, zeros should not be removed for sats.
