### PR TITLE
Fix native building on Fedora and add a target to build only the executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ webserve:
 	cd ${WEBROOT} && $(MAKE) serve
 webe2etest:
 	cd ${WEBROOT} && $(MAKE) test-e2e
+qt-linux-bin: # build only the executable, skip deb/rpm/AppImage packaging
+	$(MAKE) buildweb
+	cd frontends/qt && $(MAKE) linux-bin
 qt-linux: # run inside dockerdev
 	$(MAKE) buildweb
 	cd frontends/qt && $(MAKE) linux

--- a/frontends/qt/BitBox.pro
+++ b/frontends/qt/BitBox.pro
@@ -19,7 +19,6 @@ TEMPLATE = app
 CFORTIFY = -O2 -D_FORTIFY_SOURCE=2
 CSTACK = -fstack-protector-all -fstack-check
 CMISC = -fwrapv
-CASLR = -fPIE -fPIC
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which has been marked as deprecated (the exact warnings
@@ -47,6 +46,9 @@ win32 {
     QMAKE_CXXFLAGS += $$CFORTIFY
     QMAKE_CXXFLAGS += $$CSTACK
     QMAKE_CXXFLAGS += $$CMISC
+    # On Debian/Ubuntu (docker) GCC adds -fPIE by default, but other
+    # toolchains (e.g. Fedora/GCC) do not.
+    QMAKE_CXXFLAGS += -fPIE
 }
 
 # https://stackoverflow.com/questions/18462420/how-to-specify-mac-platform-in-qmake-qtcreator

--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -18,7 +18,7 @@ base:
 clean:
 	-rm -rf build
 	cd server && $(MAKE) clean
-linux:
+linux-bin:
 	$(MAKE) clean
 	cd server && $(MAKE) linux
 	$(MAKE) base
@@ -28,6 +28,7 @@ linux:
 	mv build/BitBox build/linux-tmp
 	cp build/assets.rcc build/linux-tmp/
 	cp server/libserver.so build/linux-tmp
+linux: linux-bin
 	cd build/linux-tmp && \
 		/opt/linuxdeployqt-continuous-x86_64.AppImage --appimage-extract && \
 		./squashfs-root/AppRun BitBox \


### PR DESCRIPTION
This pull request introduces two improvements:
- Fix native builds on Fedora
- Add a make target to build only the executable, without generating the DEB, RPM, or AppImage packages

