### PR TITLE
Speed up initial BTC sync by deferring accounts discovery scanning 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Bitcoin: show account details for the persisted receive address type by default
+- Bitcoin: improve initial sync speed by deferring accounts discovery
 - Add external block explorer links to used addresses
 - Settings search
 - Support macOS "Number Format" system setting

--- a/backend/account_discovery.go
+++ b/backend/account_discovery.go
@@ -7,6 +7,7 @@ import (
 
 	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 )
 
 // accountDiscoveryStatus is the account state that hidden discovery policy needs.
@@ -114,4 +115,30 @@ func (coordinator *accountDiscoveryCoordinator) startIfReady() accountDiscoveryA
 	}
 	coordinator.started = true
 	return accountDiscoveryActions{start: true}
+}
+
+// nextDiscoveryAccountNumber returns the next hidden account number that discovery should create.
+func nextDiscoveryAccountNumber(
+	coinCode coinpkg.Code,
+	candidates []accountCandidate,
+) (uint16, bool) {
+	maxAccountNumber := -1
+	var maxAccount *config.Account
+	for _, candidate := range candidates {
+		if maxAccount == nil || int(candidate.number) > maxAccountNumber {
+			maxAccountNumber = int(candidate.number)
+			maxAccount = candidate.account
+		}
+	}
+
+	// Account scan gap limit:
+	// - Previous account must be used for the next one to be scanned, but:
+	// - The first accounts up to the hard limit are always scanned as before we had accounts
+	//   discovery, the BitBoxApp allowed manual creation of that many accounts, so we need to scan
+	//   these.
+	nextAccountNumber := maxAccountNumber + 1
+	if maxAccount == nil || maxAccount.Used || nextAccountNumber < accountsHardLimit(coinCode) {
+		return uint16(nextAccountNumber), true
+	}
+	return 0, false
 }

--- a/backend/account_discovery.go
+++ b/backend/account_discovery.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"slices"
+
+	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+)
+
+// accountDiscoveryStatus is the account state that hidden discovery policy needs.
+type accountDiscoveryStatus struct {
+	code     accountsTypes.Code
+	coinCode coinpkg.Code
+	hidden   bool
+	synced   bool
+}
+
+// accountDiscoveryActions are side effects requested by the discovery coordinator.
+type accountDiscoveryActions struct {
+	start    bool
+	addCoins []coinpkg.Code
+}
+
+// accountDiscoveryCoordinator owns the hidden-account discovery state machine.
+type accountDiscoveryCoordinator struct {
+	// discoveryCoins are the only coins for which hidden discovery accounts are created.
+	discoveryCoins []coinpkg.Code
+
+	// started records whether hidden discovery has opened for the current keystore session.
+	started bool
+
+	// visibleTracked records whether the coordinator has received the current visible startup
+	// account snapshot. It distinguishes "no snapshot yet" from "all visible accounts synced".
+	visibleTracked bool
+
+	// visiblePending contains visible account codes that still need to finish startup sync before
+	// hidden discovery can open.
+	visiblePending map[accountsTypes.Code]struct{}
+}
+
+// newAccountDiscoveryCoordinator creates a coordinator for the coins that support hidden discovery.
+func newAccountDiscoveryCoordinator(discoveryCoins []coinpkg.Code) *accountDiscoveryCoordinator {
+	return &accountDiscoveryCoordinator{
+		discoveryCoins: slices.Clone(discoveryCoins),
+		visiblePending: map[accountsTypes.Code]struct{}{},
+	}
+}
+
+// reset closes hidden discovery and forgets the previous visible startup account set.
+func (coordinator *accountDiscoveryCoordinator) reset() {
+	coordinator.started = false
+	coordinator.visibleTracked = false
+	coordinator.visiblePending = map[accountsTypes.Code]struct{}{}
+}
+
+// hiddenAccountsCanLoad reports whether hidden persisted accounts should be loaded into the runtime
+// account registry.
+func (coordinator *accountDiscoveryCoordinator) hiddenAccountsCanLoad() bool {
+	return coordinator.started
+}
+
+// runNow opens hidden discovery immediately and requests a full discovery pass. It is used by
+// explicit helper paths that ask to run discovery directly instead of waiting for visible account
+// sync, so it requests a pass even if discovery was already open.
+func (coordinator *accountDiscoveryCoordinator) runNow() accountDiscoveryActions {
+	coordinator.started = true
+	return accountDiscoveryActions{start: true}
+}
+
+// connect records the current visible startup account set and opens hidden discovery
+// immediately if all visible accounts are already synced.
+func (coordinator *accountDiscoveryCoordinator) connect(
+	accounts []accountDiscoveryStatus,
+) accountDiscoveryActions {
+	coordinator.visibleTracked = true
+	coordinator.visiblePending = map[accountsTypes.Code]struct{}{}
+	for _, account := range accounts {
+		if account.hidden {
+			continue
+		}
+		if !account.synced {
+			coordinator.visiblePending[account.code] = struct{}{}
+		}
+	}
+	return coordinator.startIfReady()
+}
+
+// syncDone updates discovery after an account sync event. If usageKnown is false, the event may
+// open hidden discovery but will not advance the account's coin.
+func (coordinator *accountDiscoveryCoordinator) syncDone(
+	account accountDiscoveryStatus,
+	usageKnown bool,
+) accountDiscoveryActions {
+	if !account.hidden && account.synced {
+		delete(coordinator.visiblePending, account.code)
+	}
+	if !coordinator.started {
+		return coordinator.startIfReady()
+	}
+	if !usageKnown || !slices.Contains(coordinator.discoveryCoins, account.coinCode) {
+		return accountDiscoveryActions{}
+	}
+	return accountDiscoveryActions{addCoins: []coinpkg.Code{account.coinCode}}
+}
+
+// startIfReady opens hidden discovery after the visible startup account set has been observed and
+// all visible accounts have synced.
+func (coordinator *accountDiscoveryCoordinator) startIfReady() accountDiscoveryActions {
+	if coordinator.started || !coordinator.visibleTracked ||
+		len(coordinator.visiblePending) != 0 {
+		return accountDiscoveryActions{}
+	}
+	coordinator.started = true
+	return accountDiscoveryActions{start: true}
+}

--- a/backend/account_discovery_test.go
+++ b/backend/account_discovery_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"testing"
+
+	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/stretchr/testify/require"
+)
+
+func discoveryStatus(
+	code accountsTypes.Code,
+	coinCode coinpkg.Code,
+	hidden bool,
+	synced bool,
+) accountDiscoveryStatus {
+	return accountDiscoveryStatus{
+		code:     code,
+		coinCode: coinCode,
+		hidden:   hidden,
+		synced:   synced,
+	}
+}
+
+func TestAccountDiscoveryCoordinatorStartsAfterVisibleAccountsSync(t *testing.T) {
+	coordinator := newAccountDiscoveryCoordinator([]coinpkg.Code{coinpkg.CodeBTC, coinpkg.CodeLTC})
+
+	require.Empty(t, coordinator.connect([]accountDiscoveryStatus{
+		discoveryStatus("btc-0", coinpkg.CodeBTC, false, false),
+		discoveryStatus("ltc-0", coinpkg.CodeLTC, false, false),
+		discoveryStatus("btc-1", coinpkg.CodeBTC, true, false),
+	}))
+
+	require.Empty(t, coordinator.syncDone(
+		discoveryStatus("btc-0", coinpkg.CodeBTC, false, true),
+		true,
+	))
+
+	require.Equal(t,
+		accountDiscoveryActions{start: true},
+		coordinator.syncDone(discoveryStatus("ltc-0", coinpkg.CodeLTC, false, true), true),
+	)
+	require.True(t, coordinator.hiddenAccountsCanLoad())
+}
+
+func TestAccountDiscoveryCoordinatorStartsWithoutVisibleAccounts(t *testing.T) {
+	coordinator := newAccountDiscoveryCoordinator([]coinpkg.Code{coinpkg.CodeBTC})
+
+	require.Equal(t, accountDiscoveryActions{start: true}, coordinator.connect(nil))
+	require.True(t, coordinator.hiddenAccountsCanLoad())
+}
+
+func TestAccountDiscoveryCoordinatorAdvancesDiscoveryCoins(t *testing.T) {
+	coordinator := newAccountDiscoveryCoordinator([]coinpkg.Code{coinpkg.CodeBTC, coinpkg.CodeLTC})
+	require.Equal(t,
+		accountDiscoveryActions{start: true},
+		coordinator.connect([]accountDiscoveryStatus{
+			discoveryStatus("btc-0", coinpkg.CodeBTC, false, true),
+		}),
+	)
+
+	require.Equal(t,
+		accountDiscoveryActions{addCoins: []coinpkg.Code{coinpkg.CodeBTC}},
+		coordinator.syncDone(discoveryStatus("btc-1", coinpkg.CodeBTC, true, true), true),
+	)
+	require.Empty(t, coordinator.syncDone(
+		discoveryStatus("eth-0", coinpkg.CodeETH, false, true),
+		true,
+	))
+	require.Empty(t, coordinator.syncDone(
+		discoveryStatus("btc-1", coinpkg.CodeBTC, true, true),
+		false,
+	))
+}
+
+func TestAccountDiscoveryCoordinatorForceStart(t *testing.T) {
+	coordinator := newAccountDiscoveryCoordinator([]coinpkg.Code{coinpkg.CodeBTC})
+
+	require.Equal(t,
+		accountDiscoveryActions{start: true},
+		coordinator.runNow(),
+	)
+	require.Equal(t,
+		accountDiscoveryActions{start: true},
+		coordinator.runNow(),
+	)
+	require.True(t, coordinator.hiddenAccountsCanLoad())
+}

--- a/backend/account_discovery_test.go
+++ b/backend/account_discovery_test.go
@@ -7,6 +7,7 @@ import (
 
 	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,4 +88,31 @@ func TestAccountDiscoveryCoordinatorForceStart(t *testing.T) {
 		coordinator.runNow(),
 	)
 	require.True(t, coordinator.hiddenAccountsCanLoad())
+}
+
+func TestNextDiscoveryAccountNumber(t *testing.T) {
+	account4 := &config.Account{Code: "account-4"}
+	account5 := &config.Account{Code: "account-5"}
+	usedAccount5 := &config.Account{Code: "used-account-5", Used: true}
+
+	accountNumber, ok := nextDiscoveryAccountNumber(coinpkg.CodeBTC, nil)
+	require.True(t, ok)
+	require.Equal(t, uint16(0), accountNumber)
+
+	accountNumber, ok = nextDiscoveryAccountNumber(coinpkg.CodeBTC, []accountCandidate{
+		{account: account4, number: 4},
+	})
+	require.True(t, ok)
+	require.Equal(t, uint16(5), accountNumber)
+
+	_, ok = nextDiscoveryAccountNumber(coinpkg.CodeBTC, []accountCandidate{
+		{account: account5, number: 5},
+	})
+	require.False(t, ok)
+
+	accountNumber, ok = nextDiscoveryAccountNumber(coinpkg.CodeBTC, []accountCandidate{
+		{account: usedAccount5, number: 5},
+	})
+	require.True(t, ok)
+	require.Equal(t, uint16(6), accountNumber)
 }

--- a/backend/account_planning.go
+++ b/backend/account_planning.go
@@ -104,28 +104,3 @@ func nextAccountNumberAfter(candidates []accountCandidate) uint16 {
 	}
 	return nextAccountNumber
 }
-
-func nextDiscoveryAccountNumber(
-	coinCode coinpkg.Code,
-	candidates []accountCandidate,
-) (uint16, bool) {
-	maxAccountNumber := -1
-	var maxAccount *config.Account
-	for _, candidate := range candidates {
-		if maxAccount == nil || int(candidate.number) > maxAccountNumber {
-			maxAccountNumber = int(candidate.number)
-			maxAccount = candidate.account
-		}
-	}
-
-	// Account scan gap limit:
-	// - Previous account must be used for the next one to be scanned, but:
-	// - The first accounts up to the hard limit are always scanned as before we had accounts
-	//   discovery, the BitBoxApp allowed manual creation of that many accounts, so we need to scan
-	//   these.
-	nextAccountNumber := maxAccountNumber + 1
-	if maxAccount == nil || maxAccount.Used || nextAccountNumber < accountsHardLimit(coinCode) {
-		return uint16(nextAccountNumber), true
-	}
-	return 0, false
-}

--- a/backend/account_planning_test.go
+++ b/backend/account_planning_test.go
@@ -198,30 +198,3 @@ func TestNextManualAccountNumber(t *testing.T) {
 	})
 	require.Equal(t, errAccountLimitReached, errp.Cause(err))
 }
-
-func TestNextDiscoveryAccountNumber(t *testing.T) {
-	account4 := &config.Account{Code: "account-4"}
-	account5 := &config.Account{Code: "account-5"}
-	usedAccount5 := &config.Account{Code: "used-account-5", Used: true}
-
-	accountNumber, ok := nextDiscoveryAccountNumber(coinpkg.CodeBTC, nil)
-	require.True(t, ok)
-	require.Equal(t, uint16(0), accountNumber)
-
-	accountNumber, ok = nextDiscoveryAccountNumber(coinpkg.CodeBTC, []accountCandidate{
-		{account: account4, number: 4},
-	})
-	require.True(t, ok)
-	require.Equal(t, uint16(5), accountNumber)
-
-	_, ok = nextDiscoveryAccountNumber(coinpkg.CodeBTC, []accountCandidate{
-		{account: account5, number: 5},
-	})
-	require.False(t, ok)
-
-	accountNumber, ok = nextDiscoveryAccountNumber(coinpkg.CodeBTC, []accountCandidate{
-		{account: usedAccount5, number: 5},
-	})
-	require.True(t, ok)
-	require.Equal(t, uint16(6), accountNumber)
-}

--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1208,6 +1208,10 @@ func (backend *Backend) initPersistedAccounts() {
 	// will not be loaded, unless their keystore has watch-only enabled.
 outer:
 	for _, account := range backend.filterAccounts(&persistedAccounts, keystoreConnectedOrWatch) {
+		if account.HiddenBecauseUnused && !backend.discovery.hiddenAccountsCanLoad() {
+			continue
+		}
+
 		coin, err := backend.Coin(account.CoinCode)
 		if err != nil {
 			backend.log.Errorf("skipping persisted account %s/%s, could not find coin",
@@ -1361,6 +1365,8 @@ func (backend *Backend) ReinitializeAccounts() {
 
 	backend.log.Info("Reinitializing accounts")
 	backend.initAccounts(true)
+	backend.executeAccountDiscoveryActionsLocked(
+		backend.discovery.connect(backend.discoveryAccountStatusesLocked()))
 }
 
 // The accountsAndKeystoreLock must be held when calling this function.
@@ -1420,10 +1426,80 @@ func (backend *Backend) uninitAccounts(force bool) {
 //     and still be able to receive to P2TR in the highest account. Such a P2TR
 //     account would not be discovered by other BIP44-compatible software.
 func (backend *Backend) maybeAddHiddenUnusedAccounts() {
+	defer backend.accountsAndKeystoreLock.Lock()()
+	backend.executeAccountDiscoveryActionsLocked(backend.discovery.runNow())
+}
+
+// executeStartHiddenDiscoveryLocked loads hidden persisted accounts and adds
+// the current hidden discovery frontier for all discovery coins.
+//
+// The accountsAndKeystoreLock must be held when calling this function.
+func (backend *Backend) executeStartHiddenDiscoveryLocked() {
+	backend.initPersistedAccounts()
+	backend.emitAccountsStatusChanged()
+	backend.configureHistoryExchangeRates()
+	backend.addHiddenDiscoveryAccountsForCoinsLocked(backend.coinPolicy().discoveryCoins())
+}
+
+// discoveryAccountStatus converts a runtime account into the state needed by hidden discovery
+// policy.
+func (backend *Backend) discoveryAccountStatus(account accounts.Interface) accountDiscoveryStatus {
+	return accountDiscoveryStatus{
+		code:     account.Config().Config.Code,
+		coinCode: account.Coin().Code(),
+		hidden:   account.Config().Config.HiddenBecauseUnused,
+		synced:   account.Synced(),
+	}
+}
+
+// discoveryAccountStatusesLocked returns a snapshot of all runtime accounts for hidden discovery
+// policy.
+//
+// The accountsAndKeystoreLock must be held when calling this function.
+func (backend *Backend) discoveryAccountStatusesLocked() []accountDiscoveryStatus {
+	statuses := make([]accountDiscoveryStatus, 0, len(backend.accounts))
+	for _, account := range backend.accounts {
+		statuses = append(statuses, backend.discoveryAccountStatus(account))
+	}
+	return statuses
+}
+
+// executeAccountDiscoveryActionsLocked applies hidden discovery actions to config/runtime
+// accounts.
+//
+// The accountsAndKeystoreLock must be held when calling this function.
+func (backend *Backend) executeAccountDiscoveryActionsLocked(actions accountDiscoveryActions) {
+	if actions.start {
+		backend.executeStartHiddenDiscoveryLocked()
+	}
+	if len(actions.addCoins) != 0 {
+		backend.addHiddenDiscoveryAccountsForCoinsLocked(actions.addCoins)
+	}
+}
+
+// updateHiddenDiscoveryAfterAccountSync sends one account sync result through the discovery
+// coordinator. If usageKnown is false, the event may open hidden discovery but will not advance the
+// account's coin.
+func (backend *Backend) updateHiddenDiscoveryAfterAccountSync(
+	account accounts.Interface,
+	usageKnown bool,
+) {
+	defer backend.accountsAndKeystoreLock.Lock()()
+	if backend.accounts.lookup(account.Config().Config.Code) != account {
+		return
+	}
+	backend.executeAccountDiscoveryActionsLocked(
+		backend.discovery.syncDone(backend.discoveryAccountStatus(account), usageKnown))
+}
+
+// addHiddenDiscoveryAccountsForCoinsLocked adds the next hidden discovery account for each selected
+// coin when the account gap rules say another account should be scanned.
+//
+// The accountsAndKeystoreLock must be held when calling this function.
+func (backend *Backend) addHiddenDiscoveryAccountsForCoinsLocked(coinCodes []coinpkg.Code) {
 	if backend.tstMaybeAddHiddenUnusedAccounts != nil {
 		defer backend.tstMaybeAddHiddenUnusedAccounts()
 	}
-	defer backend.accountsAndKeystoreLock.Lock()()
 	if backend.keystore == nil {
 		return
 	}
@@ -1468,7 +1544,7 @@ func (backend *Backend) maybeAddHiddenUnusedAccounts() {
 	}
 
 	// Enable accounts discovery for these coins.
-	for _, coinCode := range backend.coinPolicy().discoveryCoins() {
+	for _, coinCode := range coinCodes {
 		coin, err := backend.Coin(coinCode)
 		if err != nil {
 			backend.log.Errorf("could not find coin %s", coinCode)
@@ -1513,12 +1589,15 @@ func (backend *Backend) checkAccountUsed(account accounts.Interface) {
 		txs, err := account.Transactions()
 		if err != nil {
 			log.WithError(err).Error("discoverAccount")
+			if !account.FatalError() {
+				backend.updateHiddenDiscoveryAfterAccountSync(account, false)
+			}
 			return
 		}
 
 		if len(txs) == 0 {
 			// Invoke this here too because even if an account is unused, we scan up to 5 accounts.
-			backend.maybeAddHiddenUnusedAccounts()
+			backend.updateHiddenDiscoveryAfterAccountSync(account, true)
 			return
 		}
 	}
@@ -1527,7 +1606,9 @@ func (backend *Backend) checkAccountUsed(account accounts.Interface) {
 	err := backend.config.ModifyAccountsConfig(func(accountsConfig *config.AccountsConfig) error {
 		acct := accountsConfig.Lookup(account.Config().Config.Code)
 		if acct == nil {
-			return errp.Newf("could not find account")
+			// Runtime-only accounts, such as ERC20 token accounts, do not have their own persisted
+			// account config to mark as used.
+			return nil
 		}
 		emitUpdate = !acct.Used || acct.HiddenBecauseUnused
 		acct.Used = true
@@ -1542,7 +1623,7 @@ func (backend *Backend) checkAccountUsed(account accounts.Interface) {
 	if emitUpdate {
 		backend.emitAccountsStatusChanged()
 	}
-	backend.maybeAddHiddenUnusedAccounts()
+	backend.updateHiddenDiscoveryAfterAccountSync(account, true)
 }
 
 // LookupEthAccountCode takes an Ethereum address and returns the corresponding account code and account name

--- a/backend/accounts_test.go
+++ b/backend/accounts_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	accountsMocks "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/mocks"
@@ -64,6 +63,28 @@ func checkShownAccountsLen(t *testing.T, b *Backend, expectedLoaded int, expecte
 		}
 	}
 	require.Equal(t, expectedPersisted, cntPersisted)
+}
+
+// installSyncedAccountMocks configures test account constructors whose Synced methods are controlled
+// by the returned map. Tests use this to model startup sync progress without network activity.
+func installSyncedAccountMocks(t *testing.T, b *Backend) map[accountsTypes.Code]bool {
+	t.Helper()
+	synced := map[accountsTypes.Code]bool{}
+	b.makeBtcAccount = func(config *accounts.AccountConfig, coin *btc.Coin, gapLimits *types.GapLimits, getAddress func(coinpkg.Code, blockchain.ScriptHashHex) (*addresses.AccountAddress, error), log *logrus.Entry) accounts.Interface {
+		accountMock := MockBtcAccount(t, config, coin, gapLimits, log)
+		accountMock.SyncedFunc = func() bool {
+			return synced[config.Config.Code]
+		}
+		return accountMock
+	}
+	b.makeEthAccount = func(config *accounts.AccountConfig, coin *eth.Coin, httpClient *http.Client, log *logrus.Entry) accounts.Interface {
+		accountMock := MockEthAccount(config, coin, httpClient, log)
+		accountMock.SyncedFunc = func() bool {
+			return synced[config.Config.Code]
+		}
+		return accountMock
+	}
+	return synced
 }
 
 // TestAccounts performs a series of typical actions related accounts.
@@ -1079,6 +1100,228 @@ func TestMaybeAddHiddenUnusedAccounts(t *testing.T) {
 	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-6"))
 }
 
+// TestHiddenDiscoveryStartsAfterVisibleAccountsSynced verifies the startup priority rule: hidden
+// discovery does not create scanning accounts while any visible account is still doing initial sync.
+func TestHiddenDiscoveryStartsAfterVisibleAccountsSynced(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	synced := installSyncedAccountMocks(t, b)
+	ks := makeBitBox02Multi()
+	ks.RootFingerprintFunc = func() ([]byte, error) {
+		return rootFingerprint1, nil
+	}
+	b.registerKeystore(ks)
+
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-1"))
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-ltc-1"))
+
+	synced["v0-55555555-btc-0"] = true
+	synced["v0-55555555-eth-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-eth-0"), true)
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-1"))
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-ltc-1"))
+
+	synced["v0-55555555-ltc-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-ltc-0"), true)
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-1"))
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-ltc-1"))
+}
+
+// TestHiddenDiscoveryAdvancesOnlySyncedCoin verifies that after startup discovery has opened, a
+// hidden account sync only advances discovery for its own coin and non-discovery coins are ignored.
+func TestHiddenDiscoveryAdvancesOnlySyncedCoin(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	synced := installSyncedAccountMocks(t, b)
+	ks := makeBitBox02Multi()
+	ks.RootFingerprintFunc = func() ([]byte, error) {
+		return rootFingerprint1, nil
+	}
+	b.registerKeystore(ks)
+
+	synced["v0-55555555-btc-0"] = true
+	synced["v0-55555555-ltc-0"] = true
+	synced["v0-55555555-eth-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-ltc-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-eth-0"), true)
+	require.NotNil(t, b.Accounts().lookup("v0-55555555-btc-1"))
+	require.NotNil(t, b.Accounts().lookup("v0-55555555-ltc-1"))
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-2"))
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-ltc-2"))
+
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-eth-1"))
+
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-1"), true)
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-2"))
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-ltc-2"))
+}
+
+// TestHiddenDiscoveryStartsAfterNonFatalTransactionError verifies that a transient transaction
+// loading error does not keep hidden discovery closed after visible accounts have synced.
+func TestHiddenDiscoveryStartsAfterNonFatalTransactionError(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	synced := installSyncedAccountMocks(t, b)
+	ks := makeBitBox02Multi()
+	ks.RootFingerprintFunc = func() ([]byte, error) {
+		return rootFingerprint1, nil
+	}
+	b.registerKeystore(ks)
+
+	synced["v0-55555555-btc-0"] = true
+	synced["v0-55555555-ltc-0"] = true
+	synced["v0-55555555-eth-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-eth-0"), true)
+	ltcAccount := b.Accounts().lookup("v0-55555555-ltc-0")
+	ltcAccount.(*accountsMocks.InterfaceMock).TransactionsFunc = func() (accounts.OrderedTransactions, error) {
+		return nil, errp.New("transactions unavailable")
+	}
+
+	b.tstCheckAccountUsed = nil
+	b.checkAccountUsed(ltcAccount)
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-1"))
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-ltc-1"))
+}
+
+// TestHiddenDiscoveryRefreshesVisibleAccountsAfterReinitialize verifies that account changes before
+// hidden discovery starts are included in the visible startup gate.
+func TestHiddenDiscoveryRefreshesVisibleAccountsAfterReinitialize(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	synced := installSyncedAccountMocks(t, b)
+	ks := makeBitBox02Multi()
+	ks.RootFingerprintFunc = func() ([]byte, error) {
+		return rootFingerprint1, nil
+	}
+	b.registerKeystore(ks)
+
+	synced["v0-55555555-btc-0"] = true
+	synced["v0-55555555-ltc-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-ltc-0"), true)
+
+	newAccountCode, err := b.CreateAndPersistAccountConfig(coinpkg.CodeBTC, "new account", ks)
+	require.NoError(t, err)
+	require.Equal(t, accountsTypes.Code("v0-55555555-btc-1"), newAccountCode)
+
+	synced["v0-55555555-eth-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-eth-0"), true)
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-2"))
+
+	synced["v0-55555555-btc-1"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-1"), true)
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-2"))
+}
+
+// TestHiddenDiscoveryIgnoresStaleAccountAfterReinitialize verifies that an old runtime account
+// callback cannot satisfy the refreshed visible startup gate after accounts are rebuilt.
+func TestHiddenDiscoveryIgnoresStaleAccountAfterReinitialize(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	synced := installSyncedAccountMocks(t, b)
+	ks := makeBitBox02Multi()
+	ks.RootFingerprintFunc = func() ([]byte, error) {
+		return rootFingerprint1, nil
+	}
+	b.registerKeystore(ks)
+
+	staleEthAccount := b.Accounts().lookup("v0-55555555-eth-0")
+	synced["v0-55555555-btc-0"] = true
+	synced["v0-55555555-ltc-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-ltc-0"), true)
+
+	newAccountCode, err := b.CreateAndPersistAccountConfig(coinpkg.CodeBTC, "new account", ks)
+	require.NoError(t, err)
+	require.Equal(t, accountsTypes.Code("v0-55555555-btc-1"), newAccountCode)
+
+	synced["v0-55555555-eth-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(staleEthAccount, true)
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-2"))
+
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-eth-0"), true)
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-2"))
+
+	synced["v0-55555555-btc-1"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-1"), true)
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-2"))
+}
+
+// TestHiddenDiscoveryStartsAfterERC20TokenWithTransactions verifies that runtime-only token accounts
+// do not block hidden discovery after their transaction history has been classified.
+func TestHiddenDiscoveryStartsAfterERC20TokenWithTransactions(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	synced := installSyncedAccountMocks(t, b)
+	ks := makeBitBox02Multi()
+	ks.RootFingerprintFunc = func() ([]byte, error) {
+		return rootFingerprint1, nil
+	}
+	b.registerKeystore(ks)
+	require.NoError(t, b.SetTokenActive("v0-55555555-eth-0", "eth-erc20-usdt", true))
+
+	synced["v0-55555555-btc-0"] = true
+	synced["v0-55555555-ltc-0"] = true
+	synced["v0-55555555-eth-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-ltc-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-eth-0"), true)
+	require.Nil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-1"))
+
+	tokenAccountCode := accountsTypes.Code("v0-55555555-eth-0-eth-erc20-usdt")
+	synced[tokenAccountCode] = true
+	tokenAccount := b.Accounts().lookup(tokenAccountCode)
+	tokenAccount.(*accountsMocks.InterfaceMock).TransactionsFunc = func() (accounts.OrderedTransactions, error) {
+		return accounts.OrderedTransactions{&accounts.TransactionData{}}, nil
+	}
+
+	b.tstCheckAccountUsed = nil
+	b.checkAccountUsed(tokenAccount)
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-1"))
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-ltc-1"))
+}
+
+// TestPersistedHiddenDiscoveryAccountsWaitForVisibleSync verifies that hidden accounts from a
+// previous run are not initialized during registration before visible accounts have priority.
+func TestPersistedHiddenDiscoveryAccountsWaitForVisibleSync(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	synced := installSyncedAccountMocks(t, b)
+	ks := makeBitBox02Multi()
+	ks.RootFingerprintFunc = func() ([]byte, error) {
+		return rootFingerprint1, nil
+	}
+	require.NoError(t, b.config.ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
+		if err := b.persistDefaultAccountConfigs(ks, cfg); err != nil {
+			return err
+		}
+		_, err := b.createAndPersistAccountConfig(coinpkg.CodeBTC, 1, true, "", ks, nil, cfg)
+		return err
+	}))
+
+	b.registerKeystore(ks)
+	require.NotNil(t, b.config.AccountsConfig().Lookup("v0-55555555-btc-1"))
+	require.Nil(t, b.Accounts().lookup("v0-55555555-btc-1"))
+
+	synced["v0-55555555-btc-0"] = true
+	synced["v0-55555555-ltc-0"] = true
+	synced["v0-55555555-eth-0"] = true
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-ltc-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-eth-0"), true)
+	b.updateHiddenDiscoveryAfterAccountSync(b.Accounts().lookup("v0-55555555-btc-0"), true)
+	require.NotNil(t, b.Accounts().lookup("v0-55555555-btc-1"))
+}
+
 func TestWatchonly(t *testing.T) {
 	// No watchonly - accounts are loaded when registering keystore and unloaded when deregistering
 	// keystore.
@@ -1119,18 +1362,8 @@ func TestWatchonly(t *testing.T) {
 		rootFingerprint, err := ks.RootFingerprint()
 		require.NoError(t, err)
 
-		hiddenAccountsAdded := make(chan struct{})
-		b.tstMaybeAddHiddenUnusedAccounts = func() {
-			close(hiddenAccountsAdded)
-		}
-
 		b.registerKeystore(ks)
-
-		select {
-		case <-hiddenAccountsAdded:
-		case <-time.After(5 * time.Second):
-			require.Fail(t, "expected hidden accounts to be added")
-		}
+		b.maybeAddHiddenUnusedAccounts()
 
 		require.Greater(t, len(b.Config().AccountsConfig().Accounts), 3)
 
@@ -1288,13 +1521,6 @@ func TestWatchonly(t *testing.T) {
 		b := newBackend(t, testnetDisabled, regtestDisabled)
 		defer b.Close()
 
-		// registering a keystore calls `go maybeAddHiddenunusedAccounts()` - we need wait for it to
-		// complete to avoid race conditions in this test about which account is added at what time.
-		hiddenAccountsAdded := make(chan struct{})
-		b.tstMaybeAddHiddenUnusedAccounts = func() {
-			close(hiddenAccountsAdded)
-		}
-
 		ks := makeBitBox02Multi()
 		ks.RootFingerprintFunc = func() ([]byte, error) {
 			return rootFingerprint1, nil
@@ -1306,15 +1532,8 @@ func TestWatchonly(t *testing.T) {
 		b.registerKeystore(ks)
 		checkShownAccountsLen(t, b, 3, 3)
 
-		select {
-		case <-hiddenAccountsAdded:
-		case <-time.After(5 * time.Second):
-			require.Fail(t, "expected hidden accounts to be added")
-		}
-
 		require.NoError(t, b.SetWatchonly(rootFingerprint, true))
 
-		// An account has already been added as part of autodiscover, so we add two.
 		newAccountCode1, err := b.CreateAndPersistAccountConfig(
 			coinpkg.CodeBTC,
 			"Bitcoin account name",

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -234,6 +234,8 @@ type Backend struct {
 
 	accountsAndKeystoreLock locker.Locker
 	accounts                AccountsList
+	// discovery owns hidden account discovery state while backend executes its commands.
+	discovery *accountDiscoveryCoordinator
 	// keystore is nil if no keystore is connected.
 	keystore keystore.Keystore
 	// Called to remove the current keystore observer, if any.
@@ -357,6 +359,8 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 
 	backend.bluetooth = bluetooth.New(log)
 	backend.bluetooth.Observe(backend.Notify)
+
+	backend.discovery = newAccountDiscoveryCoordinator(backend.coinPolicy().discoveryCoins())
 
 	return backend, nil
 }
@@ -760,6 +764,7 @@ func (backend *Backend) registerKeystore(ks keystore.Keystore) {
 	log.Info("registering keystore")
 	backend.observeKeystore(ks)
 	backend.keystore = ks
+	backend.discovery.reset()
 	backend.Notify(observable.Event{
 		Subject: "keystores",
 		Action:  action.Reload,
@@ -799,12 +804,12 @@ func (backend *Backend) registerKeystore(ks keystore.Keystore) {
 	}
 
 	backend.initAccounts(false)
+	backend.executeAccountDiscoveryActionsLocked(
+		backend.discovery.connect(backend.discoveryAccountStatusesLocked()))
 
 	backend.aoppKeystoreRegistered()
 
 	backend.connectKeystore.onConnect(backend.keystore)
-
-	go backend.maybeAddHiddenUnusedAccounts()
 }
 
 func (backend *Backend) observeKeystore(ks keystore.Keystore) {


### PR DESCRIPTION
The shape of the code in discover_accounts.go is such that the rules for discovery are isolated and can be unit tested. Currently there is no events channel and worker goroutine to work through the discovery events, but the shape is pretty close if we wanna go there in the future.