### PR TITLE
update: prevent stale synchronized state

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -92,7 +92,7 @@ type Backend interface {
 	NotifyUser(string)
 	SystemOpen(string) error
 	ReinitializeAccounts()
-	GetUpdate() *backend.UpdateFile
+	GetUpdate() backend.UpdateState
 	Banners() *banners.Banners
 	Environment() backend.Environment
 	ClearCache() error

--- a/backend/update.go
+++ b/backend/update.go
@@ -31,6 +31,7 @@ type updateChecker struct {
 	check updateCheckFunc
 
 	latest     *UpdateFile
+	revision   uint64
 	latestLock locker.Locker
 	cancel     context.CancelFunc
 }
@@ -45,6 +46,12 @@ type UpdateFile struct {
 
 	// Description gives additional information on the release.
 	Description string `json:"description"`
+}
+
+// UpdateState is the revisioned result of the latest successful update check.
+type UpdateState struct {
+	Revision uint64      `json:"revision"`
+	Update   *UpdateFile `json:"update"`
 }
 
 func newUpdateChecker(proxy *socksproxy.SocksProxy) *updateChecker {
@@ -134,21 +141,29 @@ func (checker *updateChecker) checkAndSet(ctx context.Context) {
 func (checker *updateChecker) set(updateFile *UpdateFile) {
 	unlock := checker.latestLock.Lock()
 	checker.latest = updateFile
+	checker.revision++
+	state := UpdateState{
+		Revision: checker.revision,
+		Update:   checker.latest,
+	}
 	unlock()
 
 	checker.Notify(observable.Event{
 		Subject: "update",
 		Action:  action.Replace,
-		Object:  updateFile,
+		Object:  state,
 	})
 }
 
-func (checker *updateChecker) get() *UpdateFile {
+func (checker *updateChecker) get() UpdateState {
 	defer checker.latestLock.RLock()()
-	return checker.latest
+	return UpdateState{
+		Revision: checker.revision,
+		Update:   checker.latest,
+	}
 }
 
 // GetUpdate returns the result of the latest successful update check.
-func (backend *Backend) GetUpdate() *UpdateFile {
+func (backend *Backend) GetUpdate() UpdateState {
 	return backend.updateChecker.get()
 }

--- a/backend/update_test.go
+++ b/backend/update_test.go
@@ -66,11 +66,13 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 
 		checker.checkAndSet(context.Background())
 
-		require.Same(t, update, checker.get())
+		state := checker.get()
+		require.Equal(t, uint64(1), state.Revision)
+		require.Same(t, update, state.Update)
 		event := <-events
 		require.Equal(t, "update", event.Subject)
 		require.Equal(t, action.Replace, event.Action)
-		require.Same(t, update, event.Object)
+		require.Equal(t, state, event.Object)
 	})
 
 	t.Run("no update clears cached update", func(t *testing.T) {
@@ -79,7 +81,8 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 			check: func(context.Context) (*UpdateFile, error) {
 				return nil, nil
 			},
-			latest: &UpdateFile{Description: "old update"},
+			latest:   &UpdateFile{Description: "old update"},
+			revision: 4,
 		}
 		checker.Observe(func(event observable.Event) {
 			events <- event
@@ -87,8 +90,10 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 
 		checker.checkAndSet(context.Background())
 
-		require.Nil(t, checker.get())
-		require.Nil(t, (<-events).Object)
+		state := checker.get()
+		require.Equal(t, uint64(5), state.Revision)
+		require.Nil(t, state.Update)
+		require.Equal(t, state, (<-events).Object)
 	})
 
 	t.Run("error retains cached update", func(t *testing.T) {
@@ -98,7 +103,8 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 			check: func(context.Context) (*UpdateFile, error) {
 				return nil, errors.New("offline")
 			},
-			latest: update,
+			latest:   update,
+			revision: 4,
 		}
 		checker.Observe(func(event observable.Event) {
 			events <- event
@@ -106,7 +112,9 @@ func TestUpdateCheckerCheckAndSet(t *testing.T) {
 
 		checker.checkAndSet(context.Background())
 
-		require.Same(t, update, checker.get())
+		state := checker.get()
+		require.Equal(t, uint64(4), state.Revision)
+		require.Same(t, update, state.Update)
 		select {
 		case event := <-events:
 			t.Fatalf("unexpected event: %+v", event)

--- a/frontends/web/src/api/version.ts
+++ b/frontends/web/src/api/version.ts
@@ -12,16 +12,21 @@ export type TUpdateFile = {
   description: string;
 };
 
+export type TUpdateState = {
+  revision: number;
+  update: TUpdateFile | null;
+};
+
 export const getVersion = (): Promise<string> => {
   return apiGet('version');
 };
 
-export const getUpdate = (): Promise<TUpdateFile | null> => {
+export const getUpdate = (): Promise<TUpdateState> => {
   return apiGet('update');
 };
 
 export const subscribeUpdate = (
-  cb: TSubscriptionCallback<TUpdateFile | null>
+  cb: TSubscriptionCallback<TUpdateState>
 ) => (
   subscribeEndpoint('update', cb)
 );

--- a/frontends/web/src/components/banners/update.test.tsx
+++ b/frontends/web/src/components/banners/update.test.tsx
@@ -3,7 +3,7 @@
 import '../../../__mocks__/i18n';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { TUpdateFile } from '@/api/version';
+import type { TUpdateFile, TUpdateState } from '@/api/version';
 import { Update } from './update';
 
 const versionApiMocks = vi.hoisted(() => ({
@@ -29,14 +29,16 @@ const update: TUpdateFile = {
   version: '4.52.0',
   description: 'A new version is ready.',
 };
+const noUpdateState: TUpdateState = { revision: 0, update: null };
+const updateState: TUpdateState = { revision: 1, update };
 
 describe('components/banners/update', () => {
-  let notifyUpdate: ((update: TUpdateFile | null) => void) | undefined;
+  let notifyUpdate: ((state: TUpdateState) => void) | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
     notifyUpdate = undefined;
-    versionApiMocks.getUpdate.mockResolvedValue(null);
+    versionApiMocks.getUpdate.mockResolvedValue(noUpdateState);
     versionApiMocks.subscribeUpdate.mockImplementation((cb: typeof notifyUpdate) => {
       notifyUpdate = cb;
       return () => {};
@@ -44,7 +46,7 @@ describe('components/banners/update', () => {
   });
 
   it('renders a cached update', async () => {
-    versionApiMocks.getUpdate.mockResolvedValue(update);
+    versionApiMocks.getUpdate.mockResolvedValue(updateState);
 
     render(<Update />);
 
@@ -58,7 +60,7 @@ describe('components/banners/update', () => {
     await waitFor(() => expect(versionApiMocks.subscribeUpdate).toHaveBeenCalledOnce());
     expect(container.firstChild).toBeNull();
 
-    act(() => notifyUpdate?.(update));
+    act(() => notifyUpdate?.(updateState));
 
     expect(screen.getByText(update.description, { exact: false })).toBeInTheDocument();
   });

--- a/frontends/web/src/components/banners/update.tsx
+++ b/frontends/web/src/components/banners/update.tsx
@@ -10,7 +10,7 @@ import style from './update.module.css';
 
 export const Update = () => {
   const { t } = useTranslation();
-  const file = useSync(getUpdate, subscribeUpdate);
+  const file = useSync(getUpdate, subscribeUpdate, state => state.revision)?.update;
   if (!file) {
     return null;
   }

--- a/frontends/web/src/hooks/api.test.ts
+++ b/frontends/web/src/hooks/api.test.ts
@@ -137,5 +137,42 @@ describe('hooks for api calls', () => {
       // and returns it. The returned value should be `subscriptionValue`
       await waitFor(() => expect(result.current).toBe(subscriptionValue));
     });
+
+    it('keeps the response with the highest revision', async () => {
+      type TRevisionedValue = {
+        revision: number;
+        value: string;
+      };
+      const apiValue: TRevisionedValue = { revision: 1, value: 'apiValue' };
+      const subscriptionValue: TRevisionedValue = { revision: 2, value: 'subscriptionValue' };
+      let resolveApiCall: (value: TRevisionedValue) => void = () => {};
+      let subscriptionCallback: TSubscriptionCallback<TRevisionedValue> | undefined;
+      const apiPromise = new Promise<TRevisionedValue>((resolve) => {
+        resolveApiCall = resolve;
+      });
+      const mockApiCall = vi.fn(() => apiPromise);
+      const mockSubscription = vi.fn((callback: TSubscriptionCallback<TRevisionedValue>) => {
+        subscriptionCallback = callback;
+        return () => {};
+      });
+
+      const { result } = renderHook(() => useSync(
+        mockApiCall,
+        mockSubscription,
+        data => data.revision,
+      ));
+
+      act(() => subscriptionCallback?.(subscriptionValue));
+      await waitFor(() => expect(result.current).toBe(subscriptionValue));
+
+      await act(async () => {
+        resolveApiCall(apiValue);
+        await apiPromise;
+      });
+      expect(result.current).toBe(subscriptionValue);
+
+      act(() => subscriptionCallback?.(apiValue));
+      expect(result.current).toBe(subscriptionValue);
+    });
   });
 });

--- a/frontends/web/src/hooks/api.ts
+++ b/frontends/web/src/hooks/api.ts
@@ -82,12 +82,22 @@ export const useLoad = <T>(
 export const useSync = <T>(
   apiCall: () => Promise<T>,
   subscription: ((callback: TSubscriptionCallback<T>) => TUnsubscribe),
+  getRevision?: (data: T) => number,
 ): (T | undefined) => {
   const [response, setResponse] = useState<T>();
   const mounted = useMountedRef();
   const onData = (data: T) => {
     if (mounted.current) {
-      setResponse(data);
+      setResponse((current) => {
+        if (
+          current !== undefined
+          && getRevision !== undefined
+          && getRevision(current) >= getRevision(data)
+        ) {
+          return current;
+        }
+        return data;
+      });
     }
   };
   useEffect(

--- a/frontends/web/src/routes/settings/components/about/app-version-setting.test.tsx
+++ b/frontends/web/src/routes/settings/components/about/app-version-setting.test.tsx
@@ -4,7 +4,7 @@ import '../../../../../__mocks__/i18n';
 import type { ReactNode } from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { TUpdateFile } from '@/api/version';
+import type { TUpdateFile, TUpdateState } from '@/api/version';
 import { AppVersion } from './app-version-setting';
 
 const versionApiMocks = vi.hoisted(() => ({
@@ -43,15 +43,17 @@ const update: TUpdateFile = {
   version: '4.52.0',
   description: 'A new version is ready.',
 };
+const noUpdateState: TUpdateState = { revision: 0, update: null };
+const updateState: TUpdateState = { revision: 1, update };
 
 describe('routes/settings/components/about/app-version-setting', () => {
-  let notifyUpdate: ((update: TUpdateFile | null) => void) | undefined;
+  let notifyUpdate: ((state: TUpdateState) => void) | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
     notifyUpdate = undefined;
     versionApiMocks.getVersion.mockResolvedValue('4.51.3');
-    versionApiMocks.getUpdate.mockResolvedValue(null);
+    versionApiMocks.getUpdate.mockResolvedValue(noUpdateState);
     versionApiMocks.subscribeUpdate.mockImplementation((cb: typeof notifyUpdate) => {
       notifyUpdate = cb;
       return () => {};
@@ -59,7 +61,7 @@ describe('routes/settings/components/about/app-version-setting', () => {
   });
 
   it('renders a cached update', async () => {
-    versionApiMocks.getUpdate.mockResolvedValue(update);
+    versionApiMocks.getUpdate.mockResolvedValue(updateState);
 
     render(<AppVersion />);
 
@@ -74,7 +76,7 @@ describe('routes/settings/components/about/app-version-setting', () => {
     expect(await screen.findByText('settings.info.up-to-date')).toBeInTheDocument();
     await waitFor(() => expect(versionApiMocks.subscribeUpdate).toHaveBeenCalledOnce());
 
-    act(() => notifyUpdate?.(update));
+    act(() => notifyUpdate?.(updateState));
 
     expect(screen.getByText('settings.info.out-of-date')).toBeInTheDocument();
   });

--- a/frontends/web/src/routes/settings/components/about/app-version-setting.tsx
+++ b/frontends/web/src/routes/settings/components/about/app-version-setting.tsx
@@ -13,13 +13,14 @@ export const AppVersion = () => {
   const { t } = useTranslation();
 
   const version = useLoad(getVersion);
-  const update = useSync(getUpdate, subscribeUpdate);
+  const updateState = useSync(getUpdate, subscribeUpdate, state => state.revision);
+  const update = updateState?.update;
 
   const secondaryText = !!update ? t('settings.info.out-of-date') : t('settings.info.up-to-date');
   const icon = !!update ? <RedDot width={8} height={8} /> : <Checked />;
   const versionNumber = !!version ? version : '-';
 
-  if (update === undefined) {
+  if (updateState === undefined) {
     return <StyledSkeleton />;
   }
 


### PR DESCRIPTION
The initial HTTP response and update events can arrive in either order. Without ordering
information, a stale HTTP response can overwrite a newer event, or a stale event can
overwrite a newer HTTP response.

Add revisions to update snapshots and make the Update consumers retain the newest revision.
This is a quick fix scoped to Update only.

A general solution would need to define ordering for every useSync endpoint and would
require a larger refactor of the shared synchronization API and its backend event contracts.