### PR TITLE
lightning: prefer connected wallet for top-ups

### DIFF
--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -69,6 +69,7 @@ type Backend interface {
 	Coin(coinpkg.Code) (coinpkg.Coin, error)
 	Testing() bool
 	Accounts() backend.AccountsList
+	DefaultLightningTopUpAccountCode() (*accountsTypes.Code, error)
 	PrepareSwap(buyAccountCode, sellAccountCode accountsTypes.Code, routeID, sellAmount string) (*backend.SwapPreparation, error)
 	SwapAccounts() (backend.SwapAccounts, error)
 	SwapStatus() backend.SwapStatus
@@ -227,6 +228,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/keystore/{rootFingerprint}/features", handlers.getKeystoreFeatures).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/keystore-name", handlers.getKeystoreName).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts", handlers.getAccounts).Methods("GET")
+	getAPIRouterNoError(apiRouter)("/lightning/topup/default-account", handlers.getDefaultLightningTopUpAccount).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/swap/accounts", handlers.getSwapAccounts).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/swap/status", handlers.getSwapStatus).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/accounts/balance-summary", handlers.getAccountsBalanceSummary).Methods("GET")
@@ -841,6 +843,24 @@ func (handlers *Handlers) getAccounts(*http.Request) interface{} {
 		))
 	}
 	return accounts
+}
+
+func (handlers *Handlers) getDefaultLightningTopUpAccount(*http.Request) interface{} {
+	type response struct {
+		Success      bool                `json:"success"`
+		Data         *accountsTypes.Code `json:"data"`
+		ErrorMessage string              `json:"errorMessage,omitempty"`
+		ErrorCode    string              `json:"errorCode,omitempty"`
+	}
+
+	accountCode, err := handlers.backend.DefaultLightningTopUpAccountCode()
+	if err != nil {
+		if errCode, ok := errp.Cause(err).(errp.ErrorCode); ok {
+			return response{Success: false, ErrorCode: string(errCode)}
+		}
+		return response{Success: false, ErrorMessage: err.Error()}
+	}
+	return response{Success: true, Data: accountCode}
 }
 
 func (handlers *Handlers) getSwapAccounts(*http.Request) interface{} {

--- a/backend/lightning.go
+++ b/backend/lightning.go
@@ -2,7 +2,14 @@
 
 package backend
 
-import coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+import (
+	"bytes"
+
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
+	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
+)
 
 // coinCodeLightning is a portfolio-only pseudo coin code. Use BTC for formatting and conversions;
 // backend.Coin(coinCodeLightning) does not resolve.
@@ -31,6 +38,52 @@ func (backend *Backend) lightningFormattedBalance() (*coinFormattedAmount, error
 		lightningBalance.Available().BigInt(),
 	)
 	return &formattedBalance, nil
+}
+
+// DefaultLightningTopUpAccountCode returns the first funded Bitcoin account of the connected
+// keystore. If none is available, it returns the first funded account of any keystore.
+func (backend *Backend) DefaultLightningTopUpAccountCode() (*accountsTypes.Code, error) {
+	connectedKeystore := backend.Keystore()
+	var connectedRootFingerprint []byte
+	if connectedKeystore != nil {
+		var err error
+		connectedRootFingerprint, err = connectedKeystore.RootFingerprint()
+		if err != nil {
+			backend.log.WithError(err).Error("could not identify connected keystore")
+		}
+	}
+
+	var firstEligibleAccountCode *accountsTypes.Code
+	for _, account := range backend.Accounts() {
+		accountConfig := account.Config().Config
+		if accountConfig.Inactive || accountConfig.HiddenBecauseUnused || account.Coin().Code() != coinpkg.CodeBTC {
+			continue
+		}
+		balance, err := account.Balance()
+		if err != nil {
+			if errp.Cause(err) == accounts.ErrSyncInProgress {
+				return nil, err
+			}
+			backend.log.WithField("code", accountConfig.Code).WithError(err).Error("could not get account balance")
+			continue
+		} else if balance == nil || balance.Available().BigInt().Sign() <= 0 {
+			continue
+		}
+
+		accountCode := accountConfig.Code
+		if firstEligibleAccountCode == nil {
+			firstEligibleAccountCode = &accountCode
+		}
+		rootFingerprint, err := accountConfig.SigningConfigurations.RootFingerprint()
+		if err != nil {
+			backend.log.WithField("code", accountConfig.Code).WithError(err).Error("could not identify root fingerprint")
+			continue
+		}
+		if connectedRootFingerprint != nil && bytes.Equal(rootFingerprint, connectedRootFingerprint) {
+			return &accountCode, nil
+		}
+	}
+	return firstEligibleAccountCode, nil
 }
 
 func insertLightningFormattedBalance(

--- a/backend/lightning_test.go
+++ b/backend/lightning_test.go
@@ -3,11 +3,16 @@
 package backend
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
+	accountsMocks "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/mocks"
+	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
 	coinpkg "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,6 +48,98 @@ func TestLightningFormattedBalanceWithoutAccount(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Nil(t, balance)
+}
+
+func TestDefaultLightningTopUpAccountCode(t *testing.T) {
+	setup := func(t *testing.T) (*Backend, accountsTypes.Code, accountsTypes.Code) {
+		t.Helper()
+		backend := newBackend(t, testnetDisabled, regtestDisabled)
+		t.Cleanup(func() {
+			require.NoError(t, backend.Close())
+		})
+
+		disconnectedKeystore := makeBitBox02Multi()
+		connectedKeystore := makeBitBox02Multi()
+		connectedKeystore.RootFingerprintFunc = keystoreHelper2().RootFingerprint
+		connectedKeystore.ExtendedPublicKeyFunc = keystoreHelper2().ExtendedPublicKey
+		connectedKeystore.BTCXPubsFunc = keystoreHelper2().BTCXPubs
+
+		disconnectedRootFingerprint, err := disconnectedKeystore.RootFingerprint()
+		require.NoError(t, err)
+		connectedRootFingerprint, err := connectedKeystore.RootFingerprint()
+		require.NoError(t, err)
+
+		backend.registerKeystore(disconnectedKeystore)
+		require.NoError(t, backend.SetWatchonly(disconnectedRootFingerprint, true))
+		backend.DeregisterKeystore()
+		backend.registerKeystore(connectedKeystore)
+		connectedSecondAccountCode, err := backend.CreateAndPersistAccountConfig(
+			coinpkg.CodeBTC,
+			"Second connected Bitcoin account",
+			connectedKeystore,
+		)
+		require.NoError(t, err)
+
+		var disconnectedAccountCode accountsTypes.Code
+		var connectedFirstAccountCode accountsTypes.Code
+		for _, account := range backend.Accounts() {
+			accountConfig := account.Config().Config
+			if accountConfig.Inactive || accountConfig.HiddenBecauseUnused || account.Coin().Code() != coinpkg.CodeBTC {
+				continue
+			}
+			rootFingerprint, err := accountConfig.SigningConfigurations.RootFingerprint()
+			require.NoError(t, err)
+			switch {
+			case bytes.Equal(rootFingerprint, disconnectedRootFingerprint) && disconnectedAccountCode == "":
+				disconnectedAccountCode = accountConfig.Code
+			case bytes.Equal(rootFingerprint, connectedRootFingerprint) && connectedFirstAccountCode == "":
+				connectedFirstAccountCode = accountConfig.Code
+			}
+		}
+		require.NotEmpty(t, disconnectedAccountCode)
+		require.NotEmpty(t, connectedFirstAccountCode)
+		require.NotEqual(t, connectedFirstAccountCode, connectedSecondAccountCode)
+		zeroAllAccountBalances(t, backend)
+		return backend, disconnectedAccountCode, connectedSecondAccountCode
+	}
+
+	t.Run("prefers first funded account of connected keystore", func(t *testing.T) {
+		backend, disconnectedAccountCode, connectedSecondAccountCode := setup(t)
+		setAccountBalance(t, backend, disconnectedAccountCode, 1)
+		setAccountBalance(t, backend, connectedSecondAccountCode, 1)
+
+		accountCode, err := backend.DefaultLightningTopUpAccountCode()
+
+		require.NoError(t, err)
+		require.NotNil(t, accountCode)
+		require.Equal(t, connectedSecondAccountCode, *accountCode)
+	})
+
+	t.Run("falls back when connected keystore has no funded account", func(t *testing.T) {
+		backend, disconnectedAccountCode, _ := setup(t)
+		setAccountBalance(t, backend, disconnectedAccountCode, 1)
+
+		accountCode, err := backend.DefaultLightningTopUpAccountCode()
+
+		require.NoError(t, err)
+		require.NotNil(t, accountCode)
+		require.Equal(t, disconnectedAccountCode, *accountCode)
+	})
+
+	t.Run("propagates sync in progress while connected account balance is syncing", func(t *testing.T) {
+		backend, disconnectedAccountCode, connectedSecondAccountCode := setup(t)
+		setAccountBalance(t, backend, disconnectedAccountCode, 1)
+		connectedAccount, ok := backend.Accounts().lookup(connectedSecondAccountCode).(*accountsMocks.InterfaceMock)
+		require.True(t, ok)
+		connectedAccount.BalanceFunc = func() (*accounts.Balance, error) {
+			return nil, accounts.ErrSyncInProgress
+		}
+
+		accountCode, err := backend.DefaultLightningTopUpAccountCode()
+
+		require.Equal(t, accounts.ErrSyncInProgress, errp.Cause(err))
+		require.Nil(t, accountCode)
+	})
 }
 
 func TestInsertLightningFormattedBalance(t *testing.T) {

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -180,6 +180,13 @@ export const getLightningAccount = async (): Promise<TLightningAccount | null> =
   return apiGet('lightning/account');
 };
 
+export const getDefaultLightningTopUpAccountCode = async (): Promise<AccountCode | null> => {
+  return getApiResponse<AccountCode | null>(
+    'lightning/topup/default-account',
+    'Error calling getDefaultLightningTopUpAccountCode'
+  );
+};
+
 export const getLightningAddress = async (): Promise<string | null> => {
   return getApiResponse<string | null>('lightning/address', 'Error calling getLightningAddress');
 };

--- a/frontends/web/src/routes/lightning/topup/topup.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import * as accountApi from '@/api/account';
 import { convertFromCurrency, convertToCurrency } from '@/api/coins';
-import { getBoardingAddress, getLightningBalance } from '@/api/lightning';
+import { getBoardingAddress, getDefaultLightningTopUpAccountCode, getLightningBalance } from '@/api/lightning';
 import { connectKeystore } from '@/api/keystores';
 import { useLoad } from '@/hooks/api';
 import { useMountedRef } from '@/hooks/mount';
@@ -82,6 +82,9 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
     [activeAccounts]
   );
   const topUpAccounts = useLoad(() => getTopUpAccounts(btcAccounts), [btcAccounts]);
+  const defaultSourceAccountCode = useLoad(
+    () => getDefaultLightningTopUpAccountCode().catch(() => null)
+  );
   const [sourceAccountCode, setSourceAccountCode] = useState<accountApi.AccountCode>('');
   const sourceAccount = topUpAccounts?.find(account => account.code === sourceAccountCode);
   const { balance: lightningBalance, reloadBalance: reloadLightningBalance } = useLightningBalance();
@@ -115,10 +118,17 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
       setSourceAccountCode('');
       return;
     }
-    if (!sourceAccountCode || !topUpAccounts.some(account => account.code === sourceAccountCode)) {
-      setSourceAccountCode(topUpAccounts[0]?.code || '');
+    if (defaultSourceAccountCode === undefined) {
+      return;
     }
-  }, [sourceAccountCode, topUpAccounts]);
+    if (!sourceAccountCode || !topUpAccounts.some(account => account.code === sourceAccountCode)) {
+      setSourceAccountCode(
+        topUpAccounts.find(account => account.code === defaultSourceAccountCode)?.code
+          || topUpAccounts[0]?.code
+          || ''
+      );
+    }
+  }, [defaultSourceAccountCode, sourceAccountCode, topUpAccounts]);
 
   const convertToFiat = useCallback(async (value: string) => {
     const request = ++conversionRequest.current;


### PR DESCRIPTION
Top-up currently preselects the first funded Bitcoin account, even when that account belongs to a disconnected wallet.

Select the first funded Bitcoin account belonging to the connected keystore, falling back to the first funded account overall. Expose this choice through a backend endpoint and wait for it before rendering the top-up form.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
