### PR TITLE
backend: resolve full-tree lint findings

### DIFF
--- a/backend/coins/btc/blockchain/blockchain.go
+++ b/backend/coins/btc/blockchain/blockchain.go
@@ -62,7 +62,7 @@ func (history TxHistory) Status() string {
 	}
 	status := bytes.Buffer{}
 	for _, tx := range history {
-		status.WriteString(fmt.Sprintf("%s:%d:", tx.TXHash.Hash().String(), tx.Height))
+		fmt.Fprintf(&status, "%s:%d:", tx.TXHash.Hash().String(), tx.Height)
 	}
 	return hex.EncodeToString(chainhash.HashB(status.Bytes()))
 }

--- a/backend/handlers/handlers.go
+++ b/backend/handlers/handlers.go
@@ -1870,24 +1870,13 @@ func (handlers *Handlers) getKeystoreShowBackupBanner(r *http.Request) interface
 		backupReminderConfig = keystoreConfig.BackupReminderAllowed
 	}
 
-	boolPtr := func(value bool) *bool {
-		v := value
-		return &v
-	}
-
 	show := overThreshold
-	backupReminderAllowed := backupReminderConfig
 
 	if backupReminderConfig == nil {
-		if overThreshold {
-			show = false
-			backupReminderAllowed = boolPtr(false)
-		} else {
-			backupReminderAllowed = boolPtr(true)
-		}
+		show = false
 		if err := handlers.backend.Config().ModifyAccountsConfig(func(cfg *config.AccountsConfig) error {
 			keystoreConfig := cfg.GetOrAddKeystore(rootFingerprint)
-			value := *backupReminderAllowed
+			value := !overThreshold
 			keystoreConfig.BackupReminderAllowed = &value
 			return nil
 		}); err != nil {


### PR DESCRIPTION
CI evaluates these code paths under the current linters. The backup-reminder
state used an assignment that was always overwritten before use, while
blockchain status formatting created an intermediate string.

Simplify the reminder branch without changing its tri-state behavior and write
directly to the status buffer. This removes the lint failures and avoids an
unnecessary allocation.