### PR TITLE
backend: decouple rates from account reload

### DIFF
--- a/backend/accounts.go
+++ b/backend/accounts.go
@@ -1358,10 +1358,8 @@ func (backend *Backend) initAccounts(force bool) {
 
 	backend.emitAccountsStatusChanged()
 
-	// The updater fetches rates only for active accounts, so this seems the most
-	// appropriate place to update exchange rate configuration.
-	// Every time fiats or coins list is changed in the UI settings, ReinitializedAccounts
-	// is invoked which triggers this method.
+	// The updater fetches rates only for active accounts, so update its configuration whenever
+	// this operation changes the loaded account set.
 	backend.configureHistoryExchangeRates()
 }
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -404,6 +404,13 @@ func (backend *Backend) configureHistoryExchangeRates() {
 	backend.ratesUpdater.ReconfigureHistory(coins, fiats)
 }
 
+// ReconfigureHistoryExchangeRates updates the historical exchange-rate pairs to match the loaded
+// accounts and configured fiat currencies.
+func (backend *Backend) ReconfigureHistoryExchangeRates() {
+	defer backend.accountsAndKeystoreLock.RLock()()
+	backend.configureHistoryExchangeRates()
+}
+
 func (backend *Backend) notifyNewTxs(account accounts.Interface) {
 	notifier := account.Notifier()
 	if notifier == nil {

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -91,7 +91,7 @@ type Backend interface {
 	RegisterTestKeystore(string, software.Edition) error
 	NotifyUser(string)
 	SystemOpen(string) error
-	ReinitializeAccounts()
+	ReconfigureHistoryExchangeRates()
 	GetUpdate() backend.UpdateState
 	Banners() *banners.Banners
 	Environment() backend.Environment
@@ -230,7 +230,7 @@ func NewHandlers(
 	getAPIRouterNoError(apiRouter)("/set-token-active", handlers.postSetTokenActive).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/set-account-receive-script-type", handlers.postSetAccountReceiveScriptType).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/rename-account", handlers.postRenameAccount).Methods("POST")
-	getAPIRouterNoError(apiRouter)("/accounts/reinitialize", handlers.postAccountsReinitialize).Methods("POST")
+	getAPIRouterNoError(apiRouter)("/rates/reconfigure-history", handlers.postReconfigureHistoryExchangeRates).Methods("POST")
 	getAPIRouterNoError(apiRouter)("/chart-data", handlers.getChartData).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/supported-coins", handlers.getSupportedCoins).Methods("GET")
 	getAPIRouterNoError(apiRouter)("/test/register", handlers.postRegisterTestKeystore).Methods("POST")
@@ -1012,8 +1012,8 @@ func (handlers *Handlers) postSetAccountReceiveScriptType(r *http.Request) inter
 	return response{Success: true}
 }
 
-func (handlers *Handlers) postAccountsReinitialize(*http.Request) interface{} {
-	handlers.backend.ReinitializeAccounts()
+func (handlers *Handlers) postReconfigureHistoryExchangeRates(*http.Request) interface{} {
+	handlers.backend.ReconfigureHistoryExchangeRates()
 	return nil
 }
 

--- a/frontends/web/src/api/backend.ts
+++ b/frontends/web/src/api/backend.ts
@@ -49,10 +49,6 @@ export const renameAccount = (accountCode: AccountCode, name: string): Promise<T
   return apiPost('rename-account', { accountCode, name });
 };
 
-export const reinitializeAccounts = (): Promise<null> => {
-  return apiPost('accounts/reinitialize');
-};
-
 export const getTesting = (): Promise<boolean> => {
   return apiGet('testing');
 };

--- a/frontends/web/src/api/rates.ts
+++ b/frontends/web/src/api/rates.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { apiPost } from '@/utils/request';
+
+export const reconfigureHistoryRates = (): Promise<null> => {
+  return apiPost('rates/reconfigure-history');
+};

--- a/frontends/web/src/contexts/RatesProvider.tsx
+++ b/frontends/web/src/contexts/RatesProvider.tsx
@@ -4,8 +4,8 @@ import { ReactNode, useEffect, useState } from 'react';
 import { RatesContext } from './RatesContext';
 import { Fiat } from '@/api/account';
 import { BtcUnit, setBtcUnit as setBackendBtcUnit } from '@/api/coins';
+import { reconfigureHistoryRates } from '@/api/rates';
 import { useConfig } from './ConfigProvider';
-import { reinitializeAccounts } from '@/api/backend';
 import { equal } from '@/utils/equal';
 
 type TProps = {
@@ -71,9 +71,7 @@ export const RatesProvider = ({ children }: TProps) => {
 
   const handleChangeSelectedFiat = (selected: Fiat[]) => {
     setActiveCurrencies(selected);
-    // Need to reconfigure currency exchange rates updater
-    // which is done during accounts reset.
-    reinitializeAccounts();
+    void reconfigureHistoryRates();
   };
 
   return (


### PR DESCRIPTION
Replace the frontend account reload request with a dedicated historical rates
refresh.

Keep internal account reinitialization until membership updates become
incremental.

This avoids a needless full resync when changing the currency settings.