### PR TITLE
frontend: harden AOPP VASP matching

### DIFF
--- a/frontends/web/src/components/aopp/vasp.test.tsx
+++ b/frontends/web/src/components/aopp/vasp.test.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Vasp } from './vasp';
+
+describe('components/aopp/vasp', () => {
+  it('shows known VASP branding for exact hostnames', () => {
+    render(<Vasp hostname="bitcoinsuisse.com" />);
+
+    expect(screen.getByRole('img', { name: 'bitcoinsuisse.com' })).toBeInTheDocument();
+    expect(screen.getByText('bitcoinsuisse.com')).toBeInTheDocument();
+  });
+
+  it('shows known VASP branding for subdomains with a dot boundary', () => {
+    render(<Vasp hostname="login.bitcoinsuisse.com" />);
+
+    expect(screen.getByRole('img', { name: 'bitcoinsuisse.com' })).toBeInTheDocument();
+    expect(screen.getByText('bitcoinsuisse.com')).toBeInTheDocument();
+    expect(screen.getByText('login.bitcoinsuisse.com')).toBeInTheDocument();
+  });
+
+  it('does not show known VASP branding for host suffix spoofs', () => {
+    render(<Vasp hostname="evilbitcoinsuisse.com" />);
+
+    expect(screen.queryByRole('img', { name: 'bitcoinsuisse.com' })).not.toBeInTheDocument();
+    expect(screen.getByText('evilbitcoinsuisse.com')).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/components/aopp/vasp.tsx
+++ b/frontends/web/src/components/aopp/vasp.tsx
@@ -36,14 +36,18 @@ const VASPHostnameMap: TVASPMap = {
   'testing.aopp.group': 'AOPP.group',
 };
 
+const matchesVaspHostname = (hostname: string, vasp: string): boolean => (
+  hostname === vasp || hostname.endsWith(`.${vasp}`)
+);
+
 export const Vasp = ({
   fallback,
   hostname,
   prominent,
   withLogoText,
 }: TVASPProps) => {
-  const subdomainOfVasp = Object.keys(VASPLogoMap).find((vasp) => hostname.endsWith(vasp));
-  const knownVasp = subdomainOfVasp || (hostname in VASPLogoMap && hostname);
+  const normalizedHostname = hostname.toLowerCase();
+  const knownVasp = Object.keys(VASPLogoMap).find((vasp) => matchesVaspHostname(normalizedHostname, vasp));
 
   if (!knownVasp) {
     return fallback || (
@@ -61,6 +65,7 @@ export const Vasp = ({
       <p className={`${styles.hostname as string} ${styles.capitalized as string}`}>
         {knownVasp in VASPHostnameMap ? VASPHostnameMap[knownVasp] : knownVasp}
       </p>
+      {normalizedHostname !== knownVasp ? (<p className={styles.hostname}>{hostname}</p>) : null}
       {withLogoText ? (<p>{withLogoText}</p>) : null}
     </div>
   );


### PR DESCRIPTION
AOPP requester branding matched known VASPs with a raw string suffix. A callback host like evilbitcoinsuisse.com could therefore render Bitcoin Suisse branding even though it is not that domain or one of its subdomains.

Require an exact host match or a dot-boundary subdomain match, and keep the real callback host visible when branding a subdomain. Add regression tests for exact, subdomain, and suffix-spoof hosts.
