### PR TITLE
ios: support Xcode 26 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
           name: BitBoxApp-macos-${{github.sha}}.zip
           if-no-files-found: error
   ios:
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       GO_SRC_DIR: src/github.com/BitBoxSwiss/bitbox-wallet-app
     steps:

--- a/frontends/ios/BitBoxApp/BitBoxApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/frontends/ios/BitBoxApp/BitBoxApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mkrd/Swift-BigInt.git",
       "state" : {
-        "revision" : "b07e961f4c999671cf8c2dc80e740899e8946013",
-        "version" : "2.3.0"
+        "revision" : "7e2117797cd1b608303cc2da1a3a2263cc4e7727",
+        "version" : "2.4.0"
       }
     }
   ],

--- a/frontends/ios/Makefile
+++ b/frontends/ios/Makefile
@@ -1,4 +1,4 @@
-IOS_TEST_DESTINATION ?= platform=iOS Simulator,name=iPhone 16
+IOS_TEST_DESTINATION ?= platform=iOS Simulator,name=iPhone 17
 
 prepare:
 	cd ../../ && ${MAKE} buildweb


### PR DESCRIPTION
Update Swift-BigInt to 2.4.0 to fix its Xcode 26 compilation failure.

Run iOS CI on macos-26 with an available iPhone 17 simulator so future current-toolchain incompatibilities are caught.