### PR TITLE
frontend: change amountSat to amount string

### DIFF
--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -25,7 +25,7 @@ export type TLightningAccount = {
 export type TLightningInvoice = {
   bolt11: string;
   description?: string;
-  amountSat?: number;
+  amountSat?: string;
 };
 
 export type TLightningPayment = {
@@ -42,7 +42,7 @@ export type TLightningPayment = {
 };
 
 export type TReceivePaymentRequest = {
-  amountSat: number;
+  amountSat: string;
   description: string;
 };
 
@@ -52,19 +52,19 @@ export type TReceivePaymentResponse = {
 
 export type TSendPaymentRequest = {
   bolt11: string;
-  amountSat?: number;
-  approvedFeeSat: number;
+  amountSat?: string;
+  approvedFeeSat: string;
 };
 
 export type TPreparePaymentRequest = {
   bolt11: string;
-  amountSat?: number;
+  amountSat?: string;
 };
 
 export type TPreparePaymentResponse = {
-  amountSat: number;
-  feeSat: number;
-  totalDebitSat: number;
+  amountSat: string;
+  feeSat: string;
+  totalDebitSat: string;
 };
 
 export type TServiceStatus = 'operational' | 'degraded' | 'partial' | 'major' | 'unknown';

--- a/frontends/web/src/routes/lightning/receive/receive.tsx
+++ b/frontends/web/src/routes/lightning/receive/receive.tsx
@@ -46,7 +46,7 @@ export function Receive() {
   const [step, setStep] = useState<TStep>('create-invoice');
   const [payments, setPayments] = useState<TLightningPayment[]>();
   const lightningAddress = useSync(getLightningAddress, subscribeLightningAddress);
-  const invoiceAmountSat = invoiceAmount ? Number(invoiceAmount.amount) : undefined;
+  const invoiceAmountSat = invoiceAmount ? invoiceAmount.amount : undefined;
 
   const newInvoice = useCallback(() => {
     setInputSatsText('');
@@ -149,9 +149,11 @@ export function Receive() {
     }
   }, [payments, receivePaymentResponse, step]);
 
+  const hasZeroOrSmallerInvoice = Number(invoiceAmountSat) <= 0;
+
   const receivePayment = useCallback(async () => {
     setReceiveError(undefined);
-    if (invoiceAmountSat === undefined || invoiceAmountSat <= 0) {
+    if (invoiceAmountSat === undefined || hasZeroOrSmallerInvoice) {
       setReceiveError(t('send.error.invalidAmount'));
       return;
     }
@@ -171,7 +173,7 @@ export function Receive() {
         setReceiveError(String(e));
       }
     }
-  }, [description, invoiceAmountSat, t]);
+  }, [description, hasZeroOrSmallerInvoice, invoiceAmountSat, t]);
 
   const renderSteps = () => {
     switch (step) {
@@ -222,7 +224,7 @@ export function Receive() {
             </Grid>
           </ViewContent>
           <ViewButtons>
-            <Button primary onClick={receivePayment} disabled={invoiceAmountSat === undefined || invoiceAmountSat <= 0}>
+            <Button primary onClick={receivePayment} disabled={invoiceAmountSat === undefined || hasZeroOrSmallerInvoice}>
               {t('lightning.receive.invoice.create')}
             </Button>
             <Button secondary onClick={back}>

--- a/frontends/web/src/routes/lightning/send/components/invoice-details.tsx
+++ b/frontends/web/src/routes/lightning/send/components/invoice-details.tsx
@@ -10,7 +10,7 @@ import { Skeleton } from '@/components/skeleton/skeleton';
 import { useMountedRef } from '@/hooks/mount';
 import styles from '../send.module.css';
 
-const useInvoiceAmount = (amountSat?: number) => {
+const useInvoiceAmount = (amountSat?: string) => {
   const [invoiceAmount, setInvoiceAmount] = useState<TAmountWithConversions>();
   const mounted = useMountedRef();
 
@@ -21,7 +21,7 @@ const useInvoiceAmount = (amountSat?: number) => {
       return;
     }
 
-    getBtcSatAmount({ source: 'sat', amount: amountSat.toString() })
+    getBtcSatAmount({ source: 'sat', amount: amountSat })
       .then((response) => {
         if (mounted.current && response.success) {
           setInvoiceAmount(response.amount);
@@ -56,12 +56,12 @@ const AmountValue = ({ amount, showFiat = false }: TAmountValueProps) => {
   );
 };
 
-const satsAmount = (amountSat?: number): TAmountWithConversions | undefined => {
+const satsAmount = (amountSat?: string): TAmountWithConversions | undefined => {
   if (amountSat === undefined) {
     return undefined;
   }
   return {
-    amount: amountSat.toString(),
+    amount: amountSat,
     unit: 'sat',
     estimated: false,
   };
@@ -73,7 +73,7 @@ type TProps = {
 };
 
 type TPaymentAmountDetailsProps = {
-  amountSat?: number;
+  amountSat?: string;
 };
 
 type TPaymentDetailsProps = {

--- a/frontends/web/src/routes/lightning/send/components/review-step.tsx
+++ b/frontends/web/src/routes/lightning/send/components/review-step.tsx
@@ -13,8 +13,11 @@ import { useMountedRef } from '@/hooks/mount';
 import { PaymentAmountDetails, PaymentDetails, PaymentFeeDetails } from './invoice-details';
 import { SendingSpinner } from './sending-spinner';
 
-const isValidCustomAmount = (amount?: number): amount is number => (
-  typeof amount === 'number' && Number.isFinite(amount) && Number.isInteger(amount) && amount > 0
+const isValidCustomAmount = (amount?: number) => (
+  typeof amount === 'number'
+  && Number.isFinite(amount)
+  && Number.isInteger(amount)
+  && amount > 0
 );
 
 type TProps = {
@@ -30,12 +33,12 @@ export const ReviewStep = ({
 }: TProps) => {
   const { t } = useTranslation();
   const mounted = useMountedRef();
-  const customAmountRef = useRef<number>();
+  const customAmountRef = useRef<string>();
   const invoice = paymentDetails?.type === TPaymentInputTypeVariant.BOLT11 ? paymentDetails.invoice : undefined;
-  const [customAmount, setCustomAmount] = useState<number>();
+  const [customAmount, setCustomAmount] = useState<string>();
   const debouncedCustomAmount = useDebounce(customAmount, 300);
   const [fees, setFees] = useState<TPreparePaymentResponse>();
-  const [preparedCustomAmount, setPreparedCustomAmount] = useState<number>();
+  const [preparedCustomAmount, setPreparedCustomAmount] = useState<string>();
   const [prepareError, setPrepareError] = useState<string>();
   const [isPreparing, setIsPreparing] = useState(false);
   const [isSending, setIsSending] = useState(false);
@@ -58,7 +61,7 @@ export const ReviewStep = ({
     setIsPreparing(false);
   }, []);
 
-  const startPreparingFees = useCallback((amountSat?: number) => {
+  const startPreparingFees = useCallback((amountSat?: string) => {
     setIsPreparing(true);
     setFees(undefined);
     setPreparedCustomAmount(amountSat);
@@ -67,7 +70,7 @@ export const ReviewStep = ({
 
   const applyPreparedFees = useCallback((
     nextFees: TPreparePaymentResponse,
-    amountSat?: number,
+    amountSat?: string,
   ) => {
     setFees(nextFees);
     setPreparedCustomAmount(amountSat);
@@ -75,7 +78,7 @@ export const ReviewStep = ({
     setIsPreparing(false);
   }, []);
 
-  const applyPrepareError = useCallback((errorMessage: string, amountSat: number) => {
+  const applyPrepareError = useCallback((errorMessage: string, amountSat: string) => {
     setFees(undefined);
     setPreparedCustomAmount(amountSat);
     setPrepareError(errorMessage);
@@ -83,17 +86,17 @@ export const ReviewStep = ({
     setSendError(undefined);
   }, []);
 
-  const getActiveFees = useCallback((amountSat?: number) => (
+  const getActiveFees = useCallback((amountSat?: string) => (
     invoice?.amountSat === undefined
       ? preparedCustomAmount === amountSat ? fees : undefined
       : fees
   ), [fees, invoice?.amountSat, preparedCustomAmount]);
 
-  const preparePayment = useCallback(async (amountSat?: number) => {
+  const preparePayment = useCallback(async (amountSat?: string) => {
     if (!invoice) {
       return;
     }
-    if (invoice.amountSat === undefined && !isValidCustomAmount(amountSat)) {
+    if (invoice.amountSat === undefined && !isValidCustomAmount(Number(amountSat))) {
       return;
     }
     const isCustomAmount = amountSat !== undefined;
@@ -136,7 +139,7 @@ export const ReviewStep = ({
     toErrorMessage,
   ]);
 
-  const retryPreparePayment = useCallback(async (errorMessage: string, amountSat?: number) => {
+  const retryPreparePayment = useCallback(async (errorMessage: string, amountSat?: string) => {
     setSendError(errorMessage);
     await preparePayment(amountSat);
   }, [preparePayment]);
@@ -146,7 +149,7 @@ export const ReviewStep = ({
       return;
     }
     const isAmountlessInvoice = invoice.amountSat === undefined;
-    if (isAmountlessInvoice && !isValidCustomAmount(customAmount)) {
+    if (isAmountlessInvoice && !isValidCustomAmount(Number(customAmount))) {
       setSendError(t('send.error.invalidAmount'));
       return;
     }
@@ -267,8 +270,8 @@ export const ReviewStep = ({
                   placeholder={t('lightning.receive.amountSats.placeholder')}
                   id="amountSatsInput"
                   onInput={(event: ChangeEvent<HTMLInputElement>) => {
-                    const amount = event.target.valueAsNumber;
-                    setCustomAmount(Number.isNaN(amount) ? undefined : amount);
+                    const amount = event.target.value;
+                    setCustomAmount(Number.isNaN(Number(amount)) ? undefined : amount);
                   }}
                   value={customAmount ? `${customAmount}` : ''}
                   autoFocus


### PR DESCRIPTION
The frontend should handle amounts as string so we dont run into JavaScript 64-bit floating point number limitations.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
