### PR TITLE
lightning: add lnurl pay send flow

### DIFF
--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -173,7 +173,7 @@ func (lightning *Lightning) PostPreparePayment(r *http.Request) interface{} {
 		return errorResponse(err)
 	}
 
-	fee, err := lightning.PreparePayment(jsonBody.Bolt11, jsonBody.AmountSat)
+	fee, err := lightning.PreparePayment(jsonBody)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -199,11 +199,13 @@ func (lightning *Lightning) GetReceivePayment(r *http.Request) interface{} {
 // PostSendPayment handles the POST request to send a payment.
 func (lightning *Lightning) PostSendPayment(r *http.Request) interface{} {
 	var jsonBody sendPaymentRequest
-	if err := json.NewDecoder(r.Body).Decode(&jsonBody); err != nil {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&jsonBody); err != nil {
 		return errorResponse(err)
 	}
 
-	if err := lightning.SendPayment(jsonBody.Bolt11, jsonBody.AmountSat, jsonBody.ApprovedFeeSat); err != nil {
+	if err := lightning.SendPayment(jsonBody); err != nil {
 		return errorResponse(err)
 	}
 

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -55,7 +55,9 @@ type breezSDK interface {
 	RegisterLightningAddress(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error)
 	Parse(string) (breez_sdk_spark.InputType, error)
 	PrepareSendPayment(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error)
+	PrepareLnurlPay(breez_sdk_spark.PrepareLnurlPayRequest) (breez_sdk_spark.PrepareLnurlPayResponse, error)
 	SendPayment(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error)
+	LnurlPay(breez_sdk_spark.LnurlPayRequest) (breez_sdk_spark.LnurlPayResponse, error)
 	ReceivePayment(breez_sdk_spark.ReceivePaymentRequest) (breez_sdk_spark.ReceivePaymentResponse, error)
 	ListPayments(breez_sdk_spark.ListPaymentsRequest) (breez_sdk_spark.ListPaymentsResponse, error)
 }

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -3,6 +3,7 @@
 package lightning
 
 import (
+	"encoding/json"
 	"errors"
 	"math/big"
 	"strconv"
@@ -16,20 +17,32 @@ import (
 )
 
 const (
-	errPaymentApprovalRequired     errp.ErrorCode = "paymentApprovalRequired"
-	errLightningInsufficientFunds  errp.ErrorCode = "lightningInsufficientFunds"
-	errLightningInvoiceAlreadyUsed errp.ErrorCode = "lightningInvoiceAlreadyUsed"
+	errPaymentApprovalRequired      errp.ErrorCode = "paymentApprovalRequired"
+	errLightningInvalidAmount       errp.ErrorCode = "lightningInvalidAmount"
+	errLightningInvalidPaymentInput errp.ErrorCode = "lightningInvalidPaymentInput"
+	errLightningInsufficientFunds   errp.ErrorCode = "lightningInsufficientFunds"
+	errLightningInvoiceAlreadyUsed  errp.ErrorCode = "lightningInvoiceAlreadyUsed"
 )
 
-type lightningInvoice struct {
-	Bolt11      string  `json:"bolt11"`
+type lightningBolt11Invoice struct {
+	Invoice     string  `json:"invoice"`
 	Description *string `json:"description,omitempty"`
 	AmountSat   *uint64 `json:"amountSat,omitempty"`
 }
 
-type parsePaymentInputResponse struct {
-	Type    string           `json:"type"`
-	Invoice lightningInvoice `json:"invoice"`
+type lightningLNURLPay struct {
+	Input        string  `json:"input"`
+	Address      *string `json:"address,omitempty"`
+	Domain       string  `json:"domain"`
+	Description  *string `json:"description,omitempty"`
+	MinAmountSat uint64  `json:"minAmountSat"`
+	MaxAmountSat uint64  `json:"maxAmountSat"`
+}
+
+type paymentInput struct {
+	Type     string                  `json:"type"`
+	Bolt11   *lightningBolt11Invoice `json:"invoice,omitempty"`
+	LNURLPay *lightningLNURLPay      `json:"lnurlPay,omitempty"`
 }
 
 type lightningPayment struct {
@@ -50,12 +63,14 @@ type receivePaymentResponse struct {
 }
 
 type preparePaymentRequest struct {
-	Bolt11    string  `json:"bolt11"`
-	AmountSat *uint64 `json:"amountSat"`
+	Type         string  `json:"type"`
+	PaymentInput string  `json:"paymentInput"`
+	AmountSat    *uint64 `json:"amountSat,omitempty"`
 }
 
 type sendPaymentRequest struct {
-	Bolt11         string  `json:"bolt11"`
+	Type           string  `json:"type"`
+	PaymentInput   string  `json:"paymentInput"`
 	AmountSat      *uint64 `json:"amountSat"`
 	ApprovedFeeSat uint64  `json:"approvedFeeSat"`
 }
@@ -66,14 +81,73 @@ type paymentFee struct {
 	TotalDebitSat uint64 `json:"totalDebitSat"`
 }
 
+const (
+	paymentInputTypeBolt11   = "bolt11"
+	paymentInputTypeLNURLPay = "lnurlPay"
+)
+
+type msatToSatRounding int
+
+const (
+	roundToFloor msatToSatRounding = iota
+	roundToCeil
+)
+
+func msatToSat(msat uint64, rounding msatToSatRounding) uint64 {
+	if rounding == roundToCeil {
+		return (msat + 999) / 1000
+	}
+	return msat / 1000
+}
+
+func validateLNURLPayAmount(payRequest breez_sdk_spark.LnurlPayRequestDetails, amountSat uint64) error {
+	if amountSat == 0 {
+		return errLightningInvalidAmount
+	}
+	if amountSat < msatToSat(payRequest.MinSendable, roundToCeil) ||
+		amountSat > msatToSat(payRequest.MaxSendable, roundToFloor) {
+		return errLightningInvalidAmount
+	}
+	return nil
+}
+
+func lnurlPayDescription(metadataStr string) *string {
+	var metadata [][]string
+	if err := json.Unmarshal([]byte(metadataStr), &metadata); err != nil {
+		return nil
+	}
+	for _, entry := range metadata {
+		// LUD-06 requires a text/plain entry:
+		// https://github.com/lnurl/luds/blob/luds/06.md
+		// Use the first valid one as the payment description and ignore malformed entries.
+		if len(entry) >= 2 && entry[0] == "text/plain" {
+			description := entry[1]
+			return &description
+		}
+	}
+	return nil
+}
+
+func toLightningLNURLPay(inputStr string, payRequest breez_sdk_spark.LnurlPayRequestDetails) lightningLNURLPay {
+	return lightningLNURLPay{
+		Input:        inputStr,
+		Address:      payRequest.Address,
+		Domain:       payRequest.Domain,
+		Description:  lnurlPayDescription(payRequest.MetadataStr),
+		MinAmountSat: msatToSat(payRequest.MinSendable, roundToCeil),
+		MaxAmountSat: msatToSat(payRequest.MaxSendable, roundToFloor),
+	}
+}
+
 // ParsePaymentInput validates and classifies a lightning input string.
-func (lightning *Lightning) ParsePaymentInput(inputStr string) (*parsePaymentInputResponse, error) {
+func (lightning *Lightning) ParsePaymentInput(inputStr string) (*paymentInput, error) {
 	if err := lightning.CheckActive(); err != nil {
 		return nil, err
 	}
 	input, err := lightning.sdkService.Parse(inputStr)
 	if err != nil {
-		return nil, err
+		lightning.log.WithError(err).Error("Parse lightning payment input failed")
+		return nil, errLightningInvalidPaymentInput
 	}
 
 	switch inputType := input.(type) {
@@ -85,14 +159,14 @@ func (lightning *Lightning) ParsePaymentInput(inputStr string) (*parsePaymentInp
 		var amountSat *uint64
 		if inputType.Field0.AmountMsat != nil {
 			amount = strconv.FormatUint(*inputType.Field0.AmountMsat, 10)
-			value := *inputType.Field0.AmountMsat / 1000
+			value := msatToSat(*inputType.Field0.AmountMsat, roundToCeil)
 			amountSat = &value
 		}
 		lightning.log.Printf("Input is BOLT11 invoice for %s msats", amount)
-		return &parsePaymentInputResponse{
-			Type: "bolt11",
-			Invoice: lightningInvoice{
-				Bolt11:      inputType.Field0.Invoice.Bolt11,
+		return &paymentInput{
+			Type: paymentInputTypeBolt11,
+			Bolt11: &lightningBolt11Invoice{
+				Invoice:     inputType.Field0.Invoice.Bolt11,
 				Description: inputType.Field0.Description,
 				AmountSat:   amountSat,
 			},
@@ -101,6 +175,21 @@ func (lightning *Lightning) ParsePaymentInput(inputStr string) (*parsePaymentInp
 	case breez_sdk_spark.InputTypeLnurlPay:
 		lightning.log.Printf("Input is LNURL-Pay/Lightning address accepting min/max %d/%d msats",
 			inputType.Field0.MinSendable, inputType.Field0.MaxSendable)
+		lnurlPay := toLightningLNURLPay(inputStr, inputType.Field0)
+		return &paymentInput{
+			Type:     paymentInputTypeLNURLPay,
+			LNURLPay: &lnurlPay,
+		}, nil
+
+	case breez_sdk_spark.InputTypeLightningAddress:
+		lightning.log.Printf("Input is Lightning address %s accepting min/max %d/%d msats",
+			inputType.Field0.Address, inputType.Field0.PayRequest.MinSendable, inputType.Field0.PayRequest.MaxSendable)
+		lnurlPay := toLightningLNURLPay(inputStr, inputType.Field0.PayRequest)
+		lnurlPay.Address = &inputType.Field0.Address
+		return &paymentInput{
+			Type:     paymentInputTypeLNURLPay,
+			LNURLPay: &lnurlPay,
+		}, nil
 
 	case breez_sdk_spark.InputTypeLnurlWithdraw:
 		lightning.log.Printf("Input is LNURL-Withdraw for min/max %d/%d msats",
@@ -132,7 +221,6 @@ func (lightning *Lightning) ParsePaymentInput(inputStr string) (*parsePaymentInp
 
 	default:
 		lightning.log.Errorf("Input type not supported %T", input)
-		return nil, errp.New("Invoice format not supported")
 	}
 	return nil, errp.New("Invoice format not supported")
 }
@@ -216,7 +304,7 @@ func parseLightningUint(value interface{ String() string }) uint64 {
 	return parsed
 }
 
-func prepareSendPaymentRequest(paymentInvoice string, amount *uint64) breez_sdk_spark.PrepareSendPaymentRequest {
+func prepareBolt11PaymentRequest(paymentInvoice string, amount *uint64) breez_sdk_spark.PrepareSendPaymentRequest {
 	request := breez_sdk_spark.PrepareSendPaymentRequest{
 		PaymentRequest: paymentInvoice,
 	}
@@ -227,7 +315,17 @@ func prepareSendPaymentRequest(paymentInvoice string, amount *uint64) breez_sdk_
 	return request
 }
 
-func preparedPaymentFee(prepareResponse breez_sdk_spark.PrepareSendPaymentResponse) (*paymentFee, error) {
+func prepareLNURLPayRequest(
+	payRequest breez_sdk_spark.LnurlPayRequestDetails,
+	amount uint64,
+) breez_sdk_spark.PrepareLnurlPayRequest {
+	return breez_sdk_spark.PrepareLnurlPayRequest{
+		Amount:     new(big.Int).SetUint64(amount),
+		PayRequest: payRequest,
+	}
+}
+
+func preparedBolt11PaymentFee(prepareResponse breez_sdk_spark.PrepareSendPaymentResponse) (*paymentFee, error) {
 	if paymentMethod, ok := prepareResponse.PaymentMethod.(breez_sdk_spark.SendPaymentMethodBolt11Invoice); ok {
 		amountSat := parseLightningUint(prepareResponse.Amount)
 		feeSat := paymentMethod.LightningFeeSats
@@ -238,6 +336,14 @@ func preparedPaymentFee(prepareResponse breez_sdk_spark.PrepareSendPaymentRespon
 		}, nil
 	}
 	return nil, errp.Newf("Payment method %v not supported", prepareResponse.PaymentMethod)
+}
+
+func preparedLNURLPayFee(prepareResponse breez_sdk_spark.PrepareLnurlPayResponse) *paymentFee {
+	return &paymentFee{
+		AmountSat:     prepareResponse.AmountSats,
+		FeeSat:        prepareResponse.FeeSats,
+		TotalDebitSat: prepareResponse.AmountSats + prepareResponse.FeeSats,
+	}
 }
 
 func checkApprovedPaymentFee(fee uint64, approvedFee uint64) error {
@@ -269,18 +375,46 @@ func lightningPaymentError(err error) error {
 	return err
 }
 
-// PreparePayment computes the fee quote for the provided payment request.
-func (lightning *Lightning) PreparePayment(paymentInvoice string, amountSat *uint64) (*paymentFee, error) {
+func (lightning *Lightning) parseLNURLPayRequest(inputStr string) (*breez_sdk_spark.LnurlPayRequestDetails, error) {
+	input, err := lightning.sdkService.Parse(inputStr)
+	if err != nil {
+		lightning.log.WithError(err).Error("Parse LNURL-Pay request failed")
+		return nil, errLightningInvalidPaymentInput
+	}
+
+	switch inputType := input.(type) {
+	case breez_sdk_spark.InputTypeLnurlPay:
+		return &inputType.Field0, nil
+	case breez_sdk_spark.InputTypeLightningAddress:
+		return &inputType.Field0.PayRequest, nil
+	default:
+		return nil, errLightningInvalidPaymentInput
+	}
+}
+
+// PreparePayment computes the fee quote for the provided payment input.
+func (lightning *Lightning) PreparePayment(request preparePaymentRequest) (*paymentFee, error) {
+	switch request.Type {
+	case paymentInputTypeBolt11:
+		return lightning.prepareBolt11Payment(request.PaymentInput, request.AmountSat)
+	case paymentInputTypeLNURLPay:
+		return lightning.prepareLNURLPay(request.PaymentInput, request.AmountSat)
+	default:
+		return nil, errp.New("Payment type not supported")
+	}
+}
+
+func (lightning *Lightning) prepareBolt11Payment(paymentInvoice string, amountSat *uint64) (*paymentFee, error) {
 	if err := lightning.CheckActive(); err != nil {
 		return nil, err
 	}
-	prepareResponse, err := lightning.sdkService.PrepareSendPayment(prepareSendPaymentRequest(paymentInvoice, amountSat))
+	prepareResponse, err := lightning.sdkService.PrepareSendPayment(prepareBolt11PaymentRequest(paymentInvoice, amountSat))
 	if err != nil {
 		lightning.log.WithError(err).Error("Prepare lightning payment failed")
 		return nil, lightningPaymentError(err)
 	}
 
-	fee, err := preparedPaymentFee(prepareResponse)
+	fee, err := preparedBolt11PaymentFee(prepareResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -295,27 +429,79 @@ func (lightning *Lightning) PreparePayment(paymentInvoice string, amountSat *uin
 	return fee, nil
 }
 
-// SendPayment executes a payment for the provided payment request.
-func (lightning *Lightning) SendPayment(paymentInvoice string, amount *uint64, approvedFee uint64) error {
+func (lightning *Lightning) prepareLNURLPay(inputStr string, amountSat *uint64) (*paymentFee, error) {
+	if err := lightning.CheckActive(); err != nil {
+		return nil, err
+	}
+	if amountSat == nil || *amountSat == 0 {
+		return nil, errLightningInvalidAmount
+	}
+
+	payRequest, err := lightning.parseLNURLPayRequest(inputStr)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateLNURLPayAmount(*payRequest, *amountSat); err != nil {
+		return nil, err
+	}
+
+	prepareResponse, err := lightning.sdkService.PrepareLnurlPay(prepareLNURLPayRequest(*payRequest, *amountSat))
+	if err != nil {
+		lightning.log.WithError(err).Error("Prepare LNURL-Pay failed")
+		return nil, lightningPaymentError(err)
+	}
+
+	fee := preparedLNURLPayFee(prepareResponse)
+	balance, err := lightning.Balance()
+	if err != nil {
+		return nil, err
+	}
+	if err := checkPaymentBalance(fee, balance); err != nil {
+		return fee, err
+	}
+	lightning.log.Printf("LNURL-Pay Fee: %v sats", fee.FeeSat)
+	return fee, nil
+}
+
+// SendPayment executes the provided payment input.
+func (lightning *Lightning) SendPayment(request sendPaymentRequest) error {
+	switch request.Type {
+	case paymentInputTypeBolt11:
+		return lightning.sendBolt11Payment(request)
+	case paymentInputTypeLNURLPay:
+		return lightning.sendLNURLPay(request)
+	default:
+		return errp.New("Payment type not supported")
+	}
+}
+
+func (lightning *Lightning) sendBolt11Payment(request sendPaymentRequest) error {
 	if err := lightning.CheckActive(); err != nil {
 		return err
 	}
-	lightning.log.Infof("Sending payment to %+v", paymentInvoice)
-	if amount != nil {
-		lightning.log.Infof("Optional amount: %+v sat", *amount)
+	lightning.log.Infof("Sending payment to %+v", request.PaymentInput)
+	if request.AmountSat != nil {
+		lightning.log.Infof("Optional amount: %+v sat", *request.AmountSat)
 	}
 
-	prepareResponse, err := lightning.sdkService.PrepareSendPayment(prepareSendPaymentRequest(paymentInvoice, amount))
+	prepareResponse, err := lightning.sdkService.PrepareSendPayment(prepareBolt11PaymentRequest(request.PaymentInput, request.AmountSat))
 	if err != nil {
 		lightning.log.WithError(err).Error("Prepare send lightning payment failed")
 		return lightningPaymentError(err)
 	}
 
-	fee, err := preparedPaymentFee(prepareResponse)
+	fee, err := preparedBolt11PaymentFee(prepareResponse)
 	if err != nil {
 		return err
 	}
-	if err := checkApprovedPaymentFee(fee.FeeSat, approvedFee); err != nil {
+	if err := checkApprovedPaymentFee(fee.FeeSat, request.ApprovedFeeSat); err != nil {
+		return err
+	}
+	balance, err := lightning.Balance()
+	if err != nil {
+		return err
+	}
+	if err := checkPaymentBalance(fee, balance); err != nil {
 		return err
 	}
 
@@ -331,6 +517,53 @@ func (lightning *Lightning) SendPayment(paymentInvoice string, amount *uint64, a
 
 	if err != nil {
 		lightning.log.WithError(err).Error("Send lightning payment failed")
+		return lightningPaymentError(err)
+	}
+	return nil
+}
+
+func (lightning *Lightning) sendLNURLPay(request sendPaymentRequest) error {
+	if err := lightning.CheckActive(); err != nil {
+		return err
+	}
+	if request.AmountSat == nil || *request.AmountSat == 0 {
+		return errLightningInvalidAmount
+	}
+
+	lightning.log.Infof("Sending LNURL-Pay payment to %+v", request.PaymentInput)
+	lightning.log.Infof("Amount: %+v sat", *request.AmountSat)
+
+	payRequest, err := lightning.parseLNURLPayRequest(request.PaymentInput)
+	if err != nil {
+		return err
+	}
+	if err := validateLNURLPayAmount(*payRequest, *request.AmountSat); err != nil {
+		return err
+	}
+
+	prepareResponse, err := lightning.sdkService.PrepareLnurlPay(prepareLNURLPayRequest(*payRequest, *request.AmountSat))
+	if err != nil {
+		lightning.log.WithError(err).Error("Prepare LNURL-Pay failed")
+		return lightningPaymentError(err)
+	}
+
+	fee := preparedLNURLPayFee(prepareResponse)
+	if err := checkApprovedPaymentFee(fee.FeeSat, request.ApprovedFeeSat); err != nil {
+		return err
+	}
+	balance, err := lightning.Balance()
+	if err != nil {
+		return err
+	}
+	if err := checkPaymentBalance(fee, balance); err != nil {
+		return err
+	}
+
+	_, err = lightning.sdkService.LnurlPay(breez_sdk_spark.LnurlPayRequest{
+		PrepareResponse: prepareResponse,
+	})
+	if err != nil {
+		lightning.log.WithError(err).Error("Send LNURL-Pay failed")
 		return lightningPaymentError(err)
 	}
 	return nil

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -174,7 +174,118 @@ func TestParseLightningUint(t *testing.T) {
 	require.Equal(t, uint64(99), parseLightningUint(big.NewInt(99)))
 }
 
-func TestPrepareSendPaymentRequest(t *testing.T) {
+func TestMsatToSatCeil(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, uint64(0), msatToSat(0, roundToCeil))
+	require.Equal(t, uint64(1), msatToSat(1, roundToCeil))
+	require.Equal(t, uint64(1), msatToSat(1000, roundToCeil))
+	require.Equal(t, uint64(2), msatToSat(1001, roundToCeil))
+	require.Equal(t, uint64(2), msatToSat(2000, roundToCeil))
+}
+
+func TestMsatToSatFloor(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, uint64(0), msatToSat(0, roundToFloor))
+	require.Equal(t, uint64(0), msatToSat(999, roundToFloor))
+	require.Equal(t, uint64(1), msatToSat(1000, roundToFloor))
+	require.Equal(t, uint64(1), msatToSat(1999, roundToFloor))
+	require.Equal(t, uint64(2), msatToSat(2000, roundToFloor))
+}
+
+func TestMsatToSatInvalidRoundingDefaultsToFloor(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		require.Equal(t, uint64(1), msatToSat(1999, msatToSatRounding(99)))
+	})
+}
+
+func TestValidateLNURLPayAmount(t *testing.T) {
+	t.Parallel()
+
+	payRequest := breez_sdk_spark.LnurlPayRequestDetails{
+		MinSendable: 1500,
+		MaxSendable: 9999,
+	}
+
+	testCases := []struct {
+		name      string
+		amountSat uint64
+		wantErr   bool
+	}{
+		{
+			name:      "zero amount",
+			amountSat: 0,
+			wantErr:   true,
+		},
+		{
+			name:      "below rounded-up minimum",
+			amountSat: 1,
+			wantErr:   true,
+		},
+		{
+			name:      "at rounded-up minimum",
+			amountSat: 2,
+		},
+		{
+			name:      "at rounded-down maximum",
+			amountSat: 9,
+		},
+		{
+			name:      "above rounded-down maximum",
+			amountSat: 10,
+			wantErr:   true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateLNURLPayAmount(payRequest, testCase.amountSat)
+			if testCase.wantErr {
+				require.ErrorIs(t, err, errLightningInvalidAmount)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestLnurlPayDescription(t *testing.T) {
+	t.Parallel()
+
+	description := lnurlPayDescription(`[["text/identifier","alice@example.com"],["text/plain","Coffee"]]`)
+	require.NotNil(t, description)
+	require.Equal(t, "Coffee", *description)
+
+	require.Nil(t, lnurlPayDescription(`[["text/identifier","alice@example.com"]]`))
+	require.Nil(t, lnurlPayDescription(`not-json`))
+}
+
+func TestToLightningLNURLPay(t *testing.T) {
+	t.Parallel()
+
+	address := "alice@example.com"
+	lnurlPay := toLightningLNURLPay("lnurl-input", breez_sdk_spark.LnurlPayRequestDetails{
+		MinSendable: 1500,
+		MaxSendable: 9999,
+		MetadataStr: `[["text/plain","Tip jar"]]`,
+		Domain:      "example.com",
+		Address:     &address,
+	})
+
+	require.Equal(t, "lnurl-input", lnurlPay.Input)
+	require.Equal(t, "alice@example.com", *lnurlPay.Address)
+	require.Equal(t, "example.com", lnurlPay.Domain)
+	require.Equal(t, "Tip jar", *lnurlPay.Description)
+	require.Equal(t, uint64(2), lnurlPay.MinAmountSat)
+	require.Equal(t, uint64(9), lnurlPay.MaxAmountSat)
+}
+
+func TestPrepareBolt11PaymentRequest(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -198,7 +309,7 @@ func TestPrepareSendPaymentRequest(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			request := prepareSendPaymentRequest("lnbc1invoice", testCase.amountSat)
+			request := prepareBolt11PaymentRequest("lnbc1invoice", testCase.amountSat)
 
 			require.Equal(t, "lnbc1invoice", request.PaymentRequest)
 			if testCase.expectedAmount == nil {
@@ -211,7 +322,25 @@ func TestPrepareSendPaymentRequest(t *testing.T) {
 	}
 }
 
-func TestPreparedPaymentFee(t *testing.T) {
+func TestPrepareLNURLPayRequest(t *testing.T) {
+	t.Parallel()
+
+	payRequest := breez_sdk_spark.LnurlPayRequestDetails{
+		Callback:    "https://example.com/lnurl-pay",
+		MinSendable: 1000,
+		MaxSendable: 100000,
+		MetadataStr: `[["text/plain","Coffee"]]`,
+		Domain:      "example.com",
+		Url:         "https://example.com/.well-known/lnurlp/alice",
+	}
+
+	request := prepareLNURLPayRequest(payRequest, 123)
+
+	require.Equal(t, 0, request.Amount.Cmp(big.NewInt(123)))
+	require.Equal(t, payRequest, request.PayRequest)
+}
+
+func TestPreparedBolt11PaymentFee(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -248,7 +377,7 @@ func TestPreparedPaymentFee(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			quote, err := preparedPaymentFee(testCase.response)
+			quote, err := preparedBolt11PaymentFee(testCase.response)
 
 			if testCase.expectedErr != "" {
 				require.Error(t, err)
@@ -262,6 +391,21 @@ func TestPreparedPaymentFee(t *testing.T) {
 			require.Equal(t, testCase.expected, quote)
 		})
 	}
+}
+
+func TestPreparedLNURLPayFee(t *testing.T) {
+	t.Parallel()
+
+	fee := preparedLNURLPayFee(breez_sdk_spark.PrepareLnurlPayResponse{
+		AmountSats: 123,
+		FeeSats:    7,
+	})
+
+	require.Equal(t, &paymentFee{
+		AmountSat:     123,
+		FeeSat:        7,
+		TotalDebitSat: 130,
+	}, fee)
 }
 
 func TestValidateApprovedLightningFee(t *testing.T) {

--- a/frontends/web/src/api/lightning-errors.ts
+++ b/frontends/web/src/api/lightning-errors.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TFunction } from 'i18next';
+
+export enum TLightningErrorCode {
+  PAYMENT_APPROVAL_REQUIRED = 'paymentApprovalRequired',
+  INVALID_AMOUNT = 'lightningInvalidAmount',
+  INVALID_PAYMENT_INPUT = 'lightningInvalidPaymentInput',
+  INSUFFICIENT_FUNDS = 'lightningInsufficientFunds',
+  INVOICE_ALREADY_USED = 'lightningInvoiceAlreadyUsed',
+}
+
+// Backend error codes arrive over JSON, so keep the lookup defensive for unknown runtime values.
+const lightningErrorTranslationKeys: Partial<Record<string, string>> = {
+  [TLightningErrorCode.PAYMENT_APPROVAL_REQUIRED]: 'error.paymentApprovalRequired',
+  [TLightningErrorCode.INVALID_AMOUNT]: 'error.lightningInvalidAmount',
+  [TLightningErrorCode.INVALID_PAYMENT_INPUT]: 'error.lightningInvalidPaymentInput',
+  [TLightningErrorCode.INSUFFICIENT_FUNDS]: 'error.lightningInsufficientFunds',
+  [TLightningErrorCode.INVOICE_ALREADY_USED]: 'error.lightningInvoiceAlreadyUsed',
+};
+
+export class TSdkError extends Error {
+  code?: TLightningErrorCode;
+
+  constructor(message: string, code?: TLightningErrorCode) {
+    super(message);
+    this.code = code;
+
+    Object.setPrototypeOf(this, TSdkError.prototype);
+  }
+}
+
+export const toLightningErrorMessage = (t: TFunction, error: unknown): string => {
+  if (error instanceof TSdkError) {
+    if (error.code) {
+      const translationKey = lightningErrorTranslationKeys[error.code];
+      if (translationKey) {
+        return t(translationKey);
+      }
+    }
+    return error.message;
+  }
+  return String(error);
+};

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -4,6 +4,7 @@ import type { AccountCode, TAmountWithConversions, TBalance, TTransactionStatus 
 import type { TSubscriptionCallback, TUnsubscribe } from '@/api/subscribe';
 import { subscribeEndpoint } from '@/api/subscribe';
 import { apiGet, apiPost } from '@/utils/request';
+import { type TLightningErrorCode, TSdkError } from './lightning-errors';
 
 export type TLightningResponse<T> =
   | {
@@ -13,7 +14,7 @@ export type TLightningResponse<T> =
   | {
     success: false;
     errorMessage?: string;
-    errorCode?: string;
+    errorCode?: TLightningErrorCode;
   };
 
 export type TLightningAccount = {
@@ -22,10 +23,19 @@ export type TLightningAccount = {
   num: number;
 };
 
-export type TLightningInvoice = {
-  bolt11: string;
+export type TLightningBolt11Invoice = {
+  invoice: string;
   description?: string;
   amountSat?: number;
+};
+
+export type TLightningLNURLPay = {
+  input: string;
+  address?: string;
+  domain: string;
+  description?: string;
+  minAmountSat: number;
+  maxAmountSat: number;
 };
 
 export type TLightningPayment = {
@@ -51,14 +61,25 @@ export type TReceivePaymentResponse = {
 };
 
 export type TSendPaymentRequest = {
-  bolt11: string;
+  type: TPaymentInputType.BOLT11;
+  paymentInput: string;
   amountSat?: number;
+  approvedFeeSat: number;
+} | {
+  type: TPaymentInputType.LNURL_PAY;
+  paymentInput: string;
+  amountSat: number;
   approvedFeeSat: number;
 };
 
 export type TPreparePaymentRequest = {
-  bolt11: string;
+  type: TPaymentInputType.BOLT11;
+  paymentInput: string;
   amountSat?: number;
+} | {
+  type: TPaymentInputType.LNURL_PAY;
+  paymentInput: string;
+  amountSat: number;
 };
 
 export type TPreparePaymentResponse = {
@@ -73,29 +94,22 @@ export type TSparkStatus = {
   status: TServiceStatus;
 };
 
-export enum TPaymentInputTypeVariant {
+export enum TPaymentInputType {
   BOLT11 = 'bolt11',
+  LNURL_PAY = 'lnurlPay',
 }
 
-export type TPaymentInputType = {
-  type: TPaymentInputTypeVariant.BOLT11;
-  invoice: TLightningInvoice;
+export type TPaymentInput = {
+  type: TPaymentInputType.BOLT11;
+  invoice: TLightningBolt11Invoice;
+} | {
+  type: TPaymentInputType.LNURL_PAY;
+  lnurlPay: TLightningLNURLPay;
 };
 
 export type TParsePaymentInputRequest = {
   s: string;
 };
-
-export class TSdkError extends Error {
-  code?: string;
-
-  constructor(message: string, code?: string) {
-    super(message);
-    this.code = code;
-
-    Object.setPrototypeOf(this, TSdkError.prototype);
-  }
-}
 
 const queryString = (params: Record<string, string | number | undefined | null>): string => {
   const searchParams = new URLSearchParams();
@@ -161,8 +175,8 @@ export const getListPayments = async (): Promise<TLightningPayment[]> => {
   return getApiResponse<TLightningPayment[]>('lightning/list-payments', 'Error calling getListPayments');
 };
 
-export const getParsePaymentInput = async (params: TParsePaymentInputRequest): Promise<TPaymentInputType> => {
-  return getApiResponse<TPaymentInputType>(`lightning/parse-payment-input?${queryString(params)}`, 'Error calling getParsePaymentInput');
+export const getParsePaymentInput = async (params: TParsePaymentInputRequest): Promise<TPaymentInput> => {
+  return getApiResponse<TPaymentInput>(`lightning/parse-payment-input?${queryString(params)}`, 'Error calling getParsePaymentInput');
 };
 
 export const getBoardingAddress = async (): Promise<string> => {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -918,6 +918,8 @@
     "aoppVersion": "Unknown version.",
     "keystoreTimeout": "Wallet request expired. Please try again.",
     "lightningInsufficientFunds": "Insufficient funds in your Lightning wallet.",
+    "lightningInvalidAmount": "Invalid amount.",
+    "lightningInvalidPaymentInput": "Invalid invoice or payment request.",
     "lightningInvoiceAlreadyUsed": "This Lightning invoice was already used. Please request a new invoice.",
     "paymentApprovalRequired": "Payment fee increased. Please review and approve again.",
     "wrongKeystore": "Wrong wallet connected. Please make sure to insert the correct device matching this account.",
@@ -1657,6 +1659,9 @@
       },
       "invoice": {
         "input": "Or paste your invoice here"
+      },
+      "lnurlPay": {
+        "invalidAmount": "Enter an amount between {{minAmount}} and {{maxAmount}} sats."
       },
       "qrCode": {
         "label": "Scan lightning invoice"

--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -8,7 +8,6 @@ import { Button, Input, NumberInput, OptionalLabel } from '../../../components/f
 import {
   TLightningPayment,
   TReceivePaymentResponse,
-  TSdkError,
   getLightningAddress,
   getListPayments,
   getReceivePayment,
@@ -27,6 +26,7 @@ import { RatesContext } from '@/contexts/RatesContext';
 import { CopyableInput } from '@/components/copy/Copy';
 import { useSync } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
+import { toLightningErrorMessage } from '@/api/lightning-errors';
 import styles from './receive.module.css';
 
 type TStep = 'create-invoice' | 'wait' | 'invoice' | 'success';
@@ -165,11 +165,7 @@ export function Receive() {
       setStep('invoice');
     } catch (e) {
       setStep('create-invoice');
-      if (e instanceof TSdkError) {
-        setReceiveError(e.message);
-      } else {
-        setReceiveError(String(e));
-      }
+      setReceiveError(toLightningErrorMessage(t, e));
     }
   }, [description, invoiceAmountSat, t]);
 

--- a/frontends/web/src/routes/lightning/send/components/bolt11-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/bolt11-review-step.tsx
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import { useMemo } from 'react';
+import { TPaymentInputType, type TLightningBolt11Invoice } from '@/api/lightning';
+import { Button, Input } from '@/components/forms';
+import { Column, Grid } from '@/components/layout';
+import { Spinner } from '@/components/spinner/Spinner';
+import { Status } from '@/components/status/status';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { Bolt11PaymentDetails, PaymentAmountDetails, PaymentFeeDetails } from './payment-input-details';
+import { type TPaymentReviewDetails, usePaymentReview } from '../hooks/use-payment-review';
+import { SendingSpinner } from './sending-spinner';
+
+type TProps = {
+  invoice: TLightningBolt11Invoice;
+  backToPaymentInput: (nextInputError?: string) => void;
+  onSuccess: () => void;
+};
+
+export const Bolt11ReviewStep = ({
+  invoice,
+  backToPaymentInput,
+  onSuccess,
+}: TProps) => {
+  const { t } = useTranslation();
+  const needsCustomAmount = invoice.amountSat === undefined;
+  // Keep paymentDetails stable because usePaymentReview depends on this object in effects.
+  const paymentDetails = useMemo<TPaymentReviewDetails>(() => ({
+    type: TPaymentInputType.BOLT11,
+    details: invoice,
+  }), [invoice]);
+  const {
+    canSend,
+    customAmount,
+    fees,
+    isSending,
+    preparedPayment,
+    sendError,
+    sendPayment,
+    setCustomAmount,
+  } = usePaymentReview({
+    paymentDetails,
+    backToPaymentInput,
+    onSuccess,
+  });
+
+  if (isSending) {
+    return <SendingSpinner />;
+  }
+
+  return (
+    <View fitContent minHeight="100%">
+      <ViewContent>
+        <Grid col="1">
+          <Column>
+            <Status dismissibleKey="" type="warning" hidden={!sendError}>
+              {sendError}
+            </Status>
+            {needsCustomAmount ? (
+              <>
+                <Input
+                  type="number"
+                  min={0}
+                  label={t('lightning.receive.amountSats.label')}
+                  placeholder={t('lightning.receive.amountSats.placeholder')}
+                  id="amountSatsInput"
+                  onInput={(event) => {
+                    const amount = event.currentTarget.valueAsNumber;
+                    setCustomAmount(Number.isNaN(amount) ? undefined : amount);
+                  }}
+                  value={customAmount ? `${customAmount}` : ''}
+                  autoFocus
+                />
+                <Input
+                  type="text"
+                  label={t('lightning.receive.description.label')}
+                  placeholder={t('lightning.receive.description.placeholder')}
+                  id="descriptionInput"
+                  readOnly
+                  disabled
+                  value={invoice.description || ''}
+                />
+                <Status dismissibleKey="" type="error" hidden={preparedPayment?.status !== 'error'}>
+                  {preparedPayment?.status === 'error' ? preparedPayment.error : undefined}
+                </Status>
+                {(preparedPayment?.status === 'preparing' || fees) && (
+                  <>
+                    <PaymentAmountDetails amountSat={fees?.amountSat} />
+                    <PaymentFeeDetails fees={fees} totalWithFiat />
+                  </>
+                )}
+              </>
+            ) : (
+              fees
+                ? <Bolt11PaymentDetails description={invoice.description} fees={fees} />
+                : preparedPayment?.status === 'preparing' && <Spinner text={t('loading')} />
+            )}
+          </Column>
+        </Grid>
+      </ViewContent>
+      <ViewButtons>
+        <Button
+          primary
+          onClick={sendPayment}
+          disabled={!canSend}>
+          {t('generic.send')}
+        </Button>
+        <Button secondary onClick={() => backToPaymentInput()}>
+          {t('button.back')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/send/components/lnurl-pay-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/lnurl-pay-review-step.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TPaymentInputType, type TLightningLNURLPay } from '@/api/lightning';
+import { Button, Input } from '@/components/forms';
+import { Column, Grid } from '@/components/layout';
+import { Status } from '@/components/status/status';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { LNURLPayRecipientDetails, PaymentAmountDetails, PaymentFeeDetails } from './payment-input-details';
+import { type TPaymentReviewDetails, usePaymentReview } from '../hooks/use-payment-review';
+import { SendingSpinner } from './sending-spinner';
+
+type TProps = {
+  lnurlPay: TLightningLNURLPay;
+  backToPaymentInput: (nextInputError?: string) => void;
+  onSuccess: () => void;
+};
+
+export const LNURLPayReviewStep = ({
+  lnurlPay,
+  backToPaymentInput,
+  onSuccess,
+}: TProps) => {
+  const { t } = useTranslation();
+  // Keep paymentDetails stable because usePaymentReview depends on this object in effects.
+  const paymentDetails = useMemo<TPaymentReviewDetails>(() => ({
+    type: TPaymentInputType.LNURL_PAY,
+    details: lnurlPay,
+  }), [lnurlPay]);
+  const {
+    amountError,
+    canSend,
+    customAmount,
+    fees,
+    isSending,
+    preparedPayment,
+    sendError,
+    sendPayment,
+    setCustomAmount,
+  } = usePaymentReview({
+    paymentDetails,
+    backToPaymentInput,
+    onSuccess,
+  });
+
+  if (isSending) {
+    return <SendingSpinner />;
+  }
+
+  const prepareError = amountError || (preparedPayment?.status === 'error' ? preparedPayment.error : undefined);
+
+  return (
+    <View fitContent minHeight="100%">
+      <ViewContent>
+        <Grid col="1">
+          <Column>
+            <Status dismissibleKey="" type="warning" hidden={!sendError}>
+              {sendError}
+            </Status>
+            <Input
+              type="number"
+              min={lnurlPay.minAmountSat}
+              max={lnurlPay.maxAmountSat}
+              label={t('lightning.receive.amountSats.label')}
+              placeholder={t('lightning.receive.amountSats.placeholder')}
+              id="amountSatsInput"
+              onInput={(event) => {
+                const amount = event.currentTarget.valueAsNumber;
+                setCustomAmount(Number.isNaN(amount) ? undefined : amount);
+              }}
+              value={customAmount ?? ''}
+              autoFocus
+            />
+            <LNURLPayRecipientDetails lnurlPay={lnurlPay} />
+            <Status dismissibleKey="" type="error" hidden={!prepareError}>
+              {prepareError}
+            </Status>
+            {(preparedPayment?.status === 'preparing' || fees) && (
+              <>
+                <PaymentAmountDetails amountSat={fees?.amountSat} />
+                <PaymentFeeDetails fees={fees} totalWithFiat />
+              </>
+            )}
+          </Column>
+        </Grid>
+      </ViewContent>
+      <ViewButtons>
+        <Button
+          primary
+          onClick={sendPayment}
+          disabled={!canSend}>
+          {t('generic.send')}
+        </Button>
+        <Button secondary onClick={() => backToPaymentInput()}>
+          {t('button.back')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/send/components/payment-input-details.tsx
+++ b/frontends/web/src/routes/lightning/send/components/payment-input-details.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TAmountWithConversions } from '@/api/account';
 import { getBtcSatAmount } from '@/api/coins';
-import { TPaymentInputType, TPreparePaymentResponse } from '@/api/lightning';
+import { type TLightningLNURLPay, type TPreparePaymentResponse } from '@/api/lightning';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { Skeleton } from '@/components/skeleton/skeleton';
 import { useMountedRef } from '@/hooks/mount';
@@ -67,7 +67,7 @@ const satsAmount = (amountSat?: number): TAmountWithConversions | undefined => {
   };
 };
 
-type TProps = {
+type TPaymentFeeDetailsProps = {
   fees?: TPreparePaymentResponse;
   totalWithFiat?: boolean;
 };
@@ -76,9 +76,13 @@ type TPaymentAmountDetailsProps = {
   amountSat?: number;
 };
 
-type TPaymentDetailsProps = {
-  input: TPaymentInputType;
+type TBolt11PaymentDetailsProps = {
+  description?: string;
   fees: TPreparePaymentResponse;
+};
+
+type TLNURLPayRecipientDetailsProps = {
+  lnurlPay: TLightningLNURLPay;
 };
 
 export const PaymentAmountDetails = ({ amountSat }: TPaymentAmountDetailsProps) => {
@@ -93,7 +97,7 @@ export const PaymentAmountDetails = ({ amountSat }: TPaymentAmountDetailsProps) 
   );
 };
 
-export const PaymentFeeDetails = ({ fees, totalWithFiat = false }: TProps) => {
+export const PaymentFeeDetails = ({ fees, totalWithFiat = false }: TPaymentFeeDetailsProps) => {
   const { t } = useTranslation();
   const feeAmount = satsAmount(fees?.feeSat);
   const totalDebitAmountSat = satsAmount(fees?.totalDebitSat);
@@ -115,18 +119,37 @@ export const PaymentFeeDetails = ({ fees, totalWithFiat = false }: TProps) => {
   );
 };
 
-export const PaymentDetails = ({ input, fees }: TPaymentDetailsProps) => {
+export const LNURLPayRecipientDetails = ({ lnurlPay }: TLNURLPayRecipientDetailsProps) => {
   const { t } = useTranslation();
-  const { invoice } = input;
+
+  return (
+    <>
+      <h1 className={styles.title}>{t('lightning.send.confirm.title')}</h1>
+      <div className={styles.info}>
+        <h2 className={styles.label}>{t('send.confirm.to')}</h2>
+        {lnurlPay.address || lnurlPay.domain}
+      </div>
+      {lnurlPay.description && (
+        <div className={styles.info}>
+          <h2 className={styles.label}>{t('lightning.send.confirm.memo')}</h2>
+          {lnurlPay.description}
+        </div>
+      )}
+    </>
+  );
+};
+
+export const Bolt11PaymentDetails = ({ description, fees }: TBolt11PaymentDetailsProps) => {
+  const { t } = useTranslation();
 
   return (
     <>
       <h1 className={styles.title}>{t('lightning.send.confirm.title')}</h1>
       <PaymentAmountDetails amountSat={fees.amountSat} />
-      {invoice.description && (
+      {description && (
         <div className={styles.info}>
           <h2 className={styles.label}>{t('lightning.send.confirm.memo')}</h2>
-          {invoice.description}
+          {description}
         </div>
       )}
       <PaymentFeeDetails fees={fees} totalWithFiat />

--- a/frontends/web/src/routes/lightning/send/components/review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/review-step.tsx
@@ -1,316 +1,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { TPaymentInputTypeVariant, type TPaymentInputType, type TPreparePaymentResponse, postPreparePayment, postSendPayment, TSdkError } from '@/api/lightning';
-import { Button, Input } from '@/components/forms';
-import { Column, Grid } from '@/components/layout';
-import { Spinner } from '@/components/spinner/Spinner';
-import { Status } from '@/components/status/status';
-import { View, ViewButtons, ViewContent } from '@/components/view/view';
-import { useDebounce } from '@/hooks/debounce';
-import { useMountedRef } from '@/hooks/mount';
-import { PaymentAmountDetails, PaymentDetails, PaymentFeeDetails } from './invoice-details';
-import { SendingSpinner } from './sending-spinner';
-
-const isValidCustomAmount = (amount?: number): amount is number => (
-  typeof amount === 'number' && Number.isFinite(amount) && Number.isInteger(amount) && amount > 0
-);
+import { TPaymentInputType, type TPaymentInput } from '@/api/lightning';
+import { Bolt11ReviewStep } from './bolt11-review-step';
+import { LNURLPayReviewStep } from './lnurl-pay-review-step';
 
 type TProps = {
-  paymentDetails?: TPaymentInputType;
-  backToSelectInvoice: (nextInputError?: string) => void;
+  paymentInput: TPaymentInput;
+  backToPaymentInput: (nextInputError?: string) => void;
   onSuccess: () => void;
 };
 
 export const ReviewStep = ({
-  paymentDetails,
-  backToSelectInvoice,
+  paymentInput,
+  backToPaymentInput,
   onSuccess,
 }: TProps) => {
-  const { t } = useTranslation();
-  const mounted = useMountedRef();
-  const customAmountRef = useRef<number>();
-  const invoice = paymentDetails?.type === TPaymentInputTypeVariant.BOLT11 ? paymentDetails.invoice : undefined;
-  const [customAmount, setCustomAmount] = useState<number>();
-  const debouncedCustomAmount = useDebounce(customAmount, 300);
-  const [fees, setFees] = useState<TPreparePaymentResponse>();
-  const [preparedCustomAmount, setPreparedCustomAmount] = useState<number>();
-  const [prepareError, setPrepareError] = useState<string>();
-  const [isPreparing, setIsPreparing] = useState(false);
-  const [isSending, setIsSending] = useState(false);
-  const [sendError, setSendError] = useState<string>();
-
-  const toErrorMessage = useCallback((error: unknown): string => {
-    if (error instanceof TSdkError) {
-      if (error.code) {
-        return t(`error.${error.code}`);
-      }
-      return error.message;
-    }
-    return String(error);
-  }, [t]);
-
-  const resetCustomAmountFees = useCallback(() => {
-    setFees(undefined);
-    setPreparedCustomAmount(undefined);
-    setPrepareError(undefined);
-    setIsPreparing(false);
-  }, []);
-
-  const startPreparingFees = useCallback((amountSat?: number) => {
-    setIsPreparing(true);
-    setFees(undefined);
-    setPreparedCustomAmount(amountSat);
-    setPrepareError(undefined);
-  }, []);
-
-  const applyPreparedFees = useCallback((
-    nextFees: TPreparePaymentResponse,
-    amountSat?: number,
-  ) => {
-    setFees(nextFees);
-    setPreparedCustomAmount(amountSat);
-    setPrepareError(undefined);
-    setIsPreparing(false);
-  }, []);
-
-  const applyPrepareError = useCallback((errorMessage: string, amountSat: number) => {
-    setFees(undefined);
-    setPreparedCustomAmount(amountSat);
-    setPrepareError(errorMessage);
-    setIsPreparing(false);
-    setSendError(undefined);
-  }, []);
-
-  const getActiveFees = useCallback((amountSat?: number) => (
-    invoice?.amountSat === undefined
-      ? preparedCustomAmount === amountSat ? fees : undefined
-      : fees
-  ), [fees, invoice?.amountSat, preparedCustomAmount]);
-
-  const preparePayment = useCallback(async (amountSat?: number) => {
-    if (!invoice) {
-      return;
-    }
-    if (invoice.amountSat === undefined && !isValidCustomAmount(amountSat)) {
-      return;
-    }
-    const isCustomAmount = amountSat !== undefined;
-
-    startPreparingFees(amountSat);
-
-    try {
-      const fees = await postPreparePayment({
-        bolt11: invoice.bolt11,
-        amountSat,
-      });
-
-      const discardFees = isCustomAmount && customAmountRef.current !== amountSat;
-      if (!mounted.current || discardFees) {
-        return;
-      }
-
-      applyPreparedFees(fees, amountSat);
-    } catch (error) {
-      const discardFees = isCustomAmount && customAmountRef.current !== amountSat;
-      if (!mounted.current || discardFees) {
-        return;
-      }
-
-      if (!isCustomAmount) {
-        setIsPreparing(false);
-        backToSelectInvoice(toErrorMessage(error));
-        return;
-      }
-
-      applyPrepareError(toErrorMessage(error), amountSat);
-    }
-  }, [
-    invoice,
-    mounted,
-    applyPrepareError,
-    applyPreparedFees,
-    backToSelectInvoice,
-    startPreparingFees,
-    toErrorMessage,
-  ]);
-
-  const retryPreparePayment = useCallback(async (errorMessage: string, amountSat?: number) => {
-    setSendError(errorMessage);
-    await preparePayment(amountSat);
-  }, [preparePayment]);
-
-  const sendPayment = useCallback(async () => {
-    if (!invoice) {
-      return;
-    }
-    const isAmountlessInvoice = invoice.amountSat === undefined;
-    if (isAmountlessInvoice && !isValidCustomAmount(customAmount)) {
-      setSendError(t('send.error.invalidAmount'));
-      return;
-    }
-
-    const activeFees = getActiveFees(customAmount);
-    if (!activeFees) {
-      return;
-    }
-
-    setIsSending(true);
-    setSendError(undefined);
-
-    try {
-      await postSendPayment({
-        bolt11: invoice.bolt11,
-        amountSat: invoice.amountSat === undefined ? customAmount : undefined,
-        approvedFeeSat: activeFees.feeSat,
-      });
-      onSuccess();
-    } catch (error) {
-      if (mounted.current) {
-        setIsSending(false);
-      }
-
-      const errorMessage = toErrorMessage(error);
-      if (error instanceof TSdkError && error.code === 'lightningInvoiceAlreadyUsed') {
-        backToSelectInvoice(errorMessage);
-        return;
-      }
-      if (
-        error instanceof TSdkError
-        && error.code === 'paymentApprovalRequired'
-      ) {
-        await retryPreparePayment(errorMessage, isAmountlessInvoice ? customAmount : undefined);
-        return;
-      }
-
-      setSendError(errorMessage);
-    }
-  }, [
-    customAmount,
-    backToSelectInvoice,
-    getActiveFees,
-    mounted,
-    onSuccess,
-    invoice,
-    retryPreparePayment,
-    t,
-    toErrorMessage,
-  ]);
-
-  // Reset all review-local state when a new invoice enters the review step.
-  useEffect(() => {
-    setCustomAmount(undefined);
-    resetCustomAmountFees();
-    setIsSending(false);
-    setSendError(undefined);
-
-    if (!invoice || invoice.amountSat === undefined) {
-      return;
-    }
-
-    void preparePayment();
-  }, [invoice, preparePayment, resetCustomAmountFees]);
-
-  // Clear the current custom-amount fees whenever the typed amount changes.
-  useEffect(() => {
-    if (!invoice || invoice.amountSat !== undefined) {
-      return;
-    }
-
-    customAmountRef.current = customAmount;
-    setSendError(undefined);
-    resetCustomAmountFees();
-  }, [customAmount, invoice, resetCustomAmountFees]);
-
-  // Prepare fees for the custom amount after the debounced amount settles on a valid value.
-  useEffect(() => {
-    if (!invoice || invoice.amountSat !== undefined) {
-      return;
-    }
-
-    if (debouncedCustomAmount !== customAmount) {
-      return;
-    }
-
-    void preparePayment(debouncedCustomAmount);
-  }, [customAmount, debouncedCustomAmount, invoice, preparePayment]);
-
-
-  if (!invoice || !paymentDetails || paymentDetails.type !== TPaymentInputTypeVariant.BOLT11) {
-    return null;
+  switch (paymentInput.type) {
+  case TPaymentInputType.BOLT11:
+    return (
+      <Bolt11ReviewStep
+        invoice={paymentInput.invoice}
+        backToPaymentInput={backToPaymentInput}
+        onSuccess={onSuccess}
+      />
+    );
+  case TPaymentInputType.LNURL_PAY:
+    return (
+      <LNURLPayReviewStep
+        lnurlPay={paymentInput.lnurlPay}
+        backToPaymentInput={backToPaymentInput}
+        onSuccess={onSuccess}
+      />
+    );
   }
-
-  if (isSending) {
-    return <SendingSpinner />;
-  }
-
-  const isAmountlessInvoice = invoice.amountSat === undefined;
-  const paymentFees = getActiveFees(customAmount);
-  const canSend = !!paymentFees;
-  const showCustomAmountFees = isPreparing || paymentFees;
-
-  return (
-    <View fitContent minHeight="100%">
-      <ViewContent>
-        <Grid col="1">
-          <Column>
-            <Status dismissibleKey="" type="warning" hidden={!sendError}>
-              {sendError}
-            </Status>
-            {isAmountlessInvoice ? (
-              <>
-                <Input
-                  type="number"
-                  min="0"
-                  label={t('lightning.receive.amountSats.label')}
-                  placeholder={t('lightning.receive.amountSats.placeholder')}
-                  id="amountSatsInput"
-                  onInput={(event: ChangeEvent<HTMLInputElement>) => {
-                    const amount = event.target.valueAsNumber;
-                    setCustomAmount(Number.isNaN(amount) ? undefined : amount);
-                  }}
-                  value={customAmount ? `${customAmount}` : ''}
-                  autoFocus
-                />
-                <Input
-                  type="text"
-                  label={t('lightning.receive.description.label')}
-                  placeholder={t('lightning.receive.description.placeholder')}
-                  id="descriptionInput"
-                  readOnly
-                  disabled
-                  value={invoice.description || ''}
-                />
-                <Status dismissibleKey="" type="error" hidden={!prepareError}>
-                  {prepareError}
-                </Status>
-                {showCustomAmountFees && (
-                  <>
-                    <PaymentAmountDetails amountSat={paymentFees?.amountSat} />
-                    <PaymentFeeDetails fees={paymentFees} totalWithFiat />
-                  </>
-                )}
-              </>
-            ) : (
-              paymentFees
-                ? <PaymentDetails input={paymentDetails} fees={paymentFees} />
-                : isPreparing && <Spinner text={t('loading')} />
-            )}
-          </Column>
-        </Grid>
-      </ViewContent>
-      <ViewButtons>
-        <Button
-          primary
-          onClick={sendPayment}
-          disabled={!canSend}>
-          {t('generic.send')}
-        </Button>
-        <Button secondary onClick={() => backToSelectInvoice()}>
-          {t('button.back')}
-        </Button>
-      </ViewButtons>
-    </View>
-  );
 };

--- a/frontends/web/src/routes/lightning/send/components/select-payment-input-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/select-payment-input-step.tsx
@@ -16,22 +16,22 @@ type TProps = {
   onSubmit: (input: string) => Promise<boolean>;
 };
 
-export const SelectInvoiceStep = ({
+export const SelectPaymentInputStep = ({
   inputError,
   onCancel,
   onSubmit,
 }: TProps) => {
   const { t } = useTranslation();
-  const [invoiceInput, setInvoiceInput] = useState('');
+  const [paymentInput, setPaymentInput] = useState('');
 
   const scanQRVideo = useMemo(() => (
     <ScanQRVideo onResult={(result: string) => void onSubmit(result)} />
   ), [onSubmit]);
 
-  const submitInvoiceInput = async () => {
-    const success = await onSubmit(invoiceInput);
+  const submitPaymentInput = async () => {
+    const success = await onSubmit(paymentInput);
     if (success) {
-      setInvoiceInput('');
+      setPaymentInput('');
     }
   };
 
@@ -47,15 +47,15 @@ export const SelectInvoiceStep = ({
             {scanQRVideo}
             <Input
               placeholder={t('lightning.send.invoice.input')}
-              onInput={(event: ChangeEvent<HTMLInputElement>) => setInvoiceInput(event.target.value)}
-              value={invoiceInput}
+              onInput={(event: ChangeEvent<HTMLInputElement>) => setPaymentInput(event.target.value)}
+              value={paymentInput}
               autoFocus={!runningInAndroid() && !runningInIOS()}
             />
           </Column>
         </Grid>
       </ViewContent>
       <ViewButtons>
-        <Button disabled={!invoiceInput} primary onClick={submitInvoiceInput}>
+        <Button disabled={!paymentInput} primary onClick={submitPaymentInput}>
           {t('generic.send')}
         </Button>
         <Button secondary onClick={onCancel}>

--- a/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
+++ b/frontends/web/src/routes/lightning/send/hooks/use-payment-review.ts
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { type TFunction } from 'i18next';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TLightningErrorCode, TSdkError, toLightningErrorMessage } from '@/api/lightning-errors';
+import { TPaymentInputType, type TLightningBolt11Invoice, type TLightningLNURLPay, type TPreparePaymentRequest, type TPreparePaymentResponse, type TSendPaymentRequest, postPreparePayment, postSendPayment } from '@/api/lightning';
+import { useDebounce } from '@/hooks/debounce';
+import { useMountedRef } from '@/hooks/mount';
+
+type TPreparedPayment =
+  | { status: 'preparing'; amountSat?: number }
+  | { status: 'ready'; amountSat?: number; fees: TPreparePaymentResponse }
+  | { status: 'error'; amountSat?: number; error: string };
+
+const isPositiveInteger = (amount?: number): amount is number => (
+  typeof amount === 'number' && Number.isFinite(amount) && Number.isInteger(amount) && amount > 0
+);
+
+export type TPaymentReviewDetails = {
+  type: TPaymentInputType.BOLT11;
+  details: TLightningBolt11Invoice;
+} | {
+  type: TPaymentInputType.LNURL_PAY;
+  details: TLightningLNURLPay;
+};
+
+type TUsePaymentReviewProps = {
+  paymentDetails: TPaymentReviewDetails;
+  backToPaymentInput: (nextInputError?: string) => void;
+  onSuccess: () => void;
+};
+
+const isValidAmount = (paymentDetails: TPaymentReviewDetails, amount?: number): amount is number => {
+  if (!isPositiveInteger(amount)) {
+    return false;
+  }
+  if (paymentDetails.type === TPaymentInputType.BOLT11) {
+    return true;
+  }
+  return amount >= paymentDetails.details.minAmountSat && amount <= paymentDetails.details.maxAmountSat;
+};
+
+const invalidAmountError = (paymentDetails: TPaymentReviewDetails, t: TFunction): string => {
+  if (paymentDetails.type === TPaymentInputType.BOLT11) {
+    return t('send.error.invalidAmount');
+  }
+  return t('lightning.send.lnurlPay.invalidAmount', {
+    maxAmount: paymentDetails.details.maxAmountSat,
+    minAmount: paymentDetails.details.minAmountSat,
+  });
+};
+
+export const usePaymentReview = ({
+  paymentDetails,
+  backToPaymentInput,
+  onSuccess,
+}: TUsePaymentReviewProps) => {
+  const { t } = useTranslation();
+  const fixedAmountSat = paymentDetails.type === TPaymentInputType.BOLT11
+    ? paymentDetails.details.amountSat
+    : undefined;
+  const needsCustomAmount = fixedAmountSat === undefined;
+  const mounted = useMountedRef();
+  const customAmountRef = useRef<number>();
+  const [customAmount, setCustomAmount] = useState<number>();
+  const debouncedCustomAmount = useDebounce(customAmount, 300);
+  const [preparedPayment, setPreparedPayment] = useState<TPreparedPayment>();
+  const [isSending, setIsSending] = useState(false);
+  const [sendError, setSendError] = useState<string>();
+  const currentAmountSat = needsCustomAmount ? customAmount : fixedAmountSat;
+  const amountError = needsCustomAmount && currentAmountSat !== undefined && !isValidAmount(paymentDetails, currentAmountSat)
+    ? invalidAmountError(paymentDetails, t)
+    : undefined;
+
+  const preparePayment = useCallback(async (amountSat?: number) => {
+    let preparePaymentRequest: TPreparePaymentRequest;
+    switch (paymentDetails.type) {
+    case TPaymentInputType.BOLT11:
+      if (needsCustomAmount && !isValidAmount(paymentDetails, amountSat)) {
+        return;
+      }
+      preparePaymentRequest = {
+        type: TPaymentInputType.BOLT11,
+        paymentInput: paymentDetails.details.invoice,
+        amountSat,
+      };
+      break;
+    case TPaymentInputType.LNURL_PAY:
+      if (!isValidAmount(paymentDetails, amountSat)) {
+        return;
+      }
+      preparePaymentRequest = {
+        type: TPaymentInputType.LNURL_PAY,
+        paymentInput: paymentDetails.details.input,
+        amountSat,
+      };
+      break;
+    }
+
+    setPreparedPayment({
+      status: 'preparing',
+      amountSat,
+    });
+
+    try {
+      const fees = await postPreparePayment(preparePaymentRequest);
+
+      if (!mounted.current || (needsCustomAmount && customAmountRef.current !== amountSat)) {
+        return;
+      }
+
+      setPreparedPayment({
+        status: 'ready',
+        amountSat,
+        fees,
+      });
+    } catch (error) {
+      if (!mounted.current || (needsCustomAmount && customAmountRef.current !== amountSat)) {
+        return;
+      }
+
+      if (!needsCustomAmount) {
+        setPreparedPayment(undefined);
+        backToPaymentInput(toLightningErrorMessage(t, error));
+        return;
+      }
+
+      setPreparedPayment({
+        status: 'error',
+        amountSat,
+        error: toLightningErrorMessage(t, error),
+      });
+      setSendError(undefined);
+    }
+  }, [
+    backToPaymentInput,
+    mounted,
+    needsCustomAmount,
+    paymentDetails,
+    t,
+  ]);
+
+  const fees = preparedPayment?.status === 'ready'
+    && (!needsCustomAmount || preparedPayment.amountSat === currentAmountSat)
+    ? preparedPayment.fees
+    : undefined;
+
+  const sendPayment = useCallback(async () => {
+    if (needsCustomAmount && !isValidAmount(paymentDetails, currentAmountSat)) {
+      setSendError(invalidAmountError(paymentDetails, t));
+      return;
+    }
+
+    if (currentAmountSat === undefined) {
+      return;
+    }
+
+    if (!fees) {
+      return;
+    }
+
+    setIsSending(true);
+    setSendError(undefined);
+
+    try {
+      const sendPaymentRequest: TSendPaymentRequest = (() => {
+        switch (paymentDetails.type) {
+        case TPaymentInputType.BOLT11:
+          return {
+            type: TPaymentInputType.BOLT11,
+            paymentInput: paymentDetails.details.invoice,
+            amountSat: paymentDetails.details.amountSat === undefined ? currentAmountSat : undefined,
+            approvedFeeSat: fees.feeSat,
+          };
+        case TPaymentInputType.LNURL_PAY:
+          return {
+            type: TPaymentInputType.LNURL_PAY,
+            paymentInput: paymentDetails.details.input,
+            amountSat: currentAmountSat,
+            approvedFeeSat: fees.feeSat,
+          };
+        }
+      })();
+      await postSendPayment(sendPaymentRequest);
+      onSuccess();
+    } catch (error) {
+      if (!mounted.current) {
+        return;
+      }
+
+      setIsSending(false);
+      const errorMessage = toLightningErrorMessage(t, error);
+
+      if (error instanceof TSdkError && error.code === TLightningErrorCode.INVOICE_ALREADY_USED) {
+        backToPaymentInput(errorMessage);
+        return;
+      }
+      // It is possible that the fee retrieved during the prepare phase is no longer valid and that we need to re-prepare.
+      if (error instanceof TSdkError && error.code === TLightningErrorCode.PAYMENT_APPROVAL_REQUIRED) {
+        setSendError(errorMessage);
+        // Fixed-amount BOLT11 invoices already encode the amount; pass amountSat only when the user entered it.
+        const amountSat = paymentDetails.type === TPaymentInputType.BOLT11 && paymentDetails.details.amountSat !== undefined
+          ? undefined
+          : currentAmountSat;
+        await preparePayment(amountSat);
+        return;
+      }
+
+      setSendError(errorMessage);
+    }
+  }, [
+    backToPaymentInput,
+    fees,
+    mounted,
+    needsCustomAmount,
+    onSuccess,
+    currentAmountSat,
+    paymentDetails,
+    preparePayment,
+    t,
+  ]);
+
+  useEffect(() => {
+    setCustomAmount(undefined);
+    setPreparedPayment(undefined);
+    setIsSending(false);
+    setSendError(undefined);
+
+    if (!needsCustomAmount) {
+      preparePayment();
+    }
+  }, [fixedAmountSat, needsCustomAmount, paymentDetails, preparePayment]);
+
+  useEffect(() => {
+    if (!needsCustomAmount) {
+      return;
+    }
+
+    customAmountRef.current = customAmount;
+    setSendError(undefined);
+    setPreparedPayment(undefined);
+  }, [customAmount, needsCustomAmount]);
+
+  useEffect(() => {
+    if (!needsCustomAmount || debouncedCustomAmount !== customAmount || customAmount === undefined) {
+      return;
+    }
+
+    preparePayment(customAmount);
+  }, [customAmount, debouncedCustomAmount, needsCustomAmount, preparePayment]);
+
+  return {
+    canSend: !!fees,
+    customAmount,
+    amountError,
+    fees,
+    isSending,
+    preparedPayment,
+    sendError,
+    sendPayment,
+    setCustomAmount,
+  };
+};

--- a/frontends/web/src/routes/lightning/send/send.tsx
+++ b/frontends/web/src/routes/lightning/send/send.tsx
@@ -3,34 +3,25 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { type TPaymentInputType, TSdkError, getParsePaymentInput } from '@/api/lightning';
+import { type TPaymentInput, getParsePaymentInput } from '@/api/lightning';
 import { GuideWrapper, GuidedContent, Header, Main } from '@/components/layout';
 import { ReviewStep } from './components/review-step';
-import { SelectInvoiceStep } from './components/select-invoice-step';
+import { SelectPaymentInputStep } from './components/select-payment-input-step';
 import { SuccessStep } from './components/success-step';
+import { toLightningErrorMessage } from '@/api/lightning-errors';
 
-type TSendStep = 'select-invoice' | 'review' | 'success';
+type TSendStep = 'select-payment-input' | 'review' | 'success';
 
 export const Send = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [step, setStep] = useState<TSendStep>('select-invoice');
-  const [paymentDetails, setPaymentDetails] = useState<TPaymentInputType>();
+  const [step, setStep] = useState<TSendStep>('select-payment-input');
+  const [paymentInput, setPaymentInput] = useState<TPaymentInput>();
   const [inputError, setInputError] = useState<string>();
 
-  const toErrorMessage = useCallback((error: unknown): string => {
-    if (error instanceof TSdkError) {
-      if (error.code) {
-        return t(`error.${error.code}`);
-      }
-      return error.message;
-    }
-    return String(error);
-  }, [t]);
-
-  const resetToInvoiceEntry = useCallback((nextInputError?: string) => {
-    setStep('select-invoice');
-    setPaymentDetails(undefined);
+  const resetToPaymentInputEntry = useCallback((nextInputError?: string) => {
+    setStep('select-payment-input');
+    setPaymentInput(undefined);
     setInputError(nextInputError);
   }, []);
 
@@ -39,14 +30,14 @@ export const Send = () => {
 
     try {
       const result = await getParsePaymentInput({ s: rawInput });
-      setPaymentDetails(result);
+      setPaymentInput(result);
       setStep('review');
       return true;
     } catch (error) {
-      setInputError(toErrorMessage(error));
+      setInputError(toLightningErrorMessage(t, error));
       return false;
     }
-  }, [toErrorMessage]);
+  }, [t]);
 
   const showSuccess = useCallback(() => {
     setStep('success');
@@ -66,17 +57,17 @@ export const Send = () => {
       <GuidedContent>
         <Main>
           <Header title={<h2>{t('lightning.send.title')}</h2>} />
-          {step === 'select-invoice' && (
-            <SelectInvoiceStep
+          {step === 'select-payment-input' && (
+            <SelectPaymentInputStep
               inputError={inputError}
               onCancel={() => navigate('/lightning')}
               onSubmit={submitPaymentInput}
             />
           )}
-          {step === 'review' && (
+          {step === 'review' && paymentInput && (
             <ReviewStep
-              paymentDetails={paymentDetails}
-              backToSelectInvoice={resetToInvoiceEntry}
+              paymentInput={paymentInput}
+              backToPaymentInput={resetToPaymentInputEntry}
               onSuccess={showSuccess}
             />
           )}


### PR DESCRIPTION
Add LNURL Pay support to the Lightning send flow while keeping rail selection inside the backend lightning package. Parse payment inputs into explicit BOLT11 and LNURL Pay variants, prepare and send each rail through the shared payment endpoints, and return localized error codes for invalid input and amounts.

Refactor the frontend review step into rail-specific BOLT11 and LNURL Pay components. Pass each component only the payload it needs, keep BOLT11 behavior aligned with the existing review flow, and keep LNURL Pay as an amount-entry flow within the server-provided min and max bounds.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
