### PR TITLE
lightning: display bitcoin top-up states

### DIFF
--- a/backend/lightning/address_test.go
+++ b/backend/lightning/address_test.go
@@ -77,6 +77,9 @@ type testBreezSDK struct {
 	getLightningAddress            func() (*breez_sdk_spark.LightningAddressInfo, error)
 	checkLightningAddressAvailable func(breez_sdk_spark.CheckLightningAddressRequest) (bool, error)
 	registerLightningAddress       func(breez_sdk_spark.RegisterLightningAddressRequest) (breez_sdk_spark.LightningAddressInfo, error)
+	getInfo                        func(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error)
+	listPayments                   func(breez_sdk_spark.ListPaymentsRequest) (breez_sdk_spark.ListPaymentsResponse, error)
+	listUnclaimedDeposits          func(breez_sdk_spark.ListUnclaimedDepositsRequest) (breez_sdk_spark.ListUnclaimedDepositsResponse, error)
 }
 
 func (sdk *testBreezSDK) GetLightningAddress() (*breez_sdk_spark.LightningAddressInfo, error) {
@@ -93,6 +96,22 @@ func (sdk *testBreezSDK) RegisterLightningAddress(
 	request breez_sdk_spark.RegisterLightningAddressRequest,
 ) (breez_sdk_spark.LightningAddressInfo, error) {
 	return sdk.registerLightningAddress(request)
+}
+
+func (sdk *testBreezSDK) GetInfo(request breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
+	return sdk.getInfo(request)
+}
+
+func (sdk *testBreezSDK) ListPayments(
+	request breez_sdk_spark.ListPaymentsRequest,
+) (breez_sdk_spark.ListPaymentsResponse, error) {
+	return sdk.listPayments(request)
+}
+
+func (sdk *testBreezSDK) ListUnclaimedDeposits(
+	request breez_sdk_spark.ListUnclaimedDepositsRequest,
+) (breez_sdk_spark.ListUnclaimedDepositsResponse, error) {
+	return sdk.listUnclaimedDeposits(request)
 }
 
 func TestEnsureLightningAddressExistingAddress(t *testing.T) {
@@ -626,4 +645,47 @@ func TestLightningAddressChangedEventNotifiesSubscribers(t *testing.T) {
 		Action:  action.Replace,
 		Object:  &address,
 	}, <-events)
+}
+
+func TestDepositEventsReloadPayments(t *testing.T) {
+	testCases := []struct {
+		name  string
+		event breez_sdk_spark.SdkEvent
+	}{
+		{
+			name: "new deposits",
+			event: breez_sdk_spark.SdkEventNewDeposits{
+				NewDeposits: []breez_sdk_spark.DepositInfo{{Txid: "txid"}},
+			},
+		},
+		{
+			name: "unclaimed deposits",
+			event: breez_sdk_spark.SdkEventUnclaimedDeposits{
+				UnclaimedDeposits: []breez_sdk_spark.DepositInfo{{Txid: "txid"}},
+			},
+		},
+		{
+			name: "claimed deposits",
+			event: breez_sdk_spark.SdkEventClaimedDeposits{
+				ClaimedDeposits: []breez_sdk_spark.DepositInfo{{Txid: "txid"}},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			lightning := newTestLightning(t, nil)
+			events := make(chan observable.Event, 1)
+			lightning.Observe(func(event observable.Event) {
+				events <- event
+			})
+
+			lightning.OnEvent(testCase.event)
+
+			require.Equal(t, observable.Event{
+				Subject: "lightning/list-payments",
+				Action:  action.Reload,
+			}, <-events)
+		})
+	}
 }

--- a/backend/lightning/event.go
+++ b/backend/lightning/event.go
@@ -8,6 +8,13 @@ import (
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 )
 
+func (lightning *Lightning) notifyListPaymentsReload() {
+	lightning.Notify(observable.Event{
+		Subject: "lightning/list-payments",
+		Action:  action.Reload,
+	})
+}
+
 // OnEvent handles Breez SDK events and forwards relevant updates to observers.
 func (lightning *Lightning) OnEvent(e breez_sdk_spark.SdkEvent) {
 	switch event := e.(type) {
@@ -18,39 +25,37 @@ func (lightning *Lightning) OnEvent(e breez_sdk_spark.SdkEvent) {
 		// SDK was unable to claim some deposits automatically
 		unclaimedDeposits := event.UnclaimedDeposits
 		_ = unclaimedDeposits
+		lightning.notifyListPaymentsReload()
 		lightning.log.Infof("Spark: unable to claim some deposit automatically. Event: %v", e)
 	case breez_sdk_spark.SdkEventClaimedDeposits:
 		// Deposits were successfully claimed
 		claimedDeposits := event.ClaimedDeposits
 		_ = claimedDeposits
+		lightning.notifyListPaymentsReload()
 		lightning.log.Infof("Spark: deposit successfully claimed. Event: %v", e)
+	case breez_sdk_spark.SdkEventNewDeposits:
+		newDeposits := event.NewDeposits
+		_ = newDeposits
+		lightning.notifyListPaymentsReload()
+		lightning.log.Infof("Spark: new deposit detected. Event: %v", e)
 	case breez_sdk_spark.SdkEventPaymentSucceeded:
 		// A payment completed successfully
 		payment := event.Payment
 		_ = payment
 
-		lightning.Notify(observable.Event{
-			Subject: "lightning/list-payments",
-			Action:  action.Reload,
-		})
+		lightning.notifyListPaymentsReload()
 		lightning.log.Infof("Spark: payment completed successfully. Event: %v", e)
 	case breez_sdk_spark.SdkEventPaymentPending:
 		// A payment is pending (waiting for confirmation)
 		pendingPayment := event.Payment
 		_ = pendingPayment
-		lightning.Notify(observable.Event{
-			Subject: "lightning/list-payments",
-			Action:  action.Reload,
-		})
+		lightning.notifyListPaymentsReload()
 		lightning.log.Infof("Spark: payment waiting for confirmation. Event: %v", e)
 	case breez_sdk_spark.SdkEventPaymentFailed:
 		// A payment failed
 		failedPayment := event.Payment
 		_ = failedPayment
-		lightning.Notify(observable.Event{
-			Subject: "lightning/list-payments",
-			Action:  action.Reload,
-		})
+		lightning.notifyListPaymentsReload()
 		lightning.log.Infof("Spark: payment failed. Event: %v", e)
 	case breez_sdk_spark.SdkEventLightningAddressChanged:
 		lightning.Notify(observable.Event{

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -38,6 +38,7 @@ func NewHandlers(
 	handleNoError("/activate", lightning.PostActivate).Methods("POST")
 	handleNoError("/deactivate", lightning.PostDeactivate).Methods("POST")
 	handleNoError("/balance", lightning.GetBalance).Methods("GET")
+	handleNoError("/block-explorer-tx-prefix", lightning.GetBlockExplorerTxPrefix).Methods("GET")
 	handleNoError("/spark-status", lightning.GetSparkStatus).Methods("GET")
 	handleNoError("/list-payments", lightning.GetListPayments).Methods("GET")
 	handleNoError("/parse-payment-input", lightning.GetParsePaymentInput).Methods("GET")
@@ -69,6 +70,14 @@ func (lightning *Lightning) GetAccount(_ *http.Request) interface{} {
 		RootFingerprint: account.RootFingerprint,
 		Code:            account.Code,
 		Number:          account.Number,
+	}
+}
+
+// GetBlockExplorerTxPrefix handles the GET request to retrieve the Bitcoin transaction explorer prefix.
+func (lightning *Lightning) GetBlockExplorerTxPrefix(_ *http.Request) interface{} {
+	return responseDto{
+		Success: true,
+		Data:    lightning.btcCoin.BlockExplorerTransactionURLPrefix(),
 	}
 }
 
@@ -161,14 +170,19 @@ func (lightning *Lightning) GetBalance(_ *http.Request) interface{} {
 		Unit:        btcCoin.GetFormatUnit(false),
 		Conversions: coin.Conversions(balance.Available(), btcCoin, false, lightning.ratesUpdater),
 	}
+	formattedIncomingAmount := coin.FormattedAmountWithConversions{
+		Amount:      btcCoin.FormatAmount(balance.Incoming(), false),
+		Unit:        btcCoin.GetFormatUnit(false),
+		Conversions: coin.Conversions(balance.Incoming(), btcCoin, false, lightning.ratesUpdater),
+	}
 
 	return responseDto{
 		Success: true,
 		Data: accounts.FormattedAccountBalance{
 			HasAvailable: balance.Available().BigInt().Sign() > 0,
 			Available:    formattedAvailableAmount,
-			HasIncoming:  false,
-			Incoming:     coin.FormattedAmountWithConversions{},
+			HasIncoming:  balance.Incoming().BigInt().Sign() > 0,
+			Incoming:     formattedIncomingAmount,
 		},
 	}
 }

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -60,6 +60,7 @@ type breezSDK interface {
 	LnurlPay(breez_sdk_spark.LnurlPayRequest) (breez_sdk_spark.LnurlPayResponse, error)
 	ReceivePayment(breez_sdk_spark.ReceivePaymentRequest) (breez_sdk_spark.ReceivePaymentResponse, error)
 	ListPayments(breez_sdk_spark.ListPaymentsRequest) (breez_sdk_spark.ListPaymentsResponse, error)
+	ListUnclaimedDeposits(breez_sdk_spark.ListUnclaimedDepositsRequest) (breez_sdk_spark.ListUnclaimedDepositsResponse, error)
 }
 
 // Lightning manages the Breez SDK Spark integration.
@@ -237,10 +238,9 @@ func (lightning *Lightning) notifyReady() {
 	})
 }
 
-// Balance returns the balance of the lightning account.
-func (lightning *Lightning) Balance() (*accounts.Balance, error) {
+func (lightning *Lightning) availableBalance() (coin.Amount, error) {
 	if err := lightning.CheckActive(); err != nil {
-		return nil, err
+		return coin.Amount{}, err
 	}
 
 	ensureSynced := false
@@ -250,13 +250,24 @@ func (lightning *Lightning) Balance() (*accounts.Balance, error) {
 		EnsureSynced: &ensureSynced,
 	})
 	if err != nil {
+		return coin.Amount{}, errp.Wrap(err, "breez: get info")
+	}
+	return coin.NewAmountFromInt64(int64(info.BalanceSats)), nil
+}
+
+// Balance returns the balance of the lightning account.
+func (lightning *Lightning) Balance() (*accounts.Balance, error) {
+	available, err := lightning.availableBalance()
+	if err != nil {
 		return nil, err
 	}
 
-	balanceSats := info.BalanceSats
+	deposits, err := lightning.sdkService.ListUnclaimedDeposits(breez_sdk_spark.ListUnclaimedDepositsRequest{})
+	if err != nil {
+		return nil, errp.Wrap(err, "breez: list unclaimed deposits")
+	}
 
-	amount := coin.NewAmountFromInt64(int64(balanceSats))
-	return accounts.NewBalance(amount, coin.Amount{}), nil
+	return accounts.NewBalance(available, lightning.unclaimedDepositsAmount(deposits.Deposits)), nil
 }
 
 // SparkStatus is the operational status of the Spark network.

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -5,6 +5,7 @@ package lightning
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
@@ -45,6 +46,22 @@ type paymentInput struct {
 	LNURLPay *lightningLNURLPay      `json:"lnurlPay,omitempty"`
 }
 
+type bitcoinDepositState string
+
+const (
+	bitcoinDepositStateConfirming bitcoinDepositState = "confirming"
+	bitcoinDepositStateClaiming   bitcoinDepositState = "claiming"
+	bitcoinDepositStateComplete   bitcoinDepositState = "complete"
+	bitcoinDepositStateUnclaimed  bitcoinDepositState = "unclaimed"
+)
+
+type bitcoinDeposit struct {
+	TxID       string              `json:"txid"`
+	Vout       uint32              `json:"vout"`
+	State      bitcoinDepositState `json:"state"`
+	ClaimError string              `json:"claimError,omitempty"`
+}
+
 type lightningPayment struct {
 	ID                   string                              `json:"id"`
 	Type                 accounts.TxType                     `json:"type"`
@@ -56,6 +73,7 @@ type lightningPayment struct {
 	DeductedAmountAtTime coin.FormattedAmountWithConversions `json:"deductedAmountAtTime"`
 	Fee                  coin.FormattedAmountWithConversions `json:"fee"`
 	Invoice              string                              `json:"invoice,omitempty"`
+	BitcoinDeposit       *bitcoinDeposit                     `json:"bitcoinDeposit,omitempty"`
 }
 
 type receivePaymentResponse struct {
@@ -273,6 +291,13 @@ func (lightning *Lightning) toLightningPayment(payment breez_sdk_spark.Payment) 
 		DeductedAmountAtTime: deductedAmount.FormatWithConversionsAtTime(lightning.btcCoin, timestamp, lightning.ratesUpdater),
 		Fee:                  fee.FormatWithConversions(lightning.btcCoin, true, lightning.ratesUpdater),
 	}
+	// Claimed Bitcoin deposits appear in ListPayments, sometimes without payment details. Mark them
+	// as complete top-ups based on the payment method so the frontend can identify them reliably.
+	if payment.Method == breez_sdk_spark.PaymentMethodDeposit && result.Status == accounts.TxStatusComplete {
+		result.BitcoinDeposit = &bitcoinDeposit{
+			State: bitcoinDepositStateComplete,
+		}
+	}
 
 	if payment.Details == nil {
 		return result
@@ -290,6 +315,10 @@ func (lightning *Lightning) toLightningPayment(payment breez_sdk_spark.Payment) 
 				result.Description = *details.InvoiceDetails.Description
 			}
 			result.Invoice = details.InvoiceDetails.Invoice
+		}
+	case breez_sdk_spark.PaymentDetailsDeposit:
+		if result.BitcoinDeposit != nil {
+			result.BitcoinDeposit.TxID = details.TxId
 		}
 	}
 
@@ -323,6 +352,65 @@ func toLightningTransaction(payment breez_sdk_spark.Payment) *accounts.Transacti
 		tx.Fee = nil
 	}
 	return tx
+}
+
+func bitcoinDepositClaimError(claimError *breez_sdk_spark.DepositClaimError) string {
+	if claimError == nil {
+		return ""
+	}
+	switch err := (*claimError).(type) {
+	case breez_sdk_spark.DepositClaimErrorMaxDepositClaimFeeExceeded:
+		return fmt.Sprintf(
+			"Claim fee too high: required %d sats at %d sat/vbyte",
+			err.RequiredFeeSats,
+			err.RequiredFeeRateSatPerVbyte,
+		)
+	case breez_sdk_spark.DepositClaimErrorMissingUtxo:
+		return "Deposit output could not be found"
+	case breez_sdk_spark.DepositClaimErrorGeneric:
+		return err.Message
+	default:
+		return "Deposit could not be claimed"
+	}
+}
+
+func bitcoinDepositStateFromSDK(deposit breez_sdk_spark.DepositInfo) bitcoinDepositState {
+	if deposit.ClaimError != nil {
+		return bitcoinDepositStateUnclaimed
+	}
+	if deposit.IsMature {
+		return bitcoinDepositStateClaiming
+	}
+	return bitcoinDepositStateConfirming
+}
+
+func (lightning *Lightning) toBitcoinDepositPayment(deposit breez_sdk_spark.DepositInfo) lightningPayment {
+	amount := coin.NewAmountFromInt64(int64(deposit.AmountSats))
+	depositInfo := &bitcoinDeposit{
+		TxID:       deposit.Txid,
+		Vout:       deposit.Vout,
+		State:      bitcoinDepositStateFromSDK(deposit),
+		ClaimError: bitcoinDepositClaimError(deposit.ClaimError),
+	}
+
+	return lightningPayment{
+		ID:                   fmt.Sprintf("bitcoin-deposit:%s:%d", deposit.Txid, deposit.Vout),
+		Type:                 accounts.TxTypeReceive,
+		Status:               accounts.TxStatusPending,
+		Amount:               amount.FormatWithConversions(lightning.btcCoin, false, lightning.ratesUpdater),
+		AmountAtTime:         amount.FormatWithConversionsAtTime(lightning.btcCoin, nil, lightning.ratesUpdater),
+		DeductedAmountAtTime: coin.NewAmountFromInt64(0).FormatWithConversionsAtTime(lightning.btcCoin, nil, lightning.ratesUpdater),
+		Fee:                  coin.NewAmountFromInt64(0).FormatWithConversions(lightning.btcCoin, true, lightning.ratesUpdater),
+		BitcoinDeposit:       depositInfo,
+	}
+}
+
+func (lightning *Lightning) unclaimedDepositsAmount(deposits []breez_sdk_spark.DepositInfo) coin.Amount {
+	amount := coin.NewAmountFromInt64(0)
+	for _, deposit := range deposits {
+		amount = coin.SumAmounts(amount, coin.NewAmountFromInt64(int64(deposit.AmountSats)))
+	}
+	return amount
 }
 
 func parseLightningUint(value interface{ String() string }) uint64 {
@@ -382,8 +470,8 @@ func checkApprovedPaymentFee(fee uint64, approvedFee uint64) error {
 	return nil
 }
 
-func checkPaymentBalance(fee *paymentFee, balance *accounts.Balance) error {
-	if new(big.Int).SetUint64(fee.TotalDebitSat).Cmp(balance.Available().BigInt()) > 0 {
+func checkPaymentBalance(fee *paymentFee, availableBalance coin.Amount) error {
+	if new(big.Int).SetUint64(fee.TotalDebitSat).Cmp(availableBalance.BigInt()) > 0 {
 		return errLightningInsufficientFunds
 	}
 	return nil
@@ -447,11 +535,11 @@ func (lightning *Lightning) prepareBolt11Payment(paymentInvoice string, amountSa
 	if err != nil {
 		return nil, err
 	}
-	balance, err := lightning.Balance()
+	availableBalance, err := lightning.availableBalance()
 	if err != nil {
 		return nil, err
 	}
-	if err := checkPaymentBalance(fee, balance); err != nil {
+	if err := checkPaymentBalance(fee, availableBalance); err != nil {
 		return fee, err
 	}
 	lightning.log.Printf("Lightning Fee: %v sats", fee.FeeSat)
@@ -481,11 +569,11 @@ func (lightning *Lightning) prepareLNURLPay(inputStr string, amountSat *uint64) 
 	}
 
 	fee := preparedLNURLPayFee(prepareResponse)
-	balance, err := lightning.Balance()
+	availableBalance, err := lightning.availableBalance()
 	if err != nil {
 		return nil, err
 	}
-	if err := checkPaymentBalance(fee, balance); err != nil {
+	if err := checkPaymentBalance(fee, availableBalance); err != nil {
 		return fee, err
 	}
 	lightning.log.Printf("LNURL-Pay Fee: %v sats", fee.FeeSat)
@@ -526,11 +614,11 @@ func (lightning *Lightning) sendBolt11Payment(request sendPaymentRequest) error 
 	if err := checkApprovedPaymentFee(fee.FeeSat, request.ApprovedFeeSat); err != nil {
 		return err
 	}
-	balance, err := lightning.Balance()
+	availableBalance, err := lightning.availableBalance()
 	if err != nil {
 		return err
 	}
-	if err := checkPaymentBalance(fee, balance); err != nil {
+	if err := checkPaymentBalance(fee, availableBalance); err != nil {
 		return err
 	}
 
@@ -580,11 +668,11 @@ func (lightning *Lightning) sendLNURLPay(request sendPaymentRequest) error {
 	if err := checkApprovedPaymentFee(fee.FeeSat, request.ApprovedFeeSat); err != nil {
 		return err
 	}
-	balance, err := lightning.Balance()
+	availableBalance, err := lightning.availableBalance()
 	if err != nil {
 		return err
 	}
-	if err := checkPaymentBalance(fee, balance); err != nil {
+	if err := checkPaymentBalance(fee, availableBalance); err != nil {
 		return err
 	}
 
@@ -666,10 +754,17 @@ func (lightning *Lightning) ListPayments() ([]lightningPayment, error) {
 	if err != nil {
 		return nil, err
 	}
+	deposits, err := lightning.sdkService.ListUnclaimedDeposits(breez_sdk_spark.ListUnclaimedDepositsRequest{})
+	if err != nil {
+		return nil, errp.Wrap(err, "breez: list unclaimed deposits")
+	}
 
 	lightning.log.Infof("List payments: %+v", rawPayments)
 
-	payments := make([]lightningPayment, 0, len(rawPayments))
+	payments := make([]lightningPayment, 0, len(deposits.Deposits)+len(rawPayments))
+	for _, deposit := range deposits.Deposits {
+		payments = append(payments, lightning.toBitcoinDepositPayment(deposit))
+	}
 	for _, payment := range rawPayments {
 		payments = append(payments, lightning.toLightningPayment(payment))
 	}

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -242,6 +242,125 @@ func TestToLightningPaymentSparkNilInvoiceDetails(t *testing.T) {
 	})
 }
 
+func TestToLightningPaymentBitcoinDeposit(t *testing.T) {
+	lightning := makeTestLightning()
+	details := breez_sdk_spark.PaymentDetails(breez_sdk_spark.PaymentDetailsDeposit{
+		TxId: "deposit-txid",
+	})
+
+	payment := lightning.toLightningPayment(breez_sdk_spark.Payment{
+		Id:          "deposit-id",
+		PaymentType: breez_sdk_spark.PaymentTypeReceive,
+		Status:      breez_sdk_spark.PaymentStatusCompleted,
+		Amount:      big.NewInt(123),
+		Fees:        big.NewInt(0),
+		Timestamp:   42,
+		Method:      breez_sdk_spark.PaymentMethodDeposit,
+		Details:     &details,
+	})
+
+	require.Equal(t, &bitcoinDeposit{
+		TxID:  "deposit-txid",
+		State: bitcoinDepositStateComplete,
+	}, payment.BitcoinDeposit)
+}
+
+func TestToLightningPaymentBitcoinDepositWithoutDetails(t *testing.T) {
+	lightning := makeTestLightning()
+
+	payment := lightning.toLightningPayment(breez_sdk_spark.Payment{
+		Id:          "deposit-id",
+		PaymentType: breez_sdk_spark.PaymentTypeReceive,
+		Status:      breez_sdk_spark.PaymentStatusCompleted,
+		Amount:      big.NewInt(123),
+		Fees:        big.NewInt(0),
+		Method:      breez_sdk_spark.PaymentMethodDeposit,
+	})
+
+	require.Equal(t, &bitcoinDeposit{
+		State: bitcoinDepositStateComplete,
+	}, payment.BitcoinDeposit)
+}
+
+func TestToBitcoinDepositPayment(t *testing.T) {
+	lightning := makeTestLightning()
+	claimError := breez_sdk_spark.DepositClaimError(breez_sdk_spark.DepositClaimErrorGeneric{
+		Message: "claim failed",
+	})
+
+	testCases := []struct {
+		name        string
+		deposit     breez_sdk_spark.DepositInfo
+		expected    bitcoinDeposit
+		expectedID  string
+		expectedAmt string
+	}{
+		{
+			name: "confirming deposit",
+			deposit: breez_sdk_spark.DepositInfo{
+				Txid:       "txid-confirming",
+				Vout:       1,
+				AmountSats: 123,
+				IsMature:   false,
+			},
+			expected: bitcoinDeposit{
+				TxID:  "txid-confirming",
+				Vout:  1,
+				State: bitcoinDepositStateConfirming,
+			},
+			expectedID:  "bitcoin-deposit:txid-confirming:1",
+			expectedAmt: "0.00000123",
+		},
+		{
+			name: "claiming deposit",
+			deposit: breez_sdk_spark.DepositInfo{
+				Txid:       "txid-claiming",
+				Vout:       2,
+				AmountSats: 456,
+				IsMature:   true,
+			},
+			expected: bitcoinDeposit{
+				TxID:  "txid-claiming",
+				Vout:  2,
+				State: bitcoinDepositStateClaiming,
+			},
+			expectedID:  "bitcoin-deposit:txid-claiming:2",
+			expectedAmt: "0.00000456",
+		},
+		{
+			name: "unclaimed deposit",
+			deposit: breez_sdk_spark.DepositInfo{
+				Txid:       "txid-unclaimed",
+				Vout:       3,
+				AmountSats: 789,
+				IsMature:   true,
+				ClaimError: &claimError,
+			},
+			expected: bitcoinDeposit{
+				TxID:       "txid-unclaimed",
+				Vout:       3,
+				State:      bitcoinDepositStateUnclaimed,
+				ClaimError: "claim failed",
+			},
+			expectedID:  "bitcoin-deposit:txid-unclaimed:3",
+			expectedAmt: "0.00000789",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			payment := lightning.toBitcoinDepositPayment(testCase.deposit)
+
+			require.Equal(t, testCase.expectedID, payment.ID)
+			require.Equal(t, accounts.TxTypeReceive, payment.Type)
+			require.Equal(t, accounts.TxStatusPending, payment.Status)
+			require.Equal(t, coinAmountWithConversions(testCase.expectedAmt), payment.Amount)
+			require.Equal(t, testCase.expectedAmt, payment.AmountAtTime.Amount)
+			require.Equal(t, &testCase.expected, payment.BitcoinDeposit)
+		})
+	}
+}
+
 func TestToLightningPaymentSendWithMissingTimestamp(t *testing.T) {
 	lightning := makeTestLightning()
 
@@ -261,6 +380,99 @@ func TestToLightningPaymentSendWithMissingTimestamp(t *testing.T) {
 	require.Equal(t, "0.00000005", payment.Fee.Amount)
 	require.True(t, payment.AmountAtTime.Estimated)
 	require.True(t, payment.DeductedAmountAtTime.Estimated)
+}
+
+func makeActiveLightningWithSDK(t *testing.T, sdk breezSDK) *Lightning {
+	t.Helper()
+
+	coinLightning := makeTestLightning()
+	lightning := newTestLightning(t, nil)
+	lightning.btcCoin = coinLightning.btcCoin
+	lightning.ratesUpdater = coinLightning.ratesUpdater
+	lightning.sdkService = sdk
+	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{
+		Seed:            "test mnemonic",
+		RootFingerprint: []byte{0xde, 0xad, 0xbe, 0xef},
+		Code:            "v0-deadbeef-ln-0",
+		Number:          0,
+	}))
+	return lightning
+}
+
+func TestListPaymentsIncludesBitcoinDeposits(t *testing.T) {
+	lightning := makeActiveLightningWithSDK(t, &testBreezSDK{
+		listPayments: func(breez_sdk_spark.ListPaymentsRequest) (breez_sdk_spark.ListPaymentsResponse, error) {
+			return breez_sdk_spark.ListPaymentsResponse{
+				Payments: []breez_sdk_spark.Payment{
+					{
+						Id:          "payment-id",
+						PaymentType: breez_sdk_spark.PaymentTypeReceive,
+						Status:      breez_sdk_spark.PaymentStatusCompleted,
+						Amount:      big.NewInt(100),
+						Fees:        big.NewInt(0),
+					},
+				},
+			}, nil
+		},
+		listUnclaimedDeposits: func(breez_sdk_spark.ListUnclaimedDepositsRequest) (breez_sdk_spark.ListUnclaimedDepositsResponse, error) {
+			return breez_sdk_spark.ListUnclaimedDepositsResponse{
+				Deposits: []breez_sdk_spark.DepositInfo{
+					{
+						Txid:       "deposit-txid",
+						Vout:       1,
+						AmountSats: 200,
+						IsMature:   false,
+					},
+				},
+			}, nil
+		},
+	})
+
+	payments, err := lightning.ListPayments()
+
+	require.NoError(t, err)
+	require.Len(t, payments, 2)
+	require.Equal(t, "bitcoin-deposit:deposit-txid:1", payments[0].ID)
+	require.NotNil(t, payments[0].BitcoinDeposit)
+	require.Equal(t, "payment-id", payments[1].ID)
+	require.Nil(t, payments[1].BitcoinDeposit)
+}
+
+func TestBalanceIncludesIncomingBitcoinDeposits(t *testing.T) {
+	lightning := makeActiveLightningWithSDK(t, &testBreezSDK{
+		getInfo: func(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
+			return breez_sdk_spark.GetInfoResponse{
+				BalanceSats: 100,
+			}, nil
+		},
+		listUnclaimedDeposits: func(breez_sdk_spark.ListUnclaimedDepositsRequest) (breez_sdk_spark.ListUnclaimedDepositsResponse, error) {
+			return breez_sdk_spark.ListUnclaimedDepositsResponse{
+				Deposits: []breez_sdk_spark.DepositInfo{
+					{AmountSats: 200},
+					{AmountSats: 300},
+				},
+			}, nil
+		},
+	})
+
+	balance, err := lightning.Balance()
+
+	require.NoError(t, err)
+	require.Equal(t, coin.NewAmountFromInt64(100), balance.Available())
+	require.Equal(t, coin.NewAmountFromInt64(500), balance.Incoming())
+}
+
+func TestAvailableBalanceDoesNotLoadBitcoinDeposits(t *testing.T) {
+	lightning := makeActiveLightningWithSDK(t, &testBreezSDK{
+		getInfo: func(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
+			return breez_sdk_spark.GetInfoResponse{BalanceSats: 100}, nil
+		},
+	})
+
+	available, err := lightning.availableBalance()
+
+	require.NoError(t, err)
+	require.Equal(t, coin.NewAmountFromInt64(100), available)
 }
 
 func TestParseLightningUint(t *testing.T) {
@@ -554,8 +766,8 @@ func TestCheckPaymentBalance(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			balance := accounts.NewBalance(coin.NewAmountFromInt64(testCase.availableSat), coin.NewAmountFromInt64(0))
-			err := checkPaymentBalance(&paymentFee{TotalDebitSat: testCase.totalDebitSat}, balance)
+			availableBalance := coin.NewAmountFromInt64(testCase.availableSat)
+			err := checkPaymentBalance(&paymentFee{TotalDebitSat: testCase.totalDebitSat}, availableBalance)
 			require.Equal(t, testCase.expectedErr, errp.Cause(err))
 		})
 	}

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -38,6 +38,15 @@ export type TLightningLNURLPay = {
   maxAmountSat: number;
 };
 
+export type TBitcoinDepositState = 'confirming' | 'claiming' | 'complete' | 'unclaimed';
+
+export type TBitcoinDeposit = {
+  txid: string;
+  vout: number;
+  state: TBitcoinDepositState;
+  claimError?: string;
+};
+
 export type TLightningPayment = {
   id: string;
   type: 'send' | 'receive';
@@ -49,6 +58,7 @@ export type TLightningPayment = {
   deductedAmountAtTime: TAmountWithConversions;
   fee: TAmountWithConversions;
   invoice?: string;
+  bitcoinDeposit?: TBitcoinDeposit;
 };
 
 export type TReceivePaymentRequest = {
@@ -203,6 +213,10 @@ export const postDeactivate = async (): Promise<void> => {
 
 export const getLightningBalance = async (): Promise<TBalance> => {
   return getApiResponse<TBalance>('lightning/balance', 'Error calling getLightningBalance');
+};
+
+export const getBlockExplorerTxPrefix = async (): Promise<string> => {
+  return getApiResponse<string>('lightning/block-explorer-tx-prefix', 'Error calling getBlockExplorerTxPrefix');
 };
 
 export const getSparkStatus = async (): Promise<TSparkStatus> => {

--- a/frontends/web/src/components/icon/assets/icons/warning-yellow.svg
+++ b/frontends/web/src/components/icon/assets/icons/warning-yellow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="#F5A04C" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path stroke="none" d="M0 0h24v24H0z"/><path d="M12 9v4M10.363 3.591 2.257 17.125a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636-2.87L13.637 3.59a1.914 1.914 0 0 0-3.274 0zM12 16h.01"/></svg>

--- a/frontends/web/src/components/icon/icon.tsx
+++ b/frontends/web/src/components/icon/icon.tsx
@@ -70,6 +70,7 @@ import walletConnectDarkSVG from './assets/icons/wallet-connect-dark.svg';
 import walletConnectLightSVG from './assets/icons/wallet-connect-light.svg';
 import walletConnectDefaultSVG from './assets/icons/wallet-connect-default.svg';
 import warningSVG from './assets/icons/warning.svg';
+import warningYellowSVG from './assets/icons/warning-yellow.svg';
 import warningPNG from './assets/icons/warning.png';
 import warningOutlinedSVG from './assets/icons/warning-outlined.svg';
 import qrCodeDarkSVG from './assets/icons/qr-dark.svg';
@@ -205,6 +206,7 @@ export const Sync = (props: ImgProps) => (<img src={syncSVG} draggable={false} {
 export const SyncLight = (props: ImgProps) => (<img src={syncLightSVG} draggable={false} {...props} />);
 export const SelectedCheckLight = (props: ImgProps) => (<img src={selectedCheckLightSVG} draggable={false} {...props} />);
 export const Warning = (props: ImgProps) => (<img src={warningSVG} draggable={false} {...props} />);
+export const WarningYellow = (props: ImgProps) => (<img src={warningYellowSVG} draggable={false} {...props} />);
 /* WarningOLD is only used in attestation-check-settings and bip-85-settings */
 export const WarningOLD = (props: ImgProps) => (<img src={warningPNG} draggable={false} {...props} />);
 /* WarningOutlined is only used in factory reset */

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1593,6 +1593,20 @@
         "title": "Create lightning wallet"
       }
     },
+    "bitcoinDeposit": {
+      "claim": "Claim top-up or refund",
+      "label": "Bitcoin top-up",
+      "state": {
+        "claiming": "Claiming deposit",
+        "confirming": "Waiting for confirmations",
+        "unclaimed": "Claim required"
+      },
+      "stateShort": {
+        "claiming": "Claiming",
+        "confirming": "Confirming",
+        "unclaimed": "Claim required"
+      }
+    },
     "closeWithdrawFunds": {
       "accountDestination": "Account coins will be sent to",
       "confirm": "Confirm closing of lightning wallet",

--- a/frontends/web/src/routes/lightning/components/lightning-payment.tsx
+++ b/frontends/web/src/routes/lightning/components/lightning-payment.tsx
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useTranslation } from 'react-i18next';
-import type { TLightningPayment } from '@/api/lightning';
+import type { TBitcoinDepositState, TLightningPayment } from '@/api/lightning';
 import { useMediaQuery } from '@/hooks/mediaquery';
-import { Loupe } from '@/components/icon/icon';
+import { Loupe, WarningYellow } from '@/components/icon/icon';
 import { parseTimeLong, parseTimeShort } from '@/utils/date';
 import { ProgressRing } from '@/components/progressRing/progressRing';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
@@ -18,6 +18,7 @@ type TProps = TLightningPayment & {
 
 export const LightningPayment = ({
   amountAtTime,
+  bitcoinDeposit,
   deductedAmountAtTime,
   description,
   id,
@@ -38,9 +39,12 @@ export const LightningPayment = ({
       }}>
       <div className={styles.txContent} data-testid="transaction" data-tx-type={type}>
         <span className={styles.txIcon}>
-          <Arrow status={status} type={type} />
+          {bitcoinDeposit?.state === 'unclaimed'
+            ? <WarningYellow />
+            : <Arrow status={status} type={type} />}
         </span>
         <PaymentStatus
+          bitcoinDeposit={bitcoinDeposit}
           description={description}
           status={status}
           time={time}
@@ -63,29 +67,63 @@ export const LightningPayment = ({
   );
 };
 
-type TPaymentStatusProps = Pick<TLightningPayment, 'description' | 'status' | 'time' | 'type'>;
+type TPaymentStatusProps = Pick<TLightningPayment, 'bitcoinDeposit' | 'description' | 'status' | 'time' | 'type'>;
 
 const PaymentStatus = ({
+  bitcoinDeposit,
   description,
   status,
   time,
   type,
 }: TPaymentStatusProps) => {
+  const { t } = useTranslation();
   const showDate = status === 'complete' && !!time;
+  const isCompleteBitcoinDeposit = bitcoinDeposit?.state === 'complete';
 
   return (
     <span className={styles.txInfoColumn}>
       <span className={styles.txNote}>
-        <span className={description ? styles.txNoteText : styles.txType}>
-          {description || <FallbackLabel type={type} />}
+        <span className={description && !bitcoinDeposit ? styles.txNoteText : styles.txType}>
+          {bitcoinDeposit
+            ? t('lightning.bitcoinDeposit.label')
+            : description || <FallbackLabel type={type} />}
         </span>
       </span>
-      {showDate ? (
+      {bitcoinDeposit && !isCompleteBitcoinDeposit ? (
+        <BitcoinDepositProgress state={bitcoinDeposit.state} />
+      ) : showDate ? (
         <PaymentDate time={time} />
       ) : status === 'pending' ? (
         <PaymentProgress status={status} type={type} />
       ) : (
         <PaymentStatusText status={status} type={type} />
+      )}
+    </span>
+  );
+};
+
+type TBitcoinDepositProgressProps = {
+  state: TBitcoinDepositState;
+};
+
+const BitcoinDepositProgress = ({ state }: TBitcoinDepositProgressProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <span className={styles.txProgress}>
+      <span className={styles.txProgressTextLong}>
+        {t(`lightning.bitcoinDeposit.state.${state}`)}
+      </span>
+      <span className={styles.txProgressTextShort}>
+        {t(`lightning.bitcoinDeposit.stateShort.${state}`)}
+      </span>
+      {state !== 'unclaimed' && (
+        <ProgressRing
+          className={styles.iconProgress}
+          width={18}
+          value={state === 'confirming' ? 33 : 66}
+          isComplete={false}
+        />
       )}
     </span>
   );

--- a/frontends/web/src/routes/lightning/components/payment-details.module.css
+++ b/frontends/web/src/routes/lightning/components/payment-details.module.css
@@ -1,0 +1,3 @@
+.claimButton {
+    width: 100%;
+}

--- a/frontends/web/src/routes/lightning/components/payment-details.tsx
+++ b/frontends/web/src/routes/lightning/components/payment-details.tsx
@@ -3,28 +3,39 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TLightningPayment } from '@/api/lightning';
+import { A } from '@/components/anchor/anchor';
+import { ExternalLink } from '@/components/icon';
 import { Dialog } from '@/components/dialog/dialog';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import { Button } from '@/components/forms/button';
 import { TxDetailRow } from '@/components/transactions/components/tx-detail-dialog/tx-detail-row';
 import { parseTimeLongWithYear } from '@/utils/date';
 import { getTxSign } from '@/utils/transaction';
 import styles from '@/components/transactions/components/tx-detail-dialog/tx-detail-dialog.module.css';
+import paymentStyles from './payment-details.module.css';
 
 type TTxDetailsDialog = {
   open: boolean;
   onClose: () => void;
   payment: TLightningPayment;
+  explorerURL?: string;
 };
 
 export const PaymentDetailsDialog = ({
   open,
   onClose,
   payment,
+  explorerURL,
 }: TTxDetailsDialog) => {
   const { i18n, t } = useTranslation();
 
-  const typeText = payment.type === 'receive' ? t('generic.received') : t('generic.sent');
+  const typeText = payment.bitcoinDeposit
+    ? t('lightning.bitcoinDeposit.label')
+    : payment.type === 'receive' ? t('generic.received') : t('generic.sent');
   const sign = payment.amount.amount === '0' ? '' : getTxSign(payment.type);
+  const statusText = payment.bitcoinDeposit && payment.bitcoinDeposit.state !== 'complete'
+    ? t(`lightning.bitcoinDeposit.state.${payment.bitcoinDeposit.state}`)
+    : t(`transaction.status.${payment.status}`, { context: payment.type });
 
   return (
     <Dialog
@@ -35,14 +46,18 @@ export const PaymentDetailsDialog = ({
       medium>
       {payment && (
         <div className={styles.container}>
-          <TxDetailRow>
-            <p className={styles.label}>{t('lightning.send.confirm.note')}</p>
-            <span>{payment.description || '-'}</span>
-          </TxDetailRow>
-          <TxDetailRow>
-            <p className={styles.label}>{t('transaction.details.date')}</p>
-            <span>{payment.time ? parseTimeLongWithYear(payment.time, i18n.language) : '-'}</span>
-          </TxDetailRow>
+          {!payment.bitcoinDeposit && (
+            <TxDetailRow>
+              <p className={styles.label}>{t('lightning.send.confirm.note')}</p>
+              <span>{payment.description || '-'}</span>
+            </TxDetailRow>
+          )}
+          {(!payment.bitcoinDeposit || payment.time) && (
+            <TxDetailRow>
+              <p className={styles.label}>{t('transaction.details.date')}</p>
+              <span>{payment.time ? parseTimeLongWithYear(payment.time, i18n.language) : '-'}</span>
+            </TxDetailRow>
+          )}
           <TxDetailRow>
             <p className={styles.label}>{t('transaction.details.amount')}</p>
             <span>
@@ -93,8 +108,29 @@ export const PaymentDetailsDialog = ({
           </TxDetailRow>
           <TxDetailRow>
             <p className={styles.label}>{t('transaction.details.status')}</p>
-            <span>{t(`transaction.status.${payment.status}`, { context: payment.type })}</span>
+            <span>{statusText}</span>
           </TxDetailRow>
+          {payment.bitcoinDeposit && (
+            <>
+              {explorerURL && payment.bitcoinDeposit.txid && (
+                <div className={styles.explorerLinkContainer}>
+                  <A
+                    className={styles.explorerLink}
+                    href={explorerURL + payment.bitcoinDeposit.txid}
+                    title={`${t('transaction.explorerTitle')}\n${explorerURL}${payment.bitcoinDeposit.txid}`}>
+                    <ExternalLink />
+                    {' '}
+                    {t('transaction.explorerTitle')}
+                  </A>
+                </div>
+              )}
+              {payment.bitcoinDeposit.state === 'unclaimed' && (
+                <Button className={paymentStyles.claimButton} primary>
+                  {t('lightning.bitcoinDeposit.claim')}
+                </Button>
+              )}
+            </>
+          )}
         </div>
       )}
     </Dialog>
@@ -104,12 +140,14 @@ export const PaymentDetailsDialog = ({
 type TTransactionDetails = {
   id: string | null;
   payment?: TLightningPayment;
+  explorerURL?: string;
   onClose: () => void;
 };
 
 export const PaymentDetails = ({
   id,
   payment,
+  explorerURL,
   onClose,
 }: TTransactionDetails) => {
   const [open, setOpen] = useState(false);
@@ -127,6 +165,7 @@ export const PaymentDetails = ({
   return (
     <PaymentDetailsDialog
       open={open}
+      explorerURL={explorerURL}
       onClose={() => {
         setOpen(false);
         onClose();

--- a/frontends/web/src/routes/lightning/lightning.tsx
+++ b/frontends/web/src/routes/lightning/lightning.tsx
@@ -6,6 +6,7 @@ import * as accountApi from '../../api/account';
 import { getDeviceList } from '../../api/devices';
 import {
   TLightningPayment,
+  getBlockExplorerTxPrefix,
   getLightningBalance,
   getListPayments,
   subscribeListPayments,
@@ -43,6 +44,7 @@ export const Lightning = () => {
   const [error, setError] = useState<string>();
   const [detailID, setDetailID] = useState<TLightningPayment['id'] | null>(null);
   const mounted = useMountedRef();
+  const blockExplorerTxPrefix = useLoad(getBlockExplorerTxPrefix);
   const devices = useLoad(getDeviceList);
 
   const onStateChange = useCallback(async () => {
@@ -202,6 +204,7 @@ export const Lightning = () => {
 
               <PaymentDetails
                 id={detailID}
+                explorerURL={blockExplorerTxPrefix}
                 payment={payments?.find(payment => payment.id === detailID)}
                 onClose={() => setDetailID(null)}
               />


### PR DESCRIPTION
Show incoming Bitcoin top-ups from the Breez Spark SDK as pending receive rows in the Lightning activity list. Merge unclaimed deposits into list-payments, surface their state and claim error metadata, and include their amount in the incoming Lightning balance.

Reload the payment list for new, claimed, and unclaimed deposit events so the UI reflects the Bitcoin deposit lifecycle. Add backend coverage for deposit state mapping, list merging, balance accounting, and event notifications.

The manual claim flow will be implemented in a following commit.