### PR TITLE
dev: bind servers to loopback by default

### DIFF
--- a/cmd/servewallet/main.go
+++ b/cmd/servewallet/main.go
@@ -26,12 +26,20 @@ import (
 )
 
 const (
-	port    = 8082
-	address = "0.0.0.0"
-	darwin  = "darwin"
+	port               = 8082
+	defaultBindAddress = "127.0.0.1"
+	bindAddressEnvVar  = "BITBOX_DEV_BIND_HOST"
+	darwin             = "darwin"
 )
 
 var backend *backendPkg.Backend
+
+func bindAddress() string {
+	if address := os.Getenv(bindAddressEnvVar); address != "" {
+		return address
+	}
+	return defaultBindAddress
+}
 
 // webdevEnvironment implements backend.Environment.
 type webdevEnvironment struct {
@@ -189,6 +197,7 @@ func (webdevEnvironment) DetectDarkTheme() bool {
 
 func main() {
 	config.SetAppDir("appfolder.dev")
+	address := bindAddress()
 
 	mainnet := flag.Bool("mainnet", false, "switch to mainnet instead of testnet coins")
 	regtest := flag.Bool("regtest", false, "use regtest instead of testnet coins")

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "dev": "npm run start",
-    "start": "vite --cors --host",
+    "start": "vite --cors",
     "build": "npm run typescript && vite build",
     "lint": "npm run typescript && eslint ./src ./tests",
     "postlint": "node ./scripts/sort-json.mjs ./src/locales --check",

--- a/frontends/web/vite.config.mjs
+++ b/frontends/web/vite.config.mjs
@@ -7,6 +7,7 @@ import { configDefaults } from 'vitest/config';
 
 export default defineConfig((env) => {
   const envVars = loadEnv(env.mode, process.cwd(), '')
+  const host = envVars.BITBOX_DEV_BIND_HOST || '127.0.0.1'
   const port = envVars.VITE_PORT
   return {
     // Relative base path so the js/css files are referenced with `./index-...js` instead of
@@ -37,6 +38,7 @@ export default defineConfig((env) => {
         ],
     },
     server: {
+      host,
       port: typeof port !== 'undefined' ? port : 8080,
       strictPort: true,
     }

--- a/scripts/dockerdev.sh
+++ b/scripts/dockerdev.sh
@@ -40,7 +40,8 @@ dockerdev () {
            --platform "linux/amd64" \
            --privileged -v /dev/bus/usb:/dev/bus/usb \
            --interactive --tty \
-           --name=$container_name -p 8080:8080 -p 8082:8082 \
+           --env BITBOX_DEV_BIND_HOST=0.0.0.0 \
+           --name=$container_name -p 127.0.0.1:8080:8080 -p 127.0.0.1:8082:8082 \
            --add-host="dev.shiftcrypto.ch:176.9.28.202" \
            --add-host="dev1.shiftcrypto.ch:176.9.28.155" \
            --add-host="dev2.shiftcrypto.ch:176.9.28.156" \


### PR DESCRIPTION
servewallet and Vite should not listen on every host interface during normal local development. Dev mode exposes unauthenticated local services.

Docker still needs BITBOX_DEV_BIND_HOST=0.0.0.0 inside the container because published ports are reached through the container's external interface. The published host ports are bound to 127.0.0.1 so they remain accessible from the host without exposing them to the LAN.
