### PR TITLE
events: initialize subscriptions with snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,10 +108,8 @@ Key custom hooks in `src/hooks/` handle all async data:
 
 - **`useLoad(apiCall, deps)`** — Calls a promise, returns `undefined` while loading, re-calls when
   deps change. Always checks `mounted.current` before `setState`.
-- **`useSubscribe(subscription)`** — Subscribes to a WebSocket event, returns `undefined` until the
-  first event. Unsubscribes on unmount.
-- **`useSync(apiCall, subscription)`** — Loads data once via `apiCall`, then stays in sync via
-  `subscription`. Best for data that changes in real time (account status, balance).
+- **`useSubscribe(subscription)`** — Subscribes to a backend value and requests its current snapshot
+  through the event stream. Returns `undefined` until the first event and unsubscribes on unmount.
 - **`useMountedRef()`** — Returns a ref that is `true` while mounted, `false` after unmount. Used
   to guard async `setState` calls.
 - **`useDefault(value, fallback)`** — Returns `fallback` when `value` is `undefined`.

--- a/backend/coins/btc/handlers/handlers.go
+++ b/backend/coins/btc/handlers/handlers.go
@@ -124,18 +124,18 @@ func (handlers *Handlers) ensureAccountInitialized(h func(*http.Request) (interf
 
 // getTxInfoJSON encodes a given transaction in JSON.
 // If `detail` is false, Coin related details, fees and historical fiat amount won't be included.
-func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail bool) Transaction {
-	accountConfig := handlers.account.Config()
+func getTxInfoJSON(account accounts.Interface, txInfo *accounts.TransactionData, detail bool) Transaction {
+	accountConfig := account.Config()
 	var feeString coin.FormattedAmountWithConversions
 	if txInfo.Fee != nil {
-		feeString = txInfo.Fee.FormatWithConversions(handlers.account.Coin(), true, accountConfig.RateUpdater)
+		feeString = txInfo.Fee.FormatWithConversions(account.Coin(), true, accountConfig.RateUpdater)
 	}
-	amount := txInfo.Amount.FormatWithConversions(handlers.account.Coin(), false, accountConfig.RateUpdater)
+	amount := txInfo.Amount.FormatWithConversions(account.Coin(), false, accountConfig.RateUpdater)
 	var formattedTime *string
 	timestamp := txInfo.Timestamp
 
-	deductedAmountAtTime := txInfo.DeductedAmount.FormatWithConversionsAtTime(handlers.account.Coin(), timestamp, accountConfig.RateUpdater)
-	amountAtTime := txInfo.Amount.FormatWithConversionsAtTime(handlers.account.Coin(), timestamp, accountConfig.RateUpdater)
+	deductedAmountAtTime := txInfo.DeductedAmount.FormatWithConversionsAtTime(account.Coin(), timestamp, accountConfig.RateUpdater)
+	amountAtTime := txInfo.Amount.FormatWithConversionsAtTime(account.Coin(), timestamp, accountConfig.RateUpdater)
 
 	if timestamp != nil {
 		t := timestamp.Format(time.RFC3339)
@@ -162,12 +162,12 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 		DeductedAmountAtTime: deductedAmountAtTime,
 		Time:                 formattedTime,
 		Addresses:            addresses,
-		Note:                 handlers.account.TxNote(txInfo.InternalID),
+		Note:                 account.TxNote(txInfo.InternalID),
 		Fee:                  feeString,
 	}
 
 	if detail {
-		switch handlers.account.Coin().(type) {
+		switch account.Coin().(type) {
 		case *btc.Coin:
 			txInfoJSON.VSize = txInfo.VSize
 			txInfoJSON.Size = txInfo.Size
@@ -181,14 +181,15 @@ func (handlers *Handlers) getTxInfoJSON(txInfo *accounts.TransactionData, detail
 	return txInfoJSON
 }
 
-func (handlers *Handlers) getAccountTransactions(*http.Request) (interface{}, error) {
+// Transactions returns an account's current transaction list in its API representation.
+func Transactions(account accounts.Interface) interface{} {
 	var result struct {
 		Success      bool          `json:"success"`
 		Transactions []Transaction `json:"list"`
 	}
-	txs, err := handlers.account.Transactions()
+	txs, err := account.Transactions()
 	if err != nil {
-		return result, nil
+		return result
 	}
 	result.Transactions = []Transaction{}
 	for _, txInfo := range txs {
@@ -196,10 +197,15 @@ func (handlers *Handlers) getAccountTransactions(*http.Request) (interface{}, er
 			// skipping 0 amount erc20 txs to mitigate Address Poisoning attack
 			continue
 		}
-		result.Transactions = append(result.Transactions, handlers.getTxInfoJSON(txInfo, false))
+		txInfoJSON := getTxInfoJSON(account, txInfo, false)
+		result.Transactions = append(result.Transactions, txInfoJSON)
 	}
 	result.Success = true
-	return result, nil
+	return result
+}
+
+func (handlers *Handlers) getAccountTransactions(*http.Request) (interface{}, error) {
+	return Transactions(handlers.account), nil
 }
 
 func (handlers *Handlers) getAccountTransaction(r *http.Request) (interface{}, error) {
@@ -213,7 +219,7 @@ func (handlers *Handlers) getAccountTransaction(r *http.Request) (interface{}, e
 			continue
 		}
 
-		return handlers.getTxInfoJSON(txInfo, true), nil
+		return getTxInfoJSON(handlers.account, txInfo, true), nil
 	}
 	return nil, nil
 }
@@ -574,21 +580,26 @@ type statusResponse struct {
 	FatalError bool `json:"fatalError"`
 }
 
-func (handlers *Handlers) getAccountStatus(*http.Request) (interface{}, error) {
-	if handlers.account == nil {
-		return statusResponse{Disabled: true}, nil
+// Status returns an account's current status in its API representation.
+func Status(account accounts.Interface) interface{} {
+	if account == nil {
+		return statusResponse{Disabled: true}
 	}
-	offlineErr := handlers.account.Offline()
+	offlineErr := account.Offline()
 	var offlineError *string
 	if offlineErr != nil {
 		s := offlineErr.Error()
 		offlineError = &s
 	}
 	return statusResponse{
-		Synced:       handlers.account.Synced(),
+		Synced:       account.Synced(),
 		OfflineError: offlineError,
-		FatalError:   handlers.account.FatalError(),
-	}, nil
+		FatalError:   account.FatalError(),
+	}
+}
+
+func (handlers *Handlers) getAccountStatus(*http.Request) (interface{}, error) {
+	return Status(handlers.account), nil
 }
 
 func (handlers *Handlers) getReceiveAddresses(*http.Request) (interface{}, error) {

--- a/backend/devices/bitbox02/device.go
+++ b/backend/devices/bitbox02/device.go
@@ -87,6 +87,12 @@ func NewDevice(
 				Action:  action.Replace,
 				Object:  device.Device.Status(),
 			})
+		case firmware.EventAttestationCheckDone:
+			device.Notify(observable.Event{
+				Subject: string(ev),
+				Action:  action.Replace,
+				Object:  device.Attestation(),
+			})
 		default:
 			device.Notify(observable.Event{
 				Subject: string(ev),

--- a/backend/devices/bitbox02/handlers/handlers.go
+++ b/backend/devices/bitbox02/handlers/handlers.go
@@ -61,7 +61,6 @@ func NewHandlers(
 ) *Handlers {
 	handlers := &Handlers{log: log.WithField("device", "bitbox02")}
 
-	handleFunc("/status", handlers.getStatusHandler).Methods("GET")
 	handleFunc("/attestation", handlers.getAttestationHandler).Methods("GET")
 	handleFunc("/channel-hash", handlers.getChannelHash).Methods("GET")
 	handleFunc("/channel-hash-verify", handlers.postChannelHashVerify).Methods("POST")
@@ -71,7 +70,6 @@ func NewHandlers(
 	handleFunc("/change-password", handlers.postChangePassword).Methods("POST")
 	handleFunc("/backups/create", handlers.postCreateBackup).Methods("POST")
 	handleFunc("/backups/check", handlers.postCheckBackup).Methods("POST")
-	handleFunc("/backups/list", handlers.getBackupsList).Methods("GET")
 	handleFunc("/backups/restore", handlers.postBackupsRestore).Methods("POST")
 	handleFunc("/check-sdcard", handlers.getCheckSDCard).Methods("GET")
 	handleFunc("/insert-sdcard", handlers.postInsertSDCard).Methods("POST")
@@ -121,13 +119,14 @@ func maybeBB02Err(err error, log *logrus.Entry) bitbox02Response {
 	return result
 }
 
-func (handlers *Handlers) getStatusHandler(_ *http.Request) interface{} {
-	return handlers.device.Status()
+// Attestation returns the result of the device attestation check.
+func (handlers *Handlers) Attestation() interface{} {
+	handlers.log.Debug("Attestation")
+	return handlers.device.Attestation()
 }
 
 func (handlers *Handlers) getAttestationHandler(_ *http.Request) interface{} {
-	handlers.log.Debug("Attestation")
-	return handlers.device.Attestation()
+	return handlers.Attestation()
 }
 
 func (handlers *Handlers) getDeviceInfo(_ *http.Request) interface{} {
@@ -198,7 +197,8 @@ func (handlers *Handlers) postCreateBackup(r *http.Request) interface{} {
 	return bitbox02Response{Success: true}
 }
 
-func (handlers *Handlers) getBackupsList(_ *http.Request) interface{} {
+// Backups returns a device's current backup list in its API representation.
+func Backups(device BitBox02, log *logrus.Entry) interface{} {
 	type backupResponse struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`
@@ -209,10 +209,10 @@ func (handlers *Handlers) getBackupsList(_ *http.Request) interface{} {
 		Backups []backupResponse `json:"backups"`
 	}
 
-	handlers.log.Debug("List backups ")
-	backups, err := handlers.device.ListBackups()
+	log.Debug("List backups ")
+	backups, err := device.ListBackups()
 	if err != nil {
-		return maybeBB02Err(err, handlers.log)
+		return maybeBB02Err(err, log)
 	}
 	sort.Slice(backups, func(i, j int) bool {
 		return backups[i].Time.After(backups[j].Time)

--- a/backend/devices/bitbox02bootloader/handlers/handlers.go
+++ b/backend/devices/bitbox02bootloader/handlers/handlers.go
@@ -35,7 +35,6 @@ func NewHandlers(
 ) *Handlers {
 	handlers := &Handlers{log: log.WithField("device", "bitbox02-bootloader")}
 
-	handleFunc("/status", handlers.getStatusHandler).Methods("GET")
 	handleFunc("/upgrade-firmware", handlers.postUpgradeFirmwareHandler).Methods("POST")
 	handleFunc("/reboot", handlers.postRebootHandler).Methods("POST")
 	handleFunc("/show-firmware-hash-enabled", handlers.getShowFirmwareHashEnabledHandler).Methods("GET")
@@ -67,10 +66,6 @@ type bootloaderResponse struct {
 func (handlers *Handlers) errorResponse(err error) bootloaderResponse {
 	handlers.log.WithError(err).Error("BitBox02 bootloader request failed")
 	return bootloaderResponse{Success: false, ErrorMessage: err.Error()}
-}
-
-func (handlers *Handlers) getStatusHandler(_ *http.Request) interface{} {
-	return handlers.device.Status()
 }
 
 func (handlers *Handlers) postUpgradeFirmwareHandler(_ *http.Request) interface{} {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -133,6 +133,8 @@ type Handlers struct {
 	// that is served, so the client knows where and how to connect to.
 	apiData           *ConnectionData
 	backendEvents     chan interface{}
+	eventQueue        chan queuedEvent
+	snapshots         map[string]func() interface{}
 	websocketUpgrader websocket.Upgrader
 	log               *logrus.Entry
 }
@@ -170,6 +172,8 @@ func NewHandlers(
 		backend:       backend,
 		apiData:       connData,
 		backendEvents: make(chan interface{}, 1000),
+		eventQueue:    make(chan queuedEvent, 1000),
+		snapshots:     map[string]func() interface{}{},
 		websocketUpgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
@@ -177,6 +181,8 @@ func NewHandlers(
 		},
 		log: log,
 	}
+	go handlers.processEvents()
+	handlers.registerSnapshots()
 
 	getAPIRouter := func(subrouter *mux.Router) func(string, func(*http.Request) (interface{}, error)) *mux.Route {
 		return func(path string, f func(*http.Request) (interface{}, error)) *mux.Route {
@@ -201,6 +207,7 @@ func NewHandlers(
 	}
 
 	apiRouter := router.PathPrefix("/api").Subrouter()
+	getAPIRouterNoError(apiRouter)("/events/snapshot", handlers.postEventsSnapshot).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/qr", handlers.getQRCode).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/config", handlers.getAppConfig).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/config/default", handlers.getDefaultConfig).Methods("GET")
@@ -209,9 +216,6 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/number-format", handlers.getNumberFormat).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/notify-user", handlers.postNotify).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/open", handlers.postOpen).Methods("POST")
-	getAPIRouterNoError(apiRouter)("/update", handlers.getUpdate).Methods("GET")
-	getAPIRouterNoError(apiRouter)("/banners/{key}", handlers.getBanners).Methods("GET")
-	getAPIRouterNoError(apiRouter)("/using-mobile-data", handlers.getUsingMobileData).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/authenticate", handlers.postAuthenticate).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/force-auth", handlers.postForceAuth).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/set-dark-theme", handlers.postDarkTheme).Methods("POST")
@@ -220,9 +224,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/testing", handlers.getTesting).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/dev-servers", handlers.getDevServers).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/account-add", handlers.postAddAccount).Methods("POST")
-	getAPIRouterNoError(apiRouter)("/keystores", handlers.getKeystores).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/keystore/{rootFingerprint}/features", handlers.getKeystoreFeatures).Methods("GET")
-	getAPIRouterNoError(apiRouter)("/accounts", handlers.getAccounts).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/swap/accounts", handlers.getSwapAccounts).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/swap/status", handlers.getSwapStatus).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts/balance-summary", handlers.getAccountsBalanceSummary).Methods("GET")
@@ -237,8 +239,6 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/test/deregister", handlers.postDeregisterTestKeystore).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/coins/convert-to-plain-fiat", handlers.getConvertToPlainFiat).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/coins/convert-from-fiat", handlers.getConvertFromFiat).Methods("GET")
-	getAPIRouterNoError(apiRouter)("/coins/{coinCode}/fiat-prices", handlers.getCoinFiatPrices).Methods("GET")
-	getAPIRouterNoError(apiRouter)("/coins/{coinCode}/headers/status", handlers.getHeadersStatus).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/coins/btc/set-unit", handlers.postBtcFormatUnit).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/coins/btc/parse-external-amount", handlers.getBTCParseExternalAmount).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/certs/download", handlers.postCertsDownload).Methods("POST")
@@ -256,7 +256,6 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/market/bitrefill/info/{action}/{code}", handlers.getMarketBitrefillInfo).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/bitsurance/lookup", handlers.postBitsuranceLookup).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/bitsurance/url", handlers.getBitsuranceURL).Methods("GET")
-	getAPIRouterNoError(apiRouter)("/aopp", handlers.getAOPP).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/aopp/cancel", handlers.postAOPPCancel).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/aopp/approve", handlers.postAOPPApprove).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/aopp/choose-account", handlers.postAOPPChooseAccount).Methods("POST")
@@ -270,10 +269,8 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/notes/export", handlers.postExportNotes).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/notes/import", handlers.postImportNotes).Methods("POST")
 
-	getAPIRouterNoError(apiRouter)("/bluetooth/state", handlers.getBluetoothState).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/bluetooth/connect", handlers.postBluetoothConnect).Methods("POST")
 
-	getAPIRouterNoError(apiRouter)("/online", handlers.getOnline).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/keystore/show-backup-banner/{rootFingerprint}", handlers.getKeystoreShowBackupBanner).Methods("GET")
 
 	devicesRouter := getAPIRouterNoError(apiRouter.PathPrefix("/devices").Subrouter())
@@ -358,10 +355,10 @@ func NewHandlers(
 	events := backend.Start()
 	go func() {
 		for {
-			handlers.backendEvents <- <-events
+			handlers.pushEvent(<-events)
 		}
 	}()
-	backend.Observe(func(event observable.Event) { handlers.backendEvents <- event })
+	backend.Observe(func(event observable.Event) { handlers.pushEvent(event) })
 
 	return handlers
 }
@@ -610,18 +607,6 @@ func (handlers *Handlers) postOpen(r *http.Request) interface{} {
 	return response{Success: true}
 }
 
-func (handlers *Handlers) getUpdate(*http.Request) interface{} {
-	return handlers.backend.GetUpdate()
-}
-
-func (handlers *Handlers) getBanners(r *http.Request) interface{} {
-	return handlers.backend.Banners().GetMessage(banners.MessageKey(mux.Vars(r)["key"]))
-}
-
-func (handlers *Handlers) getUsingMobileData(r *http.Request) interface{} {
-	return handlers.backend.Environment().UsingMobileData()
-}
-
 func (handlers *Handlers) postAuthenticate(r *http.Request) interface{} {
 	type response struct {
 		Success      bool   `json:"success"`
@@ -705,7 +690,7 @@ func (handlers *Handlers) postAddAccount(r *http.Request) interface{} {
 	return response{Success: true, AccountCode: accountCode}
 }
 
-func (handlers *Handlers) getKeystores(*http.Request) interface{} {
+func (handlers *Handlers) keystores() interface{} {
 	type json struct {
 		Type keystore.Type `json:"type"`
 	}
@@ -769,7 +754,7 @@ func (handlers *Handlers) getKeystoreFeatures(r *http.Request) interface{} {
 	}
 }
 
-func (handlers *Handlers) getAccounts(*http.Request) interface{} {
+func (handlers *Handlers) accounts() interface{} {
 	persistedAccounts := handlers.backend.Config().AccountsConfig()
 
 	accounts := []*accountJSON{}
@@ -1115,8 +1100,8 @@ func (handlers *Handlers) getConvertToPlainFiat(r *http.Request) interface{} {
 	}
 }
 
-func (handlers *Handlers) getCoinFiatPrices(r *http.Request) interface{} {
-	coin, err := handlers.backend.Coin(coinpkg.Code(mux.Vars(r)["coinCode"]))
+func (handlers *Handlers) coinFiatPrices(coinCode coinpkg.Code) interface{} {
+	coin, err := handlers.backend.Coin(coinCode)
 	if err != nil {
 		return nil
 	}
@@ -1164,14 +1149,13 @@ func (handlers *Handlers) getConvertFromFiat(r *http.Request) interface{} {
 	}
 }
 
-func (handlers *Handlers) getHeadersStatus(r *http.Request) interface{} {
+func (handlers *Handlers) headersStatus(coinCode coinpkg.Code) interface{} {
 	type response struct {
 		Success      bool            `json:"success"`
 		ErrorMessage string          `json:"errorMessage,omitempty"`
 		Status       *headers.Status `json:"status,omitempty"`
 	}
 
-	coinCode := coinpkg.Code(mux.Vars(r)["coinCode"])
 	switch coinCode {
 	case coinpkg.CodeBTC, coinpkg.CodeTBTC, coinpkg.CodeLTC, coinpkg.CodeTLTC:
 	default:
@@ -1182,7 +1166,11 @@ func (handlers *Handlers) getHeadersStatus(r *http.Request) interface{} {
 	if err != nil {
 		return response{Success: false, ErrorMessage: err.Error()}
 	}
-	status, err := coin.(*btc.Coin).Headers().Status()
+	btcCoin := coin.(*btc.Coin)
+	if btcCoin.Headers() == nil {
+		return response{Success: false, ErrorMessage: "coin headers not initialized"}
+	}
+	status, err := btcCoin.Headers().Status()
 	if err != nil {
 		return response{Success: false, ErrorMessage: err.Error()}
 	}
@@ -1672,7 +1660,7 @@ func (handlers *Handlers) getMarketBitrefillInfo(r *http.Request) interface{} {
 	}
 }
 
-func (handlers *Handlers) getAOPP(r *http.Request) interface{} {
+func (handlers *Handlers) aopp() interface{} {
 	return handlers.backend.AOPP()
 }
 
@@ -1793,10 +1781,6 @@ func (handlers *Handlers) postImportNotes(r *http.Request) interface{} {
 	return result{Success: true, Data: data}
 }
 
-func (handlers *Handlers) getBluetoothState(r *http.Request) interface{} {
-	return handlers.backend.Bluetooth().State()
-}
-
 func (handlers *Handlers) postBluetoothConnect(r *http.Request) interface{} {
 	var identifier string
 	if err := json.NewDecoder(r.Body).Decode(&identifier); err != nil {
@@ -1806,10 +1790,6 @@ func (handlers *Handlers) postBluetoothConnect(r *http.Request) interface{} {
 
 	handlers.backend.Environment().BluetoothConnect(identifier)
 	return nil
-}
-
-func (handlers *Handlers) getOnline(r *http.Request) interface{} {
-	return handlers.backend.IsOnline()
 }
 
 func (handlers *Handlers) getKeystoreShowBackupBanner(r *http.Request) interface{} {

--- a/backend/handlers/handlers_test.go
+++ b/backend/handlers/handlers_test.go
@@ -8,11 +8,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/arguments"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/usb"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/handlers"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/test"
 	"github.com/gorilla/mux"
 )
@@ -80,6 +83,54 @@ func TestGetNativeLocale(t *testing.T) {
 	test.DecodeHandlerResponse(t, &locale, res.Body)
 	if locale != ptLocale {
 		t.Errorf("locale = %q; want %q", locale, ptLocale)
+	}
+}
+
+func TestEventSnapshot(t *testing.T) {
+	args := arguments.NewArguments(
+		test.TstTempDir("eventsnapshot"),
+		true,
+		false,
+		true,
+		nil,
+	)
+	back, err := backend.NewBackend(args, &backendEnv{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer back.Close()
+
+	h := handlers.NewHandlers(back, handlers.NewConnectionData(0, ""))
+	r := httptest.NewRequest(http.MethodPost, "/api/events/snapshot", strings.NewReader(`"online"`))
+	w := httptest.NewRecorder()
+	h.Router.ServeHTTP(w, r)
+	res := w.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("res.StatusCode = %d; want %d", res.StatusCode, http.StatusOK)
+	}
+	var response struct {
+		Success bool `json:"success"`
+	}
+	test.DecodeHandlerResponse(t, &response, res.Body)
+	if !response.Success {
+		t.Fatal("snapshot request was not successful")
+	}
+
+	timeout := time.After(time.Second)
+	for {
+		select {
+		case value := <-h.Events():
+			event, ok := value.(observable.Event)
+			if !ok || event.Subject != "online" {
+				continue
+			}
+			if event.Action != action.Replace || event.Object != true {
+				t.Fatalf("unexpected snapshot event: %#v", event)
+			}
+			return
+		case <-timeout:
+			t.Fatal("timed out waiting for snapshot event")
+		}
 	}
 }
 

--- a/backend/handlers/snapshots.go
+++ b/backend/handlers/snapshots.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/banners"
+	accountHandlers "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc/handlers"
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/bitbox02"
+	bitbox02Handlers "github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/bitbox02/handlers"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/devices/bitbox02bootloader"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
+)
+
+type queuedEvent struct {
+	value           interface{}
+	snapshotSubject string
+	snapshotResult  chan bool
+}
+
+func (handlers *Handlers) registerSnapshots() {
+	handlers.registerSnapshot("accounts", func() interface{} {
+		return handlers.accounts()
+	})
+	handlers.registerSnapshot("aopp", func() interface{} {
+		return handlers.aopp()
+	})
+	handlers.registerSnapshot("bluetooth/state", func() interface{} {
+		return handlers.backend.Bluetooth().State()
+	})
+	handlers.registerSnapshot("devices/registered", func() interface{} {
+		return handlers.getDevicesRegistered(nil)
+	})
+	handlers.registerSnapshot("keystores", func() interface{} {
+		return handlers.keystores()
+	})
+	handlers.registerSnapshot("online", func() interface{} {
+		return handlers.backend.IsOnline()
+	})
+	handlers.registerSnapshot("update", func() interface{} {
+		return handlers.backend.GetUpdate()
+	})
+	handlers.registerSnapshot("using-mobile-data", func() interface{} {
+		return handlers.backend.Environment().UsingMobileData()
+	})
+	for _, key := range []banners.MessageKey{
+		banners.KeyBitBox01,
+		banners.KeyBitBox02,
+		banners.KeyBitBox02Nova,
+	} {
+		handlers.registerSnapshot("banners/"+string(key), func() interface{} {
+			return handlers.backend.Banners().GetMessage(key)
+		})
+	}
+}
+
+func (handlers *Handlers) registerSnapshot(subject string, snapshot func() interface{}) {
+	handlers.snapshots[subject] = snapshot
+}
+
+func (handlers *Handlers) snapshot(subject string) (interface{}, bool) {
+	snapshot, ok := handlers.snapshots[subject]
+	if ok {
+		return snapshot(), true
+	}
+
+	parts := strings.Split(subject, "/")
+	if len(parts) == 3 && parts[0] == "account" {
+		for _, account := range handlers.backend.Accounts() {
+			if string(account.Config().Config.Code) != parts[1] {
+				continue
+			}
+			switch parts[2] {
+			case "status":
+				return accountHandlers.Status(account), true
+			case "transactions":
+				return accountHandlers.Transactions(account), true
+			}
+		}
+		return nil, false
+	}
+	if len(parts) == 3 && parts[0] == "coins" && parts[2] == "fiat-prices" {
+		return handlers.coinFiatPrices(coinpkg.Code(parts[1])), true
+	}
+	if len(parts) == 4 && parts[0] == "coins" && parts[2] == "headers" && parts[3] == "status" {
+		return handlers.headersStatus(coinpkg.Code(parts[1])), true
+	}
+	if len(parts) >= 4 && parts[0] == "devices" {
+		device, ok := handlers.backend.DevicesRegistered()[parts[2]]
+		if !ok {
+			return nil, false
+		}
+		switch parts[1] {
+		case bitbox02.PlatformName:
+			device, ok := device.(*bitbox02.Device)
+			if !ok {
+				return nil, false
+			}
+			switch {
+			case len(parts) == 4 && parts[3] == "status":
+				return device.Status(), true
+			case len(parts) == 4 && parts[3] == "attestationCheckDone":
+				return device.Attestation(), true
+			case len(parts) == 5 && parts[3] == "backups" && parts[4] == "list":
+				return bitbox02Handlers.Backups(device, handlers.log), true
+			}
+		case bitbox02bootloader.ProductName:
+			device, ok := device.(*bitbox02bootloader.Device)
+			if ok && len(parts) == 4 && parts[3] == "status" {
+				return device.Status(), true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (handlers *Handlers) pushEvent(value interface{}) {
+	handlers.eventQueue <- queuedEvent{value: value}
+}
+
+func (handlers *Handlers) pushSnapshot(subject string) bool {
+	result := make(chan bool)
+	handlers.eventQueue <- queuedEvent{
+		snapshotSubject: subject,
+		snapshotResult:  result,
+	}
+	return <-result
+}
+
+// processEvents puts initial snapshots and live updates on one ordered stream. Reload snapshots
+// are resolved here, after the producer has released any locks held while emitting the event.
+func (handlers *Handlers) processEvents() {
+	for queued := range handlers.eventQueue {
+		if queued.snapshotResult != nil {
+			snapshot, ok := handlers.snapshot(queued.snapshotSubject)
+			if ok {
+				handlers.backendEvents <- observable.Event{
+					Subject: queued.snapshotSubject,
+					Action:  action.Replace,
+					Object:  snapshot,
+				}
+			}
+			queued.snapshotResult <- ok
+			continue
+		}
+
+		value := queued.value
+		event, ok := value.(observable.Event)
+		if ok && event.Action == action.Reload {
+			snapshot, found := handlers.snapshot(event.Subject)
+			if !found {
+				handlers.log.WithField("subject", event.Subject).Error("missing event snapshot")
+				continue
+			}
+			event.Action = action.Replace
+			event.Object = snapshot
+			value = event
+		}
+		handlers.backendEvents <- value
+	}
+}
+
+func (handlers *Handlers) postEventsSnapshot(r *http.Request) interface{} {
+	var subject string
+	if err := json.NewDecoder(r.Body).Decode(&subject); err != nil {
+		return struct {
+			Success bool `json:"success"`
+		}{Success: false}
+	}
+	return struct {
+		Success bool `json:"success"`
+	}{Success: handlers.pushSnapshot(subject)}
+}

--- a/backend/handlers/snapshots_test.go
+++ b/backend/handlers/snapshots_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func newSnapshotTestHandlers() *Handlers {
+	handlers := &Handlers{
+		backendEvents: make(chan interface{}, 10),
+		eventQueue:    make(chan queuedEvent, 10),
+		snapshots:     map[string]func() interface{}{},
+		log:           logrus.NewEntry(logrus.New()),
+	}
+	go handlers.processEvents()
+	return handlers
+}
+
+func TestInitialSnapshotAndEventsAreOrdered(t *testing.T) {
+	handlers := newSnapshotTestHandlers()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	handlers.registerSnapshot("state", func() interface{} {
+		close(started)
+		<-release
+		return "initial"
+	})
+
+	result := make(chan bool)
+	go func() {
+		result <- handlers.pushSnapshot("state")
+	}()
+	<-started
+	handlers.pushEvent(observable.Event{
+		Subject: "state",
+		Action:  action.Replace,
+		Object:  "updated",
+	})
+	close(release)
+
+	require.True(t, <-result)
+	require.Equal(t, observable.Event{
+		Subject: "state",
+		Action:  action.Replace,
+		Object:  "initial",
+	}, <-handlers.backendEvents)
+	require.Equal(t, observable.Event{
+		Subject: "state",
+		Action:  action.Replace,
+		Object:  "updated",
+	}, <-handlers.backendEvents)
+}
+
+func TestReloadEventIsReplacedWithSnapshot(t *testing.T) {
+	handlers := newSnapshotTestHandlers()
+	handlers.registerSnapshot("state", func() interface{} { return "current" })
+
+	handlers.pushEvent(observable.Event{
+		Subject: "state",
+		Action:  action.Reload,
+	})
+
+	require.Equal(t, observable.Event{
+		Subject: "state",
+		Action:  action.Replace,
+		Object:  "current",
+	}, <-handlers.backendEvents)
+}
+
+func TestUnknownSnapshot(t *testing.T) {
+	handlers := newSnapshotTestHandlers()
+	require.False(t, handlers.pushSnapshot("unknown"))
+}

--- a/frontends/web/src/api/account.ts
+++ b/frontends/web/src/api/account.ts
@@ -60,10 +60,6 @@ export type TAccount = TAccountBase & {
   accountNumber?: number;
 };
 
-export const getAccounts = (): Promise<TAccount[]> => {
-  return apiGet('accounts');
-};
-
 export type CoinFormattedAmount = {
   coinCode: CoinCode;
   coinName: string;

--- a/frontends/web/src/api/accountsync.ts
+++ b/frontends/web/src/api/accountsync.ts
@@ -2,7 +2,7 @@
 
 import type { TUnsubscribe } from '@/utils/transport-common';
 import type { AccountCode, TAccount, TStatus, TTransactions } from './account';
-import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
+import { TSubscriptionCallback, subscribeEndpoint, subscribeEvent } from './subscribe';
 
 /**
  * Subscribes the given function on the "account" event and receives the
@@ -24,13 +24,12 @@ export const syncAddressesCount = (code: AccountCode) => {
   return (
     cb: TSubscriptionCallback<number>
   ) => {
-    return subscribeEndpoint(`account/${code}/synced-addresses-count`, cb);
+    return subscribeEvent(`account/${code}/synced-addresses-count`, cb);
   };
 };
 
 /**
- * Fired when status of an account changed, mostly
- * used as event to call accountAPI.getStatus(code).
+ * Sends the current account status and fires whenever it changes.
  * Returns a method to unsubscribe.
  */
 export const statusChanged = (
@@ -48,7 +47,7 @@ export const syncdone = (
   code: AccountCode,
   cb: () => void,
 ): TUnsubscribe => {
-  return subscribeEndpoint(`account/${code}/sync-done`, cb);
+  return subscribeEvent(`account/${code}/sync-done`, cb);
 };
 
 /**

--- a/frontends/web/src/api/aopp.ts
+++ b/frontends/web/src/api/aopp.ts
@@ -3,7 +3,7 @@
 import type { AccountCode } from './account';
 import type { TUnsubscribe } from '@/utils/transport-common';
 import type { NonEmptyArray } from '@/utils/types';
-import { apiGet, apiPost } from '@/utils/request';
+import { apiPost } from '@/utils/request';
 import { subscribeEndpoint } from './subscribe';
 
 type TAccount = {
@@ -56,10 +56,6 @@ type TChooseAccountResponse = {
 
 export const chooseAccount = (accountCode: AccountCode): Promise<TChooseAccountResponse> => {
   return apiPost('aopp/choose-account', { accountCode });
-};
-
-export const getAOPP = (): Promise<Aopp> => {
-  return apiGet('aopp');
 };
 
 export const subscribeAOPP = (

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -4,7 +4,7 @@ import type { AccountCode, CoinCode, ScriptType } from './account';
 import type { ERC20CoinCode } from './erc20';
 import type { FailResponse, SuccessResponse } from './response';
 import { apiGet, apiPost } from '@/utils/request';
-import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
+import { TSubscriptionCallback, subscribeEvent } from './subscribe';
 
 export type TCoin = {
   coinCode: CoinCode;
@@ -96,7 +96,7 @@ export const syncConnectKeystore = () => {
   return (
     cb: TSubscriptionCallback<TSyncConnectKeystore>
   ) => {
-    return subscribeEndpoint('connect-keystore', (
+    return subscribeEvent('connect-keystore', (
       obj: TSyncConnectKeystore,
     ) => {
       cb(obj);
@@ -130,7 +130,7 @@ export type TAuthEventObject = {
 export const subscribeAuth = (
   cb: TSubscriptionCallback<TAuthEventObject>
 ) => (
-  subscribeEndpoint('auth', cb)
+  subscribeEvent('auth', cb)
 );
 
 export const onAuthSettingChanged = (): Promise<void> => {

--- a/frontends/web/src/api/backup.ts
+++ b/frontends/web/src/api/backup.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { FailResponse } from './response';
-import { apiGet } from '@/utils/request';
 import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
 
 export type Backup = {
@@ -15,14 +14,8 @@ type BackupResponse = {
   backups: Backup[];
 };
 
-export const getBackupList = (
-  deviceID: string
-): Promise<BackupResponse | FailResponse> => {
-  return apiGet(`devices/bitbox02/${deviceID}/backups/list`);
-};
-
 export const subscribeBackupList = (deviceID: string) => (
-  (cb: TSubscriptionCallback<BackupResponse>) => (
+  (cb: TSubscriptionCallback<BackupResponse | FailResponse>) => (
     subscribeEndpoint(`devices/bitbox02/${deviceID}/backups/list`, cb)
   )
 );

--- a/frontends/web/src/api/banners.ts
+++ b/frontends/web/src/api/banners.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { TMessageTypes } from '@/utils/types';
-import { apiGet } from '@/utils/request';
 import { subscribeEndpoint, TUnsubscribe } from './subscribe';
 
 export type TBannerInfo = {
@@ -13,10 +12,6 @@ export type TBannerInfo = {
   };
   dismissible?: boolean;
   type?: TMessageTypes;
-};
-
-export const getBanner = (msgKey: string): Promise<TBannerInfo> => {
-  return apiGet(`banners/${msgKey}`);
 };
 
 export const syncBanner = (

--- a/frontends/web/src/api/bitbox02.ts
+++ b/frontends/web/src/api/bitbox02.ts
@@ -3,7 +3,7 @@
 import type { TUnsubscribe } from '@/utils/transport-common';
 import type { SuccessResponse, FailResponse } from './response';
 import { apiGet, apiPost } from '@/utils/request';
-import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
+import { TSubscriptionCallback, subscribeEndpoint, subscribeEvent } from './subscribe';
 
 // BitBox02 error codes.
 export const errUserAbort = 104;
@@ -140,10 +140,6 @@ export type TStatus = 'connected'
   | 'unpaired'
   | 'uninitialized';
 
-export const getStatus = (deviceID: string): Promise<TStatus> => {
-  return apiGet(`devices/bitbox02/${deviceID}/status`);
-};
-
 type TChannelHash = {
   hash: string;
   deviceVerified: boolean;
@@ -200,7 +196,7 @@ export const channelHashChanged = (
   deviceID: string,
   cb: () => void,
 ): TUnsubscribe => {
-  return subscribeEndpoint(`devices/bitbox02/${deviceID}/channelHashChanged`, cb);
+  return subscribeEvent(`devices/bitbox02/${deviceID}/channelHashChanged`, cb);
 };
 
 /**
@@ -209,7 +205,7 @@ export const channelHashChanged = (
  */
 export const attestationCheckDone = (
   deviceID: string,
-  cb: () => void,
+  cb: TSubscriptionCallback<boolean | null>,
 ): TUnsubscribe => {
   return subscribeEndpoint(`devices/bitbox02/${deviceID}/attestationCheckDone`, cb);
 };

--- a/frontends/web/src/api/bitbox02bootloader.ts
+++ b/frontends/web/src/api/bitbox02bootloader.ts
@@ -21,12 +21,6 @@ export type TStatus = {
   additionalUpgradeFollows: boolean;
 };
 
-export const getStatus = (
-  deviceID: string,
-): Promise<TStatus> => {
-  return apiGet(`devices/bitbox02-bootloader/${deviceID}/status`);
-};
-
 export const syncStatus = (deviceID: string) => {
   return (
     cb: TSubscriptionCallback<TStatus>

--- a/frontends/web/src/api/bluetooth.ts
+++ b/frontends/web/src/api/bluetooth.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { apiGet, apiPost } from '@/utils/request';
+import { apiPost } from '@/utils/request';
 import { subscribeEndpoint, TUnsubscribe } from './subscribe';
 
 export type TPeripheral = {
@@ -20,10 +20,6 @@ type TBluetoothState = {
   bluetoothUnauthorized: boolean;
   scanning: boolean;
   peripherals: TPeripheral[];
-};
-
-export const getState = (): Promise<TBluetoothState> => {
-  return apiGet('bluetooth/state');
 };
 
 export const connect = (identifier: string): Promise<void> => {

--- a/frontends/web/src/api/coins.ts
+++ b/frontends/web/src/api/coins.ts
@@ -90,10 +90,6 @@ type TCoinFiatPrices = {
   estimated: boolean;
 } | null;
 
-export const getCoinFiatPrices = (coinCode: CoinCode): Promise<TCoinFiatPrices> => {
-  return apiGet(`coins/${coinCode}/fiat-prices`);
-};
-
 export const subscribeCoinFiatPrices = (coinCode: CoinCode) => (
   (cb: TSubscriptionCallback<TCoinFiatPrices>): TUnsubscribe => (
     subscribeEndpoint(`coins/${coinCode}/fiat-prices`, cb)

--- a/frontends/web/src/api/devicessync.ts
+++ b/frontends/web/src/api/devicessync.ts
@@ -5,7 +5,7 @@ import { subscribeEndpoint, TSubscriptionCallback, TUnsubscribe } from './subscr
 
 /**
  * Subscribes the given function on the "devices/registered" event
- * and receives a list of all available accounts from the backend.
+ * and receives a list of all available devices from the backend.
  * Returns a method to unsubscribe.
  */
 export const syncDeviceList = (

--- a/frontends/web/src/api/keystores.ts
+++ b/frontends/web/src/api/keystores.ts
@@ -24,10 +24,6 @@ export const subscribeKeystores = (
   return subscribeEndpoint('keystores', cb);
 };
 
-export const getKeystores = (): Promise<TKeystores> => {
-  return apiGet('keystores');
-};
-
 export type TTestKeystoreEdition = 'btc-only' | 'multi';
 
 type TRegisterTestResponse = {

--- a/frontends/web/src/api/mobiledata.ts
+++ b/frontends/web/src/api/mobiledata.ts
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { apiGet } from '@/utils/request';
 import { subscribeEndpoint, TSubscriptionCallback } from './subscribe';
-
-export const getUsingMobileData = (): Promise<boolean> => {
-  return apiGet('using-mobile-data');
-};
 
 export const subscribeUsingMobileData = (
   cb: TSubscriptionCallback<boolean>

--- a/frontends/web/src/api/online.ts
+++ b/frontends/web/src/api/online.ts
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { apiGet } from '@/utils/request';
 import { subscribeEndpoint, TSubscriptionCallback } from './subscribe';
-
-export const getOnline = (): Promise<boolean> => {
-  return apiGet('online');
-};
 
 export const subscribeOnline = (
   cb: TSubscriptionCallback<boolean>

--- a/frontends/web/src/api/subscribe.test.ts
+++ b/frontends/web/src/api/subscribe.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TEvent } from '@/utils/event';
+import { subscribeEndpoint, subscribeEvent } from './subscribe';
+
+const mocks = vi.hoisted(() => ({
+  apiPost: vi.fn(),
+  apiSubscribe: vi.fn(),
+  unsubscribe: vi.fn(),
+}));
+
+vi.mock('@/utils/request', () => ({ apiPost: mocks.apiPost }));
+vi.mock('@/utils/event', () => ({ apiSubscribe: mocks.apiSubscribe }));
+
+describe('subscribeEndpoint', () => {
+  let receiveEvent: ((event: TEvent) => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    receiveEvent = undefined;
+    mocks.apiPost.mockResolvedValue({ success: true });
+    mocks.apiSubscribe.mockImplementation((_subject, observer) => {
+      receiveEvent = observer;
+      return mocks.unsubscribe;
+    });
+  });
+
+  it('requests an initial snapshot and forwards replacement events', () => {
+    const callback = vi.fn();
+    const unsubscribe = subscribeEndpoint('online', callback);
+
+    expect(mocks.apiSubscribe).toHaveBeenCalledWith('online', expect.any(Function));
+    expect(mocks.apiPost).toHaveBeenCalledWith('events/snapshot', 'online');
+
+    receiveEvent?.({ subject: 'online', action: 'replace', object: true });
+
+    expect(callback).toHaveBeenCalledWith(true);
+    expect(unsubscribe).toBe(mocks.unsubscribe);
+  });
+
+  it('does not request snapshots for transient events', () => {
+    subscribeEvent('new-txs', vi.fn());
+
+    expect(mocks.apiSubscribe).toHaveBeenCalledWith('new-txs', expect.any(Function));
+    expect(mocks.apiPost).not.toHaveBeenCalled();
+  });
+});

--- a/frontends/web/src/api/subscribe.ts
+++ b/frontends/web/src/api/subscribe.ts
@@ -1,17 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { apiSubscribe, TEvent, TUnsubscribe } from '@/utils/event';
-import { apiGet } from '@/utils/request';
+import { apiPost } from '@/utils/request';
 
 export type { TUnsubscribe };
 
 export type TSubscriptionCallback<T> = (eventObject: T) => void;
 
-/**
- * Subscribes the given function on an endpoint on which the backend
- * can push data through. This should be mostly used within api.
- */
-export const subscribeEndpoint = <T>(
+const observeEndpoint = <T>(
   endpoint: string,
   cb: TSubscriptionCallback<T>,
 ): TUnsubscribe => {
@@ -20,17 +16,32 @@ export const subscribeEndpoint = <T>(
     case 'replace':
       cb(event.object);
       break;
-    case 'reload':
-      // TODO: backend should push data with "replace" and not use "reload"
-      apiGet(event.subject)
-        .then(object => cb(object))
-        .catch(console.error);
-      break;
     default:
       throw new Error(`Event: ${JSON.stringify(event)} not supported`);
     }
   });
 };
+
+/**
+ * Subscribes to a backend value and requests its current snapshot through the
+ * same ordered event stream as live replacements.
+ */
+export const subscribeEndpoint = <T>(
+  endpoint: string,
+  cb: TSubscriptionCallback<T>,
+): TUnsubscribe => {
+  const unsubscribe = observeEndpoint(endpoint, cb);
+  apiPost('events/snapshot', endpoint).catch(console.error);
+  return unsubscribe;
+};
+
+/**
+ * Subscribes to transient backend events that do not have an initial snapshot.
+ */
+export const subscribeEvent = <T>(
+  endpoint: string,
+  cb: TSubscriptionCallback<T>,
+): TUnsubscribe => observeEndpoint(endpoint, cb);
 
 /**
  * Subscribes the given function to the backend/connected event.
@@ -41,5 +52,5 @@ export const subscribeEndpoint = <T>(
 export const backendConnected = (
   cb: (connected: boolean) => void
 ): TUnsubscribe => {
-  return subscribeEndpoint('backend/connected', cb);
+  return subscribeEvent('backend/connected', cb);
 };

--- a/frontends/web/src/api/transactions.ts
+++ b/frontends/web/src/api/transactions.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { TUnsubscribe } from '@/utils/transport-common';
-import { TSubscriptionCallback, subscribeEndpoint } from './subscribe';
+import { TSubscriptionCallback, subscribeEvent } from './subscribe';
 
 export type TNewTxs = {
   count: number;
@@ -9,5 +9,5 @@ export type TNewTxs = {
 };
 
 export const syncNewTxs = (cb: TSubscriptionCallback<TNewTxs>): TUnsubscribe => {
-  return subscribeEndpoint('new-txs', cb);
+  return subscribeEvent('new-txs', cb);
 };

--- a/frontends/web/src/api/version.ts
+++ b/frontends/web/src/api/version.ts
@@ -16,10 +16,6 @@ export const getVersion = (): Promise<string> => {
   return apiGet('version');
 };
 
-export const getUpdate = (): Promise<TUpdateFile | null> => {
-  return apiGet('update');
-};
-
 export const subscribeUpdate = (
   cb: TSubscriptionCallback<TUpdateFile | null>
 ) => (

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, Fragment } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useSync } from './hooks/api';
+import { useSubscribe } from './hooks/api';
 import { useDefault } from './hooks/default';
 import { usePrevious } from './hooks/previous';
 import { useIgnoreDrop } from './hooks/drop';
@@ -11,9 +11,7 @@ import { usePlatformClass } from './hooks/platform';
 import { useAppReady } from './hooks/appready';
 import { AppRouter } from './routes/router';
 import { Wizard as BitBox02Wizard } from './routes/device/bitbox02/wizard';
-import { getAccounts } from './api/account';
 import { syncAccountsList } from './api/accountsync';
-import { getDeviceList } from './api/devices';
 import { syncDeviceList } from './api/devicessync';
 import { syncNewTxs } from './api/transactions';
 import { notifyUser } from './api/system';
@@ -40,8 +38,8 @@ export const App = () => {
   useIgnoreDrop();
   useAppReady();
 
-  const accounts = useDefault(useSync(getAccounts, syncAccountsList), []);
-  const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});
+  const accounts = useDefault(useSubscribe(syncAccountsList), []);
+  const devices = useDefault(useSubscribe(syncDeviceList), {});
   const prevDevices = usePrevious(devices);
 
   const deviceIDs = Object.keys(devices);

--- a/frontends/web/src/components/aopp/aopp.tsx
+++ b/frontends/web/src/components/aopp/aopp.tsx
@@ -11,6 +11,7 @@ import { Message } from '@/components/message/message';
 import { Button, Field, Label, Select } from '@/components/forms';
 import { CopyableInput } from '@/components/copy/Copy';
 import { PointToBitBox02 } from '@/components/icon';
+import { useSubscribe } from '@/hooks/api';
 import { VerifyAddress } from './verifyaddress';
 import { Vasp } from './vasp';
 import styles from './aopp.module.css';
@@ -29,14 +30,9 @@ export const Aopp = () => {
   const { t } = useTranslation();
 
   const [accountCode, setAccountCode] = useState<accountAPI.AccountCode>('');
-  const [aopp, setAopp] = useState<aoppAPI.Aopp>();
+  const aopp = useSubscribe(aoppAPI.subscribeAOPP);
 
   const [prevAopp, setPrevAopp] = useState(aopp);
-
-  useEffect(() => {
-    aoppAPI.getAOPP().then(setAopp);
-    return aoppAPI.subscribeAOPP(setAopp);
-  }, []);
 
   useEffect(() => {
     if (aopp !== prevAopp) {

--- a/frontends/web/src/components/banners/banner.tsx
+++ b/frontends/web/src/components/banners/banner.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getBanner, syncBanner, TBannerInfo } from '@/api/banners';
+import { syncBanner, TBannerInfo } from '@/api/banners';
+import { useSubscribe } from '@/hooks/api';
 import { Status } from '@/components/status/status';
 import { A } from '@/components/anchor/anchor';
 import style from './banner.module.css';
@@ -14,12 +14,7 @@ type TBannerProps = {
 export const Banner = ({ msgKey }: TBannerProps) => {
   const { i18n, t } = useTranslation();
   const { fallbackLng } = i18n.options;
-  const [banner, setBanner] = useState<TBannerInfo>();
-
-  useEffect(() => {
-    getBanner(msgKey).then(setBanner);
-    syncBanner(msgKey, setBanner);
-  }, [msgKey]);
+  const banner = useSubscribe<TBannerInfo>(cb => syncBanner(msgKey, cb));
 
   if (
     !banner

--- a/frontends/web/src/components/banners/mobiledatawarning.tsx
+++ b/frontends/web/src/components/banners/mobiledatawarning.tsx
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useTranslation } from 'react-i18next';
-import { useSync } from '@/hooks/api';
-import { getUsingMobileData, subscribeUsingMobileData } from '@/api/mobiledata';
+import { useSubscribe } from '@/hooks/api';
+import { subscribeUsingMobileData } from '@/api/mobiledata';
 import { Status } from '@/components/status/status';
 
 export const MobileDataWarning = () => {
   const { t } = useTranslation();
-  const isUsingMobileData = useSync(getUsingMobileData, subscribeUsingMobileData);
+  const isUsingMobileData = useSubscribe(subscribeUsingMobileData);
   if (isUsingMobileData === undefined) {
     return null;
   }

--- a/frontends/web/src/components/banners/update.test.tsx
+++ b/frontends/web/src/components/banners/update.test.tsx
@@ -7,7 +7,6 @@ import type { TUpdateFile } from '@/api/version';
 import { Update } from './update';
 
 const versionApiMocks = vi.hoisted(() => ({
-  getUpdate: vi.fn(),
   subscribeUpdate: vi.fn(),
 }));
 
@@ -32,19 +31,21 @@ const update: TUpdateFile = {
 
 describe('components/banners/update', () => {
   let notifyUpdate: ((update: TUpdateFile | null) => void) | undefined;
+  let initialUpdate: TUpdateFile | null;
 
   beforeEach(() => {
     vi.clearAllMocks();
     notifyUpdate = undefined;
-    versionApiMocks.getUpdate.mockResolvedValue(null);
+    initialUpdate = null;
     versionApiMocks.subscribeUpdate.mockImplementation((cb: typeof notifyUpdate) => {
       notifyUpdate = cb;
+      cb?.(initialUpdate);
       return () => {};
     });
   });
 
-  it('renders a cached update', async () => {
-    versionApiMocks.getUpdate.mockResolvedValue(update);
+  it('renders an update from the initial snapshot', async () => {
+    initialUpdate = update;
 
     render(<Update />);
 

--- a/frontends/web/src/components/banners/update.tsx
+++ b/frontends/web/src/components/banners/update.tsx
@@ -2,15 +2,15 @@
 
 import { useTranslation } from 'react-i18next';
 import { runningInAndroid } from '@/utils/env';
-import { getUpdate, subscribeUpdate } from '@/api/version';
+import { subscribeUpdate } from '@/api/version';
 import { Status } from '@/components/status/status';
 import { AppDownloadLink } from '@/components/appdownloadlink/appdownloadlink';
-import { useSync } from '@/hooks/api';
+import { useSubscribe } from '@/hooks/api';
 import style from './update.module.css';
 
 export const Update = () => {
   const { t } = useTranslation();
-  const file = useSync(getUpdate, subscribeUpdate);
+  const file = useSubscribe(subscribeUpdate);
   if (!file) {
     return null;
   }

--- a/frontends/web/src/components/bluetooth/bluetooth.tsx
+++ b/frontends/web/src/components/bluetooth/bluetooth.tsx
@@ -2,8 +2,8 @@
 
 import { useTranslation } from 'react-i18next';
 import { useEffect, useRef, useState } from 'react';
-import { useSync } from '@/hooks/api';
-import { connect, getState, syncState, TPeripheral } from '@/api/bluetooth';
+import { useSubscribe } from '@/hooks/api';
+import { connect, syncState, TPeripheral } from '@/api/bluetooth';
 import { runningInIOS } from '@/utils/env';
 import { Message } from '@/components/message/message';
 import { A } from '@/components/anchor/anchor';
@@ -24,7 +24,7 @@ type Props = {
 
 const BluetoothInner = ({ peripheralContainerClassName }: Props) => {
   const { t } = useTranslation();
-  const state = useSync(getState, syncState);
+  const state = useSubscribe(syncState);
   const [showConnectionIssues, setShowConnectionIssues] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const scanningTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
+++ b/frontends/web/src/components/devices/bitbox02bootloader/bitbox02bootloader.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as bitbox02BootloaderAPI from '@/api/bitbox02bootloader';
 import { useDarkmode } from '@/hooks/darkmode';
-import { useSync, useLoad } from '@/hooks/api';
+import { useSubscribe, useLoad } from '@/hooks/api';
 import { Button } from '@/components/forms';
 import { View, ViewContent } from '@/components/view/view';
 import { BitBox02, BitBox02Inverted, BitBox02Nova, BitBox02NovaInverted } from '@/components/icon/logo';
@@ -20,10 +20,7 @@ type TProps = {
 export const BitBox02Bootloader = ({ deviceID }: TProps) => {
   const { t } = useTranslation();
   const { isDarkMode } = useDarkmode();
-  const status = useSync(
-    () => bitbox02BootloaderAPI.getStatus(deviceID),
-    bitbox02BootloaderAPI.syncStatus(deviceID),
-  );
+  const status = useSubscribe(bitbox02BootloaderAPI.syncStatus(deviceID));
   const infoResponse = useLoad(
     status === undefined || status.upgrading ? null : () => bitbox02BootloaderAPI.getInfo(deviceID),
     [deviceID, status?.upgrading],

--- a/frontends/web/src/components/dialog/firmware-upgrade-required-dialog.tsx
+++ b/frontends/web/src/components/dialog/firmware-upgrade-required-dialog.tsx
@@ -4,9 +4,8 @@ import { useCallback, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Dialog, DialogButtons } from './dialog';
-import { getDeviceList } from '@/api/devices';
 import { syncDeviceList } from '@/api/devicessync';
-import { useSync } from '@/hooks/api';
+import { useSubscribe } from '@/hooks/api';
 import { useDefault } from '@/hooks/default';
 import { Button } from '@/components/forms';
 import { AppContext } from '@/contexts/AppContext';
@@ -20,7 +19,7 @@ export const FirmwareUpgradeRequiredDialog = ({ open, onClose }: TFirmwareUpgrad
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { setFirmwareUpdateDialogOpen } = useContext(AppContext);
-  const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});
+  const devices = useDefault(useSubscribe(syncDeviceList), {});
   const deviceIDs = Object.keys(devices);
 
   const handleUpgrade = useCallback(() => {

--- a/frontends/web/src/contexts/AppProvider.tsx
+++ b/frontends/web/src/contexts/AppProvider.tsx
@@ -3,16 +3,15 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { useConfig } from './ConfigProvider';
 import { AppContext } from './AppContext';
-import { useLoad } from '@/hooks/api';
+import { useLoad, useSubscribe } from '@/hooks/api';
 import { useDefault } from '@/hooks/default';
 import { getNativeLocale } from '@/api/nativelocale';
 import { getDevServers, getTesting } from '@/api/backend';
-import { getOnline, subscribeOnline } from '@/api/online';
+import { subscribeOnline } from '@/api/online';
 import { i18nextFormat } from '@/i18n/utils';
 import type { TChartDisplay, TSessionConfig } from './AppContext';
 import { useOrientation } from '@/hooks/orientation';
 import { useMediaQuery } from '@/hooks/mediaquery';
-import { useSync } from '@/hooks/api';
 
 type TProps = {
   children: ReactNode;
@@ -22,7 +21,7 @@ export const AppProvider = ({ children }: TProps) => {
   const { config, setConfig } = useConfig();
   const nativeLocale = i18nextFormat(useDefault(useLoad(getNativeLocale), 'de-CH'));
   const isTesting = useDefault(useLoad(getTesting), false);
-  const isOnline = useSync(getOnline, subscribeOnline);
+  const isOnline = useSubscribe(subscribeOnline);
   const isDevServers = useDefault(useLoad(getDevServers), false);
   const [guideShown, setGuideShown] = useState(false);
   const [guideExists, setGuideExists] = useState(false);

--- a/frontends/web/src/hooks/api.test.ts
+++ b/frontends/web/src/hooks/api.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 import { TSubscriptionCallback } from '@/api/subscribe';
-import { useSubscribe, useLoad, useSync } from './api';
+import { useSubscribe, useLoad } from './api';
 import * as utils from './mount';
 import { TStatus } from '@/api/coins';
 import { act } from 'react';
@@ -90,52 +90,6 @@ describe('hooks for api calls', () => {
       const { result } = renderHook(() => useSubscribe(mockSubscribe()));
 
       expect(result.current).toBe(MOCK_RETURN_STATUS);
-    });
-  });
-
-
-  describe('useSync', () => {
-    it('should load promise and sync to a subscription function', async () => {
-      const apiValue = 'apiValue';
-      const subscriptionValue = 'subscriptionValue';
-      let subscriptionCallback: TSubscriptionCallback<any> | undefined;
-
-      //A mock api call which will return `apiValue` when resolved
-      const mockApiCall = vi.fn().mockResolvedValue(apiValue);
-
-      //A mock subscription fn, which accepts a callback
-      //callback will be saved to `subscriptionCallback`
-      //returns an empty fn (TUnsubscribe)
-      const mockSubscription = vi.fn((callback: TSubscriptionCallback<any>) => {
-        subscriptionCallback = callback;
-        return () => {}; // Mocking `TUnsubscribe` (a "no-op" / "empty" fn)
-      });
-
-      //Renders the hook
-      const { result } = renderHook(() => useSync(mockApiCall, mockSubscription));
-
-      // This waits for the hook to be rendered
-      // and then when the state changes the first time.
-      // This ensures that the hook has completed the API call
-      // and updated its internal state to be `apiValue`.
-      await waitFor(() => expect(result.current).toBe(apiValue));
-
-      await waitFor(() => expect(mockApiCall).toHaveBeenCalled());
-      await waitFor(() => expect(mockSubscription).toHaveBeenCalled());
-
-      // If `subscriptionCallback` is truthy
-      // it means, subscription was invoked by the hook.
-      if (subscriptionCallback) {
-        // We manually simulate receiving new data
-        // from the subscription fn.
-        act(() => {
-          subscriptionCallback && subscriptionCallback(subscriptionValue);
-        });
-      }
-
-      // Finally, we wait until the hook updates its internal state
-      // and returns it. The returned value should be `subscriptionValue`
-      await waitFor(() => expect(result.current).toBe(subscriptionValue));
     });
   });
 });

--- a/frontends/web/src/hooks/api.ts
+++ b/frontends/web/src/hooks/api.ts
@@ -72,29 +72,3 @@ export const useLoad = <T>(
   );
   return response;
 };
-
-/**
- * useSync is a hook to load a promise and sync to a subscription function.
- * It is a combination of useLoad and useSubscribe.
- * gets fired on first render, and returns undefined while loading,
- * re-renders on every update.
- */
-export const useSync = <T>(
-  apiCall: () => Promise<T>,
-  subscription: ((callback: TSubscriptionCallback<T>) => TUnsubscribe),
-): (T | undefined) => {
-  const [response, setResponse] = useState<T>();
-  const mounted = useMountedRef();
-  const onData = (data: T) => {
-    if (mounted.current) {
-      setResponse(data);
-    }
-  };
-  useEffect(
-    () => {
-      apiCall().then(onData);
-      return subscription(onData);
-    }, // we pass no dependencies because it's only queried once
-    []); // eslint-disable-line react-hooks/exhaustive-deps
-  return response;
-};

--- a/frontends/web/src/hooks/backend.ts
+++ b/frontends/web/src/hooks/backend.ts
@@ -1,16 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useState } from 'react';
-import { TKeystores, subscribeKeystores, getKeystores } from '@/api/keystores';
+import { TKeystores, subscribeKeystores } from '@/api/keystores';
+import { useSubscribe } from './api';
 
 export const useKeystores = (): TKeystores | undefined => {
-  const [keystores, setKeystores] = useState<TKeystores>();
-  useEffect(() => {
-    getKeystores().then(keystores => {
-      setKeystores(keystores);
-    });
-    // this passes the unsubscribe function directly the return function of useEffect, used when the component unmounts.
-    return subscribeKeystores(setKeystores);
-  }, []);
-  return keystores;
+  return useSubscribe(subscribeKeystores);
 };

--- a/frontends/web/src/hooks/coin-unit-price.test.ts
+++ b/frontends/web/src/hooks/coin-unit-price.test.ts
@@ -1,44 +1,50 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CoinCode } from '@/api/account';
+import type { TSubscriptionCallback } from '@/api/subscribe';
 import { useCoinUnitPrice } from './coin-unit-price';
 
-vi.mock('@/api/coins', () => ({
-  getCoinFiatPrices: vi.fn(),
-  subscribeCoinFiatPrices: vi.fn(() => () => () => {}),
+const coinApiMocks = vi.hoisted(() => ({
+  subscribeCoinFiatPrices: vi.fn(),
 }));
 
-import { getCoinFiatPrices } from '@/api/coins';
-
-const mockGetCoinFiatPrices = vi.mocked(getCoinFiatPrices);
+vi.mock('@/api/coins', () => coinApiMocks);
 
 describe('useCoinUnitPrice', () => {
-  it('returns undefined while loading', () => {
-    mockGetCoinFiatPrices.mockReturnValue(new Promise(() => {}));
+  let notifyPrice: TSubscriptionCallback<any> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notifyPrice = undefined;
+    coinApiMocks.subscribeCoinFiatPrices.mockImplementation(() => (
+      (cb: TSubscriptionCallback<any>) => {
+        notifyPrice = cb;
+        return () => {};
+      }
+    ));
+  });
+
+  it('returns undefined before the initial snapshot', () => {
     const { result } = renderHook(
       () => useCoinUnitPrice('btc' as CoinCode),
     );
     expect(result.current).toBeUndefined();
   });
 
-  it('returns TAmountWithConversions on success', async () => {
-    mockGetCoinFiatPrices.mockResolvedValue({
+  it('returns TAmountWithConversions on success', () => {
+    const price = {
       amount: '1',
       unit: 'BTC',
       conversions: { USD: '60000.00', EUR: '55000.00' } as Record<string, string>,
       estimated: false,
-    });
+    };
     const { result } = renderHook(
       () => useCoinUnitPrice('btc' as CoinCode, 'BTC'),
     );
-    await waitFor(() => expect(result.current).toEqual({
-      amount: '1',
-      unit: 'BTC',
-      conversions: { USD: '60000.00', EUR: '55000.00' },
-      estimated: false,
-    }));
-    expect(mockGetCoinFiatPrices).toHaveBeenCalledWith('btc');
+    act(() => notifyPrice?.(price));
+    expect(result.current).toEqual(price);
+    expect(coinApiMocks.subscribeCoinFiatPrices).toHaveBeenCalledWith('btc');
   });
 });

--- a/frontends/web/src/hooks/coin-unit-price.ts
+++ b/frontends/web/src/hooks/coin-unit-price.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { CoinCode, CoinUnit, TAmountWithConversions } from '@/api/account';
-import { getCoinFiatPrices, subscribeCoinFiatPrices } from '@/api/coins';
-import { useSync } from '@/hooks/api';
+import { subscribeCoinFiatPrices } from '@/api/coins';
+import { useSubscribe } from '@/hooks/api';
 
 /**
  * Fetches the fiat price of 1 unit of a coin in all fiat currencies.
@@ -13,10 +13,7 @@ export const useCoinUnitPrice = (
   coinCode: CoinCode,
   unit?: CoinUnit,
 ): TAmountWithConversions | undefined => {
-  const result = useSync(
-    () => getCoinFiatPrices(coinCode),
-    subscribeCoinFiatPrices(coinCode),
-  );
+  const result = useSubscribe(subscribeCoinFiatPrices(coinCode));
   if (!result || !unit) {
     return undefined;
   }

--- a/frontends/web/src/routes/account/account.tsx
+++ b/frontends/web/src/routes/account/account.tsx
@@ -13,7 +13,7 @@ import { InfoBlue, LoupeBlue } from '@/components/icon';
 import { GuidedContent, GuideWrapper, Header, Main } from '@/components/layout';
 import { Spinner } from '@/components/spinner/Spinner';
 import { Message } from '@/components/message/message';
-import { useLoad, useSubscribe, useSync } from '@/hooks/api';
+import { useLoad, useSubscribe } from '@/hooks/api';
 import { useBitsurance } from '@/hooks/bitsurance';
 import { useDebounce } from '@/hooks/debounce';
 import { useScrollIntoView } from '@/hooks/scroll-into-view';
@@ -76,9 +76,8 @@ const RemountAccount = ({
   const { btcUnit } = useContext(RatesContext);
 
   const [balance, setBalance] = useState<accountApi.TBalance>();
-  const status: accountApi.TStatus | undefined = useSync(
-    () => accountApi.getStatus(code),
-    cb => statusChanged(code, cb),
+  const status: accountApi.TStatus | undefined = useSubscribe(
+    cb => statusChanged(code, cb)
   );
   const syncedAddressesCount = useSubscribe(syncAddressesCount(code));
   const [transactions, setTransactions] = useState<accountApi.TTransactions>();

--- a/frontends/web/src/routes/account/add/add-account.tsx
+++ b/frontends/web/src/routes/account/add/add-account.tsx
@@ -139,8 +139,6 @@ export const AddAccount = ({ accounts }: TAddAccountProps) => {
   }, []);
 
   useEffect(() => {
-    startProcess();
-
     const unsubscribe = subscribeKeystores(() => {
       startProcess();
     });

--- a/frontends/web/src/routes/account/info/info.tsx
+++ b/frontends/web/src/routes/account/info/info.tsx
@@ -3,9 +3,9 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useSync } from '@/hooks/api';
+import { useSubscribe } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
-import { TAccount, AccountCode, TStatus, getStatus, exportAccount, getTransactionList, TTransactions } from '@/api/account';
+import { TAccount, AccountCode, TStatus, exportAccount, getTransactionList, TTransactions } from '@/api/account';
 import { findAccount, isBitcoinBased, isMessageSigningSupported } from '@/routes/account/utils';
 import { TDevices } from '@/api/devices';
 import { Header, Main } from '@/components/layout';
@@ -35,10 +35,7 @@ export const Info = ({
   const { t } = useTranslation();
   const { isDarkMode } = useDarkmode();
   const navigate = useNavigate();
-  const status: TStatus | undefined = useSync(
-    () => getStatus(code),
-    cb => statusChanged(code, cb),
-  );
+  const status: TStatus | undefined = useSubscribe(cb => statusChanged(code, cb));
   const accountReady = (
     status !== undefined
     && !status.fatalError

--- a/frontends/web/src/routes/device/bitbox02/backups.tsx
+++ b/frontends/web/src/routes/device/bitbox02/backups.tsx
@@ -2,10 +2,10 @@
 
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSync } from '@/hooks/api';
+import { useSubscribe } from '@/hooks/api';
 import { useIsScrollable } from '@/hooks/scrollable';
 import { restoreBackup, errUserAbort } from '@/api/bitbox02';
-import { getBackupList, subscribeBackupList } from '@/api/backup';
+import { subscribeBackupList } from '@/api/backup';
 import { Toast } from '@/components/toast/toast';
 import { BackupsListItem } from '@/routes/device/components/backup';
 import { Backup } from '@/api/backup';
@@ -41,7 +41,7 @@ export const BackupsV2 = ({
   const [errorText, setErrorText] = useState('');
   const scrollableContainerRef = useRef<HTMLDivElement>(null);
 
-  const backups = useSync(() => getBackupList(deviceID), subscribeBackupList(deviceID));
+  const backups = useSubscribe(subscribeBackupList(deviceID));
   const hasBackups = backups && backups.success && backups !== undefined;
   const hasMoreThanOneBackups = hasBackups && backups.backups.length > 1;
 

--- a/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
+++ b/frontends/web/src/routes/device/bitbox02/bitbox02.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { getStatus, statusChanged } from '@/api/bitbox02';
+import { statusChanged } from '@/api/bitbox02';
 import type { TDevices } from '@/api/devices';
-import { useSync } from '@/hooks/api';
+import { useSubscribe } from '@/hooks/api';
 import { BB02Settings } from '@/routes/settings/bb02-settings';
 
 type TProps = {
@@ -12,10 +12,7 @@ type TProps = {
 };
 
 export const BitBox02 = ({ deviceID, devices, hasAccounts }: TProps) => {
-  const status = useSync(
-    () => getStatus(deviceID),
-    cb => statusChanged(deviceID, cb)
-  );
+  const status = useSubscribe(cb => statusChanged(deviceID, cb));
   if (status !== 'initialized') {
     return null;
   }

--- a/frontends/web/src/routes/device/bitbox02/wizard.tsx
+++ b/frontends/web/src/routes/device/bitbox02/wizard.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useLoad, useSync } from '@/hooks/api';
-import { attestationCheckDone, getStatus, getVersion, verifyAttestation, statusChanged } from '@/api/bitbox02';
+import { useLoad, useSubscribe } from '@/hooks/api';
+import { attestationCheckDone, getVersion, statusChanged, TStatus } from '@/api/bitbox02';
 import { AppUpgradeRequired } from '@/components/appupgraderequired';
 import { FirmwareUpgradeRequired } from '@/routes/device/upgrade-firmware-required';
 import { Main } from '@/components/layout';
@@ -21,21 +21,13 @@ type TProps = {
 export const Wizard = ({ deviceID }: TProps) => {
   const navigate = useNavigate();
   const versionInfo = useLoad(() => getVersion(deviceID));
-  const attestation = useSync(
-    () => verifyAttestation(deviceID),
-    cb => attestationCheckDone(deviceID, () => {
-      verifyAttestation(deviceID).then(cb);
-    })
-  );
+  const attestation = useSubscribe<boolean | null>(cb => attestationCheckDone(deviceID, cb));
   const [setupChoice, setSetupChoice] = useState<'' | TWalletSetupChoices>('');
   const [createOptions, setCreateOptions] = useState<TWalletCreateOptions>();
   const [showWizard, setShowWizard] = useState<boolean>(false);
   // If true, we just pair and unlock, so we can hide some steps.
   const [unlockOnly, setUnlockOnly] = useState<boolean>(true);
-  const status = useSync(
-    () => getStatus(deviceID),
-    cb => statusChanged(deviceID, cb)
-  );
+  const status = useSubscribe<TStatus>(cb => statusChanged(deviceID, cb));
   const handleGetStarted = () => {
     setShowWizard(false);
     navigate('/account-summary?with-chart-animation=true');

--- a/frontends/web/src/routes/device/waiting.tsx
+++ b/frontends/web/src/routes/device/waiting.tsx
@@ -4,9 +4,8 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { i18n } from '@/i18n/i18n';
-import { getDeviceList } from '@/api/devices';
 import { syncDeviceList } from '@/api/devicessync';
-import { useSync } from '@/hooks/api';
+import { useSubscribe } from '@/hooks/api';
 import { useKeystores } from '@/hooks/backend';
 import { useDarkmode } from '@/hooks/darkmode';
 import { useDefault } from '@/hooks/default';
@@ -28,7 +27,7 @@ export const Waiting = () => {
   const { isDarkMode } = useDarkmode();
   const navigate = useNavigate();
   const keystores = useKeystores();
-  const devices = useDefault(useSync(getDeviceList, syncDeviceList), {});
+  const devices = useDefault(useSubscribe(syncDeviceList), {});
 
   // BitBox01 does not have any accounts anymore, so we route directly to the device settings.
   useEffect(() => {

--- a/frontends/web/src/routes/settings/components/about/app-version-setting.test.tsx
+++ b/frontends/web/src/routes/settings/components/about/app-version-setting.test.tsx
@@ -8,7 +8,6 @@ import type { TUpdateFile } from '@/api/version';
 import { AppVersion } from './app-version-setting';
 
 const versionApiMocks = vi.hoisted(() => ({
-  getUpdate: vi.fn(),
   getVersion: vi.fn(),
   subscribeUpdate: vi.fn(),
 }));
@@ -46,20 +45,22 @@ const update: TUpdateFile = {
 
 describe('routes/settings/components/about/app-version-setting', () => {
   let notifyUpdate: ((update: TUpdateFile | null) => void) | undefined;
+  let initialUpdate: TUpdateFile | null;
 
   beforeEach(() => {
     vi.clearAllMocks();
     notifyUpdate = undefined;
+    initialUpdate = null;
     versionApiMocks.getVersion.mockResolvedValue('4.51.3');
-    versionApiMocks.getUpdate.mockResolvedValue(null);
     versionApiMocks.subscribeUpdate.mockImplementation((cb: typeof notifyUpdate) => {
       notifyUpdate = cb;
+      cb?.(initialUpdate);
       return () => {};
     });
   });
 
-  it('renders a cached update', async () => {
-    versionApiMocks.getUpdate.mockResolvedValue(update);
+  it('renders an update from the initial snapshot', async () => {
+    initialUpdate = update;
 
     render(<AppVersion />);
 

--- a/frontends/web/src/routes/settings/components/about/app-version-setting.tsx
+++ b/frontends/web/src/routes/settings/components/about/app-version-setting.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useLoad, useSync } from '@/hooks/api';
+import { useLoad, useSubscribe } from '@/hooks/api';
 import { useTranslation } from 'react-i18next';
-import { getUpdate, getVersion, subscribeUpdate } from '@/api/version';
+import { getVersion, subscribeUpdate } from '@/api/version';
 import { open } from '@/api/system';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import { StyledSkeleton } from '@/routes/settings/bb02-settings';
@@ -13,7 +13,7 @@ export const AppVersion = () => {
   const { t } = useTranslation();
 
   const version = useLoad(getVersion);
-  const update = useSync(getUpdate, subscribeUpdate);
+  const update = useSubscribe(subscribeUpdate);
 
   const secondaryText = !!update ? t('settings.info.out-of-date') : t('settings.info.up-to-date');
   const icon = !!update ? <RedDot width={8} height={8} /> : <Checked />;

--- a/frontends/web/src/utils/event.test.ts
+++ b/frontends/web/src/utils/event.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest';
+import { apiSubscribe } from './event';
+
+const mocks = vi.hoisted(() => ({
+  apiWebsocket: vi.fn(),
+}));
+
+vi.mock('./websocket', () => ({
+  apiWebsocket: mocks.apiWebsocket,
+}));
+
+describe('apiSubscribe', () => {
+  it('registers the observer before starting the event transport', () => {
+    const observer = vi.fn();
+    mocks.apiWebsocket.mockImplementation((callback) => {
+      callback({ subject: 'online', action: 'replace', object: true });
+      return () => {};
+    });
+
+    apiSubscribe('online', observer);
+
+    expect(observer).toHaveBeenCalledWith({
+      subject: 'online',
+      action: 'replace',
+      object: true,
+    });
+  });
+});

--- a/frontends/web/src/utils/event.ts
+++ b/frontends/web/src/utils/event.ts
@@ -51,15 +51,15 @@ export const apiSubscribe = (
   subject: TSubject,
   observer: Observer
 ): TUnsubscribe => {
-  if (!subscribed) {
-    subscribed = apiWebsocket(handleEvent);
-  }
   let observers = subscriptions[subject];
   if (observers === undefined) {
     observers = [];
     subscriptions[subject] = observers;
   }
   observers.push(observer);
+  if (!subscribed) {
+    subscribed = apiWebsocket(handleEvent);
+  }
   return () => {
     if (!observers.includes(observer)) {
       console.warn('!observers.includes(observer)');

--- a/frontends/web/src/utils/transport-common.ts
+++ b/frontends/web/src/utils/transport-common.ts
@@ -8,7 +8,7 @@ export type TSubject = string;
 /**
  * This type enumerates the various actions of an event.
  */
-type TAction = 'replace' | 'reload';
+type TAction = 'replace';
 
 /**
  * This type models the events that are received from the backend.

--- a/util/observable/action/action.go
+++ b/util/observable/action/action.go
@@ -9,6 +9,6 @@ const (
 	// Replace replaces the current value of the subject with the object.
 	Replace Action = "replace"
 
-	// Reload tells the listener to reload the state of the subject.
+	// Reload tells the event adapter to replace the event with the subject's current snapshot.
 	Reload Action = "reload"
 )

--- a/util/observable/event.go
+++ b/util/observable/event.go
@@ -7,7 +7,7 @@ import "github.com/BitBoxSwiss/bitbox-wallet-app/util/observable/action"
 // Event is passed to the listeners of an observable type.
 type Event struct {
 	// Subject identifies what changed.
-	// By convention, it corresponds to the corresponding GET endpoint of the REST API.
+	// By convention, it corresponds to a frontend subscription subject.
 	Subject string `json:"subject"`
 
 	// Action describes how the change has to be applied.


### PR DESCRIPTION
Request initial values through the subscription event stream instead of a separate GET request.
This prevents a delayed GET response from overwriting a newer event.

Serialize snapshot requests with live updates in the backend event queue and convert reload
notifications to complete replacement events before delivery. Remove GET handlers that only fed
subscription initial values.

Potential alternative to https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/4248, that removes the ordering problem in general