### PR TITLE
frontend: claim & refund top-up UI

### DIFF
--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1645,6 +1645,35 @@
         "unclaimed": "Claim required"
       }
     },
+    "claimTopUp": {
+      "claimButton": "Claim top-up",
+      "claimFee": "Claim fee",
+      "confirm": {
+        "claimButton": "Confirm claim",
+        "claimTitle": "Confirm top-up claim",
+        "fee": "Fee",
+        "refundButton": "Confirm refund",
+        "refundDestination": "Refund destination",
+        "refundTitle": "Confirm top-up refund",
+        "totalAmount": "Unclaimed top-up total amount"
+      },
+      "description": "You will need to create a transaction to claim the stuck amount.",
+      "empty": "No unclaimed top-ups.",
+      "refundButton": "Refund top-up",
+      "refundFee": "Refund fee",
+      "success": {
+        "claimMessage": "Claim transaction made",
+        "claimNote": "Top-up coins will appear in your wallet once the transaction is confirmed.",
+        "claimTitle": "Claim top-up",
+        "refundMessage": "Refund transaction made",
+        "refundNote": "The refund will appear back in your on-chain wallet once the transaction is confirmed.",
+        "refundTitle": "Refund top-up"
+      },
+      "title": "Claim top-up",
+      "topUps": "Unclaimed top-ups",
+      "viewTransaction": "View transaction",
+      "warning": "You can either claim the top-up or refund it. Either choice will have a fee."
+    },
     "closeWithdrawFunds": {
       "accountDestination": "Account coins will be sent to",
       "confirm": "Confirm closing of lightning wallet",
@@ -1762,7 +1791,6 @@
       "enableWalletDescription": "Lightning enables instant and low fee payments.",
       "expert": "Expert",
       "information": "Information",
-      "manuallyClaimTopUp": "Manually claim top-up",
       "serviceProvider": "Service provider",
       "setLightningAddress": "Set lightning address",
       "shutDownWallet": "Shut down lightning wallet",

--- a/frontends/web/src/routes/lightning/claim-top-up/amount-block.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/amount-block.tsx
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TAmountWithConversions } from '@/api/account';
+import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import styles from './claim-top-up.module.css';
+
+type TProps = {
+  amount?: TAmountWithConversions;
+  label: string;
+};
+
+export const AmountBlock = ({ amount, label }: TProps) => {
+  if (!amount) {
+    return null;
+  }
+  return (
+    <div className={styles.amountBlock}>
+      <span className={styles.blockLabel}>{label}</span>
+      <div className={styles.blockAmounts}>
+        <AmountWithUnit
+          alwaysShowAmounts
+          amount={amount}
+          amountClassName={styles.amount}
+        />
+        <AmountWithUnit
+          alwaysShowAmounts
+          amount={amount}
+          convertToFiat
+          amountClassName={styles.fiat}
+          unitClassName={styles.fiat}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.module.css
+++ b/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.module.css
@@ -1,0 +1,142 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.content {
+    container-type: inline-size;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-default);
+}
+
+.description {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-half);
+}
+
+.description p {
+    margin: 0;
+}
+
+.section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-quarter);
+}
+
+.sectionTitle {
+    color: var(--color-tertiary);
+    font-size: var(--size-small);
+    font-weight: 400;
+    margin: 0;
+}
+
+.amountRows {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-quarter);
+}
+
+.amountRow {
+    align-items: baseline;
+    display: flex;
+    gap: var(--space-half);
+    justify-content: space-between;
+}
+
+.amount {
+    color: var(--color-default);
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.fiat {
+    color: var(--color-tertiary);
+    white-space: nowrap;
+}
+
+.feeActions {
+    align-items: center;
+    column-gap: var(--space-half);
+    display: grid;
+    grid-template-columns: 1fr max-content;
+    row-gap: var(--space-default);
+}
+
+.feeRow {
+    display: contents;
+}
+
+@container (max-width: 320px) {
+    .feeActions {
+        align-items: stretch;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-default);
+    }
+
+    .feeRow {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-half);
+    }
+}
+
+.amountBlock {
+    min-width: 0;
+}
+
+.blockLabel {
+    color: var(--color-tertiary);
+    display: block;
+    font-size: var(--size-small);
+    font-weight: 400;
+    margin-bottom: var(--space-quarter);
+}
+
+.blockAmounts {
+    align-items: baseline;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-quarter);
+}
+
+.refundDestination {
+    display: flex;
+    flex-direction: column;
+}
+
+.accountSelector {
+    margin-bottom: 0;
+}
+
+.actionButton {
+    grid-column: 2;
+    min-width: 0;
+}
+
+.successContent {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-default);
+}
+
+.successMessage,
+.successNote {
+    margin: 0;
+}
+
+.transactionButton {
+    align-items: center;
+    display: inline-flex;
+    gap: var(--space-quarter);
+}
+
+.transactionIcon {
+    height: 18px;
+    width: 18px;
+}
+
+.doneButton {
+    width: 100%;
+}

--- a/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/claim-top-up.tsx
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
+import type { AccountCode, TAccount } from '@/api/account';
+import { getListPayments, type TLightningPayment } from '@/api/lightning';
+import { Header, Main } from '@/components/layout';
+import { Spinner } from '@/components/spinner/Spinner';
+import { useLoad } from '@/hooks/api';
+import { ClaimTopUpConfirm } from './confirm-step';
+import { ClaimTopUpOverview } from './overview-step';
+import { ClaimTopUpSuccess } from './success-step';
+import { type TAction, type TStep } from './constants';
+import { isUnclaimedBitcoinDeposit, sumAmounts } from './utils';
+
+type TLocationState = {
+  deposits?: TLightningPayment[];
+};
+
+type TProps = {
+  activeAccounts: TAccount[];
+};
+
+type TInnerProps = {
+  activeAccounts: TAccount[];
+  deposits: TLightningPayment[];
+  loading: boolean;
+};
+
+const LightningClaimTopUpInner = ({ activeAccounts, deposits, loading }: TInnerProps) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const btcAccounts = useMemo(
+    () => activeAccounts.filter(account => account.active && account.coinCode === 'btc'),
+    [activeAccounts]
+  );
+  const totalAmount = useMemo(
+    () => sumAmounts(deposits.map(deposit => deposit.amount)),
+    [deposits]
+  );
+  const [action, setAction] = useState<TAction>('claim');
+  const [step, setStep] = useState<TStep>('overview');
+  const [refundDestinationAccountCode, setRefundDestinationAccountCode] = useState<AccountCode>(btcAccounts[0]?.code || '');
+  const isClaim = action === 'claim';
+  const canConfirm = isClaim || !!refundDestinationAccountCode;
+
+  useEffect(() => {
+    if (!btcAccounts.length) {
+      setRefundDestinationAccountCode('');
+      return;
+    }
+    if (!refundDestinationAccountCode || !btcAccounts.some(account => account.code === refundDestinationAccountCode)) {
+      setRefundDestinationAccountCode(btcAccounts[0]?.code || '');
+    }
+  }, [btcAccounts, refundDestinationAccountCode]);
+
+  const startAction = (nextAction: TAction) => {
+    setAction(nextAction);
+    setStep('confirm');
+  };
+
+  const renderContent = () => {
+    if (loading) {
+      return <Spinner text={t('lightning.initializing')} />;
+    }
+    if (step === 'success') {
+      return (
+        <ClaimTopUpSuccess
+          action={action}
+          onDone={() => navigate('/lightning')}
+        />
+      );
+    }
+    if (step === 'confirm') {
+      return (
+        <ClaimTopUpConfirm
+          action={action}
+          btcAccounts={btcAccounts}
+          canConfirm={canConfirm}
+          refundDestinationAccountCode={refundDestinationAccountCode}
+          totalAmount={totalAmount}
+          onCancel={() => setStep('overview')}
+          onConfirm={() => {
+            if (isClaim) {
+              // TODO: Call the claim API here before advancing.
+            } else {
+              // TODO: Call the refund API (to refundDestinationAccountCode) here before advancing.
+            }
+            setStep('success');
+          }}
+          onRefundDestinationChange={setRefundDestinationAccountCode}
+        />
+      );
+    }
+    return (
+      <ClaimTopUpOverview
+        deposits={deposits}
+        onCancel={() => navigate(-1)}
+        onClaim={() => startAction('claim')}
+        onRefund={() => startAction('refund')}
+      />
+    );
+  };
+
+  return (
+    <Main>
+      <Header
+        title={step === 'success'
+          ? t(`lightning.claimTopUp.success.${action}Title`)
+          : t('lightning.claimTopUp.title')
+        }
+      />
+      {renderContent()}
+    </Main>
+  );
+};
+
+export const LightningClaimTopUp = ({ activeAccounts }: TProps) => {
+  const { state } = useLocation();
+  const routeDeposits = useMemo(
+    () => ((state as TLocationState | null)?.deposits ?? []).filter(isUnclaimedBitcoinDeposit),
+    [state]
+  );
+  const payments = useLoad(getListPayments);
+  const deposits = useMemo(() => {
+    if (payments === undefined) {
+      return routeDeposits;
+    }
+    return payments.filter(isUnclaimedBitcoinDeposit);
+  }, [payments, routeDeposits]);
+  const loading = payments === undefined && routeDeposits.length === 0;
+
+  return (
+    <LightningClaimTopUpInner
+      activeAccounts={activeAccounts}
+      deposits={deposits}
+      loading={loading}
+    />
+  );
+};

--- a/frontends/web/src/routes/lightning/claim-top-up/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/confirm-step.tsx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
+import { Button } from '@/components/forms';
+import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
+import { View, ViewButtons, ViewContent, ViewHeader } from '@/components/view/view';
+import { AmountBlock } from './amount-block';
+import { CONTENT_MIN_HEIGHT, type TAction } from './constants';
+import styles from './claim-top-up.module.css';
+
+type TProps = {
+  action: TAction;
+  btcAccounts: TAccount[];
+  canConfirm: boolean;
+  refundDestinationAccountCode: AccountCode;
+  totalAmount: TAmountWithConversions;
+  onCancel: () => void;
+  onConfirm: () => void;
+  onRefundDestinationChange: (code: AccountCode) => void;
+};
+
+export const ClaimTopUpConfirm = ({
+  action,
+  btcAccounts,
+  canConfirm,
+  refundDestinationAccountCode,
+  totalAmount,
+  onCancel,
+  onConfirm,
+  onRefundDestinationChange,
+}: TProps) => {
+  const { t } = useTranslation();
+  const isClaim = action === 'claim';
+
+  return (
+    <View key="claim-top-up-confirm" minHeight={CONTENT_MIN_HEIGHT}>
+      <ViewHeader title={t(`lightning.claimTopUp.confirm.${isClaim ? 'claimTitle' : 'refundTitle'}`)} />
+      <ViewContent>
+        <div className={styles.content}>
+          {!isClaim && (
+            <div className={styles.refundDestination}>
+              <span className={styles.blockLabel}>
+                {t('lightning.claimTopUp.confirm.refundDestination')}
+              </span>
+              <GroupedAccountSelector
+                accounts={btcAccounts}
+                className={styles.accountSelector}
+                onChange={onRefundDestinationChange}
+                selected={refundDestinationAccountCode}
+              />
+            </div>
+          )}
+          <AmountBlock
+            amount={totalAmount}
+            label={t('lightning.claimTopUp.confirm.totalAmount')}
+          />
+          {/* TODO: Pass a fee once the backend exposes a claim/refund estimate. */}
+          <AmountBlock
+            label={t('lightning.claimTopUp.confirm.fee')}
+          />
+        </div>
+      </ViewContent>
+      <ViewButtons>
+        {/* TODO: Trigger the actual claim/refund once the backend exposes it. */}
+        {isClaim ? (
+          <Button primary onClick={onConfirm}>
+            {t('lightning.claimTopUp.confirm.claimButton')}
+          </Button>
+        ) : (
+          <Button danger disabled={!canConfirm} onClick={onConfirm}>
+            {t('lightning.claimTopUp.confirm.refundButton')}
+          </Button>
+        )}
+        <Button secondary onClick={onCancel}>
+          {t('dialog.cancel')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/claim-top-up/constants.ts
+++ b/frontends/web/src/routes/lightning/claim-top-up/constants.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const CONTENT_MIN_HEIGHT = '38em';
+
+export type TAction = 'claim' | 'refund';
+
+export type TStep = 'overview' | 'confirm' | 'success';

--- a/frontends/web/src/routes/lightning/claim-top-up/overview-step.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/overview-step.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import type { TAmountWithConversions } from '@/api/account';
+import type { TLightningPayment } from '@/api/lightning';
+import { AmountWithUnit } from '@/components/amount/amount-with-unit';
+import { Button } from '@/components/forms';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { AmountBlock } from './amount-block';
+import { CONTENT_MIN_HEIGHT } from './constants';
+import styles from './claim-top-up.module.css';
+
+type TAmountRowProps = {
+  amount: TAmountWithConversions;
+};
+
+const AmountRow = ({ amount }: TAmountRowProps) => (
+  <div className={styles.amountRow}>
+    <AmountWithUnit
+      alwaysShowAmounts
+      amount={amount}
+      amountClassName={styles.amount}
+    />
+    <AmountWithUnit
+      alwaysShowAmounts
+      amount={amount}
+      convertToFiat
+      amountClassName={styles.fiat}
+      unitClassName={styles.fiat}
+    />
+  </div>
+);
+
+type TFeeActionProps = {
+  amount?: TAmountWithConversions;
+  buttonText: string;
+  danger?: boolean;
+  disabled?: boolean;
+  label: string;
+  onClick: () => void;
+};
+
+const FeeAction = ({
+  amount,
+  buttonText,
+  danger,
+  disabled,
+  label,
+  onClick,
+}: TFeeActionProps) => {
+  const button = danger ? (
+    <Button
+      className={styles.actionButton}
+      danger
+      disabled={disabled}
+      onClick={onClick}>
+      {buttonText}
+    </Button>
+  ) : (
+    <Button
+      className={styles.actionButton}
+      disabled={disabled}
+      onClick={onClick}
+      primary>
+      {buttonText}
+    </Button>
+  );
+
+  return (
+    <div className={styles.feeRow}>
+      <AmountBlock amount={amount} label={label} />
+      {button}
+    </div>
+  );
+};
+
+type TProps = {
+  deposits: TLightningPayment[];
+  onCancel: () => void;
+  onClaim: () => void;
+  onRefund: () => void;
+};
+
+export const ClaimTopUpOverview = ({
+  deposits,
+  onCancel,
+  onClaim,
+  onRefund,
+}: TProps) => {
+  const { t } = useTranslation();
+  const hasDeposits = deposits.length > 0;
+
+  return (
+    <View key="claim-top-up" minHeight={CONTENT_MIN_HEIGHT}>
+      <ViewContent>
+        <div className={styles.content}>
+          <div className={styles.description}>
+            <p>{t('lightning.claimTopUp.description')}</p>
+            <p>{t('lightning.claimTopUp.warning')}</p>
+          </div>
+
+          <section className={styles.section}>
+            <h2 className={styles.sectionTitle}>{t('lightning.claimTopUp.topUps')}</h2>
+            {hasDeposits ? (
+              <div className={styles.amountRows}>
+                {deposits.map(deposit => (
+                  <AmountRow
+                    key={deposit.id}
+                    amount={deposit.amount}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p>{t('lightning.claimTopUp.empty')}</p>
+            )}
+          </section>
+
+          {/* TODO:Pass a fee to each FeeAction once the backend exposes
+              claim/refund fee estimates.*/}
+          <section className={styles.feeActions}>
+            <FeeAction
+              buttonText={t('lightning.claimTopUp.claimButton')}
+              disabled={!hasDeposits}
+              label={t('lightning.claimTopUp.claimFee')}
+              onClick={onClaim}
+            />
+            <FeeAction
+              buttonText={t('lightning.claimTopUp.refundButton')}
+              danger
+              disabled={!hasDeposits}
+              label={t('lightning.claimTopUp.refundFee')}
+              onClick={onRefund}
+            />
+          </section>
+        </div>
+      </ViewContent>
+      <ViewButtons>
+        <Button secondary onClick={onCancel}>
+          {t('dialog.cancel')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/claim-top-up/success-step.tsx
+++ b/frontends/web/src/routes/lightning/claim-top-up/success-step.tsx
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/forms';
+import { ExternalLink } from '@/components/icon';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { CONTENT_MIN_HEIGHT, type TAction } from './constants';
+import styles from './claim-top-up.module.css';
+
+type TProps = {
+  action: TAction;
+  onDone: () => void;
+};
+
+const noop = () => undefined;
+
+export const ClaimTopUpSuccess = ({
+  action,
+  onDone,
+}: TProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <View key="claim-top-up-success" minHeight={CONTENT_MIN_HEIGHT} textCenter>
+      <ViewContent withIcon="success">
+        <div className={styles.successContent}>
+          <p className={styles.successMessage}>
+            {t(`lightning.claimTopUp.success.${action}Message`)}
+          </p>
+          <p className={styles.successNote}>
+            {t(`lightning.claimTopUp.success.${action}Note`)}
+          </p>
+          {/* TODO: Open the transaction in the block explorer once the txid is available. */}
+          <Button className={styles.transactionButton} transparent onClick={noop}>
+            <ExternalLink className={styles.transactionIcon} />
+            {t('lightning.claimTopUp.viewTransaction')}
+          </Button>
+        </div>
+      </ViewContent>
+      <ViewButtons>
+        <Button className={styles.doneButton} primary onClick={onDone}>
+          {t('button.done')}
+        </Button>
+      </ViewButtons>
+    </View>
+  );
+};

--- a/frontends/web/src/routes/lightning/claim-top-up/utils.ts
+++ b/frontends/web/src/routes/lightning/claim-top-up/utils.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TAmountWithConversions } from '@/api/account';
+import type { TLightningPayment } from '@/api/lightning';
+
+export const isUnclaimedBitcoinDeposit = (payment: TLightningPayment) => (
+  payment.bitcoinDeposit?.state === 'unclaimed'
+);
+
+const sumStrings = (values: (string | undefined)[]) => {
+  const total = values.reduce((sum, value) => sum + Number(value || 0), 0);
+  return Number.isFinite(total) ? String(total) : '';
+};
+
+// TODO: Replace with a backend-provided total once claiming is wired up, so the
+// summing (and its rounding) does not happen in the frontend. Note that
+// balance.incoming is not it: that sums every deposit returned by
+// ListUnclaimedDeposits, including confirming and claiming ones.
+export const sumAmounts = (amounts: TAmountWithConversions[]): TAmountWithConversions => {
+  const currencies = new Set(
+    amounts.flatMap(amount => Object.keys(amount.conversions || {}))
+  );
+  const conversions = Object.fromEntries(
+    [...currencies].map(currency => [
+      currency,
+      sumStrings(amounts.map(amount => amount.conversions?.[currency as keyof typeof amount.conversions])),
+    ])
+  );
+  return {
+    amount: sumStrings(amounts.map(amount => amount.amount)),
+    conversions,
+    estimated: amounts.some(amount => amount.estimated),
+    unit: amounts[0]?.unit || 'sat',
+  };
+};

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
@@ -60,7 +60,7 @@ export const CloseWithdrawConfirm = ({
   const { t } = useTranslation();
 
   return (
-    <View key="close-withdraw-funds" minHeight={CONTENT_MIN_HEIGHT} width="min(420px, 100%)">
+    <View key="close-withdraw-funds" minHeight={CONTENT_MIN_HEIGHT}>
       <ViewContent>
         <div className={styles.content}>
           <p className={styles.description}>{t('lightning.closeWithdrawFunds.description')}</p>

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/failure-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/failure-step.tsx
@@ -20,7 +20,7 @@ export const CloseWithdrawFailure = ({
   const { t } = useTranslation();
 
   return (
-    <View key="close-withdraw-funds-failure" minHeight={CONTENT_MIN_HEIGHT} textCenter width="min(420px, 100%)">
+    <View key="close-withdraw-funds-failure" minHeight={CONTENT_MIN_HEIGHT} textCenter>
       <ViewContent withIcon="error">
         <div className={styles.failureContent}>
           <p className={styles.failureMessage}>

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/success-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/success-step.tsx
@@ -20,7 +20,7 @@ export const CloseWithdrawSuccess = ({
   const { t } = useTranslation();
 
   return (
-    <View key="close-withdraw-funds-success" minHeight={CONTENT_MIN_HEIGHT} textCenter width="min(420px, 100%)">
+    <View key="close-withdraw-funds-success" minHeight={CONTENT_MIN_HEIGHT} textCenter>
       <ViewContent withIcon="success">
         <div className={styles.successContent}>
           <p className={styles.successMessage}>{t('lightning.closeWithdrawFunds.success.message')}</p>

--- a/frontends/web/src/routes/lightning/components/payment-details.tsx
+++ b/frontends/web/src/routes/lightning/components/payment-details.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import type { TLightningPayment } from '@/api/lightning';
 import { A } from '@/components/anchor/anchor';
-import { ExternalLink } from '@/components/icon';
 import { Dialog } from '@/components/dialog/dialog';
+import { ExternalLink } from '@/components/icon';
 import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { Button } from '@/components/forms/button';
 import { TxDetailRow } from '@/components/transactions/components/tx-detail-dialog/tx-detail-row';
@@ -28,6 +29,7 @@ export const PaymentDetailsDialog = ({
   explorerURL,
 }: TTxDetailsDialog) => {
   const { i18n, t } = useTranslation();
+  const navigate = useNavigate();
 
   const typeText = payment.bitcoinDeposit
     ? t('lightning.bitcoinDeposit.label')
@@ -125,7 +127,14 @@ export const PaymentDetailsDialog = ({
                 </div>
               )}
               {payment.bitcoinDeposit.state === 'unclaimed' && (
-                <Button className={paymentStyles.claimButton} primary>
+                <Button
+                  className={paymentStyles.claimButton}
+                  onClick={() => navigate('/lightning/claim-top-up', {
+                    state: {
+                      deposits: [payment],
+                    },
+                  })}
+                  primary>
                   {t('lightning.bitcoinDeposit.claim')}
                 </Button>
               )}

--- a/frontends/web/src/routes/lightning/set-lnurl-address.tsx
+++ b/frontends/web/src/routes/lightning/set-lnurl-address.tsx
@@ -215,7 +215,7 @@ export const LightningSetLnurlAddress = () => {
   const renderStep = () => {
     if (!domain && error) {
       return (
-        <View textCenter verticallyCentered width="min(420px, 100%)">
+        <View textCenter verticallyCentered>
           <ViewContent>
             <p>{t('unknownError', { errorMessage: error })}</p>
           </ViewContent>
@@ -235,7 +235,7 @@ export const LightningSetLnurlAddress = () => {
     switch (step) {
     case 'form':
       return (
-        <View key="step-form" minHeight={CONTENT_MIN_HEIGHT} width="min(420px, 100%)">
+        <View key="step-form" minHeight={CONTENT_MIN_HEIGHT}>
           <ViewContent>
             <p>{t('lightning.lnurlAddress.description')}</p>
             <p>{t('lightning.lnurlAddress.choose')}</p>
@@ -272,7 +272,7 @@ export const LightningSetLnurlAddress = () => {
       );
     case 'success':
       return (
-        <View fitContent textCenter verticallyCentered width="min(420px, 100%)">
+        <View fitContent textCenter verticallyCentered>
           <ViewContent withIcon="success">
             <p>{t('lightning.lnurlAddress.success.message')}</p>
             <span className={styles.successAddress}>{address}</span>

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -51,6 +51,7 @@ import { LightningSetLnurlAddress } from './lightning/set-lnurl-address';
 import { Send as LightningSend } from './lightning/send/send';
 import { Receive as LightningReceive } from './lightning/receive/receive';
 import { LightningTopUp } from './lightning/topup/topup';
+import { LightningClaimTopUp } from './lightning/claim-top-up/claim-top-up';
 import { LightningCloseWithdrawFunds } from './lightning/close-and-withdraw-funds/close-withdraw-funds';
 
 type TAppRouterProps = {
@@ -362,6 +363,7 @@ export const AppRouter = ({ devices, devicesKey, accounts, activeAccounts }: TAp
           <Route path="activate" element={<LightningActivate />} />
           <Route path="deactivate" element={<LightningDeactivate />} />
           <Route path="set-lnurl-address" element={<LightningSetLnurlAddress />} />
+          <Route path="claim-top-up" element={<LightningClaimTopUp activeAccounts={activeAccounts} />} />
           <Route path="close-withdraw-funds" element={(
             <LightningCloseWithdrawFunds
               activeAccounts={activeAccounts}

--- a/frontends/web/src/routes/settings/lightning-settings.tsx
+++ b/frontends/web/src/routes/settings/lightning-settings.tsx
@@ -19,7 +19,6 @@ import { TPagePropsWithSettingsTabs } from './types';
 import styles from './lightning-settings.module.css';
 
 const serviceProvider = 'Spark';
-const noop = () => undefined;
 
 export const LightningSettings = ({
   devices,
@@ -88,10 +87,6 @@ export const LightningSettings = ({
         <SettingsItem
           settingName={t('lightning.settings.setLightningAddress')}
           onClick={() => navigate('/lightning/set-lnurl-address/')}
-        />
-        <SettingsItem
-          settingName={t('lightning.settings.manuallyClaimTopUp')}
-          onClick={noop}
         />
         <SubTitle className={styles.sectionTitle}>{t('lightning.settings.expert')}</SubTitle>
         <SettingsItem


### PR DESCRIPTION
[Ln UI claim & refund top-up](https://github.com/BitBoxSwiss/bitbox-wallet-app/commit/8f8072bc1a250bf2d3a1ce5d0379afdfc7c8251f)


<img width="313" height="635" alt="Screenshot 2026-07-23 at 08 55 08" src="https://github.com/user-attachments/assets/c72d32c5-cc03-489d-b03c-3ca4bafeb75e" />

<img width="294" height="637" alt="Screenshot 2026-07-23 at 09 06 22" src="https://github.com/user-attachments/assets/f6291cbc-09f5-4f58-be09-dd67296ed0dc" />

<img width="299" height="623" alt="Screenshot 2026-07-23 at 09 06 31" src="https://github.com/user-attachments/assets/d7e9a18b-df63-4b2f-b90f-f0a34023203a" />

<img width="294" height="631" alt="Screenshot 2026-07-23 at 09 06 48" src="https://github.com/user-attachments/assets/6f7cb047-9c85-4e6e-abdd-e4acd9ace543" />

<img width="296" height="632" alt="Screenshot 2026-07-23 at 09 06 59" src="https://github.com/user-attachments/assets/999c8e17-656b-4b80-994d-7deb3bc313de" />

<img width="292" height="628" alt="Screenshot 2026-07-23 at 09 07 05" src="https://github.com/user-attachments/assets/d5019656-ee1a-4f52-a57e-2c4f185acb50" />


