### PR TITLE
lightning: add lightning address setup flow

### DIFF
--- a/backend/config/lightning.go
+++ b/backend/config/lightning.go
@@ -3,6 +3,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/jsonp"
 )
@@ -17,6 +19,8 @@ type LightningAccountConfig struct {
 	Code types.Code `json:"code"`
 	// Number is the lightning account incremental number.
 	Number uint16 `json:"num"`
+	// LightningAddressLastChangedAt is the date/time when the lightning address was last changed manually.
+	LightningAddressLastChangedAt *time.Time `json:"lightningAddressLastChangedAt,omitempty"`
 }
 
 // LightningConfig holds information related to the lightning config.

--- a/backend/lightning/address.go
+++ b/backend/lightning/address.go
@@ -7,22 +7,64 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"regexp"
+	"strings"
+	"time"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 )
 
 const (
-	lightningAddressDescription = "BitBoxApp Lightning wallet"
-	lightningAddressNumberMax   = 10000
-	maxLightningAddressAttempts = 5
+	lightningAddressDescription       = "BitBoxApp Lightning wallet"
+	lightningAddressNumberMax         = 10000
+	maxLightningAddressAttempts       = 5
+	maxLightningAddressUsernameLength = 64
+	lightningAddressChangeCooldown    = 24 * time.Hour
 )
+
+const (
+	errLightningAddressInvalidUsername     errp.ErrorCode = "lightningAddressInvalidUsername"
+	errLightningAddressUsernameUnavailable errp.ErrorCode = "lightningAddressUsernameUnavailable"
+	errLightningAddressChangeCooldown      errp.ErrorCode = "lightningAddressChangeCooldown"
+)
+
+var lightningAddressUsernameRegexp = regexp.MustCompile(`^[a-z0-9]+$`)
+var lightningAddressNow = time.Now
+
+// AddressAvailability describes whether a Lightning address username can be registered.
+type AddressAvailability struct {
+	GeneratedAddress
+	Available bool `json:"available"`
+}
+
+// GeneratedAddress is an available Lightning address suggestion.
+type GeneratedAddress struct {
+	Username string `json:"username"`
+	Address  string `json:"address"`
+}
 
 func lightningAddressString(info *breez_sdk_spark.LightningAddressInfo) *string {
 	if info == nil {
 		return nil
 	}
 	return &info.LightningAddress
+}
+
+func (lightning *Lightning) lightningAddressForUsername(username string) string {
+	return username + "@" + lightning.lnurlDomain()
+}
+
+func normalizeLightningAddressUsername(username string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(username))
+	if len(normalized) > maxLightningAddressUsernameLength ||
+		!lightningAddressUsernameRegexp.MatchString(normalized) {
+		return "", errLightningAddressInvalidUsername
+	}
+	return normalized, nil
 }
 
 func generateLightningAddressUsername(random io.Reader) (string, error) {
@@ -49,6 +91,59 @@ func randomElement(random io.Reader, values []string) (string, error) {
 	return values[index.Int64()], nil
 }
 
+func (lightning *Lightning) checkLightningAddressAvailable(username string) (bool, error) {
+	available, err := lightning.sdkService.CheckLightningAddressAvailable(
+		breez_sdk_spark.CheckLightningAddressRequest{
+			Username: username,
+		},
+	)
+	if err != nil {
+		return false, errp.Wrap(err, "breez: check lightning address availability")
+	}
+	return available, nil
+}
+
+func (lightning *Lightning) generatedLightningAddressCandidate() (*GeneratedAddress, error) {
+	username, err := generateLightningAddressUsername(rand.Reader)
+	if err != nil {
+		return nil, errp.Wrap(err, "generate lightning address username")
+	}
+
+	available, err := lightning.checkLightningAddressAvailable(username)
+	if err != nil {
+		return nil, err
+	}
+	if !available {
+		return nil, nil
+	}
+
+	return &GeneratedAddress{
+		Username: username,
+		Address:  lightning.lightningAddressForUsername(username),
+	}, nil
+}
+
+// GenerateAddress returns an available Lightning address suggestion.
+func (lightning *Lightning) GenerateAddress() (*GeneratedAddress, error) {
+	if err := lightning.CheckActive(); err != nil {
+		return nil, err
+	}
+
+	for attempt := 0; attempt < maxLightningAddressAttempts; attempt++ {
+		generatedAddress, err := lightning.generatedLightningAddressCandidate()
+		if err != nil {
+			return nil, err
+		}
+		if generatedAddress == nil {
+			continue
+		}
+
+		return generatedAddress, nil
+	}
+
+	return nil, errp.New("could not find an available lightning address username")
+}
+
 func (lightning *Lightning) ensureLightningAddress() (*string, error) {
 	lightning.lightningAddressLock.Lock()
 	defer lightning.lightningAddressLock.Unlock()
@@ -66,49 +161,169 @@ func (lightning *Lightning) ensureLightningAddress() (*string, error) {
 	}
 
 	for attempt := 0; attempt < maxLightningAddressAttempts; attempt++ {
-		username, err := generateLightningAddressUsername(rand.Reader)
+		generatedAddress, err := lightning.generatedLightningAddressCandidate()
 		if err != nil {
-			return nil, errp.Wrap(err, "generate lightning address username")
+			return nil, err
 		}
-
-		available, err := lightning.sdkService.CheckLightningAddressAvailable(
-			breez_sdk_spark.CheckLightningAddressRequest{
-				Username: username,
-			},
-		)
-		if err != nil {
-			return nil, errp.Wrap(err, "breez: check lightning address availability")
-		}
-		if !available {
+		if generatedAddress == nil {
 			continue
 		}
 
 		description := lightningAddressDescription
 		registeredAddress, err := lightning.sdkService.RegisterLightningAddress(
 			breez_sdk_spark.RegisterLightningAddressRequest{
-				Username:    username,
+				Username:    generatedAddress.Username,
 				Description: &description,
 			},
 		)
 		if err != nil {
 			// The username can be claimed between the availability check and registration.
-			available, checkErr := lightning.sdkService.CheckLightningAddressAvailable(
-				breez_sdk_spark.CheckLightningAddressRequest{
-					Username: username,
-				},
-			)
+			available, checkErr := lightning.checkLightningAddressAvailable(generatedAddress.Username)
 			if checkErr == nil && !available {
 				continue
 			}
 			return nil, errp.Wrap(err, "breez: register lightning address")
 		}
-		return lightningAddressString(&registeredAddress), nil
+		address := lightningAddressString(&registeredAddress)
+		lightning.Notify(observable.Event{
+			Subject: "lightning/address",
+			Action:  action.Replace,
+			Object:  address,
+		})
+		return address, nil
 	}
 
 	return nil, errp.New("could not find an available lightning address username")
 }
 
-// LightningAddress returns the registered LNURL-pay lightning address, registering one if needed.
+func (lightning *Lightning) lightningAddress() (*string, error) {
+	if err := lightning.CheckActive(); err != nil {
+		return nil, err
+	}
+
+	address, err := lightning.sdkService.GetLightningAddress()
+	if err != nil {
+		return nil, errp.Wrap(err, "breez: get lightning address")
+	}
+	return lightningAddressString(address), nil
+}
+
+// AddressDomain returns the configured LNURL domain for Lightning addresses.
+func (lightning *Lightning) AddressDomain() string {
+	return lightning.lnurlDomain()
+}
+
+// AddressAvailability checks whether a Lightning address username is available.
+func (lightning *Lightning) AddressAvailability(username string) (*AddressAvailability, error) {
+	if err := lightning.CheckActive(); err != nil {
+		return nil, err
+	}
+
+	normalizedUsername, err := normalizeLightningAddressUsername(username)
+	if err != nil {
+		return nil, err
+	}
+
+	available, err := lightning.checkLightningAddressAvailable(normalizedUsername)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AddressAvailability{
+		GeneratedAddress: GeneratedAddress{
+			Username: normalizedUsername,
+			Address:  lightning.lightningAddressForUsername(normalizedUsername),
+		},
+		Available: available,
+	}, nil
+}
+
+func (lightning *Lightning) setLightningAddressLastChangedAt(changedAt time.Time) error {
+	if err := lightning.backendConfig.ModifyLightningConfig(func(cfg *config.LightningConfig) error {
+		if len(cfg.Accounts) == 0 {
+			return errp.New("Lightning not initialized")
+		}
+		cfg.Accounts[0].LightningAddressLastChangedAt = &changedAt
+		return nil
+	}); err != nil {
+		return errp.Wrap(err, "Error updating lightning address change timestamp")
+	}
+	return nil
+}
+
+// RegisterAddress registers the Lightning address for the given username.
+func (lightning *Lightning) RegisterAddress(username string) (*string, error) {
+	lightning.lightningAddressLock.Lock()
+	defer lightning.lightningAddressLock.Unlock()
+
+	if err := lightning.CheckActive(); err != nil {
+		return nil, err
+	}
+
+	normalizedUsername, err := normalizeLightningAddressUsername(username)
+	if err != nil {
+		return nil, err
+	}
+
+	existingAddress, err := lightning.sdkService.GetLightningAddress()
+	if err != nil {
+		return nil, errp.Wrap(err, "breez: get lightning address")
+	}
+	if existingAddress != nil && existingAddress.Username == normalizedUsername {
+		account := lightning.Account()
+		if account != nil && account.LightningAddressLastChangedAt == nil {
+			if err := lightning.setLightningAddressLastChangedAt(lightningAddressNow()); err != nil {
+				lightning.log.WithError(err).Warn("Lightning address changed, but cooldown timestamp was not persisted")
+			}
+		}
+		return lightningAddressString(existingAddress), nil
+	}
+
+	account := lightning.Account()
+	if account == nil {
+		return nil, errp.New("Lightning not initialized")
+	}
+	if account.LightningAddressLastChangedAt != nil &&
+		lightningAddressNow().Sub(*account.LightningAddressLastChangedAt) < lightningAddressChangeCooldown {
+		return nil, errLightningAddressChangeCooldown
+	}
+
+	available, err := lightning.checkLightningAddressAvailable(normalizedUsername)
+	if err != nil {
+		return nil, err
+	}
+	if !available {
+		return nil, errLightningAddressUsernameUnavailable
+	}
+
+	description := lightningAddressDescription
+	registeredAddress, err := lightning.sdkService.RegisterLightningAddress(
+		breez_sdk_spark.RegisterLightningAddressRequest{
+			Username:    normalizedUsername,
+			Description: &description,
+		},
+	)
+	if err != nil {
+		available, checkErr := lightning.checkLightningAddressAvailable(normalizedUsername)
+		if checkErr == nil && !available {
+			return nil, errLightningAddressUsernameUnavailable
+		}
+		return nil, errp.Wrap(err, "breez: register lightning address")
+	}
+
+	address := lightningAddressString(&registeredAddress)
+	if err := lightning.setLightningAddressLastChangedAt(lightningAddressNow()); err != nil {
+		lightning.log.WithError(err).Warn("Lightning address changed, but cooldown timestamp was not persisted")
+	}
+	lightning.Notify(observable.Event{
+		Subject: "lightning/address",
+		Action:  action.Replace,
+		Object:  address,
+	})
+	return address, nil
+}
+
+// LightningAddress returns the registered LNURL-pay lightning address.
 func (lightning *Lightning) LightningAddress() (*string, error) {
-	return lightning.ensureLightningAddress()
+	return lightning.lightningAddress()
 }

--- a/backend/lightning/address_test.go
+++ b/backend/lightning/address_test.go
@@ -5,17 +5,34 @@ package lightning
 import (
 	"bytes"
 	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateLightningAddressUsername(t *testing.T) {
+func withLightningAddressNow(t *testing.T, now time.Time) {
+	t.Helper()
+
+	previous := lightningAddressNow
+	lightningAddressNow = func() time.Time {
+		return now
+	}
+	t.Cleanup(func() {
+		lightningAddressNow = previous
+	})
+}
+
+func TestGenerateAddressUsername(t *testing.T) {
 	username, err := generateLightningAddressUsername(bytes.NewReader([]byte{
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 	}))
@@ -25,7 +42,7 @@ func TestGenerateLightningAddressUsername(t *testing.T) {
 	require.Regexp(t, regexp.MustCompile(`^[a-z]+[0-9]{4}$`), username)
 }
 
-func TestGenerateLightningAddressUsernameRandomFailure(t *testing.T) {
+func TestGenerateAddressUsernameRandomFailure(t *testing.T) {
 	username, err := generateLightningAddressUsername(bytes.NewReader([]byte{0xde}))
 
 	require.Empty(t, username)
@@ -86,6 +103,7 @@ func TestEnsureLightningAddressExistingAddress(t *testing.T) {
 		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
 			return &breez_sdk_spark.LightningAddressInfo{
 				LightningAddress: "existing@example.com",
+				Username:         "existing",
 			}, nil
 		},
 		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
@@ -133,6 +151,32 @@ func TestEnsureLightningAddressRetriesUnavailableUsernames(t *testing.T) {
 	require.Len(t, checkedUsernames, 2)
 	require.Equal(t, checkedUsernames[1], registeredUsername)
 	require.Equal(t, registeredUsername+"@example.com", *address)
+	require.Nil(t, lightning.Account().LightningAddressLastChangedAt)
+}
+
+func TestEnsureLightningAddressStopsAfterMaxUnavailableUsernames(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	var checkedUsernames []string
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return nil, nil
+		},
+		checkLightningAddressAvailable: func(request breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			checkedUsernames = append(checkedUsernames, request.Username)
+			return false, nil
+		},
+		registerLightningAddress: func(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			t.Fatal("unavailable address should not be registered")
+			return breez_sdk_spark.LightningAddressInfo{}, nil
+		},
+	}
+
+	address, err := lightning.ensureLightningAddress()
+	require.Nil(t, address)
+	require.Error(t, err)
+	require.Len(t, checkedUsernames, maxLightningAddressAttempts)
 }
 
 func TestEnsureLightningAddressContinuesAfterConcurrentClaim(t *testing.T) {
@@ -178,6 +222,389 @@ func TestEnsureLightningAddressContinuesAfterConcurrentClaim(t *testing.T) {
 	require.Equal(t, checkedUsernames[0], checkedUsernames[1])
 	require.Equal(t, []string{checkedUsernames[0], checkedUsernames[2]}, registeredUsernames)
 	require.Equal(t, registeredUsernames[1]+"@example.com", *address)
+}
+
+func TestLightningAddressExistingAddress(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return &breez_sdk_spark.LightningAddressInfo{
+				LightningAddress: "existing@example.com",
+				Username:         "existing",
+			}, nil
+		},
+		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			t.Fatal("availability should not be checked when only reading the current address")
+			return false, nil
+		},
+		registerLightningAddress: func(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			t.Fatal("address should not be registered when only reading the current address")
+			return breez_sdk_spark.LightningAddressInfo{}, nil
+		},
+	}
+
+	address, err := lightning.LightningAddress()
+	require.NoError(t, err)
+	require.NotNil(t, address)
+	require.Equal(t, "existing@example.com", *address)
+}
+
+func TestLightningAddressMissingAddressDoesNotRegister(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return nil, nil
+		},
+		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			t.Fatal("availability should not be checked when only reading the current address")
+			return false, nil
+		},
+		registerLightningAddress: func(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			t.Fatal("address should not be registered when only reading the current address")
+			return breez_sdk_spark.LightningAddressInfo{}, nil
+		},
+	}
+
+	address, err := lightning.LightningAddress()
+	require.NoError(t, err)
+	require.Nil(t, address)
+}
+
+func TestNormalizeLightningAddressUsername(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		expected string
+		err      error
+	}{
+		{name: "lowercase", username: "username123", expected: "username123"},
+		{name: "trim and lowercase", username: " User123 ", expected: "user123"},
+		{name: "empty", username: " ", err: errLightningAddressInvalidUsername},
+		{name: "hyphen", username: "user-name", err: errLightningAddressInvalidUsername},
+		{name: "too long", username: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", err: errLightningAddressInvalidUsername},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			username, err := normalizeLightningAddressUsername(tt.username)
+			if tt.err != nil {
+				require.Equal(t, tt.err, errp.Cause(err))
+				require.Empty(t, username)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, username)
+		})
+	}
+}
+
+func TestAddressAvailability(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	var checkedUsername string
+	lightning.sdkService = &testBreezSDK{
+		checkLightningAddressAvailable: func(request breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			checkedUsername = request.Username
+			return true, nil
+		},
+	}
+
+	availability, err := lightning.AddressAvailability(" User123 ")
+	require.NoError(t, err)
+	require.Equal(t, "user123", checkedUsername)
+	require.Equal(t, &AddressAvailability{
+		GeneratedAddress: GeneratedAddress{
+			Username: "user123",
+			Address:  "user123@bitbox.pay",
+		},
+		Available: true,
+	}, availability)
+}
+
+func TestAddressAvailabilityRejectsInvalidUsernameBeforeSDKCall(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	lightning.sdkService = &testBreezSDK{
+		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			t.Fatal("availability should not be checked for invalid usernames")
+			return false, nil
+		},
+	}
+
+	availability, err := lightning.AddressAvailability("user-name")
+	require.Nil(t, availability)
+	require.Equal(t, errLightningAddressInvalidUsername, errp.Cause(err))
+}
+
+func TestGenerateAddressRetriesUnavailableUsernamesWithoutRegistering(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	var checkedUsernames []string
+	lightning.sdkService = &testBreezSDK{
+		checkLightningAddressAvailable: func(request breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			checkedUsernames = append(checkedUsernames, request.Username)
+			return len(checkedUsernames) == 2, nil
+		},
+		registerLightningAddress: func(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			t.Fatal("generated address should not be registered")
+			return breez_sdk_spark.LightningAddressInfo{}, nil
+		},
+	}
+
+	generatedAddress, err := lightning.GenerateAddress()
+	require.NoError(t, err)
+	require.NotNil(t, generatedAddress)
+	require.Len(t, checkedUsernames, 2)
+	require.Equal(t, checkedUsernames[1], generatedAddress.Username)
+	require.Equal(t, generatedAddress.Username+"@bitbox.pay", generatedAddress.Address)
+}
+
+func TestRegisterAddress(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	withLightningAddressNow(t, now)
+
+	var checkedUsername string
+	var registeredUsername string
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return nil, nil
+		},
+		checkLightningAddressAvailable: func(request breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			checkedUsername = request.Username
+			return true, nil
+		},
+		registerLightningAddress: func(request breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			registeredUsername = request.Username
+			require.Equal(t, lightningAddressDescription, *request.Description)
+			return breez_sdk_spark.LightningAddressInfo{
+				LightningAddress: request.Username + "@example.com",
+			}, nil
+		},
+	}
+
+	address, err := lightning.RegisterAddress(" User123 ")
+	require.NoError(t, err)
+	require.NotNil(t, address)
+	require.Equal(t, "user123", checkedUsername)
+	require.Equal(t, "user123", registeredUsername)
+	require.Equal(t, "user123@example.com", *address)
+	require.NotNil(t, lightning.Account().LightningAddressLastChangedAt)
+	require.Equal(t, now, *lightning.Account().LightningAddressLastChangedAt)
+}
+
+func TestRegisterAddressReturnsSuccessWhenTimestampPersistenceFails(t *testing.T) {
+	configDir := t.TempDir()
+	appConfigFilename := filepath.Join(configDir, "app.json")
+	accountsConfigFilename := filepath.Join(configDir, "accounts.json")
+	lightningConfigFilename := filepath.Join(configDir, "lightning.json")
+	cfg, err := config.NewConfig(appConfigFilename, accountsConfigFilename, lightningConfigFilename)
+	require.NoError(t, err)
+
+	lightning := NewLightning(cfg, t.TempDir(), nil, nil, &http.Client{}, nil, nil, false)
+	activateLightningAddressTest(t, lightning)
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	withLightningAddressNow(t, now)
+
+	require.NoError(t, os.Remove(lightningConfigFilename))
+	require.NoError(t, os.Mkdir(lightningConfigFilename, 0o755))
+
+	events := make(chan observable.Event, 1)
+	lightning.Observe(func(event observable.Event) {
+		events <- event
+	})
+
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return nil, nil
+		},
+		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			return true, nil
+		},
+		registerLightningAddress: func(request breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			return breez_sdk_spark.LightningAddressInfo{
+				LightningAddress: request.Username + "@example.com",
+			}, nil
+		},
+	}
+
+	address, err := lightning.RegisterAddress("replacement")
+	require.NoError(t, err)
+	require.NotNil(t, address)
+	require.Equal(t, "replacement@example.com", *address)
+	require.NotNil(t, lightning.Account().LightningAddressLastChangedAt)
+	require.Equal(t, now, *lightning.Account().LightningAddressLastChangedAt)
+
+	require.Equal(t, observable.Event{
+		Subject: "lightning/address",
+		Action:  action.Replace,
+		Object:  address,
+	}, <-events)
+}
+
+func TestRegisterAddressUnavailable(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return nil, nil
+		},
+		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			return false, nil
+		},
+		registerLightningAddress: func(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			t.Fatal("unavailable address should not be registered")
+			return breez_sdk_spark.LightningAddressInfo{}, nil
+		},
+	}
+
+	address, err := lightning.RegisterAddress("taken")
+	require.Nil(t, address)
+	require.Equal(t, errLightningAddressUsernameUnavailable, errp.Cause(err))
+}
+
+func TestRegisterAddressCurrentUsernameIsNoop(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	lastChangedAt := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	account := *lightning.Account()
+	account.LightningAddressLastChangedAt = &lastChangedAt
+	require.NoError(t, lightning.SetAccount(&account))
+
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return &breez_sdk_spark.LightningAddressInfo{
+				LightningAddress: "existing@example.com",
+				Username:         "existing",
+			}, nil
+		},
+		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			t.Fatal("availability should not be checked when registering the current username")
+			return false, nil
+		},
+		registerLightningAddress: func(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			t.Fatal("current address should not be registered again")
+			return breez_sdk_spark.LightningAddressInfo{}, nil
+		},
+	}
+
+	address, err := lightning.RegisterAddress(" Existing ")
+	require.NoError(t, err)
+	require.NotNil(t, address)
+	require.Equal(t, "existing@example.com", *address)
+	require.Equal(t, lastChangedAt, *lightning.Account().LightningAddressLastChangedAt)
+}
+
+func TestRegisterAddressCurrentUsernameRepairsMissingTimestamp(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	withLightningAddressNow(t, now)
+
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return &breez_sdk_spark.LightningAddressInfo{
+				LightningAddress: "existing@example.com",
+				Username:         "existing",
+			}, nil
+		},
+		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			t.Fatal("availability should not be checked when registering the current username")
+			return false, nil
+		},
+		registerLightningAddress: func(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			t.Fatal("current address should not be registered again")
+			return breez_sdk_spark.LightningAddressInfo{}, nil
+		},
+	}
+
+	address, err := lightning.RegisterAddress(" Existing ")
+	require.NoError(t, err)
+	require.NotNil(t, address)
+	require.Equal(t, "existing@example.com", *address)
+	require.NotNil(t, lightning.Account().LightningAddressLastChangedAt)
+	require.Equal(t, now, *lightning.Account().LightningAddressLastChangedAt)
+}
+
+func TestRegisterAddressCooldown(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	withLightningAddressNow(t, now)
+	lastChangedAt := now.Add(-lightningAddressChangeCooldown + time.Second)
+	account := *lightning.Account()
+	account.LightningAddressLastChangedAt = &lastChangedAt
+	require.NoError(t, lightning.SetAccount(&account))
+
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return &breez_sdk_spark.LightningAddressInfo{
+				LightningAddress: "existing@example.com",
+				Username:         "existing",
+			}, nil
+		},
+		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			t.Fatal("availability should not be checked during cooldown")
+			return false, nil
+		},
+		registerLightningAddress: func(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			t.Fatal("address should not be registered during cooldown")
+			return breez_sdk_spark.LightningAddressInfo{}, nil
+		},
+	}
+
+	address, err := lightning.RegisterAddress("replacement")
+	require.Nil(t, address)
+	require.Equal(t, errLightningAddressChangeCooldown, errp.Cause(err))
+}
+
+func TestRegisterAddressAfterCooldown(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	activateLightningAddressTest(t, lightning)
+
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	withLightningAddressNow(t, now)
+	lastChangedAt := now.Add(-lightningAddressChangeCooldown - time.Second)
+	account := *lightning.Account()
+	account.LightningAddressLastChangedAt = &lastChangedAt
+	require.NoError(t, lightning.SetAccount(&account))
+
+	var registeredUsername string
+	lightning.sdkService = &testBreezSDK{
+		getLightningAddress: func() (*breez_sdk_spark.LightningAddressInfo, error) {
+			return &breez_sdk_spark.LightningAddressInfo{
+				LightningAddress: "existing@example.com",
+				Username:         "existing",
+			}, nil
+		},
+		checkLightningAddressAvailable: func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error) {
+			return true, nil
+		},
+		registerLightningAddress: func(request breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error) {
+			registeredUsername = request.Username
+			return breez_sdk_spark.LightningAddressInfo{
+				LightningAddress: request.Username + "@example.com",
+			}, nil
+		},
+	}
+
+	address, err := lightning.RegisterAddress("replacement")
+	require.NoError(t, err)
+	require.NotNil(t, address)
+	require.Equal(t, "replacement", registeredUsername)
+	require.Equal(t, "replacement@example.com", *address)
+	require.Equal(t, now, *lightning.Account().LightningAddressLastChangedAt)
 }
 
 func TestLightningAddressChangedEventNotifiesSubscribers(t *testing.T) {

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -30,6 +30,10 @@ func NewHandlers(
 ) {
 	handleNoError("/account", lightning.GetAccount).Methods("GET")
 	handleNoError("/address", lightning.GetLightningAddress).Methods("GET")
+	handleNoError("/address/domain", lightning.GetAddressDomain).Methods("GET")
+	handleNoError("/address/availability", lightning.GetAddressAvailability).Methods("GET")
+	handleNoError("/address/generate", lightning.PostGenerateAddress).Methods("POST")
+	handleNoError("/address/register", lightning.PostRegisterAddress).Methods("POST")
 	handleNoError("/ready", lightning.GetReady).Methods("GET")
 	handleNoError("/activate", lightning.PostActivate).Methods("POST")
 	handleNoError("/deactivate", lightning.PostDeactivate).Methods("POST")
@@ -71,6 +75,47 @@ func (lightning *Lightning) GetAccount(_ *http.Request) interface{} {
 // GetLightningAddress handles the GET request to retrieve the registered lightning address.
 func (lightning *Lightning) GetLightningAddress(_ *http.Request) interface{} {
 	address, err := lightning.LightningAddress()
+	if err != nil {
+		return errorResponse(err)
+	}
+	return responseDto{Success: true, Data: address}
+}
+
+// GetAddressDomain handles the GET request to retrieve the configured lightning address domain.
+func (lightning *Lightning) GetAddressDomain(_ *http.Request) interface{} {
+	return responseDto{Success: true, Data: lightning.AddressDomain()}
+}
+
+// GetAddressAvailability handles the GET request to check lightning address username availability.
+func (lightning *Lightning) GetAddressAvailability(r *http.Request) interface{} {
+	availability, err := lightning.AddressAvailability(r.URL.Query().Get("username"))
+	if err != nil {
+		return errorResponse(err)
+	}
+	return responseDto{Success: true, Data: availability}
+}
+
+// PostGenerateAddress handles the POST request to generate an available lightning address username.
+func (lightning *Lightning) PostGenerateAddress(_ *http.Request) interface{} {
+	address, err := lightning.GenerateAddress()
+	if err != nil {
+		return errorResponse(err)
+	}
+	return responseDto{Success: true, Data: address}
+}
+
+// PostRegisterAddress handles the POST request to register a lightning address username.
+func (lightning *Lightning) PostRegisterAddress(r *http.Request) interface{} {
+	var jsonBody struct {
+		Username string `json:"username"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&jsonBody); err != nil {
+		return errorResponse(err)
+	}
+
+	address, err := lightning.RegisterAddress(jsonBody.Username)
 	if err != nil {
 		return errorResponse(err)
 	}

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -158,7 +158,7 @@ func (lightning *Lightning) Activate() error {
 		return err
 	}
 
-	if err = lightning.connect(true); err != nil {
+	if err = lightning.connect(); err != nil {
 		if deactivateErr := lightning.Deactivate(); deactivateErr != nil {
 			lightning.log.Error(deactivateErr)
 		}
@@ -170,7 +170,7 @@ func (lightning *Lightning) Activate() error {
 
 // Connect needs to be called before any requests are made.
 func (lightning *Lightning) Connect() {
-	if err := lightning.connect(false); err != nil {
+	if err := lightning.connect(); err != nil {
 		lightning.log.WithError(err).Warn("BreezSDK: Error connecting SDK")
 	}
 }
@@ -302,7 +302,7 @@ func accountBreezFolder(accountCode types.Code) string {
 }
 
 // connect initializes the connection configuration and calls connect to create a Breez SDK instance.
-func (lightning *Lightning) connect(_ bool) error {
+func (lightning *Lightning) connect() error {
 	account := lightning.Account()
 
 	if account != nil && lightning.sdkService == nil {
@@ -373,6 +373,9 @@ func (lightning *Lightning) connect(_ bool) error {
 
 		lightning.sdkService = sdk
 		lightning.notifyReady()
+		if _, err := lightning.ensureLightningAddress(); err != nil {
+			lightning.log.WithError(err).Warn("BreezSDK: Error ensuring lightning address")
+		}
 	}
 	return nil
 }

--- a/frontends/web/src/api/lightning-errors.ts
+++ b/frontends/web/src/api/lightning-errors.ts
@@ -8,6 +8,9 @@ export enum TLightningErrorCode {
   INVALID_PAYMENT_INPUT = 'lightningInvalidPaymentInput',
   INSUFFICIENT_FUNDS = 'lightningInsufficientFunds',
   INVOICE_ALREADY_USED = 'lightningInvoiceAlreadyUsed',
+  ADDRESS_CHANGE_COOLDOWN = 'lightningAddressChangeCooldown',
+  ADDRESS_INVALID_USERNAME = 'lightningAddressInvalidUsername',
+  ADDRESS_USERNAME_UNAVAILABLE = 'lightningAddressUsernameUnavailable',
 }
 
 // Backend error codes arrive over JSON, so keep the lookup defensive for unknown runtime values.
@@ -17,6 +20,9 @@ const lightningErrorTranslationKeys: Partial<Record<string, string>> = {
   [TLightningErrorCode.INVALID_PAYMENT_INPUT]: 'error.lightningInvalidPaymentInput',
   [TLightningErrorCode.INSUFFICIENT_FUNDS]: 'error.lightningInsufficientFunds',
   [TLightningErrorCode.INVOICE_ALREADY_USED]: 'error.lightningInvoiceAlreadyUsed',
+  [TLightningErrorCode.ADDRESS_CHANGE_COOLDOWN]: 'error.lightningAddressChangeCooldown',
+  [TLightningErrorCode.ADDRESS_INVALID_USERNAME]: 'error.lightningAddressInvalidUsername',
+  [TLightningErrorCode.ADDRESS_USERNAME_UNAVAILABLE]: 'error.lightningAddressUsernameUnavailable',
 };
 
 export class TSdkError extends Error {

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -60,6 +60,17 @@ export type TReceivePaymentResponse = {
   invoice: string;
 };
 
+export type TLightningAddressAvailability = {
+  username: string;
+  address: string;
+  available: boolean;
+};
+
+export type TGeneratedLightningAddress = {
+  username: string;
+  address: string;
+};
+
 export type TSendPaymentRequest = {
   type: TPaymentInputType.BOLT11;
   paymentInput: string;
@@ -149,6 +160,33 @@ export const getLightningAccount = async (): Promise<TLightningAccount | null> =
 
 export const getLightningAddress = async (): Promise<string | null> => {
   return getApiResponse<string | null>('lightning/address', 'Error calling getLightningAddress');
+};
+
+export const getLightningAddressDomain = async (): Promise<string> => {
+  return getApiResponse<string>('lightning/address/domain', 'Error calling getLightningAddressDomain');
+};
+
+export const getLightningAddressAvailability = async (username: string): Promise<TLightningAddressAvailability> => {
+  return getApiResponse<TLightningAddressAvailability>(
+    `lightning/address/availability?${queryString({ username })}`,
+    'Error calling getLightningAddressAvailability'
+  );
+};
+
+export const postGenerateLightningAddress = async (): Promise<TGeneratedLightningAddress> => {
+  return postApiResponse<TGeneratedLightningAddress, undefined>(
+    'lightning/address/generate',
+    undefined,
+    'Error calling postGenerateLightningAddress'
+  );
+};
+
+export const postRegisterLightningAddress = async (username: string): Promise<string> => {
+  return postApiResponse<string, { username: string }>(
+    'lightning/address/register',
+    { username },
+    'Error calling postRegisterLightningAddress'
+  );
 };
 
 export const getLightningReady = async (): Promise<boolean> => {

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -917,6 +917,9 @@
     "aoppUnsupportedKeystore": "The connected device cannot sign messages for this asset.",
     "aoppVersion": "Unknown version.",
     "keystoreTimeout": "Wallet request expired. Please try again.",
+    "lightningAddressChangeCooldown": "Please wait before changing your Lightning address again.",
+    "lightningAddressInvalidUsername": "Use only lowercase letters and numbers.",
+    "lightningAddressUsernameUnavailable": "This name is not available.",
     "lightningInsufficientFunds": "Insufficient funds in your Lightning wallet.",
     "lightningInvalidAmount": "Invalid amount.",
     "lightningInvalidPaymentInput": "Invalid invoice or payment request.",
@@ -1601,13 +1604,14 @@
     "lnurlAddress": {
       "availability": {
         "available": "This name is available",
+        "checking": "Checking availability...",
         "taken": "This name is taken"
       },
-      "choose": "You can choose your own address below or randomly generate one.",
+      "choose": "You can choose your own address below or generate one.",
       "description": "An LNURL address is a human readable address which you can easily share to receive lightning payments",
       "generate": "Generate address",
-      "label": "LNURL",
-      "notice": "Please note, your address <strong>cannot be changed later.</strong>",
+      "label": "LNURL username",
+      "notice": "Please note, your address can only be changed <strong>once every 24 hours.</strong>",
       "success": {
         "message": "Your LNURL address has been set."
       },

--- a/frontends/web/src/routes/lightning/set-lnurl-address.module.css
+++ b/frontends/web/src/routes/lightning/set-lnurl-address.module.css
@@ -4,6 +4,18 @@
     margin-top: var(--space-default);
 }
 
+.addressInputField input {
+    min-width: 0;
+}
+
+.domain {
+    align-items: center;
+    color: var(--color-secondary);
+    display: flex;
+    flex-shrink: 0;
+    font-size: var(--size-default);
+}
+
 .generateButton {
     align-items: center;
     background: transparent;
@@ -17,6 +29,11 @@
 
 .generateButton:hover {
     cursor: pointer;
+}
+
+.generateButton:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
 }
 
 .generateButton img {

--- a/frontends/web/src/routes/lightning/set-lnurl-address.tsx
+++ b/frontends/web/src/routes/lightning/set-lnurl-address.tsx
@@ -1,63 +1,175 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ChangeEvent, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import {
+  getLightningAddress,
+  getLightningAddressAvailability,
+  getLightningAddressDomain,
+  postGenerateLightningAddress,
+  postRegisterLightningAddress,
+} from '@/api/lightning';
+import { toLightningErrorMessage } from '@/api/lightning-errors';
 import { Button, Input } from '@/components/forms';
 import { Cancel, Checked, Sync, SyncLight } from '@/components/icon';
 import { Header, Main } from '@/components/layout';
+import { Spinner } from '@/components/spinner/Spinner';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
 import { useDarkmode } from '@/hooks/darkmode';
+import { useDebounce } from '@/hooks/debounce';
+import { useMountedRef } from '@/hooks/mount';
 import { SimpleMarkup } from '@/utils/markup';
 import styles from './set-lnurl-address.module.css';
 
 const CONTENT_MIN_HEIGHT = '38em';
-const lnurlDomain = 'bitboxLN.swiss';
-// TODO: Remove mocked LNURL values once the backend supports address availability and registration.
-const initialUsername = 'tonybanana';
-const availableUsername = 'sausageman';
-const initialAddress = `${initialUsername}@${lnurlDomain}`;
-const noop = () => undefined;
+const availabilityDebounceMs = 300;
+const usernameRegexp = /^[a-z0-9]+$/;
+const maxUsernameLength = 64;
 
 type TStep = 'form' | 'success';
-type TAvailability = 'unchecked' | 'available' | 'taken';
+type TAvailability = 'unchecked' | 'checking' | 'available' | 'taken' | 'invalid' | 'error';
 
-const usernameFromAddress = (address: string) => address.split('@')[0]?.trim().toLowerCase() ?? '';
+const isValidUsername = (username: string) => (
+  username.length > 0
+    && username.length <= maxUsernameLength
+    && usernameRegexp.test(username)
+);
 
-const fullAddress = (address: string) => {
-  const username = usernameFromAddress(address);
-  return username ? `${username}@${lnurlDomain}` : '';
-};
+const normalizeUsername = (username: string) => username.trim().toLowerCase();
+
+const usernameFromAddress = (address: string | null) => address?.split('@')[0]?.trim().toLowerCase() ?? '';
 
 export const LightningSetLnurlAddress = () => {
   const { t } = useTranslation();
   const { isDarkMode } = useDarkmode();
   const navigate = useNavigate();
-  const [address, setAddress] = useState(initialAddress);
+  const mounted = useMountedRef();
+  const availabilityRequestId = useRef(0);
+  const [domain, setDomain] = useState('');
+  const [username, setUsername] = useState('');
+  const [registeredUsername, setRegisteredUsername] = useState('');
+  const [address, setAddress] = useState('');
   const [availability, setAvailability] = useState<TAvailability>('unchecked');
+  const [error, setError] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [step, setStep] = useState<TStep>('form');
+  const debouncedUsername = useDebounce(username, availabilityDebounceMs);
 
-  const checkAvailability = (nextAddress: string) => {
-    const nextUsername = usernameFromAddress(nextAddress);
-    if (!nextUsername || nextUsername === initialUsername) {
+  // Load the backend-selected domain and auto-register an initial address if none exists yet.
+  useEffect(() => {
+    Promise.all([
+      getLightningAddressDomain(),
+      getLightningAddress(),
+    ]).then(([domain, address]) => {
+      if (!mounted.current) {
+        return;
+      }
+      const currentUsername = usernameFromAddress(address);
+      setDomain(domain);
+      setAddress(address ?? '');
+      setUsername(currentUsername);
+      setRegisteredUsername(currentUsername);
+      setAvailability('unchecked');
+    }).catch((err) => {
+      if (mounted.current) {
+        setError(toLightningErrorMessage(t, err));
+      }
+    });
+  }, [mounted, t]);
+
+  // Check availability when the user edits the username, ignoring stale responses.
+  useEffect(() => {
+    const nextUsername = normalizeUsername(debouncedUsername);
+    const requestId = ++availabilityRequestId.current;
+    setError('');
+
+    if (!nextUsername || nextUsername === registeredUsername) {
       setAvailability('unchecked');
       return;
     }
-    setAvailability(nextUsername === availableUsername ? 'available' : 'taken');
+
+    if (!isValidUsername(nextUsername)) {
+      setAvailability('invalid');
+      return;
+    }
+
+    setAvailability('checking');
+    getLightningAddressAvailability(nextUsername).then((result) => {
+      if (!mounted.current || requestId !== availabilityRequestId.current) {
+        return;
+      }
+      setAvailability(result.available ? 'available' : 'taken');
+    }).catch((err) => {
+      if (!mounted.current || requestId !== availabilityRequestId.current) {
+        return;
+      }
+      setError(toLightningErrorMessage(t, err));
+      setAvailability('error');
+    });
+  }, [debouncedUsername, mounted, registeredUsername, t]);
+
+  const generateAddress = async () => {
+    // Invalidate pending availability responses for the previous username.
+    availabilityRequestId.current += 1;
+    setIsGenerating(true);
+    setError('');
+    // The generated username still flows through the debounced availability check below.
+    // Keep the UI in checking until that final response arrives to avoid available/checking flicker.
+    setAvailability('checking');
+    try {
+      const generatedAddress = await postGenerateLightningAddress();
+      if (!mounted.current) {
+        return;
+      }
+      setUsername(generatedAddress.username);
+    } catch (err) {
+      if (mounted.current) {
+        setError(toLightningErrorMessage(t, err));
+        setAvailability('error');
+      }
+    } finally {
+      if (mounted.current) {
+        setIsGenerating(false);
+      }
+    }
   };
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const nextAddress = event.target.value;
-    setAddress(nextAddress);
-    checkAvailability(nextAddress);
+  const handleUsernameInput = (value: string) => {
+    const nextUsername = normalizeUsername(value);
+    // Invalidate pending availability responses while the user is still editing.
+    availabilityRequestId.current += 1;
+    setUsername(nextUsername);
+    setError('');
+    setAvailability('unchecked');
   };
 
-  const saveAddress = () => {
+  const saveAddress = async () => {
     if (availability !== 'available') {
       return;
     }
-    setAddress(fullAddress(address));
-    setStep('success');
+
+    setIsSaving(true);
+    setError('');
+    try {
+      const registeredAddress = await postRegisterLightningAddress(username);
+      if (!mounted.current) {
+        return;
+      }
+      setAddress(registeredAddress);
+      setRegisteredUsername(usernameFromAddress(registeredAddress));
+      setStep('success');
+    } catch (err) {
+      if (mounted.current) {
+        setError(toLightningErrorMessage(t, err));
+        setAvailability('error');
+      }
+    } finally {
+      if (mounted.current) {
+        setIsSaving(false);
+      }
+    }
   };
 
   const renderAvailability = () => {
@@ -76,12 +188,50 @@ export const LightningSetLnurlAddress = () => {
           {t('lightning.lnurlAddress.availability.taken')}
         </div>
       );
+    case 'invalid':
+      return (
+        <div className={`${styles.availability || ''} ${styles.taken || ''}`}>
+          <Cancel className={styles.statusIcon} />
+          {t('error.lightningAddressInvalidUsername')}
+        </div>
+      );
+    case 'checking':
+      return (
+        <div className={styles.availability}>
+          {t('lightning.lnurlAddress.availability.checking')}
+        </div>
+      );
+    case 'error':
+      return (
+        <div className={`${styles.availability || ''} ${styles.taken || ''}`}>
+          {error}
+        </div>
+      );
     case 'unchecked':
       return <div className={styles.availability} />;
     }
   };
 
   const renderStep = () => {
+    if (!domain && error) {
+      return (
+        <View textCenter verticallyCentered width="min(420px, 100%)">
+          <ViewContent>
+            <p>{t('unknownError', { errorMessage: error })}</p>
+          </ViewContent>
+          <ViewButtons>
+            <Button secondary onClick={() => navigate(-1)}>
+              {t('button.back')}
+            </Button>
+          </ViewButtons>
+        </View>
+      );
+    }
+
+    if (!domain) {
+      return <Spinner text={t('lightning.initializing')} />;
+    }
+
     switch (step) {
     case 'form':
       return (
@@ -92,15 +242,18 @@ export const LightningSetLnurlAddress = () => {
             <SimpleMarkup tagName="p" markup={t('lightning.lnurlAddress.notice')} />
             <Input
               className={styles.addressInput}
+              classNameInputField={styles.addressInputField}
               id="lnurlAddress"
               label={t('lightning.lnurlAddress.label')}
-              onInput={handleChange}
-              value={address}
+              onInput={event => handleUsernameInput(event.target.value)}
+              value={username}
             >
+              <span className={styles.domain}>@{domain}</span>
               <button
                 aria-label={t('lightning.lnurlAddress.generate')}
                 className={styles.generateButton}
-                onClick={noop}
+                disabled={isGenerating || isSaving}
+                onClick={generateAddress}
                 type="button">
                 {isDarkMode ? <SyncLight /> : <Sync />}
               </button>
@@ -108,10 +261,10 @@ export const LightningSetLnurlAddress = () => {
             {renderAvailability()}
           </ViewContent>
           <ViewButtons>
-            <Button primary disabled={availability !== 'available'} onClick={saveAddress}>
+            <Button primary disabled={availability !== 'available' || isSaving} onClick={saveAddress}>
               {t('button.save')}
             </Button>
-            <Button secondary onClick={() => navigate(-1)}>
+            <Button secondary disabled={isSaving} onClick={() => navigate(-1)}>
               {t('dialog.cancel')}
             </Button>
           </ViewButtons>


### PR DESCRIPTION
Lightning wallets need a recoverable way to create and change the LNURL address that users share to receive payments. Previously the app only created a random address lazily when the address was read, which gave users no control over the username.

Add backend helpers and endpoints to expose the configured LNURL domain, check username availability, generate an available suggestion and register a chosen username. Keep automatic initial address creation on SDK connect so existing receive flows still get an address without an explicit settings step, but make regular address reads side-effect free.

Persist the time of a manual address change and reject further manual changes during the local 24 hour cooldown. Add the settings screen implementation that loads the current address, validates and debounces availability checks, offers generated usernames and saves the selected username through the new registration endpoint.
