### PR TITLE
frontend: LN portfolio page UI adjustments

### DIFF
--- a/frontends/web/src/routes/account/summary/accountssummary.module.css
+++ b/frontends/web/src/routes/account/summary/accountssummary.module.css
@@ -154,6 +154,10 @@
     min-width: 0;
 }
 
+.assetBalanceDetailsRowCentered {
+    align-items: center;
+}
+
 .assetBalanceDetailsCol {
     display: flex;
     flex-direction: column;

--- a/frontends/web/src/routes/account/summary/accountssummary.tsx
+++ b/frontends/web/src/routes/account/summary/accountssummary.tsx
@@ -20,7 +20,7 @@ import { Entry } from '@/components/guide/entry';
 import { Guide } from '@/components/guide/guide';
 import { HideAmountsButton } from '@/components/hideamountsbutton/hideamountsbutton';
 import { AppContext } from '@/contexts/AppContext';
-import { getAccountsByKeystore, getAccountsPerCoin } from '@/routes/account/utils';
+import { getAccountsByKeystore, getAccountsPerCoin, isBitcoinOnly } from '@/routes/account/utils';
 import { RatesContext } from '@/contexts/RatesContext';
 import { ContentWrapper } from '@/components/contentwrapper/contentwrapper';
 import { GlobalBanners } from '@/components/banners';
@@ -49,6 +49,8 @@ export const AccountsSummary = ({
   const { lightningAccount } = useLightning();
 
   const accountsByKeystore = getAccountsByKeystore(accounts);
+  const hasActiveBitcoinAccount = accounts.some(account => account.active && isBitcoinOnly(account.coinCode));
+  const hasOnlyLightningAccount = !!lightningAccount && accounts.length === 0;
 
   const accountsPerCoin = getAccountsPerCoin(accounts);
   const hasMultipleAccountsPerCoin = Object.values(accountsPerCoin).some(
@@ -208,6 +210,8 @@ export const AccountsSummary = ({
             <div className={style.keystoresContainer} data-testid="account-summary-keystores">
               {showTotalBalance && (
                 <TotalBalanceForAllKeystores
+                  hideHeader={hasOnlyLightningAccount}
+                  hideLightningUnitPrice={hasActiveBitcoinAccount}
                   summaryData={chartData}
                   coinsBalances={accountsBalanceSummary?.coinsTotalBalance}
                 />

--- a/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
+++ b/frontends/web/src/routes/account/summary/asset-balance-with-unit-price.tsx
@@ -8,20 +8,30 @@ import { Skeleton } from '@/components/skeleton/skeleton';
 import { useCoinUnitPrice } from '@/hooks/coin-unit-price';
 import style from './accountssummary.module.css';
 
-type Props = {
+type TProps = {
   amount?: TAmountWithConversions;
   coinCode: CoinCode;
   coinName: ReactNode;
   dataTestId?: string;
+  showUnitPrice?: boolean;
 };
 
-export const AssetBalanceWithUnitPrice = ({ amount, coinCode, coinName, dataTestId }: Props) => {
+export const AssetBalanceWithUnitPrice = ({
+  amount,
+  coinCode,
+  coinName,
+  dataTestId,
+  showUnitPrice = true,
+}: TProps) => {
   const unitPrice = useCoinUnitPrice(coinCode, amount?.unit);
   return (
     <div className={style.assetBalanceRow}>
       <div className={style.assetBalanceInfoFull}>
         <Logo className={style.assetBalanceLogo} coinCode={coinCode} active={true} alt={coinCode} />
-        <div className={style.assetBalanceDetailsRow}>
+        <div className={`
+          ${style.assetBalanceDetailsRow || ''}
+          ${!showUnitPrice ? style.assetBalanceDetailsRowCentered || '' : ''}
+        `}>
           <div className={style.assetBalanceDetailsCol}>
             <span
               className={`${style.assetBalanceName || ''}
@@ -31,15 +41,17 @@ export const AssetBalanceWithUnitPrice = ({ amount, coinCode, coinName, dataTest
               {coinName}
             </span>
 
-            <div data-testid="unit-price-amount">
-              <AmountWithUnit
-                alwaysShowAmounts
-                amountClassName={style.unitPrice}
-                amount={unitPrice}
-                convertToFiat
-                removeTrailingZeros
-              />
-            </div>
+            {showUnitPrice && (
+              <div data-testid="unit-price-amount">
+                <AmountWithUnit
+                  alwaysShowAmounts
+                  amountClassName={style.unitPrice}
+                  amount={unitPrice}
+                  convertToFiat
+                  removeTrailingZeros
+                />
+              </div>
+            )}
           </div>
           <div className={style.assetBalanceAmounts}>
             {amount ? (

--- a/frontends/web/src/routes/account/summary/balance-section.tsx
+++ b/frontends/web/src/routes/account/summary/balance-section.tsx
@@ -6,26 +6,29 @@ import { Amount } from '@/components/amount/amount';
 import { Skeleton } from '@/components/skeleton/skeleton';
 import style from './accountssummary.module.css';
 
-type Props = {
+type TProps = {
   name: ReactNode;
+  hideHeader?: boolean;
   totalAmount?: string;
   fiatUnit?: ConversionUnit;
   children: ReactNode;
 };
 
-export const BalanceSection = ({ name, totalAmount, fiatUnit, children }: Props) => (
+export const BalanceSection = ({ name, hideHeader, totalAmount, fiatUnit, children }: TProps) => (
   <div className={style.keystoreContainer}>
-    <div className={style.keystoreHeader}>
-      {name}
-      {totalAmount && fiatUnit ? (
-        <div className={style.keystoreBalanceAmount}>
-          <Amount amount={totalAmount} unit={fiatUnit} />
-          <span className={style.coinUnit}>
-            {fiatUnit}
-          </span>
-        </div>
-      ) : (<div className={style.keystoreBalanceAmount}><Skeleton minWidth="60px" /></div>)}
-    </div>
+    {!hideHeader && (
+      <div className={style.keystoreHeader}>
+        {name}
+        {totalAmount && fiatUnit ? (
+          <div className={style.keystoreBalanceAmount}>
+            <Amount amount={totalAmount} unit={fiatUnit} />
+            <span className={style.coinUnit}>
+              {fiatUnit}
+            </span>
+          </div>
+        ) : (<div className={style.keystoreBalanceAmount}><Skeleton minWidth="60px" /></div>)}
+      </div>
+    )}
     <div className={style.coinGroupList}>
       {children}
     </div>

--- a/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.tsx
+++ b/frontends/web/src/routes/account/summary/total-balance-for-all-keystores.tsx
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import type { KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import * as accountApi from '@/api/account';
 import { Skeleton } from '@/components/skeleton/skeleton';
 import { BalanceSection } from './balance-section';
@@ -8,32 +10,61 @@ import { AssetBalanceWithUnitPrice } from './asset-balance-with-unit-price';
 import style from './accountssummary.module.css';
 
 type TProps = {
+  hideHeader?: boolean;
+  hideLightningUnitPrice?: boolean;
   summaryData?: accountApi.TChartData;
   coinsBalances?: accountApi.CoinFormattedAmount[];
 };
 
 export const TotalBalanceForAllKeystores = ({
+  hideHeader,
+  hideLightningUnitPrice,
   summaryData,
-  coinsBalances = [],
+  coinsBalances,
 }: TProps) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const openLightning = () => navigate('/lightning');
   return (
     <BalanceSection
+      hideHeader={hideHeader}
       name={<span>{t('accountSummary.totalAssets')}</span>}
       totalAmount={summaryData?.formattedChartTotal ?? undefined}
       fiatUnit={summaryData?.chartFiat}
     >
-      {coinsBalances.length > 0 ? coinsBalances.map((balance) => (
-        <div key={balance.coinCode} className={style.coinGroupCard}>
-          <AssetBalanceWithUnitPrice
-            amount={balance.formattedAmount}
-            coinCode={balance.coinCode}
-            coinName={balance.coinName}
-          />
-        </div>
-      )) : (
+      {coinsBalances === undefined ? (
         <LoadingSkeleton />
-      )}
+      ) : coinsBalances.map((balance) => {
+        const isLightning = balance.coinCode === 'lightning';
+        const onLightningKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+          if (event.key !== 'Enter' && event.key !== ' ') {
+            return;
+          }
+          event.preventDefault();
+          openLightning();
+        };
+
+        return (
+          <div
+            key={balance.coinCode}
+            className={`
+              ${style.coinGroupCard || ''}
+              ${isLightning ? style.clickable || '' : ''}
+            `}
+            onClick={isLightning ? openLightning : undefined}
+            onKeyDown={isLightning ? onLightningKeyDown : undefined}
+            role={isLightning ? 'button' : undefined}
+            tabIndex={isLightning ? 0 : undefined}
+          >
+            <AssetBalanceWithUnitPrice
+              amount={balance.formattedAmount}
+              coinCode={balance.coinCode}
+              coinName={balance.coinName}
+              showUnitPrice={!isLightning || !hideLightningUnitPrice}
+            />
+          </div>
+        );
+      })}
     </BalanceSection>
   );
 };

--- a/frontends/web/src/routes/account/utils.test.ts
+++ b/frontends/web/src/routes/account/utils.test.ts
@@ -144,6 +144,13 @@ describe('utils/getAccountsByKeystore', () => {
 });
 
 describe('utils/bitcoin coin helpers', () => {
+  it('treats btc, tbtc, and rbtc as bitcoin-only coin codes', () => {
+    expect(isBitcoinOnly('btc')).toBe(true);
+    expect(isBitcoinOnly('tbtc')).toBe(true);
+    expect(isBitcoinOnly('rbtc')).toBe(true);
+    expect(isBitcoinOnly('lightning')).toBe(false);
+  });
+
   it('treats rbtc coin codes as bitcoin-only and bitcoin-based', () => {
     expect(isBitcoinOnly('rbtc')).toBe(true);
     expect(isBitcoinBased('rbtc')).toBe(true);


### PR DESCRIPTION
1. Hide price if theres any bitcoin account active
2. But when only LN is active then show the price
3. Remove "Total assets" and "total fiat" titles if only LN account is active
4. On tap goes to LN account