### PR TITLE
frontend: remove -02 suffix from Lightning guide

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1356,15 +1356,15 @@
     },
     "lightning": {
       "multipleDevices": {
-        "text": "Yes, just plug in your BitBox02 into a different device and activate lightning on the BitBoxApp. The lighting wallet will be the same one as your previous device if you use the same BitBox02 wallet.",
+        "text": "Yes, just plug your BitBox into a different device and activate lightning on the BitBoxApp. The lighting wallet will be the same one as your previous device if you use the same BitBox.",
         "title": "Can I use my lightning wallet on multiple devices?"
       },
       "multipleWallets": {
-        "text": "No, currently you cannot make multiple lightning wallets with the same BitBox02, nor use multiple lightning wallets on the same BitBoxApp, even if you have multiple BitBox02 wallets.",
+        "text": "No, currently you cannot make multiple lightning wallets with the same BitBox, nor use multiple lightning wallets on the same BitBoxApp, even if you have multiple BitBoxes.",
         "title": "Can I make multiple lightning wallets?"
       },
       "privateKey": {
-        "text": "The BitBoxApp lightning wallet is non-custodial, which means only you have access to the keys. The private keys are stored in the BitBoxApp. This makes your lightning wallet a “Hot wallet”, since the lightning keys are on your computer/phone instead of on your BitBox02. Therefore, only store a small amount of coins on your Lighting wallet",
+        "text": "The BitBoxApp lightning wallet is non-custodial, which means only you have access to the keys. The private keys are stored in the BitBoxApp. This makes your lightning wallet a “Hot wallet”, since the lightning keys are on your computer/phone instead of on your BitBox. Therefore, only store a small amount of coins on your Lighting wallet",
         "title": "Where are my lightning private keys stored?"
       },
       "providers": {
@@ -1390,8 +1390,8 @@
         }
       },
       "securedByBitBox": {
-        "text": "No, the BitBox02 wallet is just used to create and restore your lightning wallet. Once your lightning wallet is created, it is a “hot wallet”.",
-        "title": "Is my lightning wallet secured by my BitBox02?"
+        "text": "No, the BitBox is just used to create and restore your lightning wallet. Once your lightning wallet is created, it is a “hot wallet”.",
+        "title": "Is my lightning wallet secured by my BitBox?"
       },
       "send": {
         "cancel": {
@@ -1610,11 +1610,11 @@
     "accountLabel": "Lightning",
     "activate": {
       "connect": {
-        "content": "connect your bitbox02 to create your lightning wallet",
+        "content": "connect your BitBox to create your lightning wallet",
         "title": "Connect your device"
       },
       "disclaimer": {
-        "content": "Your lightning wallet will be made using a key derived from your BitBox02 wallet. That way you can always restore your lightning wallet using your BitBox02 or backup.\n\nHowever, unlike the BitBox02, the lightning wallet is a <strong>hot wallet</strong>. This means the keys for your lightning wallet are stored on the BitBoxApp, not on the BitBox02. You should not use the lightning wallet for a large amount of funds or long term storage.\n\n          In addition, the lightning feature is currently in beta, meaning you may encounter bugs, reliability issues or it may stop working entirely.",
+        "content": "Your lightning wallet will be made using a key derived from your BitBox. That way you can always restore your lightning wallet using your BitBox or backup.\n\nHowever, unlike the BitBox, the lightning wallet is a <strong>hot wallet</strong>. This means the keys for your lightning wallet are stored on the BitBoxApp, not on the BitBox. You should not use the lightning wallet for a large amount of funds or long term storage.\n\n          In addition, the lightning feature is currently in beta, meaning you may encounter bugs, reliability issues or it may stop working entirely.",
         "title": "How does it work with the BitBoxApp?"
       },
       "intro": {
@@ -1648,7 +1648,7 @@
     "closeWithdrawFunds": {
       "accountDestination": "Account coins will be sent to",
       "confirm": "Confirm closing of lightning wallet",
-      "description": "This will close your lightning wallet and send all remaining coins to your BitBox wallet.",
+      "description": "This will close your lightning wallet and send all remaining coins to your BitBox.",
       "failure": {
         "message": "Closing lightning wallet failed.",
         "tryAgain": "Please try again."
@@ -1663,7 +1663,7 @@
     },
     "deactivate": {
       "intro": {
-        "content": "Shutting down your lightning wallet will disconnect you from the server and you will no longer be able to use your lightning wallet to send and receive.\nFunds on your lightning wallet are not affected, you can still access them again by enabling lightning in the settings and connecting the BitBox02 wallet used to make that wallet."
+        "content": "Shutting down your lightning wallet will disconnect you from the server and you will no longer be able to use your lightning wallet to send and receive.\nFunds on your lightning wallet are not affected, you can still access them again by enabling lightning in the settings and connecting the BitBox used to make that wallet."
       },
       "success": {
         "message": "Success, your lightning wallet is now disabled"


### PR DESCRIPTION
The app uses BitBox rather than BitBox02, so align the LN guide to the rest of the app.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
