### PR TITLE
lightning: show enable wallet action

### DIFF
--- a/frontends/web/src/routes/settings/components/advanced-settings/lightning-settings-setting.tsx
+++ b/frontends/web/src/routes/settings/components/advanced-settings/lightning-settings-setting.tsx
@@ -3,22 +3,34 @@
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/badge/badge';
+import { useLightning } from '@/hooks/lightning';
 import { SettingsItem } from '@/routes/settings/components/settingsItem/settingsItem';
 import styles from './lightning-settings-setting.module.css';
 
 export const LightningSettingsSetting = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const { lightningAccount } = useLightning();
+
+  if (lightningAccount === undefined) {
+    return null;
+  }
+
+  const isLightningEnabled = lightningAccount !== null;
 
   return (
     <SettingsItem
-      settingName={t('lightning.settings.title')}
+      settingName={t(isLightningEnabled
+        ? 'lightning.settings.title'
+        : 'lightning.settings.enableWallet')}
       extraComponent={
         <Badge className={styles.beta} type="info">
           {t('generic.beta')}
         </Badge>
       }
-      onClick={() => navigate('/settings/lightning-settings')}
+      onClick={() => navigate(isLightningEnabled
+        ? '/settings/lightning-settings'
+        : '/lightning/activate/')}
     />
   );
 };

--- a/frontends/web/src/routes/settings/settings-search.test.ts
+++ b/frontends/web/src/routes/settings/settings-search.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/utils/env', () => ({
 }));
 
 const translations: Record<string, string> = {
+  'lightning.settings.enableWallet': 'Enable lightning wallet',
   'lightning.settings.title': 'Lightning settings',
   'testWallet.connect.title': 'Test wallet',
   'testWallet.disconnect.title': 'Disconnect test wallet',
@@ -21,28 +22,32 @@ const translations: Record<string, string> = {
 
 const t = ((key: string) => translations[key] || key) as TFunction;
 
-const getItems = (hasSoftwareKeystore: boolean) => getSettingsSearchItems({
+const getItems = (
+  hasSoftwareKeystore: boolean,
+  isLightningEnabled: boolean | undefined,
+) => getSettingsSearchItems({
   devices: {},
   hasAccounts: true,
   hasSoftwareKeystore,
+  isLightningEnabled,
   isTesting: true,
   t,
 });
 
 describe('settings search', () => {
   it('uses the connect title for the test wallet setting when no software wallet exists', () => {
-    const results = filterSettingsSearchItems(getItems(false), 'test wallet');
+    const results = filterSettingsSearchItems(getItems(false, true), 'test wallet');
 
     expect(results).toContainEqual({
       id: 'test-wallet',
       page: 'advanced',
       title: 'Test wallet',
     });
-    expect(filterSettingsSearchItems(getItems(false), 'disconnect')).toEqual([]);
+    expect(filterSettingsSearchItems(getItems(false, true), 'disconnect')).toEqual([]);
   });
 
   it('uses the disconnect title for the test wallet setting when a software wallet exists', () => {
-    const results = filterSettingsSearchItems(getItems(true), 'disconnect');
+    const results = filterSettingsSearchItems(getItems(true, true), 'disconnect');
 
     expect(results).toEqual([{
       id: 'test-wallet',
@@ -51,13 +56,29 @@ describe('settings search', () => {
     }]);
   });
 
-  it('includes the lightning settings row without a lightning account', () => {
-    const results = filterSettingsSearchItems(getItems(false), 'lightning settings');
+  it('uses the lightning settings title when lightning is enabled', () => {
+    const results = filterSettingsSearchItems(getItems(false, true), 'lightning settings');
 
     expect(results).toContainEqual({
       id: 'lightning-settings',
       page: 'advanced',
       title: 'Lightning settings',
     });
+  });
+
+  it('uses the enable lightning wallet title when lightning is disabled', () => {
+    const results = filterSettingsSearchItems(getItems(false, false), 'enable lightning wallet');
+
+    expect(results).toContainEqual({
+      id: 'lightning-settings',
+      page: 'advanced',
+      title: 'Enable lightning wallet',
+    });
+  });
+
+  it('hides the lightning setting while its state is loading', () => {
+    const results = filterSettingsSearchItems(getItems(false, undefined), 'lightning');
+
+    expect(results).toEqual([]);
   });
 });

--- a/frontends/web/src/routes/settings/settings-search.ts
+++ b/frontends/web/src/routes/settings/settings-search.ts
@@ -23,6 +23,7 @@ type TGetSettingsSearchItemsArgs = {
   deviceInfo?: DeviceInfo;
   devices: TDevices;
   hasAccounts: boolean;
+  isLightningEnabled: boolean | undefined;
   hasSoftwareKeystore: boolean;
   isTesting: boolean;
   t: TFunction;
@@ -103,7 +104,10 @@ const SETTINGS_SEARCH_DESCRIPTORS: TSettingsSearchDescriptor[] = [
   },
   {
     id: 'lightning-settings',
-    getTitle: ({ t }) => t('lightning.settings.title'),
+    isAvailable: ({ isLightningEnabled }) => isLightningEnabled !== undefined,
+    getTitle: ({ isLightningEnabled, t }) => t(isLightningEnabled
+      ? 'lightning.settings.title'
+      : 'lightning.settings.enableWallet'),
     page: 'advanced',
   },
   {
@@ -239,6 +243,7 @@ export const getSettingsSearchItems = ({
   deviceInfo,
   devices,
   hasAccounts,
+  isLightningEnabled,
   hasSoftwareKeystore,
   isTesting,
   t,
@@ -248,6 +253,7 @@ export const getSettingsSearchItems = ({
     devices,
     deviceIDs: Object.keys(devices),
     hasAccounts,
+    isLightningEnabled,
     hasSoftwareKeystore,
     isTesting,
     t,

--- a/frontends/web/src/routes/settings/use-settings-search.ts
+++ b/frontends/web/src/routes/settings/use-settings-search.ts
@@ -8,6 +8,7 @@ import type { TDevices } from '@/api/devices';
 import { AppContext } from '@/contexts/AppContext';
 import { useLoad } from '@/hooks/api';
 import { useKeystores } from '@/hooks/backend';
+import { useLightning } from '@/hooks/lightning';
 import {
   SETTINGS_SEARCH_QUERY_PARAM,
   filterSettingsSearchItems,
@@ -28,6 +29,7 @@ export const useSettingsSearch = ({
   const [searchParams, setSearchParams] = useSearchParams();
   const searchTerm = searchParams.get(SETTINGS_SEARCH_QUERY_PARAM) || '';
   const keystores = useKeystores();
+  const { lightningAccount } = useLightning();
   const hasSoftwareKeystore = keystores?.some(({ type }) => type === 'software') ?? false;
   const deviceId = Object.keys(devices)[0];
   const device = deviceId ? devices[deviceId] : undefined;
@@ -41,10 +43,13 @@ export const useSettingsSearch = ({
     deviceInfo,
     devices,
     hasAccounts,
+    isLightningEnabled: lightningAccount === undefined
+      ? undefined
+      : lightningAccount !== null,
     hasSoftwareKeystore,
     isTesting,
     t,
-  }), [deviceInfo, devices, hasAccounts, hasSoftwareKeystore, isTesting, t]);
+  }), [deviceInfo, devices, hasAccounts, hasSoftwareKeystore, isTesting, lightningAccount, t]);
   const searchResults = useMemo(
     () => filterSettingsSearchItems(searchItems, searchTerm),
     [searchItems, searchTerm],


### PR DESCRIPTION
Show the enable-wallet action in Advanced settings when no Lightning account exists and open activation directly.

Keep the Lightning settings action for enabled wallets and make settings search use the same state-dependent title.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
