### PR TITLE
frontend: add mocked lightning address settings flow

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -451,6 +451,7 @@
     "previous": "Previous",
     "proceedOnBitBox": "Proceed on your BitBox",
     "restore": "Restore",
+    "save": "Save",
     "select": "Select",
     "unlock": "Unlock",
     "update": "Update",
@@ -1595,6 +1596,21 @@
       }
     },
     "initializing": "Lightning account initializing...",
+    "lnurlAddress": {
+      "availability": {
+        "available": "This name is available",
+        "taken": "This name is taken"
+      },
+      "choose": "You can choose your own address below or randomly generate one.",
+      "description": "An LNURL address is a human readable address which you can easily share to receive lightning payments",
+      "generate": "Generate address",
+      "label": "LNURL",
+      "notice": "Please note, your address <strong>cannot be changed later.</strong>",
+      "success": {
+        "message": "Your LNURL address has been set."
+      },
+      "title": "Set LNURL address"
+    },
     "payments": {
       "header": {
         "amount": "Amount",

--- a/frontends/web/src/routes/lightning/set-lnurl-address.module.css
+++ b/frontends/web/src/routes/lightning/set-lnurl-address.module.css
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.addressInput {
+    margin-top: var(--space-default);
+}
+
+.generateButton {
+    align-items: center;
+    background: transparent;
+    border: none;
+    color: var(--color-secondary);
+    display: flex;
+    flex-shrink: 0;
+    justify-content: center;
+    padding: 0;
+}
+
+.generateButton:hover {
+    cursor: pointer;
+}
+
+.generateButton img {
+    height: 20px;
+    opacity: 0.75;
+    width: 20px;
+}
+
+.availability {
+    align-items: center;
+    display: flex;
+    font-size: var(--size-small);
+    gap: var(--space-quarter);
+    justify-content: center;
+    min-height: var(--space-default);
+}
+
+.available {
+    color: var(--color-success);
+}
+
+.taken {
+    color: var(--color-softred);
+}
+
+.statusIcon {
+    height: 16px;
+    width: 16px;
+}
+
+.successAddress {
+    color: var(--color-secondary);
+    display: block;
+    font-size: var(--size-small);
+    margin-top: var(--space-half);
+}

--- a/frontends/web/src/routes/lightning/set-lnurl-address.tsx
+++ b/frontends/web/src/routes/lightning/set-lnurl-address.tsx
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ChangeEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { Button, Input } from '@/components/forms';
+import { Cancel, Checked, Sync, SyncLight } from '@/components/icon';
+import { Header, Main } from '@/components/layout';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { useDarkmode } from '@/hooks/darkmode';
+import { SimpleMarkup } from '@/utils/markup';
+import styles from './set-lnurl-address.module.css';
+
+const CONTENT_MIN_HEIGHT = '38em';
+const lnurlDomain = 'bitboxLN.swiss';
+// TODO: Remove mocked LNURL values once the backend supports address availability and registration.
+const initialUsername = 'tonybanana';
+const availableUsername = 'sausageman';
+const initialAddress = `${initialUsername}@${lnurlDomain}`;
+const noop = () => undefined;
+
+type TStep = 'form' | 'success';
+type TAvailability = 'unchecked' | 'available' | 'taken';
+
+const usernameFromAddress = (address: string) => address.split('@')[0]?.trim().toLowerCase() ?? '';
+
+const fullAddress = (address: string) => {
+  const username = usernameFromAddress(address);
+  return username ? `${username}@${lnurlDomain}` : '';
+};
+
+export const LightningSetLnurlAddress = () => {
+  const { t } = useTranslation();
+  const { isDarkMode } = useDarkmode();
+  const navigate = useNavigate();
+  const [address, setAddress] = useState(initialAddress);
+  const [availability, setAvailability] = useState<TAvailability>('unchecked');
+  const [step, setStep] = useState<TStep>('form');
+
+  const checkAvailability = (nextAddress: string) => {
+    const nextUsername = usernameFromAddress(nextAddress);
+    if (!nextUsername || nextUsername === initialUsername) {
+      setAvailability('unchecked');
+      return;
+    }
+    setAvailability(nextUsername === availableUsername ? 'available' : 'taken');
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextAddress = event.target.value;
+    setAddress(nextAddress);
+    checkAvailability(nextAddress);
+  };
+
+  const saveAddress = () => {
+    if (availability !== 'available') {
+      return;
+    }
+    setAddress(fullAddress(address));
+    setStep('success');
+  };
+
+  const renderAvailability = () => {
+    switch (availability) {
+    case 'available':
+      return (
+        <div className={`${styles.availability || ''} ${styles.available || ''}`}>
+          <Checked className={styles.statusIcon} />
+          {t('lightning.lnurlAddress.availability.available')}
+        </div>
+      );
+    case 'taken':
+      return (
+        <div className={`${styles.availability || ''} ${styles.taken || ''}`}>
+          <Cancel className={styles.statusIcon} />
+          {t('lightning.lnurlAddress.availability.taken')}
+        </div>
+      );
+    case 'unchecked':
+      return <div className={styles.availability} />;
+    }
+  };
+
+  const renderStep = () => {
+    switch (step) {
+    case 'form':
+      return (
+        <View key="step-form" minHeight={CONTENT_MIN_HEIGHT} width="min(420px, 100%)">
+          <ViewContent>
+            <p>{t('lightning.lnurlAddress.description')}</p>
+            <p>{t('lightning.lnurlAddress.choose')}</p>
+            <SimpleMarkup tagName="p" markup={t('lightning.lnurlAddress.notice')} />
+            <Input
+              className={styles.addressInput}
+              id="lnurlAddress"
+              label={t('lightning.lnurlAddress.label')}
+              onInput={handleChange}
+              value={address}
+            >
+              <button
+                aria-label={t('lightning.lnurlAddress.generate')}
+                className={styles.generateButton}
+                onClick={noop}
+                type="button">
+                {isDarkMode ? <SyncLight /> : <Sync />}
+              </button>
+            </Input>
+            {renderAvailability()}
+          </ViewContent>
+          <ViewButtons>
+            <Button primary disabled={availability !== 'available'} onClick={saveAddress}>
+              {t('button.save')}
+            </Button>
+            <Button secondary onClick={() => navigate(-1)}>
+              {t('dialog.cancel')}
+            </Button>
+          </ViewButtons>
+        </View>
+      );
+    case 'success':
+      return (
+        <View fitContent textCenter verticallyCentered width="min(420px, 100%)">
+          <ViewContent withIcon="success">
+            <p>{t('lightning.lnurlAddress.success.message')}</p>
+            <span className={styles.successAddress}>{address}</span>
+          </ViewContent>
+          <ViewButtons>
+            <Button primary onClick={() => navigate('/settings/lightning-settings')}>
+              {t('button.done')}
+            </Button>
+          </ViewButtons>
+        </View>
+      );
+    }
+  };
+
+  return (
+    <Main>
+      <Header title={t('lightning.lnurlAddress.title')} />
+      {renderStep()}
+    </Main>
+  );
+};

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -47,6 +47,7 @@ import { More } from '@/routes/settings/more';
 import { Lightning } from './lightning/lightning';
 import { LightningActivate } from './lightning/activate';
 import { LightningDeactivate } from './lightning/deactivate';
+import { LightningSetLnurlAddress } from './lightning/set-lnurl-address';
 import { Send as LightningSend } from './lightning/send/send';
 import { Receive as LightningReceive } from './lightning/receive/receive';
 
@@ -352,6 +353,7 @@ export const AppRouter = ({ devices, devicesKey, accounts, activeAccounts }: TAp
           <Route index element={<Lightning />} />
           <Route path="activate" element={<LightningActivate />} />
           <Route path="deactivate" element={<LightningDeactivate />} />
+          <Route path="set-lnurl-address" element={<LightningSetLnurlAddress />} />
           <Route path="send" element={<LightningSend />} />
           <Route path="receive" element={<LightningReceive />} />
         </Route>

--- a/frontends/web/src/routes/settings/lightning-settings.tsx
+++ b/frontends/web/src/routes/settings/lightning-settings.tsx
@@ -53,7 +53,7 @@ export const LightningSettings = ({
         />
         <SettingsItem
           settingName={t('lightning.settings.setLightningAddress')}
-          onClick={noop}
+          onClick={() => navigate('/lightning/set-lnurl-address/')}
         />
         <SettingsItem
           settingName={t('lightning.settings.manuallyClaimTopUp')}


### PR DESCRIPTION
Adds a mocked Lightning address settings flow reachable from Lightning settings.

Includes:
- Editable LNURL address form
- Mock availability states
- `tonybanana@bitboxLN.swiss`: initial/no availability state
- `sausageman@bitboxLN.swiss`: available state
- Any other non-empty name: taken state
- Mock success screen after saving an available name

Initial:

<img width="319" height="631" alt="Screenshot 2026-07-08 at 14 17 12" src="https://github.com/user-attachments/assets/677fdccd-dead-4bc3-abc5-ea19baa3a4ad" />

Taken (non available):

<img width="320" height="629" alt="Screenshot 2026-07-08 at 14 17 17" src="https://github.com/user-attachments/assets/c5e4a703-bcea-472a-8b80-9218dd17918d" />


Available:

<img width="317" height="625" alt="Screenshot 2026-07-08 at 14 17 25" src="https://github.com/user-attachments/assets/939b9542-9c52-4141-b39e-ac0410c4b5de" />



Backend support is not wired yet