### PR TITLE
lightning: add close and withdraw flow

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -367,7 +367,9 @@ func NewBackend(arguments *arguments.Arguments, environment Environment) (*Backe
 	backend.lightning = lightning.NewLightning(backend.config,
 		backend.arguments.CacheDirectoryPath(),
 		backend.environment,
-		backend.Keystore, backend.httpClient,
+		backend.Keystore,
+		backend.GetAccountFromCode,
+		backend.httpClient,
 		backend.ratesUpdater,
 		btcCoin,
 		backend.DevServers())

--- a/backend/lightning/address_test.go
+++ b/backend/lightning/address_test.go
@@ -428,7 +428,7 @@ func TestRegisterAddressReturnsSuccessWhenTimestampPersistenceFails(t *testing.T
 	cfg, err := config.NewConfig(appConfigFilename, accountsConfigFilename, lightningConfigFilename)
 	require.NoError(t, err)
 
-	lightning := NewLightning(cfg, t.TempDir(), nil, nil, &http.Client{}, nil, nil, false)
+	lightning := NewLightning(cfg, t.TempDir(), nil, nil, nil, &http.Client{}, nil, nil, false)
 	activateLightningAddressTest(t, lightning)
 	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
 	withLightningAddressNow(t, now)

--- a/backend/lightning/handlers.go
+++ b/backend/lightning/handlers.go
@@ -44,6 +44,8 @@ func NewHandlers(
 	handleNoError("/parse-payment-input", lightning.GetParsePaymentInput).Methods("GET")
 	handleNoError("/prepare-payment", lightning.PostPreparePayment).Methods("POST")
 	handleNoError("/boarding-address", lightning.GetBoardingAddress).Methods("GET")
+	handleNoError("/close-withdraw-funds/prepare", lightning.PostPrepareCloseWithdraw).Methods("POST")
+	handleNoError("/close-withdraw-funds", lightning.PostCloseWithdraw).Methods("POST")
 	handleNoError("/receive-payment", lightning.GetReceivePayment).Methods("GET")
 	handleNoError("/send-payment", lightning.PostSendPayment).Methods("POST")
 }
@@ -212,6 +214,48 @@ func (lightning *Lightning) GetBoardingAddress(_ *http.Request) interface{} {
 		return errorResponse(err)
 	}
 	return responseDto{Success: true, Data: address}
+}
+
+// PostPrepareCloseWithdraw handles the POST request to prepare a full-balance on-chain withdrawal.
+func (lightning *Lightning) PostPrepareCloseWithdraw(r *http.Request) interface{} {
+	var jsonBody struct {
+		DestinationAccountCode types.Code `json:"destinationAccountCode"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&jsonBody); err != nil {
+		return errorResponse(err)
+	}
+
+	quote, err := lightning.PrepareCloseWithdraw(jsonBody.DestinationAccountCode)
+	if err != nil {
+		return errorResponse(err)
+	}
+	return responseDto{Success: true, Data: quote}
+}
+
+// PostCloseWithdraw handles the POST request to withdraw all funds and deactivate Lightning.
+func (lightning *Lightning) PostCloseWithdraw(r *http.Request) interface{} {
+	var jsonBody struct {
+		DestinationAccountCode types.Code `json:"destinationAccountCode"`
+		ApprovedBalanceSat     uint64     `json:"approvedBalanceSat"`
+		ApprovedFeeSat         uint64     `json:"approvedFeeSat"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&jsonBody); err != nil {
+		return errorResponse(err)
+	}
+
+	result, err := lightning.CloseWithdraw(
+		jsonBody.DestinationAccountCode,
+		jsonBody.ApprovedBalanceSat,
+		jsonBody.ApprovedFeeSat,
+	)
+	if err != nil {
+		return errorResponse(err)
+	}
+	return responseDto{Success: true, Data: result}
 }
 
 // GetParsePaymentInput handles the GET request to parse a payment input.

--- a/backend/lightning/lightning.go
+++ b/backend/lightning/lightning.go
@@ -73,6 +73,7 @@ type Lightning struct {
 	cacheDirectoryPath string
 	environment        environment
 	getKeystore        func() keystore.Keystore
+	getAccount         func(types.Code) (accounts.Interface, error)
 	synced             bool
 
 	log          *logrus.Entry
@@ -92,6 +93,7 @@ func NewLightning(config *config.Config,
 	cacheDirectoryPath string,
 	environment environment,
 	getKeystore func() keystore.Keystore,
+	getAccount func(types.Code) (accounts.Interface, error),
 	httpClient *http.Client,
 	ratesUpdater *rates.RateUpdater,
 	btcCoin coin.Coin,
@@ -101,6 +103,7 @@ func NewLightning(config *config.Config,
 		cacheDirectoryPath: cacheDirectoryPath,
 		environment:        environment,
 		getKeystore:        getKeystore,
+		getAccount:         getAccount,
 		log:                logging.Get().WithGroup("lightning"),
 		synced:             false,
 		sparkStatus:        breez_sdk_spark.GetSparkStatus,
@@ -192,7 +195,7 @@ func (lightning *Lightning) Disconnect() {
 	}
 }
 
-// Deactivate disconnects the instance, deletes cache folder and changes the config to inactive.
+// Deactivate changes the config to inactive, disconnects the instance and deletes the cache folder.
 func (lightning *Lightning) Deactivate() error {
 	account := lightning.Account()
 
@@ -200,14 +203,14 @@ func (lightning *Lightning) Deactivate() error {
 		return nil
 	}
 
+	if err := lightning.SetAccount(nil); err != nil {
+		return err
+	}
+
 	lightning.Disconnect()
 	workingDir := path.Join(lightning.cacheDirectoryPath, accountBreezFolder(account.Code))
 	if err := os.RemoveAll(workingDir); err != nil {
 		lightning.log.WithError(err).Error("Error deleting working directory")
-	}
-
-	if err := lightning.SetAccount(nil); err != nil {
-		return err
 	}
 
 	if lightning.environment.CanEncryptLightningMnemonic() {

--- a/backend/lightning/lightning_test.go
+++ b/backend/lightning/lightning_test.go
@@ -59,10 +59,18 @@ func (e *testEnvironment) DeleteLightningEncryptionKey(accountCode string) error
 
 func newTestLightning(t *testing.T, environment environment) *Lightning {
 	t.Helper()
+	return newTestLightningWithConfigFilename(t, environment, test.TstTempFile("lightningConfig"))
+}
+
+func newTestLightningWithConfigFilename(
+	t *testing.T,
+	environment environment,
+	lightningConfigFilename string,
+) *Lightning {
+	t.Helper()
 
 	appConfigFilename := test.TstTempFile("appConfig")
 	accountsConfigFilename := test.TstTempFile("accountsConfig")
-	lightningConfigFilename := test.TstTempFile("lightningConfig")
 
 	cfg, err := config.NewConfig(appConfigFilename, accountsConfigFilename, lightningConfigFilename)
 	require.NoError(t, err)
@@ -76,6 +84,7 @@ func newTestLightning(t *testing.T, environment environment) *Lightning {
 		test.TstTempDir("lightning-cache"),
 		environment,
 		func() keystore.Keystore { return nil },
+		nil,
 		&http.Client{},
 		nil,
 		nil,

--- a/backend/lightning/payments.go
+++ b/backend/lightning/payments.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
+	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 )
@@ -97,6 +99,18 @@ type paymentFee struct {
 	AmountSat     uint64 `json:"amountSat"`
 	FeeSat        uint64 `json:"feeSat"`
 	TotalDebitSat uint64 `json:"totalDebitSat"`
+}
+
+type closeWithdrawQuote struct {
+	Balance    coin.FormattedAmountWithConversions `json:"balance"`
+	BalanceSat uint64                              `json:"balanceSat"`
+	Fee        coin.FormattedAmountWithConversions `json:"fee"`
+	FeeSat     uint64                              `json:"feeSat"`
+}
+
+type closeWithdrawResult struct {
+	TxID         string `json:"txId,omitempty"`
+	WalletClosed bool   `json:"walletClosed"`
 }
 
 const (
@@ -463,6 +477,40 @@ func preparedLNURLPayFee(prepareResponse breez_sdk_spark.PrepareLnurlPayResponse
 	}
 }
 
+func prepareBitcoinPaymentRequest(
+	destinationAddress string,
+	amountSat uint64,
+	feePolicy breez_sdk_spark.FeePolicy,
+) breez_sdk_spark.PrepareSendPaymentRequest {
+	amount := new(big.Int).SetUint64(amountSat)
+	return breez_sdk_spark.PrepareSendPaymentRequest{
+		PaymentRequest: destinationAddress,
+		Amount:         &amount,
+		FeePolicy:      &feePolicy,
+	}
+}
+
+func preparedBitcoinPaymentFee(
+	prepareResponse breez_sdk_spark.PrepareSendPaymentResponse,
+) (*paymentFee, error) {
+	paymentMethod, ok := prepareResponse.PaymentMethod.(breez_sdk_spark.SendPaymentMethodBitcoinAddress)
+	if !ok {
+		return nil, errp.Newf("Payment method %v not supported", prepareResponse.PaymentMethod)
+	}
+	feeQuote := paymentMethod.FeeQuote.SpeedFast
+	feeSat := feeQuote.UserFeeSat + feeQuote.L1BroadcastFeeSat
+	amountSat := parseLightningUint(prepareResponse.Amount)
+	totalDebitSat := amountSat + feeSat
+	if prepareResponse.FeePolicy == breez_sdk_spark.FeePolicyFeesIncluded {
+		totalDebitSat = amountSat
+	}
+	return &paymentFee{
+		AmountSat:     amountSat,
+		FeeSat:        feeSat,
+		TotalDebitSat: totalDebitSat,
+	}, nil
+}
+
 func checkApprovedPaymentFee(fee uint64, approvedFee uint64) error {
 	if fee > approvedFee {
 		return errPaymentApprovalRequired
@@ -684,6 +732,164 @@ func (lightning *Lightning) sendLNURLPay(request sendPaymentRequest) error {
 		return lightningPaymentError(err)
 	}
 	return nil
+}
+
+func (lightning *Lightning) prepareBitcoinPayment(
+	destinationAddress string,
+	amountSat uint64,
+	feePolicy breez_sdk_spark.FeePolicy,
+) (breez_sdk_spark.PrepareSendPaymentResponse, *paymentFee, error) {
+	if err := lightning.CheckActive(); err != nil {
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, err
+	}
+	if amountSat == 0 {
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, errLightningInvalidAmount
+	}
+
+	prepareResponse, err := lightning.sdkService.PrepareSendPayment(
+		prepareBitcoinPaymentRequest(destinationAddress, amountSat, feePolicy),
+	)
+	if err != nil {
+		lightning.log.WithError(err).Error("Prepare Bitcoin payment failed")
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, lightningPaymentError(err)
+	}
+
+	fee, err := preparedBitcoinPaymentFee(prepareResponse)
+	if err != nil {
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, err
+	}
+	availableBalance, err := lightning.availableBalance()
+	if err != nil {
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil, err
+	}
+	if err := checkPaymentBalance(fee, availableBalance); err != nil {
+		return prepareResponse, fee, err
+	}
+	return prepareResponse, fee, nil
+}
+
+func (lightning *Lightning) closeWithdrawDestinationAddress(
+	destinationAccountCode accountsTypes.Code,
+) (string, error) {
+	account, err := lightning.getAccount(destinationAccountCode)
+	if err != nil {
+		return "", err
+	}
+	if !coin.IsBitcoinOnly(account.Config().Config.CoinCode) {
+		return "", errp.Newf("account %q is not a Bitcoin account", destinationAccountCode)
+	}
+	addressLists, err := account.GetUnusedReceiveAddresses()
+	if err != nil {
+		return "", err
+	}
+
+	var addressList *accounts.AddressList
+	if receiveScriptType := account.Config().Config.ReceiveScriptType; receiveScriptType != nil {
+		addressList = accounts.FindAddressListByScriptType(addressLists, *receiveScriptType)
+	}
+	if addressList == nil {
+		addressList = accounts.FindAddressListByScriptType(addressLists, signing.ScriptTypeP2WPKH)
+	}
+	if addressList == nil && len(addressLists) > 0 {
+		addressList = &addressLists[0]
+	}
+	if addressList == nil || len(addressList.Addresses) == 0 {
+		return "", errp.New("no receive address available")
+	}
+	return addressList.Addresses[0].EncodeForHumans(), nil
+}
+
+// PrepareCloseWithdraw prepares an on-chain payment that spends the full Lightning balance.
+func (lightning *Lightning) PrepareCloseWithdraw(
+	destinationAccountCode accountsTypes.Code,
+) (*closeWithdrawQuote, error) {
+	availableBalance, err := lightning.availableBalance()
+	if err != nil {
+		return nil, err
+	}
+	if availableBalance.BigInt().Sign() <= 0 {
+		return nil, errLightningInvalidAmount
+	}
+	destinationAddress, err := lightning.closeWithdrawDestinationAddress(destinationAccountCode)
+	if err != nil {
+		return nil, err
+	}
+	amountSat := availableBalance.BigInt().Uint64()
+	_, fee, err := lightning.prepareBitcoinPayment(
+		destinationAddress,
+		amountSat,
+		breez_sdk_spark.FeePolicyFeesIncluded,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	feeAmount := coin.NewAmountFromInt64(int64(fee.FeeSat))
+	return &closeWithdrawQuote{
+		Balance:    availableBalance.FormatWithConversions(lightning.btcCoin, false, lightning.ratesUpdater),
+		BalanceSat: amountSat,
+		Fee:        feeAmount.FormatWithConversions(lightning.btcCoin, true, lightning.ratesUpdater),
+		FeeSat:     fee.FeeSat,
+	}, nil
+}
+
+// CloseWithdraw spends the full Lightning balance on-chain and then deactivates the wallet.
+func (lightning *Lightning) CloseWithdraw(
+	destinationAccountCode accountsTypes.Code,
+	approvedBalanceSat uint64,
+	approvedFeeSat uint64,
+) (*closeWithdrawResult, error) {
+	availableBalance, err := lightning.availableBalance()
+	if err != nil {
+		return nil, err
+	}
+	amountSat := availableBalance.BigInt().Uint64()
+	if amountSat != approvedBalanceSat {
+		return nil, errPaymentApprovalRequired
+	}
+	if availableBalance.BigInt().Sign() <= 0 {
+		return nil, errLightningInvalidAmount
+	}
+	destinationAddress, err := lightning.closeWithdrawDestinationAddress(destinationAccountCode)
+	if err != nil {
+		return nil, err
+	}
+	prepareResponse, fee, err := lightning.prepareBitcoinPayment(
+		destinationAddress,
+		amountSat,
+		breez_sdk_spark.FeePolicyFeesIncluded,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkApprovedPaymentFee(fee.FeeSat, approvedFeeSat); err != nil {
+		return nil, err
+	}
+
+	var options breez_sdk_spark.SendPaymentOptions = breez_sdk_spark.SendPaymentOptionsBitcoinAddress{
+		ConfirmationSpeed: breez_sdk_spark.OnchainConfirmationSpeedFast,
+	}
+	response, err := lightning.sdkService.SendPayment(breez_sdk_spark.SendPaymentRequest{
+		PrepareResponse: prepareResponse,
+		Options:         &options,
+	})
+	if err != nil {
+		lightning.log.WithError(err).Error("Send Bitcoin payment failed")
+		return nil, lightningPaymentError(err)
+	}
+
+	result := &closeWithdrawResult{}
+	if response.Payment.Details != nil {
+		if details, ok := (*response.Payment.Details).(breez_sdk_spark.PaymentDetailsWithdraw); ok {
+			result.TxID = details.TxId
+		}
+	}
+	if err := lightning.Deactivate(); err != nil {
+		lightning.log.WithError(err).Error("Bitcoin withdrawal succeeded but Lightning wallet deactivation failed")
+		return result, nil
+	}
+	result.WalletClosed = true
+	return result, nil
 }
 
 // BoardingAddress returns a bitcoin address that can be used to fund lightning.

--- a/backend/lightning/payments_test.go
+++ b/backend/lightning/payments_test.go
@@ -11,16 +11,63 @@ import (
 
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts"
 	accountErrors "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/errors"
+	accountsMocks "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/mocks"
+	accountsTypes "github.com/BitBoxSwiss/bitbox-wallet-app/backend/accounts/types"
 	btccoin "github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/btc"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/coins/coin"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/config"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/rates"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/backend/signing"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/errp"
 	"github.com/BitBoxSwiss/bitbox-wallet-app/util/socksproxy"
+	"github.com/BitBoxSwiss/bitbox-wallet-app/util/test"
 	"github.com/breez/breez-sdk-spark-go/breez_sdk_spark"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/stretchr/testify/require"
 )
+
+const testCloseWithdrawDestinationAccountCode accountsTypes.Code = "btc-0"
+
+type testPaymentAddress string
+
+func (address testPaymentAddress) ID() string {
+	return string(address)
+}
+
+func (address testPaymentAddress) EncodeForHumans() string {
+	return string(address)
+}
+
+func (testPaymentAddress) AbsoluteKeypath() signing.AbsoluteKeypath {
+	return nil
+}
+
+func testCloseWithdrawAccount() accounts.Interface {
+	p2wpkh := signing.ScriptTypeP2WPKH
+	p2tr := signing.ScriptTypeP2TR
+	return &accountsMocks.InterfaceMock{
+		ConfigFunc: func() *accounts.AccountConfig {
+			return &accounts.AccountConfig{
+				Config: &config.Account{
+					CoinCode:          coin.CodeBTC,
+					ReceiveScriptType: &p2tr,
+				},
+			}
+		},
+		GetUnusedReceiveAddressesFunc: func() ([]accounts.AddressList, error) {
+			return []accounts.AddressList{
+				{
+					ScriptType: &p2wpkh,
+					Addresses:  []accounts.Address{testPaymentAddress("bc1qfallback")},
+				},
+				{
+					ScriptType: &p2tr,
+					Addresses:  []accounts.Address{testPaymentAddress("bc1pdestination")},
+				},
+			}, nil
+		},
+	}
+}
 
 func makeTestLightning() *Lightning {
 	return &Lightning{
@@ -711,6 +758,294 @@ func TestPreparedLNURLPayFee(t *testing.T) {
 		FeeSat:        7,
 		TotalDebitSat: 130,
 	}, fee)
+}
+
+func TestPrepareBitcoinPaymentRequest(t *testing.T) {
+	t.Parallel()
+
+	request := prepareBitcoinPaymentRequest(
+		"bc1qdestination",
+		10_000,
+		breez_sdk_spark.FeePolicyFeesIncluded,
+	)
+
+	require.Equal(t, "bc1qdestination", request.PaymentRequest)
+	require.NotNil(t, request.Amount)
+	require.Zero(t, (*request.Amount).Cmp(big.NewInt(10_000)))
+	require.NotNil(t, request.FeePolicy)
+	require.Equal(t, breez_sdk_spark.FeePolicyFeesIncluded, *request.FeePolicy)
+}
+
+func TestPreparedBitcoinPaymentFee(t *testing.T) {
+	t.Parallel()
+
+	feeQuote := breez_sdk_spark.SendOnchainFeeQuote{
+		SpeedFast: breez_sdk_spark.SendOnchainSpeedFeeQuote{
+			UserFeeSat:        700,
+			L1BroadcastFeeSat: 300,
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		feePolicy     breez_sdk_spark.FeePolicy
+		expectedDebit uint64
+	}{
+		{
+			name:          "fees included",
+			feePolicy:     breez_sdk_spark.FeePolicyFeesIncluded,
+			expectedDebit: 10_000,
+		},
+		{
+			name:          "fees excluded",
+			feePolicy:     breez_sdk_spark.FeePolicyFeesExcluded,
+			expectedDebit: 11_000,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			fee, err := preparedBitcoinPaymentFee(breez_sdk_spark.PrepareSendPaymentResponse{
+				PaymentMethod: breez_sdk_spark.SendPaymentMethodBitcoinAddress{FeeQuote: feeQuote},
+				Amount:        big.NewInt(10_000),
+				FeePolicy:     testCase.feePolicy,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, uint64(10_000), fee.AmountSat)
+			require.Equal(t, uint64(1_000), fee.FeeSat)
+			require.Equal(t, testCase.expectedDebit, fee.TotalDebitSat)
+		})
+	}
+}
+
+type testPaymentSDK struct {
+	breezSDK
+
+	balanceSats      uint64
+	prepareSend      func(breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error)
+	send             func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error)
+	disconnectCalled bool
+	destroyCalled    bool
+}
+
+func (sdk *testPaymentSDK) GetInfo(breez_sdk_spark.GetInfoRequest) (breez_sdk_spark.GetInfoResponse, error) {
+	return breez_sdk_spark.GetInfoResponse{BalanceSats: sdk.balanceSats}, nil
+}
+
+func (sdk *testPaymentSDK) PrepareSendPayment(
+	request breez_sdk_spark.PrepareSendPaymentRequest,
+) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+	return sdk.prepareSend(request)
+}
+
+func (sdk *testPaymentSDK) SendPayment(
+	request breez_sdk_spark.SendPaymentRequest,
+) (breez_sdk_spark.SendPaymentResponse, error) {
+	return sdk.send(request)
+}
+
+func (sdk *testPaymentSDK) Disconnect() error {
+	sdk.disconnectCalled = true
+	return nil
+}
+
+func (sdk *testPaymentSDK) Destroy() {
+	sdk.destroyCalled = true
+}
+
+func newActivePaymentTestLightning(t *testing.T, sdk *testPaymentSDK) *Lightning {
+	t.Helper()
+	return newActivePaymentTestLightningWithConfigFilename(t, sdk, test.TstTempFile("lightningConfig"))
+}
+
+func newActivePaymentTestLightningWithConfigFilename(
+	t *testing.T,
+	sdk *testPaymentSDK,
+	lightningConfigFilename string,
+) *Lightning {
+	t.Helper()
+
+	lightning := newTestLightningWithConfigFilename(t, nil, lightningConfigFilename)
+	displayLightning := makeTestLightning()
+	lightning.btcCoin = displayLightning.btcCoin
+	lightning.ratesUpdater = displayLightning.ratesUpdater
+	require.NoError(t, lightning.SetAccount(&config.LightningAccountConfig{
+		Seed:            "test mnemonic",
+		RootFingerprint: []byte{0xde, 0xad, 0xbe, 0xef},
+		Code:            "v0-deadbeef-ln-0",
+		Number:          0,
+	}))
+	lightning.sdkService = sdk
+	lightning.getAccount = func(accountCode accountsTypes.Code) (accounts.Interface, error) {
+		require.Equal(t, testCloseWithdrawDestinationAccountCode, accountCode)
+		return testCloseWithdrawAccount(), nil
+	}
+	return lightning
+}
+
+func testBitcoinPrepareResponse(feeSat uint64) breez_sdk_spark.PrepareSendPaymentResponse {
+	return breez_sdk_spark.PrepareSendPaymentResponse{
+		PaymentMethod: breez_sdk_spark.SendPaymentMethodBitcoinAddress{
+			FeeQuote: breez_sdk_spark.SendOnchainFeeQuote{
+				SpeedFast: breez_sdk_spark.SendOnchainSpeedFeeQuote{
+					UserFeeSat:        feeSat - 1,
+					L1BroadcastFeeSat: 1,
+				},
+			},
+		},
+		Amount:    big.NewInt(10_000),
+		FeePolicy: breez_sdk_spark.FeePolicyFeesIncluded,
+	}
+}
+
+func TestPrepareCloseWithdraw(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		require.Equal(t, "bc1pdestination", request.PaymentRequest)
+		require.NotNil(t, request.Amount)
+		require.Zero(t, (*request.Amount).Cmp(big.NewInt(10_000)))
+		require.NotNil(t, request.FeePolicy)
+		require.Equal(t, breez_sdk_spark.FeePolicyFeesIncluded, *request.FeePolicy)
+		return testBitcoinPrepareResponse(1_000), nil
+	}
+	sdk.send = func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		t.Fatal("prepare must not send payment")
+		return breez_sdk_spark.SendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+
+	quote, err := lightning.PrepareCloseWithdraw(testCloseWithdrawDestinationAccountCode)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(1_000), quote.FeeSat)
+	require.Equal(t, uint64(10_000), quote.BalanceSat)
+	require.Equal(t, "0.00010000", quote.Balance.Amount)
+	require.Equal(t, "0.00001000", quote.Fee.Amount)
+	require.NotNil(t, lightning.Account())
+}
+
+func TestCloseWithdraw(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		return testBitcoinPrepareResponse(1_000), nil
+	}
+	sdk.send = func(request breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		require.NotNil(t, request.Options)
+		options, ok := (*request.Options).(breez_sdk_spark.SendPaymentOptionsBitcoinAddress)
+		require.True(t, ok)
+		require.Equal(t, breez_sdk_spark.OnchainConfirmationSpeedFast, options.ConfirmationSpeed)
+		details := breez_sdk_spark.PaymentDetails(breez_sdk_spark.PaymentDetailsWithdraw{TxId: "tx-id"})
+		return breez_sdk_spark.SendPaymentResponse{
+			Payment: breez_sdk_spark.Payment{Details: &details},
+		}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+
+	result, err := lightning.CloseWithdraw(testCloseWithdrawDestinationAccountCode, 10_000, 1_000)
+
+	require.NoError(t, err)
+	require.Equal(t, "tx-id", result.TxID)
+	require.True(t, result.WalletClosed)
+	require.Nil(t, lightning.Account())
+	require.True(t, sdk.disconnectCalled)
+	require.True(t, sdk.destroyCalled)
+}
+
+func TestCloseWithdrawReturnsResultWhenSetAccountFails(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		return testBitcoinPrepareResponse(1_000), nil
+	}
+	sdk.send = func(request breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		details := breez_sdk_spark.PaymentDetails(breez_sdk_spark.PaymentDetailsWithdraw{TxId: "tx-id"})
+		return breez_sdk_spark.SendPaymentResponse{
+			Payment: breez_sdk_spark.Payment{Details: &details},
+		}, nil
+	}
+	lightningConfigFilename := test.TstTempFile("lightningConfig")
+	lightning := newActivePaymentTestLightningWithConfigFilename(t, sdk, lightningConfigFilename)
+	require.NoError(t, os.Remove(lightningConfigFilename))
+	require.NoError(t, os.Mkdir(lightningConfigFilename, 0o700))
+	t.Cleanup(func() {
+		require.NoError(t, os.Remove(lightningConfigFilename))
+	})
+
+	result, err := lightning.CloseWithdraw(testCloseWithdrawDestinationAccountCode, 10_000, 1_000)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "tx-id", result.TxID)
+	require.False(t, result.WalletClosed)
+}
+
+func TestCloseWithdrawRejectsChangedBalance(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_001}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		t.Fatal("stale quote must not prepare payment")
+		return breez_sdk_spark.PrepareSendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+
+	result, err := lightning.CloseWithdraw(testCloseWithdrawDestinationAccountCode, 10_000, 1_000)
+
+	require.Nil(t, result)
+	require.Equal(t, errPaymentApprovalRequired, errp.Cause(err))
+}
+
+func TestCloseWithdrawRejectsIncreasedFee(t *testing.T) {
+	t.Parallel()
+
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		return testBitcoinPrepareResponse(1_001), nil
+	}
+	sdk.send = func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		t.Fatal("unapproved fee must not be sent")
+		return breez_sdk_spark.SendPaymentResponse{}, nil
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+
+	result, err := lightning.CloseWithdraw(testCloseWithdrawDestinationAccountCode, 10_000, 1_000)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Equal(t, errPaymentApprovalRequired, errp.Cause(err))
+	require.NotNil(t, lightning.Account())
+	require.False(t, sdk.disconnectCalled)
+	require.False(t, sdk.destroyCalled)
+}
+
+func TestCloseWithdrawKeepsWalletActiveWhenSendFails(t *testing.T) {
+	t.Parallel()
+
+	sendErr := errors.New("send failed")
+	sdk := &testPaymentSDK{balanceSats: 10_000}
+	sdk.prepareSend = func(request breez_sdk_spark.PrepareSendPaymentRequest) (breez_sdk_spark.PrepareSendPaymentResponse, error) {
+		return testBitcoinPrepareResponse(1_000), nil
+	}
+	sdk.send = func(breez_sdk_spark.SendPaymentRequest) (breez_sdk_spark.SendPaymentResponse, error) {
+		return breez_sdk_spark.SendPaymentResponse{}, sendErr
+	}
+	lightning := newActivePaymentTestLightning(t, sdk)
+
+	result, err := lightning.CloseWithdraw(testCloseWithdrawDestinationAccountCode, 10_000, 1_000)
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, sendErr)
+	require.NotNil(t, lightning.Account())
+	require.False(t, sdk.disconnectCalled)
+	require.False(t, sdk.destroyCalled)
 }
 
 func TestValidateApprovedLightningFee(t *testing.T) {

--- a/frontends/web/src/api/lightning.ts
+++ b/frontends/web/src/api/lightning.ts
@@ -70,6 +70,18 @@ export type TReceivePaymentResponse = {
   invoice: string;
 };
 
+export type TCloseWithdrawQuote = {
+  balance: TAmountWithConversions;
+  balanceSat: number;
+  fee: TAmountWithConversions;
+  feeSat: number;
+};
+
+export type TCloseWithdrawResult = {
+  txId?: string;
+  walletClosed: boolean;
+};
+
 export type TLightningAddressAvailability = {
   username: string;
   address: string;
@@ -233,6 +245,30 @@ export const getParsePaymentInput = async (params: TParsePaymentInputRequest): P
 
 export const getBoardingAddress = async (): Promise<string> => {
   return getApiResponse<string>('lightning/boarding-address', 'Error calling getBoardingAddress');
+};
+
+export const postPrepareCloseWithdraw = async (destinationAccountCode: AccountCode): Promise<TCloseWithdrawQuote> => {
+  return postApiResponse<TCloseWithdrawQuote, { destinationAccountCode: AccountCode }>(
+    'lightning/close-withdraw-funds/prepare',
+    { destinationAccountCode },
+    'Error calling postPrepareCloseWithdraw'
+  );
+};
+
+export const postCloseWithdraw = async (
+  destinationAccountCode: AccountCode,
+  approvedBalanceSat: number,
+  approvedFeeSat: number,
+): Promise<TCloseWithdrawResult> => {
+  return postApiResponse<TCloseWithdrawResult, {
+    destinationAccountCode: AccountCode;
+    approvedBalanceSat: number;
+    approvedFeeSat: number;
+  }>(
+    'lightning/close-withdraw-funds',
+    { destinationAccountCode, approvedBalanceSat, approvedFeeSat },
+    'Error calling postCloseWithdraw'
+  );
 };
 
 export const postPreparePayment = async (data: TPreparePaymentRequest): Promise<TPreparePaymentResponse> => {

--- a/frontends/web/src/components/groupedaccountselector/groupedaccountselector.test.tsx
+++ b/frontends/web/src/components/groupedaccountselector/groupedaccountselector.test.tsx
@@ -62,4 +62,41 @@ describe('components/groupedaccountselector', () => {
 
     expect(await screen.findByRole('button', { name: 'buy.info.next' })).not.toBeDisabled();
   });
+
+  it('disables the account selector', async () => {
+    render(
+      <GroupedAccountSelector
+        accounts={[account]}
+        disabled
+        selected={account.code}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole('combobox')).toBeDisabled();
+  });
+
+  it('disables the mobile account selector trigger', async () => {
+    vi.mocked(window.matchMedia).mockReturnValue({
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      matches: true,
+      media: '(max-width: 768px)',
+      onchange: null,
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    render(
+      <GroupedAccountSelector
+        accounts={[account]}
+        disabled
+        selected={account.code}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole('button')).toBeDisabled();
+  });
 });

--- a/frontends/web/src/components/groupedaccountselector/groupedaccountselector.tsx
+++ b/frontends/web/src/components/groupedaccountselector/groupedaccountselector.tsx
@@ -3,6 +3,7 @@
 import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { AccountCode, CoinCode, CoinUnit, TAccountBase, TAmountWithConversions } from '@/api/account';
+import { syncdone } from '@/api/accountsync';
 import { Button } from '@/components/forms';
 import { Logo } from '@/components/icon/logo';
 import { USBSuccess, ChevronDownDark } from '@/components/icon';
@@ -10,6 +11,7 @@ import { Badge } from '@/components/badge/badge';
 import { InsuredShield } from '@/routes/account/components/insuredtag';
 import { RatesContext } from '@/contexts/RatesContext';
 import { getAccountsByKeystore, getDisplayedCoinUnit } from '@/routes/account/utils';
+import { unsubscribe } from '@/utils/subscriptions';
 import { Dropdown, TOption as TDropdownOption, TGroupedOption as TDropdownGroupedOption } from '@/components/dropdown/dropdown';
 import { createGroupedOptions, getBalancesForGroupedAccountSelector } from './services';
 import { AmountWithUnit } from '../amount/amount-with-unit';
@@ -124,18 +126,32 @@ export const GroupedAccountSelector = <T extends TAccountBase, >({
 
   useEffect(() => {
     let cancelled = false;
+    let balanceRequest = 0;
     //setting options without balance
     const accountsByKeystore = getAccountsByKeystore(accounts);
     const groupedOpts: TGroupedOption[] = createGroupedOptions(accountsByKeystore, isAccountDisabled);
     setOptions(groupedOpts);
     //asynchronously fetching each account's balance
-    getBalancesForGroupedAccountSelector(groupedOpts).then(nextOptions => {
-      if (!cancelled) {
-        setOptions(nextOptions);
+    const loadBalances = async () => {
+      const currentRequest = ++balanceRequest;
+      try {
+        const nextOptions = await getBalancesForGroupedAccountSelector(groupedOpts);
+        if (!cancelled && currentRequest === balanceRequest) {
+          setOptions(nextOptions);
+        }
+      } catch (error) {
+        if (!cancelled && currentRequest === balanceRequest) {
+          console.error('Failed to load account selector balances', error);
+        }
       }
-    });
+    };
+    const subscriptions = accounts
+      .filter(account => account.active)
+      .map(account => syncdone(account.code, loadBalances));
+    loadBalances();
     return () => {
       cancelled = true;
+      unsubscribe(subscriptions);
     };
   }, [accounts, isAccountDisabled]);
 
@@ -163,6 +179,7 @@ export const GroupedAccountSelector = <T extends TAccountBase, >({
     return (
       <button
         type="button"
+        disabled={disabled}
         className={`
           ${styles.trigger || ''}
           ${stackedLayout && styles.layoutOnTwoLines || ''}
@@ -187,6 +204,7 @@ export const GroupedAccountSelector = <T extends TAccountBase, >({
           ${className}
         `.trim()}
         classNamePrefix="react-select"
+        isDisabled={disabled}
         options={options}
         isSearchable={false}
         value={selectedOption}

--- a/frontends/web/src/locales/en/app.json
+++ b/frontends/web/src/locales/en/app.json
@@ -1655,6 +1655,10 @@
       },
       "fee": "Fee",
       "lightningBalanceToBeSent": "Lightning balance to be sent",
+      "partialFailure": {
+        "action": "Shut down wallet",
+        "message": "Funds were withdrawn, but the lightning wallet could not be closed. Please shut it down separately."
+      },
       "success": {
         "message": "Lightning wallet successfully closed. Coins will be sent to on-chain wallet.",
         "note": "Your coins will appear in your wallet once the transaction is confirmed."
@@ -1785,7 +1789,7 @@
         "total": "Total"
       },
       "from": "From",
-      "noBitcoinAccounts": "No Bitcoin accounts active. Please activate a Bitcoin account to top-up.",
+      "noBitcoinAccounts": "No Bitcoin accounts active. Please activate a Bitcoin account.",
       "success": {
         "message": "Top up created!"
       },

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/close-withdraw-funds.tsx
@@ -1,22 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import type { AccountCode, TAccount } from '@/api/account';
+import { getLightningBalance, postCloseWithdraw, postPrepareCloseWithdraw, type TCloseWithdrawQuote } from '@/api/lightning';
+import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
+import { Button } from '@/components/forms';
 import { Header, Main } from '@/components/layout';
+import { View, ViewButtons, ViewContent } from '@/components/view/view';
+import { useMountedRef } from '@/hooks/mount';
 import { CloseWithdrawConfirm } from './confirm-step';
 import { CloseWithdrawFailure } from './failure-step';
 import { CloseWithdrawSuccess } from './success-step';
 
-type TStep = 'confirm' | 'failure' | 'success';
+type TStep = 'confirm' | 'failure' | 'partialFailure' | 'success';
 
 type TProps = {
   activeAccounts: TAccount[];
+  hasAccounts: boolean;
+};
+
+type TPreparedQuote = TCloseWithdrawQuote & {
+  destinationAccountCode: AccountCode;
 };
 
 export const LightningCloseWithdrawFunds = ({
   activeAccounts,
+  hasAccounts,
 }: TProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -27,7 +37,16 @@ export const LightningCloseWithdrawFunds = ({
   const [destinationAccountCode, setDestinationAccountCode] = useState<AccountCode>(btcAccounts[0]?.code || '');
   const [confirmed, setConfirmed] = useState(false);
   const [step, setStep] = useState<TStep>('confirm');
-  const canClose = confirmed && !!destinationAccountCode;
+  const [balance, setBalance] = useState<TAmountWithConversions>();
+  const [quote, setQuote] = useState<TPreparedQuote>();
+  const [isClosing, setIsClosing] = useState(false);
+  const [txID, setTxID] = useState<string>();
+  const mounted = useMountedRef();
+  const isClosingRef = useRef(false);
+  const quoteRequest = useRef(0);
+  const destinationAccount = btcAccounts.find(account => account.code === destinationAccountCode);
+  const quoteMatchesDestination = quote?.destinationAccountCode === destinationAccountCode;
+  const canClose = confirmed && !!quote && quoteMatchesDestination && !isClosing;
 
   useEffect(() => {
     if (!btcAccounts.length) {
@@ -39,26 +58,138 @@ export const LightningCloseWithdrawFunds = ({
     }
   }, [btcAccounts, destinationAccountCode]);
 
+  const loadQuote = useCallback(async () => {
+    const currentRequest = ++quoteRequest.current;
+    const quoteDestinationAccountCode = destinationAccountCode;
+    setQuote(undefined);
+
+    try {
+      const lightningBalance = await getLightningBalance();
+      if (!mounted.current || currentRequest !== quoteRequest.current) {
+        return;
+      }
+      setBalance(lightningBalance.available);
+      if (!lightningBalance.hasAvailable) {
+        return;
+      }
+      if (!quoteDestinationAccountCode) {
+        return;
+      }
+      const preparedQuote = await postPrepareCloseWithdraw(quoteDestinationAccountCode);
+      if (!mounted.current || currentRequest !== quoteRequest.current) {
+        return;
+      }
+      setBalance(preparedQuote.balance);
+      setQuote({
+        ...preparedQuote,
+        destinationAccountCode: quoteDestinationAccountCode,
+      });
+    } catch (error) {
+      console.error('Failed to prepare Lightning wallet withdrawal', error);
+      if (mounted.current && currentRequest === quoteRequest.current) {
+        setStep('failure');
+      }
+    }
+  }, [destinationAccountCode, mounted]);
+
+  useEffect(() => {
+    if (step !== 'confirm' || isClosing || !destinationAccountCode) {
+      quoteRequest.current += 1;
+      return;
+    }
+    loadQuote();
+  }, [destinationAccountCode, isClosing, loadQuote, step]);
+
+  const closeWithdraw = useCallback(async () => {
+    if (
+      !quote
+      || quote.destinationAccountCode !== destinationAccountCode
+      || isClosingRef.current
+    ) {
+      return;
+    }
+    isClosingRef.current = true;
+    quoteRequest.current += 1;
+    setIsClosing(true);
+    try {
+      const result = await postCloseWithdraw(destinationAccountCode, quote.balanceSat, quote.feeSat);
+      if (!mounted.current) {
+        return;
+      }
+      setTxID(result.txId);
+      setStep(result.walletClosed ? 'success' : 'partialFailure');
+    } catch (error) {
+      console.error('Failed to close Lightning wallet and withdraw funds', error);
+      if (mounted.current) {
+        setStep('failure');
+      }
+    } finally {
+      isClosingRef.current = false;
+      if (mounted.current) {
+        setIsClosing(false);
+      }
+    }
+  }, [destinationAccountCode, mounted, quote]);
+
   const renderStep = () => {
+    if (!btcAccounts.length) {
+      const primaryAction = hasAccounts
+        ? {
+          label: t('manageAccounts.title'),
+          route: '/settings/manage-accounts',
+        }
+        : {
+          label: t('welcome.connect'),
+          route: '/',
+        };
+      return (
+        <View textCenter verticallyCentered>
+          <ViewContent>
+            <p>{t('lightning.topUp.noBitcoinAccounts')}</p>
+          </ViewContent>
+          <ViewButtons>
+            <Button primary onClick={() => navigate(primaryAction.route)}>
+              {primaryAction.label}
+            </Button>
+            <Button secondary onClick={() => navigate('/settings/lightning-settings')}>
+              {t('button.back')}
+            </Button>
+          </ViewButtons>
+        </View>
+      );
+    }
+
     switch (step) {
     case 'confirm':
       return (
         <CloseWithdrawConfirm
+          balance={balance}
           btcAccounts={btcAccounts}
           canClose={canClose}
           confirmed={confirmed}
           destinationAccountCode={destinationAccountCode}
+          fee={quote?.fee}
+          isClosing={isClosing}
           onCancel={() => navigate(-1)}
-          onClose={() => setStep('success')}
+          onClose={closeWithdraw}
           onConfirmChange={() => setConfirmed(current => !current)}
-          onDestinationAccountChange={setDestinationAccountCode}
+          onDestinationAccountChange={(code) => {
+            setConfirmed(false);
+            setDestinationAccountCode(code);
+          }}
         />
       );
     case 'failure':
+    case 'partialFailure':
       return (
         <CloseWithdrawFailure
+          partial={step === 'partialFailure'}
           onCancel={() => navigate('/settings/lightning-settings')}
           onTryAgain={() => {
+            if (step === 'partialFailure') {
+              navigate('/lightning/deactivate/');
+              return;
+            }
             setConfirmed(false);
             setStep('confirm');
           }}
@@ -66,7 +197,10 @@ export const LightningCloseWithdrawFunds = ({
       );
     case 'success':
       return (
-        <CloseWithdrawSuccess onDone={() => navigate('/settings/lightning-settings')} />
+        <CloseWithdrawSuccess
+          explorerURL={txID && destinationAccount ? `${destinationAccount.blockExplorerTxPrefix}${txID}` : undefined}
+          onDone={() => navigate('/account-summary')}
+        />
       );
     }
   };

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/confirm-step.tsx
@@ -1,26 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useTranslation } from 'react-i18next';
-import type { AccountCode, TAccount } from '@/api/account';
-import { Amount } from '@/components/amount/amount';
+import type { AccountCode, TAccount, TAmountWithConversions } from '@/api/account';
+import { AmountWithUnit } from '@/components/amount/amount-with-unit';
 import { Button, Checkbox } from '@/components/forms';
 import { GroupedAccountSelector } from '@/components/groupedaccountselector/groupedaccountselector';
+import { Skeleton } from '@/components/skeleton/skeleton';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
-import {
-  CONTENT_MIN_HEIGHT,
-  MOCK_AMOUNT_UNIT,
-  MOCK_FIAT_UNIT,
-  MOCK_LIGHTNING_BALANCE,
-  MOCK_WITHDRAW_FEE,
-  type TDisplayAmount,
-} from './constants';
+import { CONTENT_MIN_HEIGHT } from './constants';
 import styles from './close-withdraw-funds.module.css';
 
 type TProps = {
+  balance?: TAmountWithConversions;
   btcAccounts: TAccount[];
   canClose: boolean;
   confirmed: boolean;
   destinationAccountCode: AccountCode;
+  fee?: TAmountWithConversions;
+  isClosing: boolean;
   onCancel: () => void;
   onClose: () => void;
   onConfirmChange: () => void;
@@ -30,23 +27,31 @@ type TProps = {
 const AmountRow = ({
   amount,
 }: {
-  amount: TDisplayAmount;
-}) => (
-  <div className={styles.amountRow}>
-    <span className={`${styles.amountWithUnit || ''} ${styles.sats || ''}`}>
-      <Amount amount={amount.amount} unit={MOCK_AMOUNT_UNIT} /> {MOCK_AMOUNT_UNIT}
-    </span>
-    <span className={`${styles.amountWithUnit || ''} ${styles.fiat || ''}`}>
-      <Amount amount={amount.fiatAmount} unit={MOCK_FIAT_UNIT} /> {MOCK_FIAT_UNIT}
-    </span>
-  </div>
-);
+  amount?: TAmountWithConversions;
+}) => {
+  if (!amount) {
+    return <Skeleton />;
+  }
+  return (
+    <div className={styles.amountRow}>
+      <span className={`${styles.amountWithUnit || ''} ${styles.sats || ''}`}>
+        <AmountWithUnit amount={amount} />
+      </span>
+      <span className={`${styles.amountWithUnit || ''} ${styles.fiat || ''}`}>
+        <AmountWithUnit amount={amount} convertToFiat />
+      </span>
+    </div>
+  );
+};
 
 export const CloseWithdrawConfirm = ({
+  balance,
   btcAccounts,
   canClose,
   confirmed,
   destinationAccountCode,
+  fee,
+  isClosing,
   onCancel,
   onClose,
   onConfirmChange,
@@ -62,7 +67,7 @@ export const CloseWithdrawConfirm = ({
 
           <section className={styles.section}>
             <h2 className={styles.sectionTitle}>{t('lightning.closeWithdrawFunds.lightningBalanceToBeSent')}</h2>
-            <AmountRow amount={MOCK_LIGHTNING_BALANCE} />
+            <AmountRow amount={balance} />
           </section>
 
           <section className={styles.section}>
@@ -70,6 +75,7 @@ export const CloseWithdrawConfirm = ({
             <GroupedAccountSelector
               accounts={btcAccounts}
               className={styles.accountSelector}
+              disabled={isClosing}
               onChange={onDestinationAccountChange}
               selected={destinationAccountCode}
             />
@@ -77,13 +83,14 @@ export const CloseWithdrawConfirm = ({
 
           <section className={styles.section}>
             <h2 className={styles.sectionTitle}>{t('lightning.closeWithdrawFunds.fee')}</h2>
-            <AmountRow amount={MOCK_WITHDRAW_FEE} />
+            <AmountRow amount={fee} />
           </section>
 
           <Checkbox
             className={styles.confirm}
             id="confirmCloseWithdrawFunds"
             checked={confirmed}
+            disabled={isClosing}
             onChange={onConfirmChange}
           >
             {t('lightning.closeWithdrawFunds.confirm')}
@@ -91,10 +98,10 @@ export const CloseWithdrawConfirm = ({
         </div>
       </ViewContent>
       <ViewButtons>
-        <Button danger disabled={!canClose} onClick={onClose}>
+        <Button danger disabled={!canClose || isClosing} onClick={onClose}>
           {t('lightning.settings.closeAndWithdrawFunds')}
         </Button>
-        <Button secondary onClick={onCancel}>
+        <Button secondary disabled={isClosing} onClick={onCancel}>
           {t('dialog.cancel')}
         </Button>
       </ViewButtons>

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/constants.ts
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/constants.ts
@@ -1,23 +1,3 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CoinUnit, ConversionUnit } from '@/api/account';
-
 export const CONTENT_MIN_HEIGHT = '38em';
-
-export type TDisplayAmount = {
-  amount: string;
-  fiatAmount: string;
-};
-
-export const MOCK_AMOUNT_UNIT: CoinUnit = 'sat';
-export const MOCK_FIAT_UNIT: ConversionUnit = 'EUR';
-
-export const MOCK_LIGHTNING_BALANCE: TDisplayAmount = {
-  amount: '10000',
-  fiatAmount: '64.0',
-};
-
-export const MOCK_WITHDRAW_FEE: TDisplayAmount = {
-  amount: '1000',
-  fiatAmount: '6.40',
-};

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/failure-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/failure-step.tsx
@@ -7,11 +7,13 @@ import { CONTENT_MIN_HEIGHT } from './constants';
 import styles from './close-withdraw-funds.module.css';
 
 type TProps = {
+  partial: boolean;
   onCancel: () => void;
   onTryAgain: () => void;
 };
 
 export const CloseWithdrawFailure = ({
+  partial,
   onCancel,
   onTryAgain,
 }: TProps) => {
@@ -21,13 +23,21 @@ export const CloseWithdrawFailure = ({
     <View key="close-withdraw-funds-failure" minHeight={CONTENT_MIN_HEIGHT} textCenter width="min(420px, 100%)">
       <ViewContent withIcon="error">
         <div className={styles.failureContent}>
-          <p className={styles.failureMessage}>{t('lightning.closeWithdrawFunds.failure.message')}</p>
-          <p className={styles.failureNote}>{t('lightning.closeWithdrawFunds.failure.tryAgain')}</p>
+          <p className={styles.failureMessage}>
+            {t(partial
+              ? 'lightning.closeWithdrawFunds.partialFailure.message'
+              : 'lightning.closeWithdrawFunds.failure.message')}
+          </p>
+          {!partial && (
+            <p className={styles.failureNote}>{t('lightning.closeWithdrawFunds.failure.tryAgain')}</p>
+          )}
         </div>
       </ViewContent>
       <ViewButtons>
         <Button className={styles.doneButton} primary onClick={onTryAgain}>
-          {t('lightning.closeWithdrawFunds.failure.tryAgain')}
+          {t(partial
+            ? 'lightning.closeWithdrawFunds.partialFailure.action'
+            : 'lightning.closeWithdrawFunds.failure.tryAgain')}
         </Button>
         <Button className={styles.doneButton} secondary onClick={onCancel}>
           {t('dialog.cancel')}

--- a/frontends/web/src/routes/lightning/close-and-withdraw-funds/success-step.tsx
+++ b/frontends/web/src/routes/lightning/close-and-withdraw-funds/success-step.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useTranslation } from 'react-i18next';
+import { A } from '@/components/anchor/anchor';
 import { Button } from '@/components/forms';
 import { ExternalLink } from '@/components/icon';
 import { View, ViewButtons, ViewContent } from '@/components/view/view';
@@ -8,12 +9,12 @@ import { CONTENT_MIN_HEIGHT } from './constants';
 import styles from './close-withdraw-funds.module.css';
 
 type TProps = {
+  explorerURL?: string;
   onDone: () => void;
 };
 
-const noop = () => undefined;
-
 export const CloseWithdrawSuccess = ({
+  explorerURL,
   onDone,
 }: TProps) => {
   const { t } = useTranslation();
@@ -24,10 +25,12 @@ export const CloseWithdrawSuccess = ({
         <div className={styles.successContent}>
           <p className={styles.successMessage}>{t('lightning.closeWithdrawFunds.success.message')}</p>
           <p className={styles.successNote}>{t('lightning.closeWithdrawFunds.success.note')}</p>
-          <Button className={styles.transactionButton} transparent onClick={noop}>
-            <ExternalLink className={styles.transactionIcon} />
-            {t('lightning.closeWithdrawFunds.viewTransaction')}
-          </Button>
+          {explorerURL && (
+            <A className={styles.transactionButton} href={explorerURL}>
+              <ExternalLink className={styles.transactionIcon} />
+              {t('lightning.closeWithdrawFunds.viewTransaction')}
+            </A>
+          )}
         </div>
       </ViewContent>
       <ViewButtons>

--- a/frontends/web/src/routes/router.tsx
+++ b/frontends/web/src/routes/router.tsx
@@ -356,7 +356,12 @@ export const AppRouter = ({ devices, devicesKey, accounts, activeAccounts }: TAp
           <Route path="activate" element={<LightningActivate />} />
           <Route path="deactivate" element={<LightningDeactivate />} />
           <Route path="set-lnurl-address" element={<LightningSetLnurlAddress />} />
-          <Route path="close-withdraw-funds" element={<LightningCloseWithdrawFunds activeAccounts={activeAccounts} />} />
+          <Route path="close-withdraw-funds" element={(
+            <LightningCloseWithdrawFunds
+              activeAccounts={activeAccounts}
+              hasAccounts={hasAccounts}
+            />
+          )} />
           <Route path="send" element={<LightningSend />} />
           <Route path="receive" element={<LightningReceive />} />
           <Route path="topup" element={<LightningTopUp activeAccounts={activeAccounts} hasAccounts={hasAccounts} />} />

--- a/frontends/web/src/routes/settings/components/appearance/activeCurrenciesDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/activeCurrenciesDropdownSetting.tsx
@@ -17,11 +17,10 @@ const ActiveCurrenciesDropdownSetting = () => {
 
   return (
     <SettingsItem
-      disabled={!isMobile}
       collapseOnSmall
       settingName={t('newSettings.appearance.activeCurrencies.title')}
       secondaryText={t('newSettings.appearance.activeCurrencies.description')}
-      onClick={!isMobileSelectorOpen ? () => setIsMobileSelectorOpen(true) : undefined}
+      onClick={isMobile && !isMobileSelectorOpen ? () => setIsMobileSelectorOpen(true) : undefined}
       extraComponent={
         <ActiveCurrenciesDropdown
           isOpen={isMobileSelectorOpen}

--- a/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/defaultCurrencyDropdownSetting.tsx
@@ -21,11 +21,10 @@ export const DefaultCurrencyDropdownSetting = () => {
   const isMobile = useMediaQuery('(max-width: 768px)');
   return (
     <SettingsItem
-      disabled={!isMobile}
       settingName={t('newSettings.appearance.defaultCurrency.title')}
       secondaryText={t('newSettings.appearance.defaultCurrency.description')}
       collapseOnSmall
-      onClick={!isMobileSelectorOpen ? () => setIsMobileSelectorOpen(true) : undefined}
+      onClick={isMobile && !isMobileSelectorOpen ? () => setIsMobileSelectorOpen(true) : undefined}
       extraComponent={
         <Dropdown
           className={settingsDropdownStyles.select}

--- a/frontends/web/src/routes/settings/components/appearance/languageDropdownSetting.tsx
+++ b/frontends/web/src/routes/settings/components/appearance/languageDropdownSetting.tsx
@@ -25,8 +25,7 @@ export const LanguageDropdownSetting = () => {
   const isMobile = useMediaQuery('(max-width: 768px)');
   return (
     <SettingsItem
-      disabled={!isMobile}
-      onClick={!isMobileSelectorOpen ? () => setIsMobileSelectorOpen(true) : undefined}
+      onClick={isMobile && !isMobileSelectorOpen ? () => setIsMobileSelectorOpen(true) : undefined}
       settingName={<div className={styles.container}>{globe}{t('newSettings.appearance.language.title')}</div>}
       secondaryText={t('newSettings.appearance.language.description')}
       collapseOnSmall

--- a/frontends/web/src/routes/settings/components/settingsItem/settingsItem.tsx
+++ b/frontends/web/src/routes/settings/components/settingsItem/settingsItem.tsx
@@ -84,6 +84,7 @@ export const SettingsItem = ({
     <ActionableItem
       icon={icon}
       className={`${styles.container || ''} ${className}`}
+      disabled={disabled}
       onClick={notButton ? undefined : onClick}
     >
       {content}

--- a/frontends/web/src/routes/settings/lightning-settings.tsx
+++ b/frontends/web/src/routes/settings/lightning-settings.tsx
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { getLightningBalance, subscribeListPayments } from '@/api/lightning';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
 import { Header, Main } from '@/components/layout';
@@ -24,13 +26,27 @@ export const LightningSettings = ({
 }: TPagePropsWithSettingsTabs) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { lightningAccount } = useLightning();
+  const { isLightningReady, lightningAccount } = useLightning();
   const keystoreNameResponse = useLoad(
     lightningAccount
       ? () => getKeystoreName(lightningAccount.rootFingerprint)
       : null,
     [lightningAccount?.rootFingerprint]
   );
+  const [balanceLoadAttempt, setBalanceLoadAttempt] = useState(0);
+  const lightningBalance = useLoad(
+    lightningAccount && isLightningReady ? getLightningBalance : null,
+    [balanceLoadAttempt, isLightningReady, lightningAccount]
+  );
+
+  useEffect(() => {
+    if (!lightningAccount || !isLightningReady) {
+      return;
+    }
+    return subscribeListPayments(() => {
+      setBalanceLoadAttempt(current => current + 1);
+    });
+  }, [isLightningReady, lightningAccount]);
 
   const renderContent = () => {
     if (lightningAccount === undefined) {
@@ -83,6 +99,7 @@ export const LightningSettings = ({
           onClick={() => navigate('/lightning/deactivate/')}
         />
         <SettingsItem
+          disabled={!lightningBalance?.hasAvailable}
           settingName={<span className={styles.danger}>{t('lightning.settings.closeAndWithdrawFunds')}</span>}
           onClick={() => navigate('/lightning/close-withdraw-funds/')}
         />


### PR DESCRIPTION
[Note]: this is the exact same content as https://github.com/BitBoxSwiss/bitbox-wallet-app/pull/4252. However, Luca requested changes on that PR and I can't merge without his explicit approval, and he is currently on holiday and without access to GH.

I spoke to him in DM and he confirm he is ok with me merging this one, so I'm opening a new PR with the exact same content and will merge this one instead.


Prepare and broadcast a full-balance on-chain withdrawal to a selected Bitcoin account, then deactivate Lightning after a successful send.

Update the confirmation and result UI, and refresh account balances after synchronization.

Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
