### PR TITLE
ios: encrypt lightning seed key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,9 @@ jobs:
         run: |
           make gomobileinit
           (cd $GOPATH/$GO_SRC_DIR; make ios)
+      - name: Test iOS app
+        run: |
+          (cd $GOPATH/$GO_SRC_DIR; make iostest)
   windows:
     runs-on: windows-2022
     outputs:

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ android-assemble-release:
 	cd frontends/android && ${MAKE} assemble-release
 ios:
 	cd frontends/ios && ${MAKE} build
+iostest:
+	cd frontends/ios && ${MAKE} iostest
 osx-sec-check:
 	@echo "Checking build output"
 	./scripts/osx-build-check.sh

--- a/frontends/ios/BitBoxApp/BitBoxApp.xcodeproj/project.pbxproj
+++ b/frontends/ios/BitBoxApp/BitBoxApp.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		8E1846EB2E0AFF6000802D8B /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1846EA2E0AFF5B00802D8B /* NetworkMonitor.swift */; };
 		8E1846EC2E0AFF6000802D8B /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1846EA2E0AFF5B00802D8B /* NetworkMonitor.swift */; };
+		9A0000010000000000000002 /* LightningEncryptionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0000010000000000000001 /* LightningEncryptionHelper.swift */; };
+		9A0000010000000000000003 /* LightningEncryptionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0000010000000000000001 /* LightningEncryptionHelper.swift */; };
 		B536195B2E4B2D1B00B3E10D /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B536195A2E4B2D1B00B3E10D /* Launch Screen.storyboard */; };
 		B536195C2E4B2D1B00B3E10D /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B536195A2E4B2D1B00B3E10D /* Launch Screen.storyboard */; };
 		A11AC9CA2F33A45B00AB2B88 /* BreezSdkSpark in Frameworks */ = {isa = PBXBuildFile; productRef = A11AC9C92F33A45B00AB2B88 /* BreezSdkSpark */; };
@@ -113,6 +115,7 @@
 
 /* Begin PBXFileReference section */
 		8E1846EA2E0AFF5B00802D8B /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		9A0000010000000000000001 /* LightningEncryptionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightningEncryptionHelper.swift; sourceTree = "<group>"; };
 		B536195A2E4B2D1B00B3E10D /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		D700B5F82C888CB9000496D4 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		D700B5F92C986A3C000496D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -236,6 +239,7 @@
 				D700B5F92C986A3C000496D4 /* Info.plist */,
 				D76518B52B1F45B300DC03A9 /* assets */,
 				D76516082B1F3B1300DC03A9 /* BitBoxAppApp.swift */,
+				9A0000010000000000000001 /* LightningEncryptionHelper.swift */,
 				EEEE00000000000000000003 /* WidgetAppGroupSync.swift */,
 				CCCC00010000000000000004 /* WidgetShared.swift */,
 				D76516322B1F3D1A00DC03A9 /* WebView.swift */,
@@ -543,6 +547,7 @@
 				8E1846EC2E0AFF6000802D8B /* NetworkMonitor.swift in Sources */,
 				D721B20E2D36A00000767080 /* Bluetooth.swift in Sources */,
 				D700B5FE2CA2FFAF000496D4 /* BitBoxAppApp.swift in Sources */,
+				9A0000010000000000000003 /* LightningEncryptionHelper.swift in Sources */,
 				EEEE00000000000000000002 /* WidgetAppGroupSync.swift in Sources */,
 				CCCC00010000000000000002 /* WidgetShared.swift in Sources */,
 			);
@@ -556,6 +561,7 @@
 				8E1846EB2E0AFF6000802D8B /* NetworkMonitor.swift in Sources */,
 				D721B20D2D369EC100767080 /* Bluetooth.swift in Sources */,
 				D76516092B1F3B1300DC03A9 /* BitBoxAppApp.swift in Sources */,
+				9A0000010000000000000002 /* LightningEncryptionHelper.swift in Sources */,
 				EEEE00000000000000000001 /* WidgetAppGroupSync.swift in Sources */,
 				CCCC00010000000000000001 /* WidgetShared.swift in Sources */,
 			);

--- a/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/BitBoxAppApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Foundation
 import Mobileserver
 import LocalAuthentication
 import Network
@@ -21,6 +22,7 @@ protocol SetMessageHandlersProtocol {
 
 class GoEnvironment: NSObject, MobileserverGoEnvironmentInterfaceProtocol, UIDocumentInteractionControllerDelegate {
     private let bluetoothManager: BluetoothManager
+    private let lightningEncryptionHelper = LightningEncryptionHelper()
 
     init(bluetoothManager: BluetoothManager) {
         self.bluetoothManager = bluetoothManager
@@ -92,17 +94,24 @@ class GoEnvironment: NSObject, MobileserverGoEnvironmentInterfaceProtocol, UIDoc
     }
 
     func canEncryptLightningMnemonic() -> Bool {
-        false
+        true
     }
 
     func storeLightningEncryptionKey(_ accountCode: String?, p1 encryptionKey: String?) throws {
+        try lightningEncryptionHelper.storeKey(accountCode: accountCode, encryptionKey: encryptionKey)
     }
 
     func loadLightningEncryptionKey(_ accountCode: String?, error: NSErrorPointer) -> String {
-        ""
+        do {
+            return try lightningEncryptionHelper.loadKey(accountCode: accountCode)
+        } catch let loadError as NSError {
+            error?.pointee = loadError
+            return ""
+        }
     }
 
     func deleteLightningEncryptionKey(_ accountCode: String?) throws {
+        try lightningEncryptionHelper.deleteKey(accountCode: accountCode)
     }
 
     func bluetoothConnect(_ identifier: String?) {
@@ -265,6 +274,22 @@ struct BitBoxAppApp: App {
         let testnet = false;
         #endif
         MobileserverServe(appSupportDirectory.path, testnet, goEnvironment, goAPI)
+        // Re-apply this on every backend start, as these paths may be created
+        // or replaced by the backend after a previous backup exclusion.
+        excludeBackendPathsFromBackup(in: appSupportDirectory)
+    }
+
+    private func excludeBackendPathsFromBackup(in appSupportDirectory: URL) {
+        excludeFromBackup(appSupportDirectory.appendingPathComponent("lightning.json"))
+        excludeFromBackup(appSupportDirectory.appendingPathComponent("cache", isDirectory: true))
+    }
+
+    private func excludeFromBackup(_ url: URL) {
+        do {
+            try (url as NSURL).setResourceValue(true, forKey: URLResourceKey.isExcludedFromBackupKey)
+        } catch {
+            print("Could not exclude \(url.lastPathComponent) from backup: \(error)")
+        }
     }
 }
 

--- a/frontends/ios/BitBoxApp/BitBoxApp/LightningEncryptionHelper.swift
+++ b/frontends/ios/BitBoxApp/BitBoxApp/LightningEncryptionHelper.swift
@@ -1,0 +1,145 @@
+//
+//  LightningEncryptionHelper.swift
+//  BitBoxApp
+//
+
+import Foundation
+import Security
+
+protocol LightningKeychainClient {
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus
+    func add(query: [String: Any]) -> OSStatus
+    func copyMatching(query: [String: Any]) -> (status: OSStatus, data: Data?)
+    func delete(query: [String: Any]) -> OSStatus
+}
+
+final class SecItemLightningKeychainClient: LightningKeychainClient {
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+    }
+
+    func add(query: [String: Any]) -> OSStatus {
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    func copyMatching(query: [String: Any]) -> (status: OSStatus, data: Data?) {
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        return (status, item as? Data)
+    }
+
+    func delete(query: [String: Any]) -> OSStatus {
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+final class LightningEncryptionHelper {
+    static let missingKeyError = "lightning-key-missing"
+
+    private static let defaultService = "swiss.bitbox.BitBoxApp.lightning.encryption"
+    private let service: String
+    private let keychain: LightningKeychainClient
+
+    init(
+        service: String = LightningEncryptionHelper.defaultService,
+        keychain: LightningKeychainClient = SecItemLightningKeychainClient()
+    ) {
+        self.service = service
+        self.keychain = keychain
+    }
+
+    func storeKey(accountCode: String?, encryptionKey: String?) throws {
+        let account = try keychainAccount(accountCode: accountCode)
+        guard let encryptionKey, !encryptionKey.isEmpty else {
+            throw error("lightning-key-invalid")
+        }
+        guard let keyData = encryptionKey.data(using: .utf8) else {
+            throw error("lightning-key-invalid")
+        }
+
+        let query = baseQuery(account: account)
+        let attributes: [String: Any] = [
+            kSecValueData as String: keyData,
+        ]
+
+        let updateStatus = keychain.update(query: query, attributes: attributes)
+        if updateStatus == errSecSuccess {
+            return
+        }
+        if updateStatus != errSecItemNotFound {
+            throw statusError(updateStatus)
+        }
+
+        var addQuery = query
+        attributes.forEach { addQuery[$0.key] = $0.value }
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        let addStatus = keychain.add(query: addQuery)
+        if addStatus == errSecDuplicateItem {
+            // Another activation may have inserted the item after the update missed it.
+            // Store this caller's key so the persisted mnemonic and key stay in sync.
+            let retryUpdateStatus = keychain.update(query: query, attributes: attributes)
+            guard retryUpdateStatus == errSecSuccess else {
+                throw statusError(retryUpdateStatus)
+            }
+            return
+        }
+        guard addStatus == errSecSuccess else {
+            throw statusError(addStatus)
+        }
+    }
+
+    func loadKey(accountCode: String?) throws -> String {
+        let account = try keychainAccount(accountCode: accountCode)
+        var query = baseQuery(account: account)
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnData as String] = true
+
+        let result = keychain.copyMatching(query: query)
+        let status = result.status
+        if status == errSecItemNotFound {
+            throw error(Self.missingKeyError)
+        }
+        guard status == errSecSuccess else {
+            throw statusError(status)
+        }
+        guard let data = result.data, let key = String(data: data, encoding: .utf8), !key.isEmpty else {
+            throw error("lightning-key-invalid")
+        }
+        return key
+    }
+
+    func deleteKey(accountCode: String?) throws {
+        let account = try keychainAccount(accountCode: accountCode)
+        let status = keychain.delete(query: baseQuery(account: account))
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw statusError(status)
+        }
+    }
+
+    private func keychainAccount(accountCode: String?) throws -> String {
+        guard let accountCode, !accountCode.isEmpty else {
+            throw error("lightning-account-invalid")
+        }
+        return "bitboxapp.lightning.seed.\(accountCode).v1"
+    }
+
+    private func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    private func statusError(_ status: OSStatus) -> NSError {
+        error("lightning-keychain-error", status: status)
+    }
+
+    private func error(_ message: String, status: OSStatus? = nil) -> NSError {
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: message]
+        if let status {
+            userInfo["OSStatus"] = status
+        }
+        return NSError(domain: "swiss.bitbox.BitBoxApp.lightning.encryption", code: Int(status ?? -1), userInfo: userInfo)
+    }
+}

--- a/frontends/ios/BitBoxApp/BitBoxAppTests/BitBoxAppTests.swift
+++ b/frontends/ios/BitBoxApp/BitBoxAppTests/BitBoxAppTests.swift
@@ -6,31 +6,114 @@
 //
 
 import XCTest
+import Security
 @testable import BitBoxApp
 
+private final class InMemoryLightningKeychainClient: LightningKeychainClient {
+    private var items: [String: Data] = [:]
+
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        guard let key = itemKey(query: query), items[key] != nil else {
+            return errSecItemNotFound
+        }
+        guard let data = attributes[kSecValueData as String] as? Data else {
+            return errSecParam
+        }
+        items[key] = data
+        return errSecSuccess
+    }
+
+    func add(query: [String: Any]) -> OSStatus {
+        guard let key = itemKey(query: query), let data = query[kSecValueData as String] as? Data else {
+            return errSecParam
+        }
+        guard items[key] == nil else {
+            return errSecDuplicateItem
+        }
+        items[key] = data
+        return errSecSuccess
+    }
+
+    func copyMatching(query: [String: Any]) -> (status: OSStatus, data: Data?) {
+        guard let key = itemKey(query: query), let data = items[key] else {
+            return (errSecItemNotFound, nil)
+        }
+        return (errSecSuccess, data)
+    }
+
+    func delete(query: [String: Any]) -> OSStatus {
+        guard let key = itemKey(query: query), items.removeValue(forKey: key) != nil else {
+            return errSecItemNotFound
+        }
+        return errSecSuccess
+    }
+
+    private func itemKey(query: [String: Any]) -> String? {
+        guard
+            let service = query[kSecAttrService as String] as? String,
+            let account = query[kSecAttrAccount as String] as? String
+        else {
+            return nil
+        }
+        return "\(service):\(account)"
+    }
+}
+
 final class BitBoxAppTests: XCTestCase {
+    private var helper: LightningEncryptionHelper!
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        let service = "swiss.bitbox.BitBoxAppTests.lightning.encryption.\(UUID().uuidString)"
+        helper = LightningEncryptionHelper(service: service, keychain: InMemoryLightningKeychainClient())
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        try? helper?.deleteKey(accountCode: "v0-deadbeef-ln-0")
+        helper = nil
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    func testStoreAndLoadLightningEncryptionKey() throws {
+        try helper.storeKey(accountCode: "v0-deadbeef-ln-0", encryptionKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+
+        XCTAssertEqual(
+            try helper.loadKey(accountCode: "v0-deadbeef-ln-0"),
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        )
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    func testStoreUpdatesExistingLightningEncryptionKey() throws {
+        try helper.storeKey(accountCode: "v0-deadbeef-ln-0", encryptionKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+        try helper.storeKey(accountCode: "v0-deadbeef-ln-0", encryptionKey: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=")
+
+        XCTAssertEqual(
+            try helper.loadKey(accountCode: "v0-deadbeef-ln-0"),
+            "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="
+        )
+    }
+
+    func testLoadMissingLightningEncryptionKeyFails() throws {
+        XCTAssertThrowsError(try helper.loadKey(accountCode: "v0-deadbeef-ln-0")) { error in
+            XCTAssertEqual((error as NSError).localizedDescription, LightningEncryptionHelper.missingKeyError)
         }
     }
 
+    func testDeleteLightningEncryptionKey() throws {
+        try helper.storeKey(accountCode: "v0-deadbeef-ln-0", encryptionKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+        try helper.deleteKey(accountCode: "v0-deadbeef-ln-0")
+
+        XCTAssertThrowsError(try helper.loadKey(accountCode: "v0-deadbeef-ln-0")) { error in
+            XCTAssertEqual((error as NSError).localizedDescription, LightningEncryptionHelper.missingKeyError)
+        }
+    }
+
+    func testDeleteMissingLightningEncryptionKeySucceeds() throws {
+        XCTAssertNoThrow(try helper.deleteKey(accountCode: "v0-deadbeef-ln-0"))
+    }
+
+    func testInvalidInputsFail() throws {
+        XCTAssertThrowsError(try helper.storeKey(accountCode: nil, encryptionKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
+        XCTAssertThrowsError(try helper.storeKey(accountCode: "", encryptionKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="))
+        XCTAssertThrowsError(try helper.storeKey(accountCode: "v0-deadbeef-ln-0", encryptionKey: nil))
+        XCTAssertThrowsError(try helper.storeKey(accountCode: "v0-deadbeef-ln-0", encryptionKey: ""))
+    }
 }

--- a/frontends/ios/Makefile
+++ b/frontends/ios/Makefile
@@ -1,3 +1,5 @@
+IOS_TEST_DESTINATION ?= platform=iOS Simulator,name=iPhone 16
+
 prepare:
 	cd ../../ && ${MAKE} buildweb
 	rm -rf BitBoxApp/BitBoxApp/assets/web/
@@ -12,3 +14,5 @@ build:
 	${MAKE} prepare
 	xcodebuild clean build -project BitBoxApp/BitBoxApp.xcodeproj -scheme BitBoxApp -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO
 	xcodebuild clean build -project BitBoxApp/BitBoxApp.xcodeproj -scheme "BitBoxApp Testnet" -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO
+iostest:
+	xcodebuild test -project BitBoxApp/BitBoxApp.xcodeproj -scheme BitBoxApp -configuration Debug -destination '$(IOS_TEST_DESTINATION)' -only-testing:BitBoxAppTests CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
Store the backend-generated Lightning mnemonic encryption key in the iOS Keychain using an account-specific generic password item. The item is marked device-local, while the backend continues to keep only the encrypted mnemonic in the Lightning config.

Wire the gomobile environment hooks to the Keychain helper and enable Lightning mnemonic encryption on iOS. Add focused XCTest coverage for store, load, update, delete, missing-key, and invalid-input behavior.

