### PR TITLE
lightning: include payments in portfolio chart

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -396,7 +396,7 @@ func (backend *Backend) newRatesUpdater() *rates.RateUpdater {
 	updater.Observe(func(event observable.Event) {
 		backend.Notify(event)
 		backend.notifyCoinFiatPrices()
-		if backend.lightning != nil && backend.lightning.Account() != nil {
+		if backend.hasLightningAccount() {
 			backend.Notify(observable.Event{
 				Subject: "lightning/list-payments",
 				Action:  action.Reload,
@@ -433,7 +433,7 @@ func (backend *Backend) configureHistoryExchangeRates() {
 	for _, acct := range backend.accounts {
 		coins = append(coins, string(acct.Coin().Code()))
 	}
-	if backend.lightning != nil && backend.lightning.Account() != nil {
+	if backend.hasLightningAccount() {
 		coins = append(coins, string(coinpkg.CodeBTC))
 	}
 	fiats := backend.config.AppConfig().Backend.FiatList

--- a/backend/chart.go
+++ b/backend/chart.go
@@ -4,6 +4,7 @@ package backend
 
 import (
 	"math/big"
+	"slices"
 	"sort"
 	"time"
 
@@ -25,6 +26,16 @@ func (backend *Backend) allCoinCodes() []string {
 		allCoinCodes = append(allCoinCodes, string(account.Coin().Code()))
 	}
 	return allCoinCodes
+}
+
+// chartCoinCodes returns the coin codes needed to load chart rate history.
+func (backend *Backend) chartCoinCodes() []string {
+	coinCodes := backend.allCoinCodes()
+	if !backend.hasLightningAccount() || slices.Contains(coinCodes, string(coin.CodeBTC)) {
+		return coinCodes
+	}
+	// Lightning transactions require BTC coin code
+	return append(coinCodes, string(coin.CodeBTC))
 }
 
 // ChartEntry is one data point in the chart timeseries.
@@ -95,6 +106,75 @@ func (backend *Backend) addChartData(
 	}
 }
 
+func (backend *Backend) addTxsToChart(
+	coinCode coin.Code,
+	logCoinCode coin.Code,
+	fiat string,
+	coinDecimals *big.Int,
+	txs accounts.OrderedTransactions,
+	until time.Time,
+	chartEntriesDaily map[int64]RatChartEntry,
+	chartEntriesHourly map[int64]RatChartEntry,
+) (bool, error) {
+	earliestPriceAvailable := backend.RatesUpdater().HistoryEarliestTimestamp(
+		string(coinCode),
+		fiat)
+
+	earliestTxTime, err := txs.EarliestTime()
+	if errp.Cause(err) == errors.ErrNotAvailable {
+		backend.log.WithField("coin", logCoinCode).Info("ChartDataMissing/earliestTxtime")
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if earliestTxTime.IsZero() {
+		// Ignore the chart for this account, there is no timed transaction.
+		return false, nil
+	}
+	if earliestPriceAvailable.IsZero() || earliestTxTime.Before(earliestPriceAvailable) {
+		backend.log.
+			WithField("coin", logCoinCode).
+			WithField("earliestTxTime", earliestTxTime).
+			WithField("earliestPriceAvailable", earliestPriceAvailable).
+			Info("ChartDataMissing")
+		return true, nil
+	}
+
+	timeseriesDaily, err := txs.Timeseries(
+		earliestTxTime.Truncate(24*time.Hour),
+		until,
+		24*time.Hour,
+	)
+	if errp.Cause(err) == errors.ErrNotAvailable {
+		backend.log.WithField("coin", logCoinCode).Info("ChartDataMissing")
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	// Time from which the chart turns from daily points to hourly points.
+	hourlyFrom := time.Now().AddDate(0, 0, -7).Truncate(24 * time.Hour)
+	timeseriesHourly, err := txs.Timeseries(
+		hourlyFrom,
+		until,
+		time.Hour,
+	)
+	if errp.Cause(err) == errors.ErrNotAvailable {
+		backend.log.WithField("coin", logCoinCode).Info("ChartDataMissing")
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	backend.addChartData(coinCode, fiat, coinDecimals, timeseriesDaily, chartEntriesDaily)
+	backend.addChartData(coinCode, fiat, coinDecimals, timeseriesHourly, chartEntriesHourly)
+	return false, nil
+}
+
 // ChartData assembles chart data for all active accounts.
 func (backend *Backend) ChartData() (*Chart, error) {
 	// If true, we are missing headers or historical conversion rates necessary to compute the chart
@@ -108,7 +188,7 @@ func (backend *Backend) ChartData() (*Chart, error) {
 	fiat := backend.Config().AppConfig().Backend.MainFiat
 
 	// Chart data until this point in time.
-	until := backend.RatesUpdater().HistoryLatestTimestampFiat(backend.allCoinCodes(), fiat)
+	until := backend.RatesUpdater().HistoryLatestTimestampFiat(backend.chartCoinCodes(), fiat)
 	if until.IsZero() {
 		chartDataMissing = true
 		backend.log.Info("ChartDataMissing, until is zero")
@@ -120,6 +200,7 @@ func (backend *Backend) ChartData() (*Chart, error) {
 	currentTotalMissing := false
 	// Total number of transactions across all active accounts.
 	totalNumberOfTransactions := 0
+	transactionHistoryMissing := false
 	for _, account := range backend.Accounts() {
 		if account.Config().Config.Inactive {
 			continue
@@ -156,70 +237,27 @@ func (backend *Backend) ChartData() (*Chart, error) {
 			continue
 		}
 
-		// Time from which the chart turns from daily points to hourly points.
-		hourlyFrom := time.Now().AddDate(0, 0, -7).Truncate(24 * time.Hour)
-
-		earliestPriceAvailable := backend.RatesUpdater().HistoryEarliestTimestamp(
-			string(account.Coin().Code()),
-			fiat)
-
-		earliestTxTime, err := txs.EarliestTime()
-		if errp.Cause(err) == errors.ErrNotAvailable {
-			backend.log.WithField("coin", account.Coin().Code()).Info("ChartDataMissing/earliestTxtime")
-			chartDataMissing = true
-			continue
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		if earliestTxTime.IsZero() {
-			// Ignore the chart for this account, there is no timed transaction.
-			continue
-		}
-		if earliestPriceAvailable.IsZero() || earliestTxTime.Before(earliestPriceAvailable) {
-			chartDataMissing = true
-			backend.log.
-				WithField("coin", account.Coin().Code()).
-				WithField("earliestTxTime", earliestTxTime).
-				WithField("earliestPriceAvailable", earliestPriceAvailable).
-				Info("ChartDataMissing")
-			continue
-		}
-
-		timeseriesDaily, err := txs.Timeseries(
-			earliestTxTime.Truncate(24*time.Hour),
+		accountChartDataMissing, err := backend.addTxsToChart(
+			account.Coin().Code(),
+			account.Coin().Code(),
+			fiat,
+			coinDecimals,
+			txs,
 			until,
-			24*time.Hour,
+			chartEntriesDaily,
+			chartEntriesHourly,
 		)
-		if errp.Cause(err) == errors.ErrNotAvailable {
-			backend.log.WithField("coin", account.Coin().Code()).Info("ChartDataMissing")
-			chartDataMissing = true
-			continue
-		}
 		if err != nil {
 			return nil, err
 		}
-		timeseriesHourly, err := txs.Timeseries(
-			hourlyFrom,
-			until,
-			time.Hour,
-		)
-		if errp.Cause(err) == errors.ErrNotAvailable {
-			backend.log.WithField("coin", account.Coin().Code()).Info("ChartDataMissing")
+		if accountChartDataMissing {
 			chartDataMissing = true
 			continue
 		}
-		if err != nil {
-			return nil, err
-		}
-
-		backend.addChartData(account.Coin().Code(), fiat, coinDecimals, timeseriesDaily, chartEntriesDaily)
-		backend.addChartData(account.Coin().Code(), fiat, coinDecimals, timeseriesHourly, chartEntriesHourly)
 
 	}
 
-	if backend.lightning.Account() != nil {
+	if backend.hasLightningAccount() {
 		var err error
 		lightningBalance, err := backend.lightning.Balance()
 		if err != nil {
@@ -230,6 +268,38 @@ func (backend *Backend) ChartData() (*Chart, error) {
 			return nil, err
 		}
 		currentTotal.Add(currentTotal, lightningBalanceAmount)
+
+		lightningTxs, err := backend.lightning.Transactions()
+		if err != nil {
+			backend.log.WithError(err).WithField("coin", coinCodeLightning).Info("ChartDataMissing/list-payments")
+			chartDataMissing = true
+			transactionHistoryMissing = true
+			lightningTxs = nil
+		}
+		totalNumberOfTransactions += len(lightningTxs)
+
+		if !chartDataMissing {
+			btcCoin, err := backend.Coin(coin.CodeBTC)
+			if err != nil {
+				return nil, err
+			}
+			lightningChartDataMissing, err := backend.addTxsToChart(
+				coin.CodeBTC,
+				coinCodeLightning,
+				fiat,
+				coin.DecimalsExp(btcCoin, false),
+				lightningTxs,
+				until,
+				chartEntriesDaily,
+				chartEntriesHourly,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if lightningChartDataMissing {
+				chartDataMissing = true
+			}
+		}
 	}
 
 	toSortedSlice := func(s map[int64]RatChartEntry, fiat string) []ChartEntry {
@@ -281,7 +351,7 @@ func (backend *Backend) ChartData() (*Chart, error) {
 	// Even if we are still gathering data (exchange rates, block headers), we know the result
 	// already if there are no transactions. This avoids showing the user a message that we are
 	// gathering data, only to show nothing in the end.
-	if chartDataMissing && totalNumberOfTransactions == 0 {
+	if chartDataMissing && totalNumberOfTransactions == 0 && !transactionHistoryMissing {
 		backend.log.Info("ChartDataMissing forced to false")
 		chartDataMissing = false
 	}

--- a/backend/chart_test.go
+++ b/backend/chart_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"testing"
+
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChartCoinCodesIncludesBitcoinForLightning(t *testing.T) {
+	b := newBackend(t, testnetDisabled, regtestDisabled)
+	defer b.Close()
+
+	require.NoError(t, b.lightning.SetAccount(&config.LightningAccountConfig{
+		Seed:            "test mnemonic",
+		RootFingerprint: []byte{0xde, 0xad, 0xbe, 0xef},
+		Code:            "v0-deadbeef-ln-0",
+		Number:          0,
+	}))
+
+	require.Equal(t, []string{string(coinpkg.CodeBTC)}, b.chartCoinCodes())
+}

--- a/backend/lightning.go
+++ b/backend/lightning.go
@@ -8,6 +8,10 @@ import coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 // backend.Coin(coinCodeLightning) does not resolve.
 const coinCodeLightning coinpkg.Code = "lightning"
 
+func (backend *Backend) hasLightningAccount() bool {
+	return backend.lightning != nil && backend.lightning.Account() != nil
+}
+
 func (backend *Backend) lightningFormattedBalance() (*coinFormattedAmount, error) {
 	if backend.lightning.Account() == nil {
 		return nil, nil

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -296,6 +296,35 @@ func (lightning *Lightning) toLightningPayment(payment breez_sdk_spark.Payment) 
 	return result
 }
 
+func toLightningTransaction(payment breez_sdk_spark.Payment) *accounts.TransactionData {
+	if toLightningPaymentStatus(payment.Status) != accounts.TxStatusComplete {
+		return nil
+	}
+
+	var timestamp *time.Time
+	if payment.Timestamp != 0 {
+		t := time.Unix(int64(payment.Timestamp), 0).UTC()
+		timestamp = &t
+	}
+	paymentType := toLightningPaymentType(payment.PaymentType)
+	amount := coin.NewAmountFromInt64(int64(parseLightningUint(payment.Amount)))
+	fee := coin.NewAmountFromInt64(int64(parseLightningUint(payment.Fees)))
+
+	tx := &accounts.TransactionData{
+		Fee:              &fee,
+		Timestamp:        timestamp,
+		Height:           1,
+		Status:           accounts.TxStatusComplete,
+		Type:             paymentType,
+		Amount:           amount,
+		CreatedTimestamp: timestamp,
+	}
+	if paymentType == accounts.TxTypeReceive {
+		tx.Fee = nil
+	}
+	return tx
+}
+
 func parseLightningUint(value interface{ String() string }) uint64 {
 	parsed, err := strconv.ParseUint(value.String(), 10, 64)
 	if err != nil {
@@ -617,21 +646,49 @@ func (lightning *Lightning) ReceivePayment(amountSat uint64, description string)
 	return &receivePaymentResponse{Invoice: response.PaymentRequest}, nil
 }
 
-// ListPayments fetches lightning payments and converts them to the app-facing contract.
-func (lightning *Lightning) ListPayments() ([]lightningPayment, error) {
+func (lightning *Lightning) listPayments() ([]breez_sdk_spark.Payment, error) {
 	if err := lightning.CheckActive(); err != nil {
 		return nil, err
 	}
-	response, err := lightning.sdkService.ListPayments(breez_sdk_spark.ListPaymentsRequest{})
+	assetFilter := breez_sdk_spark.AssetFilter(breez_sdk_spark.AssetFilterBitcoin{})
+	response, err := lightning.sdkService.ListPayments(breez_sdk_spark.ListPaymentsRequest{
+		AssetFilter: &assetFilter,
+	})
+	if err != nil {
+		return nil, errp.Wrap(err, "breez: list payments")
+	}
+	return response.Payments, nil
+}
+
+// ListPayments fetches lightning payments and converts them to the app-facing contract.
+func (lightning *Lightning) ListPayments() ([]lightningPayment, error) {
+	rawPayments, err := lightning.listPayments()
 	if err != nil {
 		return nil, err
 	}
 
-	lightning.log.Infof("List payments: %+v", response.Payments)
+	lightning.log.Infof("List payments: %+v", rawPayments)
 
-	payments := make([]lightningPayment, 0, len(response.Payments))
-	for _, payment := range response.Payments {
+	payments := make([]lightningPayment, 0, len(rawPayments))
+	for _, payment := range rawPayments {
 		payments = append(payments, lightning.toLightningPayment(payment))
 	}
 	return payments, nil
+}
+
+// Transactions fetches lightning payments and converts them to generic transaction data for charting.
+func (lightning *Lightning) Transactions() (accounts.OrderedTransactions, error) {
+	rawPayments, err := lightning.listPayments()
+	if err != nil {
+		return nil, err
+	}
+
+	txs := make([]*accounts.TransactionData, 0, len(rawPayments))
+	for _, payment := range rawPayments {
+		tx := toLightningTransaction(payment)
+		if tx != nil {
+			txs = append(txs, tx)
+		}
+	}
+	return accounts.NewOrderedTransactions(txs), nil
 }

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -7,8 +7,10 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
+	accountErrors "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
 	btccoin "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
@@ -36,6 +38,18 @@ func makeTestLightning() *Lightning {
 		),
 		ratesUpdater: rates.NewRateUpdater(nil, os.DevNull),
 	}
+}
+
+type testPaymentsBreezSDK struct {
+	breezSDK
+
+	listPayments func(breez_sdk_spark.ListPaymentsRequest) (breez_sdk_spark.ListPaymentsResponse, error)
+}
+
+func (sdk *testPaymentsBreezSDK) ListPayments(
+	request breez_sdk_spark.ListPaymentsRequest,
+) (breez_sdk_spark.ListPaymentsResponse, error) {
+	return sdk.listPayments(request)
 }
 
 func TestToLightningPayment(t *testing.T) {
@@ -78,6 +92,84 @@ func TestToLightningPayment(t *testing.T) {
 		),
 		Invoice: "lnbc1invoice",
 	}, payment)
+}
+
+func TestTransactions(t *testing.T) {
+	lightning := newTestLightning(t, nil)
+	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{
+		Seed:            "test mnemonic",
+		RootFingerprint: []byte{0xde, 0xad, 0xbe, 0xef},
+		Code:            "v0-deadbeef-ln-0",
+		Number:          0,
+	}))
+
+	lightning.sdkService = &testPaymentsBreezSDK{
+		listPayments: func(request breez_sdk_spark.ListPaymentsRequest) (breez_sdk_spark.ListPaymentsResponse, error) {
+			require.NotNil(t, request.AssetFilter)
+			_, ok := (*request.AssetFilter).(breez_sdk_spark.AssetFilterBitcoin)
+			require.True(t, ok)
+			return breez_sdk_spark.ListPaymentsResponse{
+				Payments: []breez_sdk_spark.Payment{
+					{
+						Id:          "receive-complete",
+						PaymentType: breez_sdk_spark.PaymentTypeReceive,
+						Status:      breez_sdk_spark.PaymentStatusCompleted,
+						Amount:      big.NewInt(100),
+						Fees:        big.NewInt(1),
+						Timestamp:   100,
+					},
+					{
+						Id:          "send-complete",
+						PaymentType: breez_sdk_spark.PaymentTypeSend,
+						Status:      breez_sdk_spark.PaymentStatusCompleted,
+						Amount:      big.NewInt(30),
+						Fees:        big.NewInt(2),
+						Timestamp:   200,
+					},
+					{
+						Id:          "receive-pending",
+						PaymentType: breez_sdk_spark.PaymentTypeReceive,
+						Status:      breez_sdk_spark.PaymentStatusPending,
+						Amount:      big.NewInt(1000),
+						Fees:        big.NewInt(0),
+						Timestamp:   300,
+					},
+					{
+						Id:          "send-failed",
+						PaymentType: breez_sdk_spark.PaymentTypeSend,
+						Status:      breez_sdk_spark.PaymentStatusFailed,
+						Amount:      big.NewInt(1000),
+						Fees:        big.NewInt(10),
+						Timestamp:   400,
+					},
+					{
+						Id:          "receive-no-timestamp",
+						PaymentType: breez_sdk_spark.PaymentTypeReceive,
+						Status:      breez_sdk_spark.PaymentStatusCompleted,
+						Amount:      big.NewInt(1000),
+						Fees:        big.NewInt(0),
+						Timestamp:   0,
+					},
+				},
+			}, nil
+		},
+	}
+
+	txs, err := lightning.Transactions()
+	require.NoError(t, err)
+	require.Len(t, txs, 3)
+
+	timeseries, err := txs.Timeseries(time.Unix(0, 0), time.Unix(300, 0), time.Hour)
+	require.Nil(t, timeseries)
+	require.Equal(t, accountErrors.ErrNotAvailable, errp.Cause(err))
+
+	hasUntimestampedReceive := false
+	for _, tx := range txs {
+		if tx.Timestamp == nil && tx.Type == accounts.TxTypeReceive && tx.Amount.BigInt().Cmp(big.NewInt(1000)) == 0 {
+			hasUntimestampedReceive = true
+		}
+	}
+	require.True(t, hasUntimestampedReceive)
 }
 
 func TestToLightningPaymentSparkInvoiceDetails(t *testing.T) {

--- a/frontends/web/src/app.tsx
+++ b/frontends/web/src/app.tsx
@@ -71,7 +71,10 @@ export const App = () => {
       return;
     }
     // if no accounts are registered on specified views route to /
-    const canNavigateWithLightningAccount = currentURL === '/settings/more' || currentURL === '/accounts/all';
+    const canNavigateWithLightningAccount =
+      currentURL.startsWith('/account-summary')
+      || currentURL === '/settings/more'
+      || currentURL === '/accounts/all';
     const requiresRegularAccount =
       currentURL.startsWith('/account-summary')
       || currentURL.startsWith('/add-account')
@@ -110,8 +113,8 @@ export const App = () => {
       navigate('/');
       return;
     }
-    // if on index page and have at least 1 account, route to /account-summary
-    if (isIndex && accounts.length) {
+    // if on index page and have an account or Lightning, route to /account-summary
+    if (isIndex && (accounts.length || hasLightningAccount)) {
       // replace current history entry so that the user cannot go back to "index"
       navigate('/account-summary?with-chart-animation=true', { replace: true });
       return;
@@ -127,7 +130,7 @@ export const App = () => {
       return;
     }
 
-  }, [accounts, deviceIDs, firstDevice, lightningAccount, navigate]);
+  }, [accounts, deviceIDs, firstDevice, hasLightningAccount, lightningAccount, navigate]);
 
   useEffect(() => {
     const oldDeviceIDList = Object.keys(prevDevices || {});

--- a/frontends/web/src/components/sidebar/sidebar.tsx
+++ b/frontends/web/src/components/sidebar/sidebar.tsx
@@ -82,6 +82,7 @@ const Sidebar = ({
   const [ canUpgrade, setCanUpgrade ] = useState(false);
   const { activeSidebar, toggleSidebar } = useContext(AppContext);
   const { lightningAccount } = useLightning();
+  const hasPortfolio = accounts.length > 0 || !!lightningAccount;
 
   const deviceIDs: string[] = Object.keys(devices);
 
@@ -121,7 +122,7 @@ const Sidebar = ({
       <nav className={[style.sidebar, activeSidebar ? style.forceShow : ''].join(' ')}>
         <div key="app-logo" className={style.sidebarLogoContainer}>
           <Link
-            to={accounts.length ? '/account-summary' : '/'}
+            to={hasPortfolio ? '/account-summary' : '/'}
             onClick={handleSidebarItemClick}>
             <AppLogoInverted className={style.sidebarLogo} />
           </Link>
@@ -130,7 +131,7 @@ const Sidebar = ({
           </button>
         </div>
 
-        { accounts.length ? (
+        { hasPortfolio ? (
           <div
             key="account-summary"
             className={`${style.sidebarItem || ''} ${style.sidebarPortfolio || ''}`}


### PR DESCRIPTION
Lightning-only wallets now open the portfolio view, and completed Lightning payments are included in the transaction history used to build the chart.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
