### PR TITLE
lightning: prefer connected wallet for top-ups

### DIFF
--- a/frontends/web/src/routes/lightning/topup/topup.tsx
+++ b/frontends/web/src/routes/lightning/topup/topup.tsx
@@ -116,7 +116,11 @@ export const LightningTopUp = ({ activeAccounts, hasAccounts }: TProps) => {
       return;
     }
     if (!sourceAccountCode || !topUpAccounts.some(account => account.code === sourceAccountCode)) {
-      setSourceAccountCode(topUpAccounts[0]?.code || '');
+      setSourceAccountCode(
+        topUpAccounts.find(account => account.keystore.connected)?.code
+          || topUpAccounts[0]?.code
+          || ''
+      );
     }
   }, [sourceAccountCode, topUpAccounts]);
 


### PR DESCRIPTION
Top-up already filters the available Bitcoin accounts to those with a
balance. Prefer the first such account from the connected wallet, falling
back to the first funded account.

Codex note comparing this to the original PR:

---
The subagent found that the simplified implementation matches PR #4270 in the normal synced, error-free case.

It is not identical around balance errors:

  - Our version preserves existing getTopUpAccounts behavior, which treats balance errors as eligible. It could therefore prefer a connected account whose funding status is unknown.
  - PR #4270 skips non-sync balance errors.
  - Conversely, PR #4270 mishandles sync errors: the endpoint fails, the frontend silently falls back to the first account, and never retries. Our version behaves better here.

