### PR TITLE
lightning: add fiat input for amountless send

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1663,7 +1663,7 @@
     "send": {
       "confirm": {
         "amount": "Amount",
-        "memo": "Memo",
+        "note": "Note",
         "title": "Confirm transaction details"
       },
       "invoice": {

--- a/frontends/web/src/routes/lightning/hooks/use-sat-fiat-amount.test.ts
+++ b/frontends/web/src/routes/lightning/hooks/use-sat-fiat-amount.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getBtcSatAmount } from '@/api/coins';
+import { useSatFiatAmount } from './use-sat-fiat-amount';
+
+vi.mock('@/api/coins', () => ({
+  getBtcSatAmount: vi.fn(),
+}));
+
+const mockGetBtcSatAmount = vi.mocked(getBtcSatAmount);
+type TResponse = Awaited<ReturnType<typeof getBtcSatAmount>>;
+
+const successfulResponse = (amount: string, fiatAmount: string): TResponse => ({
+  success: true,
+  amount: {
+    amount,
+    conversions: { USD: fiatAmount },
+    unformattedConversions: { USD: fiatAmount },
+    unit: 'sat',
+    estimated: false,
+  },
+});
+
+describe('useSatFiatAmount', () => {
+  beforeEach(() => {
+    mockGetBtcSatAmount.mockReset();
+  });
+
+  it('converts sats to fiat', async () => {
+    mockGetBtcSatAmount.mockResolvedValue(successfulResponse('1200', '10.50'));
+    const { result } = renderHook(() => useSatFiatAmount({ defaultCurrency: 'USD' }));
+
+    await act(async () => {
+      await result.current.handleSatsAmountChange('1200');
+    });
+
+    expect(mockGetBtcSatAmount).toHaveBeenCalledWith({ source: 'sat', amount: '1200' });
+    expect(result.current.inputSatsText).toBe('1200');
+    expect(result.current.inputFiatText).toBe('10.50');
+    expect(result.current.amountSat).toBe(1200);
+  });
+
+  it('converts fiat to sats', async () => {
+    mockGetBtcSatAmount.mockResolvedValue(successfulResponse('1200', '10.50'));
+    const { result } = renderHook(() => useSatFiatAmount({ defaultCurrency: 'USD' }));
+
+    await act(async () => {
+      await result.current.handleFiatAmountChange('10.50');
+    });
+
+    expect(mockGetBtcSatAmount).toHaveBeenCalledWith({ source: 'fiat', amount: '10.50' });
+    expect(result.current.inputSatsText).toBe('1200');
+    expect(result.current.inputFiatText).toBe('10.50');
+    expect(result.current.amountSat).toBe(1200);
+  });
+
+  it('ignores stale conversion responses', async () => {
+    let resolveFirst!: (response: TResponse) => void;
+    mockGetBtcSatAmount
+      .mockReturnValueOnce(new Promise<TResponse>((resolve) => {
+        resolveFirst = resolve;
+      }))
+      .mockResolvedValueOnce(successfulResponse('2000', '20.00'));
+    const { result } = renderHook(() => useSatFiatAmount({ defaultCurrency: 'USD' }));
+
+    act(() => {
+      void result.current.handleSatsAmountChange('1000');
+    });
+    await act(async () => {
+      await result.current.handleSatsAmountChange('2000');
+    });
+    await act(async () => {
+      resolveFirst(successfulResponse('1000', '10.00'));
+      await Promise.resolve();
+    });
+
+    expect(result.current.inputSatsText).toBe('2000');
+    expect(result.current.inputFiatText).toBe('20.00');
+    expect(result.current.amountSat).toBe(2000);
+  });
+
+  it('invalidates an in-flight conversion when reset', async () => {
+    let resolveConversion!: (response: TResponse) => void;
+    mockGetBtcSatAmount.mockReturnValue(new Promise<TResponse>((resolve) => {
+      resolveConversion = resolve;
+    }));
+    const { result } = renderHook(() => useSatFiatAmount({ defaultCurrency: 'USD' }));
+
+    act(() => {
+      void result.current.handleSatsAmountChange('1200');
+    });
+    act(() => {
+      result.current.resetAmountInput();
+    });
+    await act(async () => {
+      resolveConversion(successfulResponse('1200', '10.50'));
+      await Promise.resolve();
+    });
+
+    expect(result.current.inputSatsText).toBe('');
+    expect(result.current.inputFiatText).toBe('');
+    expect(result.current.amountSat).toBeUndefined();
+  });
+});

--- a/frontends/web/src/routes/lightning/hooks/use-sat-fiat-amount.ts
+++ b/frontends/web/src/routes/lightning/hooks/use-sat-fiat-amount.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useRef, useState } from 'react';
+import type { Fiat } from '@/api/account';
+import { getBtcSatAmount, type TBtcSatAmount } from '@/api/coins';
+import { useMountedRef } from '@/hooks/mount';
+
+type TProps = {
+  defaultCurrency: Fiat;
+};
+
+type TAmountSource = 'sat' | 'fiat';
+
+export const useSatFiatAmount = ({ defaultCurrency }: TProps) => {
+  const mounted = useMountedRef();
+  const amountRequestId = useRef(0);
+  const [inputSatsText, setInputSatsText] = useState('');
+  const [inputFiatText, setInputFiatText] = useState('');
+  const [amount, setAmount] = useState<TBtcSatAmount>();
+  const amountSat = amount ? Number(amount.amount) : undefined;
+
+  const resetAmountInput = useCallback(() => {
+    amountRequestId.current += 1;
+    setInputSatsText('');
+    setInputFiatText('');
+    setAmount(undefined);
+  }, []);
+
+  const convertAmount = useCallback(async (
+    requestId: number,
+    source: TAmountSource,
+    inputAmount: string,
+  ) => {
+    const response = await getBtcSatAmount({ source, amount: inputAmount });
+    if (!mounted.current || requestId !== amountRequestId.current) {
+      return;
+    }
+    if (!response.success) {
+      console.error(`Failed to convert ${source === 'sat' ? 'sats' : 'fiat'} amount:`, response.errorMessage);
+      return;
+    }
+
+    setAmount(response.amount);
+    if (source === 'sat') {
+      setInputFiatText(response.amount.unformattedConversions?.[defaultCurrency] ?? '');
+    } else {
+      setInputSatsText(response.amount.amount);
+    }
+  }, [defaultCurrency, mounted]);
+
+  const handleSatsAmountChange = useCallback((satsText: string) => {
+    const requestId = ++amountRequestId.current;
+    setInputSatsText(satsText);
+    setInputFiatText('');
+    setAmount(undefined);
+
+    if (!satsText) {
+      return;
+    }
+
+    return convertAmount(requestId, 'sat', satsText);
+  }, [convertAmount]);
+
+  const handleFiatAmountChange = useCallback((fiatText: string) => {
+    const requestId = ++amountRequestId.current;
+    setInputFiatText(fiatText);
+    setInputSatsText('');
+    setAmount(undefined);
+
+    if (!fiatText) {
+      return;
+    }
+
+    return convertAmount(requestId, 'fiat', fiatText);
+  }, [convertAmount]);
+
+  return {
+    amount,
+    amountSat,
+    handleFiatAmountChange,
+    handleSatsAmountChange,
+    inputFiatText,
+    inputSatsText,
+    resetAmountInput,
+  };
+};

--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -12,7 +12,6 @@ import {
   getReceivePayment,
   subscribeLightningAddress,
 } from '@/api/lightning';
-import { getBtcSatAmount, type TBtcSatAmount } from '@/api/coins';
 import { Status } from '@/components/status/status';
 import { QRCode } from '@/components/qrcode/qrcode';
 import { Spinner } from '@/components/spinner/Spinner';
@@ -22,8 +21,8 @@ import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { useNavigate } from 'react-router-dom';
 import { RatesContext } from '@/contexts/RatesContext';
 import { useLoad, useSync } from '@/hooks/api';
-import { useMountedRef } from '@/hooks/mount';
 import { toLightningErrorMessage } from '@/api/lightning-errors';
+import { useSatFiatAmount } from '../hooks/use-sat-fiat-amount';
 import { type TReceiveStep, useReceivePaymentSuccess } from './use-receive-payment-success';
 import styles from './receive.module.css';
 
@@ -31,11 +30,15 @@ export function Receive() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { defaultCurrency } = useContext(RatesContext);
-  const mounted = useMountedRef();
-  const amountRequestId = useRef(0);
-  const [inputSatsText, setInputSatsText] = useState<string>('');
-  const [inputFiatText, setInputFiatText] = useState<string>('');
-  const [invoiceAmount, setInvoiceAmount] = useState<TBtcSatAmount>();
+  const {
+    amount: invoiceAmount,
+    amountSat: invoiceAmountSat,
+    handleFiatAmountChange,
+    handleSatsAmountChange,
+    inputFiatText,
+    inputSatsText,
+    resetAmountInput,
+  } = useSatFiatAmount({ defaultCurrency });
   const [description, setDescription] = useState<string>('');
   const [receivePaymentResponse, setReceivePaymentResponse] = useState<TReceivePaymentResponse>();
   const [receiveError, setReceiveError] = useState<string>();
@@ -43,7 +46,6 @@ export function Receive() {
   const [balanceLoadAttempt, setBalanceLoadAttempt] = useState(0);
   const lightningBalance = useLoad(getLightningBalance, [balanceLoadAttempt]);
   const lightningAddress = useSync(getLightningAddress, subscribeLightningAddress);
-  const invoiceAmountSat = invoiceAmount ? Number(invoiceAmount.amount) : undefined;
   const satsBalance = lightningBalance?.available.unit === 'sat'
     ? lightningBalance.available.amount
     : lightningBalance?.available.unformattedConversions?.sat;
@@ -59,26 +61,22 @@ export function Receive() {
   });
 
   const newInvoice = useCallback(() => {
-    setInputSatsText('');
-    setInputFiatText('');
-    setInvoiceAmount(undefined);
+    resetAmountInput();
     setDescription('');
     setReceivePaymentResponse(undefined);
     setReceiveError(undefined);
     resetReceivedPayment();
     setStep('create-invoice');
-  }, [resetReceivedPayment]);
+  }, [resetAmountInput, resetReceivedPayment]);
 
   const cancelInvoice = useCallback(() => {
-    setInputSatsText('');
-    setInputFiatText('');
-    setInvoiceAmount(undefined);
+    resetAmountInput();
     setDescription('');
     setReceivePaymentResponse(undefined);
     setReceiveError(undefined);
     resetReceivedPayment();
     setStep('address');
-  }, [resetReceivedPayment]);
+  }, [resetAmountInput, resetReceivedPayment]);
 
   const back = useCallback(() => {
     switch (step) {
@@ -94,63 +92,12 @@ export function Receive() {
       setStep('create-invoice');
       setReceiveError(undefined);
       if (step === 'success') {
-        setInputSatsText('');
-        setInputFiatText('');
+        resetAmountInput();
         resetReceivedPayment();
       }
       break;
     }
-  }, [step, navigate, resetReceivedPayment]);
-
-  const handleSatsAmountChange = useCallback(async (satsText: string) => {
-    const requestId = ++amountRequestId.current;
-    setInputSatsText(satsText);
-
-    if (!satsText) {
-      setInvoiceAmount(undefined);
-      setInputFiatText('');
-      return;
-    }
-
-    const response = await getBtcSatAmount({ source: 'sat', amount: satsText });
-    if (!mounted.current || requestId !== amountRequestId.current) {
-      return;
-    }
-    if (!response.success) {
-      console.error('Failed to convert sats amount:', response.errorMessage);
-      setInvoiceAmount(undefined);
-      setInputFiatText('');
-      return;
-    }
-
-    setInvoiceAmount(response.amount);
-    setInputFiatText(response.amount.unformattedConversions?.[defaultCurrency] ?? '');
-  }, [defaultCurrency, mounted]);
-
-  const handleFiatAmountChange = useCallback(async (fiatText: string) => {
-    const requestId = ++amountRequestId.current;
-    setInputFiatText(fiatText);
-
-    if (!fiatText) {
-      setInvoiceAmount(undefined);
-      setInputSatsText('');
-      return;
-    }
-
-    const response = await getBtcSatAmount({ source: 'fiat', amount: fiatText });
-    if (!mounted.current || requestId !== amountRequestId.current) {
-      return;
-    }
-    if (!response.success) {
-      console.error('Failed to convert fiat amount:', response.errorMessage);
-      setInvoiceAmount(undefined);
-      setInputSatsText('');
-      return;
-    }
-
-    setInvoiceAmount(response.amount);
-    setInputSatsText(response.amount.amount);
-  }, [mounted]);
+  }, [step, navigate, resetAmountInput, resetReceivedPayment]);
 
   const onDescriptionChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     const target = event.target as HTMLInputElement;

--- a/frontends/web/src/routes/lightning/send/components/bolt11-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/bolt11-review-step.tsx
@@ -3,13 +3,14 @@
 import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
 import { TPaymentInputType, type TLightningBolt11Invoice } from '@/api/lightning';
-import { Button, Input } from '@/components/forms';
+import { Button } from '@/components/forms';
 import { Column, Grid } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
 import { Status } from '@/components/status/status';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
-import { Bolt11PaymentDetails, PaymentAmountDetails, PaymentFeeDetails } from './payment-input-details';
+import { Bolt11PaymentDetails, PaymentFeeDetails, PaymentNoteDetails } from './payment-input-details';
 import { type TPaymentReviewDetails, usePaymentReview } from '../hooks/use-payment-review';
+import { CustomPaymentAmount, PaymentBalance } from './custom-payment-amount';
 import { SendingSpinner } from './sending-spinner';
 
 type TProps = {
@@ -32,7 +33,6 @@ export const Bolt11ReviewStep = ({
   }), [invoice]);
   const {
     canSend,
-    customAmount,
     fees,
     isSending,
     preparedPayment,
@@ -59,42 +59,25 @@ export const Bolt11ReviewStep = ({
             </Status>
             {needsCustomAmount ? (
               <>
-                <Input
-                  type="number"
-                  min={0}
-                  label={t('lightning.receive.amountSats.label')}
-                  placeholder={t('lightning.receive.amountSats.placeholder')}
-                  id="amountSatsInput"
-                  onInput={(event) => {
-                    const amount = event.currentTarget.valueAsNumber;
-                    setCustomAmount(Number.isNaN(amount) ? undefined : amount);
-                  }}
-                  value={customAmount ? `${customAmount}` : ''}
-                  autoFocus
+                <CustomPaymentAmount
+                  key={invoice.invoice}
+                  onAmountChange={setCustomAmount}
                 />
-                <Input
-                  type="text"
-                  label={t('lightning.receive.description.label')}
-                  placeholder={t('lightning.receive.description.placeholder')}
-                  id="descriptionInput"
-                  readOnly
-                  disabled
-                  value={invoice.description || ''}
-                />
+                <PaymentNoteDetails description={invoice.description} />
                 <Status dismissibleKey="" type="error" hidden={preparedPayment?.status !== 'error'}>
                   {preparedPayment?.status === 'error' ? preparedPayment.error : undefined}
                 </Status>
                 {(preparedPayment?.status === 'preparing' || fees) && (
-                  <>
-                    <PaymentAmountDetails amountSat={fees?.amountSat} />
-                    <PaymentFeeDetails fees={fees} totalWithFiat />
-                  </>
+                  <PaymentFeeDetails fees={fees} totalWithFiat />
                 )}
               </>
             ) : (
-              fees
-                ? <Bolt11PaymentDetails description={invoice.description} fees={fees} />
-                : preparedPayment?.status === 'preparing' && <Spinner text={t('loading')} />
+              <>
+                <PaymentBalance />
+                {fees
+                  ? <Bolt11PaymentDetails description={invoice.description} fees={fees} />
+                  : preparedPayment?.status === 'preparing' && <Spinner text={t('loading')} />}
+              </>
             )}
           </Column>
         </Grid>

--- a/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
+++ b/frontends/web/src/routes/lightning/send/components/custom-payment-amount.tsx
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useContext, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getLightningBalance } from '@/api/lightning';
+import { Balance } from '@/components/balance/balance';
+import { NumberInput } from '@/components/forms';
+import { RatesContext } from '@/contexts/RatesContext';
+import { useLoad } from '@/hooks/api';
+import { useSatFiatAmount } from '../../hooks/use-sat-fiat-amount';
+import styles from '../send.module.css';
+
+type TProps = {
+  maxAmountSat?: number;
+  minAmountSat?: number;
+  onAmountChange: (amountSat?: number) => void;
+};
+
+export const PaymentBalance = () => {
+  const { btcUnit } = useContext(RatesContext);
+  const balance = useLoad(getLightningBalance, [btcUnit]);
+
+  return (
+    <div className={styles.availableBalance}>
+      <Balance balance={balance} />
+    </div>
+  );
+};
+
+export const CustomPaymentAmount = ({
+  maxAmountSat,
+  minAmountSat = 0,
+  onAmountChange,
+}: TProps) => {
+  const { t } = useTranslation();
+  const { defaultCurrency } = useContext(RatesContext);
+  const {
+    amountSat,
+    handleFiatAmountChange,
+    handleSatsAmountChange,
+    inputFiatText,
+    inputSatsText,
+  } = useSatFiatAmount({ defaultCurrency });
+
+  useEffect(() => {
+    onAmountChange(amountSat);
+  }, [amountSat, onAmountChange]);
+
+  return (
+    <>
+      <PaymentBalance />
+      <NumberInput
+        step="1"
+        min={minAmountSat}
+        max={maxAmountSat}
+        label={t('lightning.receive.amountSats.label')}
+        placeholder={t('lightning.receive.amountSats.placeholder')}
+        id="amountSatsInput"
+        onChange={(satsText) => {
+          onAmountChange(undefined);
+          void handleSatsAmountChange(satsText);
+        }}
+        value={inputSatsText}
+        autoFocus
+      />
+      <NumberInput
+        step="any"
+        min="0"
+        label={defaultCurrency}
+        placeholder={t('send.amount.placeholder')}
+        id="amountFiatInput"
+        onChange={(fiatText) => {
+          onAmountChange(undefined);
+          void handleFiatAmountChange(fiatText);
+        }}
+        value={inputFiatText}
+      />
+    </>
+  );
+};

--- a/frontends/web/src/routes/lightning/send/components/lnurl-pay-review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/lnurl-pay-review-step.tsx
@@ -3,12 +3,13 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TPaymentInputType, type TLightningLNURLPay } from '@/api/lightning';
-import { Button, Input } from '@/components/forms';
+import { Button } from '@/components/forms';
 import { Column, Grid } from '@/components/layout';
 import { Status } from '@/components/status/status';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
-import { LNURLPayRecipientDetails, PaymentAmountDetails, PaymentFeeDetails } from './payment-input-details';
+import { LNURLPayRecipientDetails, PaymentFeeDetails } from './payment-input-details';
 import { type TPaymentReviewDetails, usePaymentReview } from '../hooks/use-payment-review';
+import { CustomPaymentAmount } from './custom-payment-amount';
 import { SendingSpinner } from './sending-spinner';
 
 type TProps = {
@@ -31,7 +32,6 @@ export const LNURLPayReviewStep = ({
   const {
     amountError,
     canSend,
-    customAmount,
     fees,
     isSending,
     preparedPayment,
@@ -58,29 +58,18 @@ export const LNURLPayReviewStep = ({
             <Status dismissibleKey="" type="warning" hidden={!sendError}>
               {sendError}
             </Status>
-            <Input
-              type="number"
-              min={lnurlPay.minAmountSat}
-              max={lnurlPay.maxAmountSat}
-              label={t('lightning.receive.amountSats.label')}
-              placeholder={t('lightning.receive.amountSats.placeholder')}
-              id="amountSatsInput"
-              onInput={(event) => {
-                const amount = event.currentTarget.valueAsNumber;
-                setCustomAmount(Number.isNaN(amount) ? undefined : amount);
-              }}
-              value={customAmount ?? ''}
-              autoFocus
+            <CustomPaymentAmount
+              key={lnurlPay.input}
+              minAmountSat={lnurlPay.minAmountSat}
+              maxAmountSat={lnurlPay.maxAmountSat}
+              onAmountChange={setCustomAmount}
             />
             <LNURLPayRecipientDetails lnurlPay={lnurlPay} />
             <Status dismissibleKey="" type="error" hidden={!prepareError}>
               {prepareError}
             </Status>
             {(preparedPayment?.status === 'preparing' || fees) && (
-              <>
-                <PaymentAmountDetails amountSat={fees?.amountSat} />
-                <PaymentFeeDetails fees={fees} totalWithFiat />
-              </>
+              <PaymentFeeDetails fees={fees} totalWithFiat />
             )}
           </Column>
         </Grid>

--- a/frontends/web/src/routes/lightning/send/components/payment-input-details.tsx
+++ b/frontends/web/src/routes/lightning/send/components/payment-input-details.tsx
@@ -76,6 +76,10 @@ type TPaymentAmountDetailsProps = {
   amountSat?: number;
 };
 
+type TPaymentNoteDetailsProps = {
+  description?: string;
+};
+
 type TBolt11PaymentDetailsProps = {
   description?: string;
   fees: TPreparePaymentResponse;
@@ -93,6 +97,21 @@ export const PaymentAmountDetails = ({ amountSat }: TPaymentAmountDetailsProps) 
     <div className={styles.info}>
       <h2 className={styles.label}>{t('lightning.send.confirm.amount')}</h2>
       <AmountValue amount={invoiceAmount} showFiat />
+    </div>
+  );
+};
+
+export const PaymentNoteDetails = ({ description }: TPaymentNoteDetailsProps) => {
+  const { t } = useTranslation();
+
+  if (!description) {
+    return null;
+  }
+
+  return (
+    <div className={styles.info}>
+      <h2 className={styles.label}>{t('lightning.send.confirm.note')}</h2>
+      {description}
     </div>
   );
 };
@@ -129,12 +148,7 @@ export const LNURLPayRecipientDetails = ({ lnurlPay }: TLNURLPayRecipientDetails
         <h2 className={styles.label}>{t('send.confirm.to')}</h2>
         {lnurlPay.address || lnurlPay.domain}
       </div>
-      {lnurlPay.description && (
-        <div className={styles.info}>
-          <h2 className={styles.label}>{t('lightning.send.confirm.memo')}</h2>
-          {lnurlPay.description}
-        </div>
-      )}
+      <PaymentNoteDetails description={lnurlPay.description} />
     </>
   );
 };
@@ -146,12 +160,7 @@ export const Bolt11PaymentDetails = ({ description, fees }: TBolt11PaymentDetail
     <>
       <h1 className={styles.title}>{t('lightning.send.confirm.title')}</h1>
       <PaymentAmountDetails amountSat={fees.amountSat} />
-      {description && (
-        <div className={styles.info}>
-          <h2 className={styles.label}>{t('lightning.send.confirm.memo')}</h2>
-          {description}
-        </div>
-      )}
+      <PaymentNoteDetails description={description} />
       <PaymentFeeDetails fees={fees} totalWithFiat />
     </>
   );

--- a/frontends/web/src/routes/lightning/send/send.module.css
+++ b/frontends/web/src/routes/lightning/send/send.module.css
@@ -27,6 +27,11 @@
     gap: 0.2rem;
 }
 
+.availableBalance {
+    margin-bottom: var(--space-default);
+    text-align: left;
+}
+
 .successCheck {
     background-color: var(--color-success);
     border: .5rem solid var(--color-success);


### PR DESCRIPTION
Show the Lightning balance and a fiat input only when reviewing an amountless invoice. Convert sats and fiat through the existing BTC sat amount endpoint before preparing fees.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
