### PR TITLE
frontend: display zero bitcoin-based amounts as 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Move insurance to Marketplace
 - Add clear cache button to settings
 - Restrict local permissions for BitBoxApp config files and directories
+- Bitcoin: display zero amounts without decimal places
 
 ## v4.51.3
 - Bundle BitBox02 and BitBox02 Nova firmware version v9.26.4

--- a/frontends/web/src/components/amount/amount.test.tsx
+++ b/frontends/web/src/components/amount/amount.test.tsx
@@ -129,8 +129,13 @@ describe('Amount formatting', () => {
   });
 
   describe('BTC/LTC coins amounts', () => {
-    let coins: NativeCoinUnit[] = ['BTC', 'TBTC', 'LTC', 'TLTC'];
+    let coins: NativeCoinUnit[] = ['BTC', 'TBTC', 'RBTC', 'LTC', 'TLTC'];
     coins.forEach(coin => {
+
+      it('0.00000000 ' + coin + ' becomes 0', () => {
+        const { container } = render(<Amount amount="0.00000000" unit={coin}/>);
+        expect(container.textContent).toBe('0');
+      });
 
       it('10.00000000 ' + coin + ' gets spaced', () => {
         const { getByTestId } = render(<Amount amount="10.00000000" unit={coin}/>);

--- a/frontends/web/src/components/amount/amount.tsx
+++ b/frontends/web/src/components/amount/amount.tsx
@@ -72,6 +72,9 @@ const formatBtc = (
   group: string,
   decimal: string
 ) => {
+  if (stripTrailingZeros(amount) === '0') {
+    return '0';
+  }
   const dot = amount.indexOf('.');
   if (dot === -1) {
     return formatLocalizedAmount(amount, group, decimal);


### PR DESCRIPTION
Displaying zero as "0.00 000 000" does not look
good and can make users look for a non-zero digit in the decimal places.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
