### PR TITLE
frontend: highlight More for Lightning settings

### DIFF
--- a/frontends/web/src/components/bottom-navigation/bottom-navigation.tsx
+++ b/frontends/web/src/components/bottom-navigation/bottom-navigation.tsx
@@ -9,6 +9,7 @@ import { useLoad } from '@/hooks/api';
 import { getVersion } from '@/api/bitbox02';
 import { RedDot } from '@/components/icon';
 import { NewBadge } from '@/components/new-badge/new-badge';
+import { getBottomNavKey } from './utils';
 import styles from './bottom-navigation.module.css';
 
 type TProps = {
@@ -24,6 +25,7 @@ export const BottomNavigation = ({
 }: TProps) => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
+  const bottomNavKey = getBottomNavKey(pathname);
   const deviceID = Object.keys(devices)[0];
   const isBitBox02 = deviceID && devices[deviceID] === 'bitbox02';
   const versionInfo = useLoad(isBitBox02 ? () => getVersion(deviceID) : null, [deviceID, isBitBox02]);
@@ -44,7 +46,7 @@ export const BottomNavigation = ({
       <Link
         className={`
           ${styles.link || ''}
-          ${pathname.startsWith('/account-summary') && styles.active || ''}
+          ${bottomNavKey === 'portfolio' && styles.active || ''}
         `}
         to="/account-summary"
       >
@@ -54,7 +56,7 @@ export const BottomNavigation = ({
       <Link
         className={`
           ${styles.link || ''}
-          ${pathname.startsWith('/account/') || pathname.startsWith('/accounts/') || pathname.startsWith('/lightning') ? (styles.active || '') : ''}
+          ${bottomNavKey === 'accounts' && styles.active || ''}
         `}
         to={accountTabURL}
       >
@@ -65,7 +67,7 @@ export const BottomNavigation = ({
         <Link
           className={`
             ${styles.link || ''}
-            ${pathname.startsWith('/market/') && styles.active || ''}
+            ${bottomNavKey === 'market' && styles.active || ''}
           `}
           to="/market/select"
         >
@@ -85,7 +87,7 @@ export const BottomNavigation = ({
       <Link
         className={`
           ${styles.link || ''}
-          ${pathname.startsWith('/settings') ? (styles.active || '') : ''}
+          ${bottomNavKey === 'more' && styles.active || ''}
         `}
         to="/settings/more"
       >

--- a/frontends/web/src/components/bottom-navigation/utils.ts
+++ b/frontends/web/src/components/bottom-navigation/utils.ts
@@ -4,11 +4,31 @@
  * Maps a pathname to the bottom-navigation tab it belongs to.
  * Used to detect tab changes for animations and state resets.
  */
-export const getBottomNavKey = (pathname: string): string => {
+const LIGHTNING_SETTINGS_PATHS = [
+  '/lightning/activate',
+  '/lightning/deactivate',
+  '/lightning/set-lnurl-address',
+  '/lightning/close-withdraw-funds',
+];
+
+const hasPathPrefix = (pathname: string, prefix: string): boolean => (
+  pathname === prefix || pathname.startsWith(`${prefix}/`)
+);
+
+export type TBottomNavKey = 'portfolio' | 'accounts' | 'market' | 'more' | 'other';
+
+export const getBottomNavKey = (pathname: string): TBottomNavKey => {
   if (pathname.startsWith('/account-summary')) {
     return 'portfolio';
   }
-  if (pathname.startsWith('/account/') || pathname.startsWith('/accounts/') || pathname.startsWith('/lightning')) {
+  if (LIGHTNING_SETTINGS_PATHS.some(prefix => hasPathPrefix(pathname, prefix))) {
+    return 'more';
+  }
+  if (
+    pathname.startsWith('/account/')
+    || pathname.startsWith('/accounts/')
+    || hasPathPrefix(pathname, '/lightning')
+  ) {
     return 'accounts';
   }
   if (pathname.startsWith('/market/')) {


### PR DESCRIPTION
Lightning settings actions live under /lightning routes, so the bottom navigation treated them as account screens. Classify those settings actions through the shared bottom navigation mapper and reuse that mapper for the active link state.

<img width="462" height="1223" alt="image" src="https://github.com/user-attachments/assets/1a30d698-d719-4613-8d9a-d4b5f33a5277" />


Before asking for reviews, here is a check list of the most common things you might need to consider:
- [ ] updating the Changelog
- [ ] writing unit tests
- [ ] checking if your changes affect other coins or tokens in unintended ways
- [ ] testing on multiple environments (Qt, Android, ...)
- [ ] having an AI review your changes
