### PR TITLE
frontend: LN close&withdraw UI components

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1593,6 +1593,22 @@
         "title": "Create lightning wallet"
       }
     },
+    "closeWithdrawFunds": {
+      "accountDestination": "Account coins will be sent to",
+      "confirm": "Confirm closing of lightning wallet",
+      "description": "This will close your lightning wallet and send all remaining coins to your BitBox wallet.",
+      "failure": {
+        "message": "Closing lightning wallet failed.",
+        "tryAgain": "Please try again."
+      },
+      "fee": "Fee",
+      "lightningBalanceToBeSent": "Lightning balance to be sent",
+      "success": {
+        "message": "Lightning wallet successfully closed. Coins will be sent to on-chain wallet.",
+        "note": "Your coins will appear in your wallet once the transaction is confirmed."
+      },
+      "viewTransaction": "View transaction"
+    },
     "deactivate": {
       "intro": {
         "content": "Shutting down your lightning wallet will disconnect you from the server and you will no longer be able to use your lightning wallet to send and receive.\nFunds on your lightning wallet are not affected, you can still access them again by enabling lightning in the settings and connecting the BitBox02 wallet used to make that wallet."

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.module.css
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.module.css
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-half);
+}
+
+.description {
+    font-size: var(--size-default);
+    margin: 0 0 var(--space-quarter);
+}
+
+.section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-quarter);
+}
+
+.sectionTitle {
+    color: var(--color-tertiary);
+    font-size: var(--size-small);
+    font-weight: 400;
+    margin: 0;
+}
+
+.amountRow {
+    align-items: center;
+    display: flex;
+    gap: var(--space-half);
+    justify-content: space-between;
+}
+
+.amountWithUnit {
+    align-items: baseline;
+    display: inline-flex;
+    gap: 0.35ch;
+    white-space: nowrap;
+}
+
+.sats {
+    color: var(--color-default);
+    font-weight: 600;
+}
+
+.fiat {
+    color: var(--color-tertiary);
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+.accountSelector {
+    margin-bottom: 0;
+}
+
+.confirm {
+    align-self: center;
+    margin-top: var(--space-default);
+}
+
+.failureContent,
+.successContent {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-half);
+}
+
+.failureMessage,
+.failureNote,
+.successMessage,
+.successNote {
+    margin: 0;
+}
+
+.transactionButton {
+    align-items: center;
+    display: inline-flex;
+    gap: var(--space-quarter);
+    margin-top: var(--space-quarter);
+}
+
+.transactionIcon {
+    height: 18px;
+    width: 18px;
+}
+
+.doneButton {
+    width: 100%;
+}

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import type { AccountCode, TAccount } from '@/api/account';
+import { Header, Main } from '@/components/layout';
+import { CloseWithdrawConfirm } from './confirm-step';
+import { CloseWithdrawFailure } from './failure-step';
+import { CloseWithdrawSuccess } from './success-step';
+
+type TStep = 'confirm' | 'failure' | 'success';
+
+type TProps = {
+  activeAccounts: TAccount[];
+};
+
+export const LightningCloseWithdrawFunds = ({
+  activeAccounts,
+}: TProps) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const btcAccounts = useMemo(
+    () => activeAccounts.filter(account => account.active && account.coinCode === 'btc'),
+    [activeAccounts]
+  );
+  const [destinationAccountCode, setDestinationAccountCode] = useState<AccountCode>(btcAccounts[0]?.code || '');
+  const [confirmed, setConfirmed] = useState(false);
+  const [step, setStep] = useState<TStep>('confirm');
+  const canClose = confirmed && !!destinationAccountCode;
+
+  useEffect(() => {
+    if (!btcAccounts.length) {
+      setDestinationAccountCode('');
+      return;
+    }
+    if (!destinationAccountCode || !btcAccounts.some(account => account.code === destinationAccountCode)) {
+      setDestinationAccountCode(btcAccounts[0]?.code || '');
+    }
+  }, [btcAccounts, destinationAccountCode]);
+
+  const renderStep = () => {
+    switch (step) {
+    case 'confirm':
+      return (
+        <CloseWithdrawConfirm
+          btcAccounts={btcAccounts}
+          canClose={canClose}
+          confirmed={confirmed}
+          destinationAccountCode={destinationAccountCode}
+          onCancel={() => navigate(-1)}
+          onClose={() => setStep('success')}
+          onConfirmChange={() => setConfirmed(current => !current)}
+          onDestinationAccountChange={setDestinationAccountCode}
+        />
+      );
+    case 'failure':
+      return (
+        <CloseWithdrawFailure
+          onCancel={() => navigate('/settings/lightning-settings')}
+          onTryAgain={() => {
+            setConfirmed(false);
+            setStep('confirm');
+          }}
+        />
+      );
+    case 'success':
+      return (
+        <CloseWithdrawSuccess onDone={() => navigate('/settings/lightning-settings')} />
+      );
+    }
+  };
+
+  return (
+    <Main>
+      <Header title={t('lightning.settings.closeAndWithdrawFunds')} />
+      {renderStep()}
+    </Main>
+  );
+};

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import type { AccountCode, TAccount } from '@/api/account';
+import { Amount } from '@/components/amount/amount';
+import { Button, Checkbox } from '@/components/forms';
+import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import {
+  CONTENT_MIN_HEIGHT,
+  MOCK_AMOUNT_UNIT,
+  MOCK_FIAT_UNIT,
+  MOCK_LIGHTNING_BALANCE,
+  MOCK_WITHDRAW_FEE,
+  type TDisplayAmount,
+} from './constants';
+import styles from './close-withdraw-funds.module.css';
+
+type TProps = {
+  btcAccounts: TAccount[];
+  canClose: boolean;
+  confirmed: boolean;
+  destinationAccountCode: AccountCode;
+  onCancel: () => void;
+  onClose: () => void;
+  onConfirmChange: () => void;
+  onDestinationAccountChange: (code: AccountCode) => void;
+};
+
+const AmountRow = ({
+  amount,
+}: {
+  amount: TDisplayAmount;
+}) => (
+  <div className={styles.amountRow}>
+    <span className={`${styles.amountWithUnit || ''} ${styles.sats || ''}`}>
+      <Amount amount={amount.amount} unit={MOCK_AMOUNT_UNIT} /> {MOCK_AMOUNT_UNIT}
+    </span>
+    <span className={`${styles.amountWithUnit || ''} ${styles.fiat || ''}`}>
+      <Amount amount={amount.fiatAmount} unit={MOCK_FIAT_UNIT} /> {MOCK_FIAT_UNIT}
+    </span>
+  </div>
+);
+
+export const CloseWithdrawConfirm = ({
+  btcAccounts,
+  canClose,
+  confirmed,
+  destinationAccountCode,
+  onCancel,
+  onClose,
+  onConfirmChange,
+  onDestinationAccountChange,
+}: TProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <View key="close-withdraw-funds" minHeight={CONTENT_MIN_HEIGHT} width="min(420px, 100%)">
+      <ViewContent>
+        <div className={styles.content}>
+          <p className={styles.description}>{t('lightning.closeWithdrawFunds.description')}</p>
+
+          <section className={styles.section}>
+            <h2 className={styles.sectionTitle}>{t('lightning.closeWithdrawFunds.lightningBalanceToBeSent')}</h2>
+            <AmountRow amount={MOCK_LIGHTNING_BALANCE} />
+          </section>
+
+          <section className={styles.section}>
+            <h2 className={styles.sectionTitle}>{t('lightning.closeWithdrawFunds.accountDestination')}</h2>
+            <GroupedAccountSelector
+              accounts={btcAccounts}
+              className={styles.accountSelector}
+              onChange={onDestinationAccountChange}
+              selected={destinationAccountCode}
+            />
+          </section>
+
+          <section className={styles.section}>
+            <h2 className={styles.sectionTitle}>{t('lightning.closeWithdrawFunds.fee')}</h2>
+            <AmountRow amount={MOCK_WITHDRAW_FEE} />
+          </section>
+
+          <Checkbox
+            className={styles.confirm}
+            id="confirmCloseWithdrawFunds"
+            checked={confirmed}
+            onChange={onConfirmChange}
+          >
+            {t('lightning.closeWithdrawFunds.confirm')}
+          </Checkbox>
+        </div>
+      </ViewContent>
+      <ViewButtons>
+        <Button danger disabled={!canClose} onClick={onClose}>
+          {t('lightning.settings.closeAndWithdrawFunds')}
+        </Button>
+        <Button secondary onClick={onCancel}>
+          {t('dialog.cancel')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/constants.ts
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/constants.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CoinUnit, ConversionUnit } from '@/api/account';
+
+export const CONTENT_MIN_HEIGHT = '38em';
+
+export type TDisplayAmount = {
+  amount: string;
+  fiatAmount: string;
+};
+
+export const MOCK_AMOUNT_UNIT: CoinUnit = 'sat';
+export const MOCK_FIAT_UNIT: ConversionUnit = 'EUR';
+
+export const MOCK_LIGHTNING_BALANCE: TDisplayAmount = {
+  amount: '10000',
+  fiatAmount: '64.0',
+};
+
+export const MOCK_WITHDRAW_FEE: TDisplayAmount = {
+  amount: '1000',
+  fiatAmount: '6.40',
+};

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/failure-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/failure-step.tsx
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/forms';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { CONTENT_MIN_HEIGHT } from './constants';
+import styles from './close-withdraw-funds.module.css';
+
+type TProps = {
+  onCancel: () => void;
+  onTryAgain: () => void;
+};
+
+export const CloseWithdrawFailure = ({
+  onCancel,
+  onTryAgain,
+}: TProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <View key="close-withdraw-funds-failure" minHeight={CONTENT_MIN_HEIGHT} textCenter width="min(420px, 100%)">
+      <ViewContent withIcon="error">
+        <div className={styles.failureContent}>
+          <p className={styles.failureMessage}>{t('lightning.closeWithdrawFunds.failure.message')}</p>
+          <p className={styles.failureNote}>{t('lightning.closeWithdrawFunds.failure.tryAgain')}</p>
+        </div>
+      </ViewContent>
+      <ViewButtons>
+        <Button className={styles.doneButton} primary onClick={onTryAgain}>
+          {t('lightning.closeWithdrawFunds.failure.tryAgain')}
+        </Button>
+        <Button className={styles.doneButton} secondary onClick={onCancel}>
+          {t('dialog.cancel')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/success-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/success-step.tsx
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/forms';
+import { ExternalLink } from '@/components/icon';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { CONTENT_MIN_HEIGHT } from './constants';
+import styles from './close-withdraw-funds.module.css';
+
+type TProps = {
+  onDone: () => void;
+};
+
+const noop = () => undefined;
+
+export const CloseWithdrawSuccess = ({
+  onDone,
+}: TProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <View key="close-withdraw-funds-success" minHeight={CONTENT_MIN_HEIGHT} textCenter width="min(420px, 100%)">
+      <ViewContent withIcon="success">
+        <div className={styles.successContent}>
+          <p className={styles.successMessage}>{t('lightning.closeWithdrawFunds.success.message')}</p>
+          <p className={styles.successNote}>{t('lightning.closeWithdrawFunds.success.note')}</p>
+          <Button className={styles.transactionButton} transparent onClick={noop}>
+            <ExternalLink className={styles.transactionIcon} />
+            {t('lightning.closeWithdrawFunds.viewTransaction')}
+          </Button>
+        </div>
+      </ViewContent>
+      <ViewButtons>
+        <Button className={styles.doneButton} primary onClick={onDone}>
+          {t('button.done')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -51,6 +51,7 @@ import { LightningSetLnurlAddress } from './lightning/set-lnurl-address';
 import { Send as LightningSend } from './lightning/send/send';
 import { Receive as LightningReceive } from './lightning/receive/receive';
 import { LightningTopUp } from './lightning/topup/topup';
+import { LightningCloseWithdrawFunds } from './lightning/close-and-withdraw-funds/close-withdraw-funds';
 
 type TAppRouterProps = {
   devices: TDevices;
@@ -355,6 +356,7 @@ export const AppRouter = ({ devices, devicesKey, accounts, activeAccounts }: TAp
           <Route path="activate" element={<LightningActivate />} />
           <Route path="deactivate" element={<LightningDeactivate />} />
           <Route path="set-lnurl-address" element={<LightningSetLnurlAddress />} />
+          <Route path="close-withdraw-funds" element={<LightningCloseWithdrawFunds activeAccounts={activeAccounts} />} />
           <Route path="send" element={<LightningSend />} />
           <Route path="receive" element={<LightningReceive />} />
           <Route path="topup" element={<LightningTopUp activeAccounts={activeAccounts} hasAccounts={hasAccounts} />} />

--- a/frontends/web/src/routes/settings/lightning-settings.tsx
+++ b/frontends/web/src/routes/settings/lightning-settings.tsx
@@ -66,7 +66,7 @@ export const LightningSettings = ({
         />
         <SettingsItem
           settingName={<span className={styles.danger}>{t('lightning.settings.closeAndWithdrawFunds')}</span>}
-          onClick={noop}
+          onClick={() => navigate('/lightning/close-withdraw-funds/')}
         />
       </>
     );


### PR DESCRIPTION
Provided 'dumb' components only; hardcoded values. Backend wiring is to-be-done (backend not ready yet). 

Accounts in the `GroupedAccountSelector` are the active BTC accounts (non-testnet).

Screenshots:

<img width="217" height="474" alt="Screenshot 2026-07-14 at 16 12 28" src="https://github.com/user-attachments/assets/ea58ded2-262b-4ecb-b618-0016281fc9db" />

<img width="220" height="467" alt="Screenshot 2026-07-14 at 16 24 14" src="https://github.com/user-attachments/assets/06751cae-b75c-459b-bcca-bc9143f1c71c" />

<img width="218" height="468" alt="Screenshot 2026-07-14 at 16 12 18" src="https://github.com/user-attachments/assets/930bea91-22a7-4664-a1a2-89115ea75d50" />
