### PR TITLE
backend: schedule update checks

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -270,6 +270,7 @@ type Backend struct {
 	etherScanRateLimiter *rate.Limiter
 	ratesUpdater         *rates.RateUpdater
 	banners              *banners.Banners
+	updateChecker        *updateChecker
 	started              bool
 
 	// For unit tests, called when `backend.checkAccountUsed()` is called.
@@ -340,6 +341,8 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	}
 	backend.notifier = notifier
 	backend.socksProxy = backendProxy
+	backend.updateChecker = newUpdateChecker(&backend.socksProxy)
+	backend.updateChecker.Observe(backend.Notify)
 	backend.httpClient = hclient
 	backend.ethupdater = eth.NewUpdater(accountUpdate, backend.httpClient, backend.etherScanRateLimiter, backend.updateETHAccounts)
 	backend.enqueueETHUpdateForAllAccountsAsync = backend.ethupdater.EnqueueUpdateForAllAccountsAsync
@@ -725,6 +728,7 @@ func (backend *Backend) Start() <-chan interface{} {
 	} else {
 		go backend.banners.Init(httpClient)
 	}
+	backend.updateChecker.start()
 
 	defer backend.accountsAndKeystoreLock.Lock()()
 	backend.initPersistedAccounts(accountLoadOptions{skipETHInitialSync: true})
@@ -1143,6 +1147,7 @@ func (backend *Backend) ClearCache() error {
 // Close shuts down the backend. After this, no other method should be called.
 func (backend *Backend) Close() error {
 	backend.started = false
+	backend.updateChecker.stop()
 	backend.ratesUpdater.Stop()
 	// Call this without `accountsAndKeystoreLock` as it eventually calls `DeregisterKeystore()`,
 	// which acquires the same lock.

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -92,7 +92,7 @@ type Backend interface {
 	NotifyUser(string)
 	SystemOpen(string) error
 	ReinitializeAccounts()
-	CheckForUpdateIgnoringErrors() *backend.UpdateFile
+	GetUpdate() *backend.UpdateFile
 	Banners() *banners.Banners
 	Environment() backend.Environment
 	ClearCache() error
@@ -611,7 +611,7 @@ func (handlers *Handlers) postOpen(r *http.Request) interface{} {
 }
 
 func (handlers *Handlers) getUpdate(*http.Request) interface{} {
-	return handlers.backend.CheckForUpdateIgnoringErrors()
+	return handlers.backend.GetUpdate()
 }
 
 func (handlers *Handlers) getBanners(r *http.Request) interface{} {

--- a/backend/update.go
+++ b/backend/update.go
@@ -3,16 +3,37 @@
 package backend
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/versioninfo"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/locker"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/logging"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/socksproxy"
 	"github.com/BitBoxSwiss/bitbox02-api-go/util/semver"
 )
 
-const updateFileURL = "https://bitboxapp.shiftcrypto.io/desktop.json"
+const (
+	updateFileURL       = "https://bitboxapp.shiftcrypto.io/desktop.json"
+	updateCheckInterval = 24 * time.Hour
+)
+
+type updateCheckFunc func(context.Context) (*UpdateFile, error)
+
+type updateChecker struct {
+	observable.Implementation
+
+	check updateCheckFunc
+
+	latest     *UpdateFile
+	latestLock locker.Locker
+	cancel     context.CancelFunc
+}
 
 // UpdateFile is retrieved from the server.
 type UpdateFile struct {
@@ -26,15 +47,27 @@ type UpdateFile struct {
 	Description string `json:"description"`
 }
 
+func newUpdateChecker(proxy *socksproxy.SocksProxy) *updateChecker {
+	return &updateChecker{
+		check: func(ctx context.Context) (*UpdateFile, error) {
+			return checkForUpdate(ctx, proxy)
+		},
+	}
+}
+
 // checkForUpdate checks whether a newer version of this application has been released.
 // It returns the retrieved update file if a newer version has been released and nil otherwise.
-func (backend *Backend) checkForUpdate() (*UpdateFile, error) {
-	client, err := backend.socksProxy.GetHTTPClient()
+func checkForUpdate(ctx context.Context, proxy *socksproxy.SocksProxy) (*UpdateFile, error) {
+	client, err := proxy.GetHTTPClient()
 	if err != nil {
 		return nil, errp.WithStack(err)
 	}
 
-	response, err := client.Get(updateFileURL)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, updateFileURL, nil)
+	if err != nil {
+		return nil, errp.WithStack(err)
+	}
+	response, err := client.Do(request)
 	if err != nil {
 		return nil, errp.WithStack(err)
 	}
@@ -58,12 +91,64 @@ func (backend *Backend) checkForUpdate() (*UpdateFile, error) {
 	return &updateFile, nil
 }
 
-// CheckForUpdateIgnoringErrors suppresses any errors that are triggered, for example, when offline.
-func (backend *Backend) CheckForUpdateIgnoringErrors() *UpdateFile {
-	updateFile, err := backend.checkForUpdate()
+func (checker *updateChecker) start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	checker.cancel = cancel
+	go checker.run(ctx, updateCheckInterval)
+}
+
+func (checker *updateChecker) stop() {
+	if checker.cancel != nil {
+		checker.cancel()
+		checker.cancel = nil
+	}
+}
+
+// run checks immediately and waits for the interval after each attempt before retrying.
+func (checker *updateChecker) run(ctx context.Context, interval time.Duration) {
+	for {
+		checker.checkAndSet(ctx)
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (checker *updateChecker) checkAndSet(ctx context.Context) {
+	updateFile, err := checker.check(ctx)
+	if ctx.Err() != nil {
+		return
+	}
 	if err != nil {
 		logging.Get().WithGroup("update").WithError(err).Warn("Check for update failed.")
-		return nil
+		return
 	}
-	return updateFile
+	checker.set(updateFile)
+}
+
+func (checker *updateChecker) set(updateFile *UpdateFile) {
+	unlock := checker.latestLock.Lock()
+	checker.latest = updateFile
+	unlock()
+
+	checker.Notify(observable.Event{
+		Subject: "update",
+		Action:  action.Replace,
+		Object:  updateFile,
+	})
+}
+
+func (checker *updateChecker) get() *UpdateFile {
+	defer checker.latestLock.RLock()()
+	return checker.latest
+}
+
+// GetUpdate returns the result of the latest successful update check.
+func (backend *Backend) GetUpdate() *UpdateFile {
+	return backend.updateChecker.get()
 }

--- a/backend/update_test.go
+++ b/backend/update_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateCheckerRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := make(chan int, 2)
+	releaseSecondCheck := make(chan struct{})
+	callCount := 0
+	checker := &updateChecker{
+		check: func(context.Context) (*UpdateFile, error) {
+			callCount++
+			calls <- callCount
+			if callCount == 2 {
+				<-releaseSecondCheck
+			}
+			return nil, nil
+		},
+	}
+	done := make(chan struct{})
+	go func() {
+		checker.run(ctx, time.Millisecond)
+		close(done)
+	}()
+
+	waitForCall := func() int {
+		select {
+		case call := <-calls:
+			return call
+		case <-time.After(time.Second):
+			require.FailNow(t, "timed out waiting for update check")
+			return 0
+		}
+	}
+	require.Equal(t, 1, waitForCall())
+	require.Equal(t, 2, waitForCall())
+	cancel()
+	close(releaseSecondCheck)
+	<-done
+	require.Equal(t, 2, callCount)
+}
+
+func TestUpdateCheckerCheckAndSet(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		events := make(chan observable.Event, 1)
+		update := &UpdateFile{Description: "update available"}
+		checker := &updateChecker{
+			check: func(context.Context) (*UpdateFile, error) {
+				return update, nil
+			},
+		}
+		checker.Observe(func(event observable.Event) {
+			events <- event
+		})
+
+		checker.checkAndSet(context.Background())
+
+		require.Same(t, update, checker.get())
+		event := <-events
+		require.Equal(t, "update", event.Subject)
+		require.Equal(t, action.Replace, event.Action)
+		require.Same(t, update, event.Object)
+	})
+
+	t.Run("no update clears cached update", func(t *testing.T) {
+		events := make(chan observable.Event, 1)
+		checker := &updateChecker{
+			check: func(context.Context) (*UpdateFile, error) {
+				return nil, nil
+			},
+			latest: &UpdateFile{Description: "old update"},
+		}
+		checker.Observe(func(event observable.Event) {
+			events <- event
+		})
+
+		checker.checkAndSet(context.Background())
+
+		require.Nil(t, checker.get())
+		require.Nil(t, (<-events).Object)
+	})
+
+	t.Run("error retains cached update", func(t *testing.T) {
+		update := &UpdateFile{Description: "cached update"}
+		events := make(chan observable.Event, 1)
+		checker := &updateChecker{
+			check: func(context.Context) (*UpdateFile, error) {
+				return nil, errors.New("offline")
+			},
+			latest: update,
+		}
+		checker.Observe(func(event observable.Event) {
+			events <- event
+		})
+
+		checker.checkAndSet(context.Background())
+
+		require.Same(t, update, checker.get())
+		select {
+		case event := <-events:
+			t.Fatalf("unexpected event: %+v", event)
+		default:
+		}
+	})
+}

--- a/frontends/web/src/api/version.ts
+++ b/frontends/web/src/api/version.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { apiGet } from '@/utils/request';
+import { subscribeEndpoint, TSubscriptionCallback } from './subscribe';
 
 /**
- * Describes the file that is loaded from 'https://bitbox.swiss/updates/desktop.json'.
+ * Describes the cached result of the backend update check.
  */
-type TUpdateFile = {
+export type TUpdateFile = {
   current: string;
   version: string;
   description: string;
@@ -18,3 +19,9 @@ export const getVersion = (): Promise<string> => {
 export const getUpdate = (): Promise<TUpdateFile | null> => {
   return apiGet('update');
 };
+
+export const subscribeUpdate = (
+  cb: TSubscriptionCallback<TUpdateFile | null>
+) => (
+  subscribeEndpoint('update', cb)
+);

--- a/frontends/web/src/components/banners/update.test.tsx
+++ b/frontends/web/src/components/banners/update.test.tsx
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../__mocks__/i18n';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TUpdateFile } from '@/api/version';
+import { Update } from './update';
+
+const versionApiMocks = vi.hoisted(() => ({
+  getUpdate: vi.fn(),
+  subscribeUpdate: vi.fn(),
+}));
+
+vi.mock('@/api/version', () => versionApiMocks);
+
+vi.mock('@/contexts/ConfigProvider', () => ({
+  useConfig: () => ({
+    config: { frontend: {} },
+    setConfig: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/darkmode', () => ({
+  useDarkmode: () => ({ isDarkMode: false }),
+}));
+
+const update: TUpdateFile = {
+  current: '4.51.3',
+  version: '4.52.0',
+  description: 'A new version is ready.',
+};
+
+describe('components/banners/update', () => {
+  let notifyUpdate: ((update: TUpdateFile | null) => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notifyUpdate = undefined;
+    versionApiMocks.getUpdate.mockResolvedValue(null);
+    versionApiMocks.subscribeUpdate.mockImplementation((cb: typeof notifyUpdate) => {
+      notifyUpdate = cb;
+      return () => {};
+    });
+  });
+
+  it('renders a cached update', async () => {
+    versionApiMocks.getUpdate.mockResolvedValue(update);
+
+    render(<Update />);
+
+    expect(await screen.findByText(update.description, { exact: false })).toBeInTheDocument();
+    expect(versionApiMocks.subscribeUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('renders an update received from the subscription', async () => {
+    const { container } = render(<Update />);
+
+    await waitFor(() => expect(versionApiMocks.subscribeUpdate).toHaveBeenCalledOnce());
+    expect(container.firstChild).toBeNull();
+
+    act(() => notifyUpdate?.(update));
+
+    expect(screen.getByText(update.description, { exact: false })).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/components/banners/update.tsx
+++ b/frontends/web/src/components/banners/update.tsx
@@ -2,15 +2,15 @@
 
 import { useTranslation } from 'react-i18next';
 import { runningInAndroid } from '@/utils/env';
-import { getUpdate } from '@/api/version';
+import { getUpdate, subscribeUpdate } from '@/api/version';
 import { Status } from '@/components/status/status';
 import { AppDownloadLink } from '@/components/appdownloadlink/appdownloadlink';
-import { useLoad } from '@/hooks/api';
+import { useSync } from '@/hooks/api';
 import style from './update.module.css';
 
 export const Update = () => {
   const { t } = useTranslation();
-  const file = useLoad(getUpdate);
+  const file = useSync(getUpdate, subscribeUpdate);
   if (!file) {
     return null;
   }

--- a/frontends/web/src/routes/settings/components/about/app-version-setting.test.tsx
+++ b/frontends/web/src/routes/settings/components/about/app-version-setting.test.tsx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import '../../../../../__mocks__/i18n';
+import type { ReactNode } from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TUpdateFile } from '@/api/version';
+import { AppVersion } from './app-version-setting';
+
+const versionApiMocks = vi.hoisted(() => ({
+  getUpdate: vi.fn(),
+  getVersion: vi.fn(),
+  subscribeUpdate: vi.fn(),
+}));
+
+vi.mock('@/api/version', () => versionApiMocks);
+
+vi.mock('@/routes/settings/components/settingsItem/settingsItem', () => ({
+  SettingsItem: ({
+    displayedValue,
+    secondaryText,
+  }: {
+    displayedValue: ReactNode;
+    secondaryText: string;
+  }) => (
+    <div>
+      <span>{secondaryText}</span>
+      <span>{displayedValue}</span>
+    </div>
+  ),
+}));
+
+vi.mock('@/routes/settings/bb02-settings', () => ({
+  StyledSkeleton: () => <div>loading</div>,
+}));
+
+vi.mock('@/components/appdownloadlink/appdownloadlink', () => ({
+  downloadLinkByLanguage: () => 'https://bitbox.swiss/download/',
+}));
+
+const update: TUpdateFile = {
+  current: '4.51.3',
+  version: '4.52.0',
+  description: 'A new version is ready.',
+};
+
+describe('routes/settings/components/about/app-version-setting', () => {
+  let notifyUpdate: ((update: TUpdateFile | null) => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notifyUpdate = undefined;
+    versionApiMocks.getVersion.mockResolvedValue('4.51.3');
+    versionApiMocks.getUpdate.mockResolvedValue(null);
+    versionApiMocks.subscribeUpdate.mockImplementation((cb: typeof notifyUpdate) => {
+      notifyUpdate = cb;
+      return () => {};
+    });
+  });
+
+  it('renders a cached update', async () => {
+    versionApiMocks.getUpdate.mockResolvedValue(update);
+
+    render(<AppVersion />);
+
+    expect(await screen.findByText('settings.info.out-of-date')).toBeInTheDocument();
+    expect(await screen.findByText('4.51.3')).toBeInTheDocument();
+    expect(versionApiMocks.subscribeUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('reacts to an update received from the subscription', async () => {
+    render(<AppVersion />);
+
+    expect(await screen.findByText('settings.info.up-to-date')).toBeInTheDocument();
+    await waitFor(() => expect(versionApiMocks.subscribeUpdate).toHaveBeenCalledOnce());
+
+    act(() => notifyUpdate?.(update));
+
+    expect(screen.getByText('settings.info.out-of-date')).toBeInTheDocument();
+  });
+});

--- a/frontends/web/src/routes/settings/components/about/app-version-setting.tsx
+++ b/frontends/web/src/routes/settings/components/about/app-version-setting.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useLoad } from '@/hooks/api';
+import { useLoad, useSync } from '@/hooks/api';
 import { useTranslation } from 'react-i18next';
-import { getUpdate, getVersion } from '@/api/version';
+import { getUpdate, getVersion, subscribeUpdate } from '@/api/version';
 import { open } from '@/api/system';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import { StyledSkeleton } from '@/routes/settings/bb02-settings';
@@ -13,7 +13,7 @@ export const AppVersion = () => {
   const { t } = useTranslation();
 
   const version = useLoad(getVersion);
-  const update = useLoad(getUpdate);
+  const update = useSync(getUpdate, subscribeUpdate);
 
   const secondaryText = !!update ? t('settings.info.out-of-date') : t('settings.info.up-to-date');
   const icon = !!update ? <RedDot width={8} height={8} /> : <Checked />;


### PR DESCRIPTION
Update checks were being triggered by frontend navigation, a regression from the previous behavior
of checking only once at launch. The backend now repeats the check daily so users who leave the app
open for a long time still receive update notifications. This is especially useful on Android and
iOS, where apps may keep running in the background.

Move remote update checks out of frontend-mounted handlers. Run one asynchronous check when the
backend starts, then another 24 hours after each attempt. Cache successful results and push them to
subscribed frontend consumers.

- Add a cancellable update-check loop in `backend/update.go`, started from `Backend.Start()` and
  stopped from `Backend.Close()`.
- Make update requests context-aware so shutdown can cancel an in-flight request.
- Protect the cached `*UpdateFile` with a read/write lock.
- On every successful check, including a successful “no update” result, replace the cache
  and emit an `update` event with `action.Replace`.
- On failure, log the error, retain the last successful value, emit no replacement, and wait until
  the next daily check.
- Replace `CheckForUpdateIgnoringErrors()` in the handler-facing backend interface with a
  side-effect-free `GetUpdate()` cache getter. Keep `GET /api/update` and its nullable response
  shape unchanged.
- Add `subscribeUpdate()` to the frontend version API. Convert both the global update banner and
  About version setting from `useLoad(getUpdate)` to `useSync(getUpdate, subscribeUpdate)`, so late
  mounts receive cached state and remain subscribed without initiating a remote check.

- `GET /api/update`: unchanged wire format, but now returns cached state only.
- WebSocket subject `update`: publishes nullable `TUpdateFile` replacement events.
- Backend handler interface: expose `GetUpdate() *UpdateFile`.
- Frontend API: expose `subscribeUpdate(callback)` alongside `getUpdate()`.

- Add backend tests with an injected check function and short interval to verify the initial
  immediate check, daily recurrence, and cancellation.
- Verify successful results are cached and emitted, successful `nil` results clear an older update,
  and failed checks preserve cached state without emitting.
- Add focused frontend tests confirming both consumers render the cached response and react to
  subscription updates.
- Run targeted Go tests with the race detector, `make webtest`, and `make weblint`.

- “Once a day” means 24 hours after the previous attempt finishes, preventing
  overlapping checks.
- Startup checks remain asynchronous so network latency cannot delay application startup.
- Failed checks receive no early retry; the next attempt occurs after the normal 24-hour interval.