### PR TITLE
backend: coalesce ETH account init sync

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -931,8 +931,19 @@ func (backend *Backend) gapLimits() *btctypes.GapLimits {
 	return gapLimits
 }
 
+// accountLoadOptions controls how persisted accounts are loaded into the runtime account registry.
+type accountLoadOptions struct {
+	// skipETHInitialSync suppresses per-account ETH init refreshes when the caller will refresh all
+	// loaded ETH accounts together.
+	skipETHInitialSync bool
+}
+
 // The accountsAndKeystoreLock must be held when calling this function.
-func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *config.Account) {
+func (backend *Backend) createAndAddAccount(
+	coin coinpkg.Coin,
+	persistedConfig *config.Account,
+	options accountLoadOptions,
+) {
 	if backend.accounts.lookup(persistedConfig.Code) != nil {
 		// Do not create/load account if it is already loaded.
 		return
@@ -941,7 +952,7 @@ func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *
 	accountConfig := &accounts.AccountConfig{
 		Config:          persistedConfig,
 		DBFolder:        backend.arguments.CacheDirectoryPath(),
-		SkipInitialSync: backend.skipETHInitialSync,
+		SkipInitialSync: options.skipETHInitialSync,
 		NotesFolder:     backend.arguments.NotesDirectoryPath(),
 		ConnectKeystore: func() (keystore.Keystore, error) {
 			accountRootFingerprint, err := persistedConfig.SigningConfigurations.RootFingerprint()
@@ -1028,7 +1039,7 @@ func (backend *Backend) createAndAddAccount(coin coinpkg.Coin, persistedConfig *
 				ActiveTokens:          nil,
 			}
 
-			backend.createAndAddAccount(token, erc20Config)
+			backend.createAndAddAccount(token, erc20Config, options)
 		}
 	default:
 		panic("unknown coin type")
@@ -1177,7 +1188,7 @@ func (backend *Backend) persistETHAccountConfig(
 }
 
 // The accountsAndKeystoreLock must be held when calling this function.
-func (backend *Backend) initPersistedAccounts() {
+func (backend *Backend) initPersistedAccounts(options accountLoadOptions) {
 	// Only load accounts which belong to connected keystores or for which watchonly is enabled.
 	keystoreConnectedOrWatch := func(accountsConfig *config.AccountsConfig, account *config.Account) bool {
 		isWatch, err := accountsConfig.IsAccountWatchOnly(account)
@@ -1240,7 +1251,7 @@ outer:
 			}
 		}
 
-		backend.createAndAddAccount(coin, account)
+		backend.createAndAddAccount(coin, account, options)
 	}
 }
 
@@ -1342,7 +1353,8 @@ func (backend *Backend) initAccounts(force bool) {
 	// Since initAccounts replaces all previous accounts, we need to properly close them first.
 	backend.uninitAccounts(force)
 
-	backend.initPersistedAccounts()
+	backend.initPersistedAccounts(accountLoadOptions{skipETHInitialSync: true})
+	backend.enqueueETHInitialSyncLocked()
 
 	backend.emitAccountsStatusChanged()
 
@@ -1351,6 +1363,18 @@ func (backend *Backend) initAccounts(force bool) {
 	// Every time fiats or coins list is changed in the UI settings, ReinitializedAccounts
 	// is invoked which triggers this method.
 	backend.configureHistoryExchangeRates()
+}
+
+// enqueueETHInitialSyncLocked asks the ETH updater to refresh all loaded ETH accounts if any exist.
+//
+// The accountsAndKeystoreLock must be held when calling this function.
+func (backend *Backend) enqueueETHInitialSyncLocked() {
+	for _, account := range backend.accounts {
+		if _, ok := account.Coin().(*eth.Coin); ok {
+			backend.enqueueETHUpdateForAllAccountsAsync()
+			return
+		}
+	}
 }
 
 // ReinitializeAccounts uninits and then reinits all accounts. This is useful to reload the accounts
@@ -1495,7 +1519,7 @@ func (backend *Backend) maybeAddHiddenUnusedAccounts() {
 				backend.log.Errorf("could not find newly persisted account %s", *newAccountCode)
 				continue
 			}
-			backend.createAndAddAccount(coin, accountConfig)
+			backend.createAndAddAccount(coin, accountConfig, accountLoadOptions{})
 			backend.emitAccountsStatusChanged()
 		}
 	}

--- a/backend/accounts/baseaccount.go
+++ b/backend/accounts/baseaccount.go
@@ -36,8 +36,8 @@ type AccountConfig struct {
 	// `backend.config.ModifyAccountsConfig()` instead.
 	Config   *config.Account
 	DBFolder string
-	// SkipInitialSync suppresses the ETH init-time per-account update when a startup batch sync
-	// will refresh the account right after loading.
+	// SkipInitialSync suppresses the ETH init-time per-account update when a batch sync will
+	// refresh the account right after loading.
 	SkipInitialSync bool
 	// NotesFolder is the folder where the transaction notes are stored. Full path.
 	NotesFolder     string

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -232,7 +232,7 @@ func TestSortAccounts(t *testing.T) {
 	for i := range accountConfigs {
 		c, err := backend.Coin(accountConfigs[i].CoinCode)
 		require.NoError(t, err)
-		backend.createAndAddAccount(c, accountConfigs[i])
+		backend.createAndAddAccount(c, accountConfigs[i], accountLoadOptions{})
 	}
 	unlockFN()
 
@@ -291,7 +291,7 @@ func TestObserveKeystoreNameChanged(t *testing.T) {
 	for i := range accountConfigs {
 		c, err := backend.Coin(accountConfigs[i].CoinCode)
 		require.NoError(t, err)
-		backend.createAndAddAccount(c, accountConfigs[i])
+		backend.createAndAddAccount(c, accountConfigs[i], accountLoadOptions{})
 	}
 	unlockFN()
 
@@ -637,6 +637,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/0'/0'"), test.TstMustXKey("xpub6Cxa67Bfe1Aw5VvLM1Ppua9x28CXH1zUYoAuBzFRjR6hWnA6aUcny84KYkeVcZWnWXxKSkxCEyMA8xic54ydBPWm5oziXpsXq6nX8FELMQn")),
 			},
 		},
+		accountLoadOptions{},
 	)
 	unlockFN()
 	require.Len(t, b.Accounts(), 1)
@@ -659,6 +660,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 				signing.NewBitcoinConfiguration(signing.ScriptTypeP2WPKH, fingerprint, mustKeypath("m/84'/2'/0'"), test.TstMustXKey("xpub6DReBHtKxgeZGBKTaaF1GjeBHa8dZwQpRfgYr3kxt782s8KKqio2pR6piBsiqHEPF7Rg3onMkwt9XrSxNTuW4N1VBjVbn6DQ3GPCBEUgtgP")),
 			},
 		},
+		accountLoadOptions{},
 	)
 	unlockFN()
 	require.Len(t, b.Accounts(), 2)
@@ -681,6 +683,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 			},
 			ActiveTokens: []string{"eth-erc20-mkr"},
 		},
+		accountLoadOptions{},
 	)
 	unlockFN()
 	// 2 more accounts: the added ETH account plus the active token for the ETH account.
@@ -710,6 +713,7 @@ func TestCreateAndAddAccount(t *testing.T) {
 			},
 			ActiveTokens: []string{"eth-erc20-usdt", "eth-erc20-bat"},
 		},
+		accountLoadOptions{},
 	)
 	unlockFN()
 	// 3 more accounts: the added ETH account plus the two active tokens for the ETH account.
@@ -769,32 +773,26 @@ func TestETHInitialSyncMode(t *testing.T) {
 	t.Run("startup-watchonly-load", func(t *testing.T) {
 		func() {
 			defer b.accountsAndKeystoreLock.Lock()()
-			b.skipETHInitialSync = true
-			defer func() { b.skipETHInitialSync = false }()
-			b.initPersistedAccounts()
+			b.initPersistedAccounts(accountLoadOptions{skipETHInitialSync: true})
 		}()
 
 		require.Equal(t, expected, captured)
 	})
 
-	t.Run("non-startup-reinit", func(t *testing.T) {
-		func() {
-			defer b.accountsAndKeystoreLock.Lock()()
-			b.uninitAccounts(true)
-		}()
-
+	t.Run("reinit-batch-load", func(t *testing.T) {
 		captured = map[accountsTypes.Code]bool{}
-		expectedNoSkip := map[accountsTypes.Code]bool{
-			"v0-55555555-eth-0":                false,
-			"v0-55555555-eth-0-eth-erc20-usdt": false,
+		enqueueAllAccountsRefreshes := 0
+		b.enqueueETHUpdateForAllAccountsAsync = func() {
+			enqueueAllAccountsRefreshes++
 		}
 
 		func() {
 			defer b.accountsAndKeystoreLock.Lock()()
-			b.initPersistedAccounts()
+			b.initAccounts(true)
 		}()
 
-		require.Equal(t, expectedNoSkip, captured)
+		require.Equal(t, expected, captured)
+		require.Equal(t, 1, enqueueAllAccountsRefreshes)
 	})
 }
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -249,6 +249,10 @@ type Backend struct {
 	// makeEthAccount creates an ETH account. In production this is `eth.NewAccount`, but can be
 	// overridden in unit tests for mocking.
 	makeEthAccount func(*accounts.AccountConfig, *eth.Coin, *http.Client, *logrus.Entry) accounts.Interface
+	// enqueueETHUpdateForAllAccountsAsync asks the ETH updater to refresh all ETH accounts without
+	// blocking the caller. In production this is `ethupdater.EnqueueUpdateForAllAccountsAsync`, but
+	// can be overridden in unit tests.
+	enqueueETHUpdateForAllAccountsAsync func()
 
 	onAccountInit   func(accounts.Interface)
 	onAccountUninit func(accounts.Interface)
@@ -280,10 +284,6 @@ type Backend struct {
 
 	// ethupdater takes care of updating ETH accounts.
 	ethupdater *eth.Updater
-
-	// skipETHInitialSync suppresses the per-account ETH init refresh while startup loads persisted
-	// accounts, so the updater's initial batch refresh is the only startup sync round.
-	skipETHInitialSync bool
 }
 
 // NewBackend creates a new backend with the given arguments.
@@ -341,6 +341,7 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	backend.socksProxy = backendProxy
 	backend.httpClient = hclient
 	backend.ethupdater = eth.NewUpdater(accountUpdate, backend.httpClient, backend.etherScanRateLimiter, backend.updateETHAccounts)
+	backend.enqueueETHUpdateForAllAccountsAsync = backend.ethupdater.EnqueueUpdateForAllAccountsAsync
 
 	ratesCache := filepath.Join(arguments.CacheDirectoryPath(), "exchangerates")
 	if err := os.MkdirAll(ratesCache, 0700); err != nil {
@@ -702,9 +703,7 @@ func (backend *Backend) Start() <-chan interface{} {
 	}
 
 	defer backend.accountsAndKeystoreLock.Lock()()
-	backend.skipETHInitialSync = true
-	backend.initPersistedAccounts()
-	backend.skipETHInitialSync = false
+	backend.initPersistedAccounts(accountLoadOptions{skipETHInitialSync: true})
 	backend.emitAccountsStatusChanged()
 
 	backend.ratesUpdater.StartCurrentRates()
@@ -851,7 +850,7 @@ func (backend *Backend) DeregisterKeystore() {
 	backend.uninitAccounts(false)
 	// TODO: classify accounts by keystore, remove only the ones belonging to the deregistered
 	// keystore. For now we just remove all, then re-add the rest.
-	backend.initPersistedAccounts()
+	backend.initPersistedAccounts(accountLoadOptions{})
 	backend.emitAccountsStatusChanged()
 	backend.connectKeystore.onDisconnect()
 }

--- a/backend/coins/eth/updater.go
+++ b/backend/coins/eth/updater.go
@@ -89,7 +89,17 @@ func (u *Updater) Close() {
 
 // EnqueueUpdateForAllAccounts enqueues an update for all ETH accounts.
 func (u *Updater) EnqueueUpdateForAllAccounts() {
-	u.updateETHAccountsCh <- struct{}{}
+	select {
+	case u.updateETHAccountsCh <- struct{}{}:
+	case <-u.quit:
+	}
+}
+
+// EnqueueUpdateForAllAccountsAsync enqueues an update for all ETH accounts without blocking the
+// caller. This is useful when accounts are loaded while backend locks are held, as the update path
+// reads the backend account list.
+func (u *Updater) EnqueueUpdateForAllAccountsAsync() {
+	go u.EnqueueUpdateForAllAccounts()
 }
 
 // PollBalances updates the balances of all ETH accounts.


### PR DESCRIPTION
Startup already has an all-account ETH updater pass. Avoid also starting one update goroutine for every loaded ETH/ERC20 account during visible account loading; those accounts are refreshed by the batch instead.

This improves startup for watch-only accounts and keystore connect for non-watch-only persisted accounts, where many visible ETH/ERC20 accounts can be loaded at once. Reinitializing visible accounts enqueues one all-account update after loading. Account creation outside those visible bulk loads keeps the existing per-account init enqueue.
